### PR TITLE
refactor: use type imports and better email function

### DIFF
--- a/server/src/cron.ts
+++ b/server/src/cron.ts
@@ -22,7 +22,7 @@ import { getResetBalancesUpdate } from "./internal/customers/cusProducts/cusEnts
 import { CusProductService } from "./internal/customers/cusProducts/CusProductService.js";
 import { createStripeCli } from "./external/stripe/utils.js";
 import { UTCDate } from "@date-fns/utc";
-import { DrizzleCli, initDrizzle } from "./db/initDrizzle.js";
+import { type DrizzleCli, initDrizzle } from "./db/initDrizzle.js";
 
 import { CusPriceService } from "./internal/customers/cusProducts/cusPrices/CusPriceService.js";
 

--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -10,7 +10,7 @@ export const initDrizzle = () => {
 
   const db = drizzle(client, {
     schema: schemas,
-    // logger: true, // Enable SQL logging for debugging
+    logger: process.env.NODE_ENV === "development", // Enable SQL logging for debugging
   });
 
   return { db, client };

--- a/server/src/external/llm/llmUtils.ts
+++ b/server/src/external/llm/llmUtils.ts
@@ -8,7 +8,7 @@ const anthropic = createAnthropic({
 });
 
 export const generateFeatureDisplay = async (feature: Feature) => {
-  let prompt = `I'm building an entitlement system and my users can create features on my platform. I also help with displaying components (like pricing table) so I need to get the feature name in singular and plural form. 
+  const prompt = `I'm building an entitlement system and my users can create features on my platform. I also help with displaying components (like pricing table) so I need to get the feature name in singular and plural form. 
   
   Based on the feature name passed in, please generate a singular and plural form, in lowercase.
   

--- a/server/src/external/posthog/createPosthogCli.ts
+++ b/server/src/external/posthog/createPosthogCli.ts
@@ -13,6 +13,6 @@ export const createPosthogCli = () => {
   }
 
   return new PostHog(process.env.POSTHOG_API_KEY, {
-    host: "https://us.i.posthog.com",
+    host: process.env.POSTHOG_HOST_URL ?? "https://us.i.posthog.com",
   });
 };

--- a/server/src/external/posthog/posthogCapture.ts
+++ b/server/src/external/posthog/posthogCapture.ts
@@ -8,11 +8,7 @@ export const posthogCapture = ({
   params: EventMessage;
 }) => {
   try {
-    if (process.env.NODE_ENV === "development") {
-      return;
-    }
-
-    if (!posthog) {
+    if (process.env.NODE_ENV === "development" || !posthog) {
       return;
     }
 

--- a/server/src/external/redis/stripeWebhookLocks.ts
+++ b/server/src/external/redis/stripeWebhookLocks.ts
@@ -1,6 +1,4 @@
-import { ErrCode } from "@/errors/errCodes.js";
 import { QueueManager } from "@/queue/QueueManager.js";
-import RecaseError from "@/utils/errorUtils.js";
 
 export const getWebhookLock = async ({
   lockKey,

--- a/server/src/external/resend/resendUtils.ts
+++ b/server/src/external/resend/resendUtils.ts
@@ -4,18 +4,26 @@ export const createCli = () => {
   return new Resend(process.env.RESEND_API_KEY);
 };
 
+export interface ResendEmailProps {
+  to: string;
+  subject: string;
+  body: string;
+  from: string
+}
+
+export const nameToEmail = (name: string) => {
+  return `${name.toLowerCase().replace(/\s+/g, ".")}@${process.env.RESEND_DOMAIN}`;
+};
+
 export const sendTextEmail = async ({
   to,
   subject,
   body,
-}: {
-  to: string;
-  subject: string;
-  body: string;
-}) => {
+  from,
+}: ResendEmailProps) => {
   const resend = createCli();
   await resend.emails.send({
-    from: `Ayush <ayush@${process.env.RESEND_DOMAIN}>`,
+    from: `${from} <${nameToEmail(from)}>`,
     to: to,
     subject: subject,
     text: body,
@@ -26,14 +34,11 @@ export const sendHtmlEmail = async ({
   to,
   subject,
   body,
-}: {
-  to: string;
-  subject: string;
-  body: string;
-}) => {
+  from
+}: ResendEmailProps) => {
   const resend = createCli();
   await resend.emails.send({
-    from: `Ayush <ayush@${process.env.RESEND_DOMAIN}>`,
+    from: `${from} <${nameToEmail(from)}>`,
     to: to,
     subject: subject,
     html: body,

--- a/server/src/external/stripe/createStripePrice/createStripeArrearProrated.ts
+++ b/server/src/external/stripe/createStripePrice/createStripeArrearProrated.ts
@@ -12,12 +12,20 @@ import {
   BillingInterval,
   BillingType,
 } from "@autumn/shared";
-import { SupabaseClient } from "@supabase/supabase-js";
 import Stripe from "stripe";
 import { billingIntervalToStripe } from "../stripePriceUtils.js";
 import { priceToInArrearTiers } from "./createStripeInArrear.js";
 import { PriceService } from "@/internal/products/prices/PriceService.js";
 import { DrizzleCli } from "@/db/initDrizzle.js";
+
+export interface StripeMeteredPriceParams {
+  db: DrizzleCli;
+  stripeCli: Stripe;
+  price: Price;
+  entitlements: EntitlementWithFeature[];
+  product: Product;
+  org: Organization;
+}
 
 export const createStripeMeteredPrice = async ({
   db,
@@ -26,14 +34,7 @@ export const createStripeMeteredPrice = async ({
   entitlements,
   product,
   org,
-}: {
-  db: DrizzleCli;
-  stripeCli: Stripe;
-  price: Price;
-  entitlements: EntitlementWithFeature[];
-  product: Product;
-  org: Organization;
-}) => {
+}: StripeMeteredPriceParams) => {
   const config = price.config as UsagePriceConfig;
   const ent = getPriceEntitlement(price, entitlements);
   const feature = ent.feature;

--- a/server/src/external/supabaseUtils.ts
+++ b/server/src/external/supabaseUtils.ts
@@ -1,4 +1,4 @@
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { createClient } from "@supabase/supabase-js";
 import fetchRetry from "fetch-retry";
 import { createLogtail } from "./logtail/logtailUtils.js";
 

--- a/server/src/external/unkeyUtils.ts
+++ b/server/src/external/unkeyUtils.ts
@@ -1,7 +1,6 @@
 // import { AppEnv } from "@autumn/shared";
 // import { Unkey } from "@unkey/api";
 
-// const UNKEY_API_ID = "api_2fcMv43jiAbBySAgDubovfpVUABP";
 // const createUnkeyCli = () => {
 //   return new Unkey({ rootKey: process.env.UNKEY_ROOT_KEY! });
 // };
@@ -21,7 +20,7 @@
 // }) => {
 //   const unkey = createUnkeyCli();
 //   const key = await unkey.keys.create({
-//     apiId: UNKEY_API_ID,
+//     apiId:  process.env.UNKEY_API_ID,
 //     name,
 //     prefix,
 //     ownerId,
@@ -47,7 +46,7 @@
 // export const validateApiKey = async (apiKey: string) => {
 //   const unkey = createUnkeyCli();
 //   const { result, error } = await unkey.keys.verify({
-//     apiId: UNKEY_API_ID,
+//     apiId:  process.env.UNKEY_API_ID,
 //     key: apiKey,
 //   });
 

--- a/server/src/external/webhooks/sendOnboardingEmail.ts
+++ b/server/src/external/webhooks/sendOnboardingEmail.ts
@@ -1,5 +1,5 @@
 import { ClerkClient } from "@clerk/express";
-import { sendHtmlEmail, sendTextEmail } from "../resend/resendUtils.js";
+import { sendHtmlEmail } from "../resend/resendUtils.js";
 
 const getWelcomeEmailBody = (userFirstName: string) => {
   return `
@@ -43,6 +43,7 @@ export const sendOnboardingEmail = async ({
       to: email,
       subject: "Anything I can help with?",
       body: getWelcomeEmailBody(user.firstName ?? "there"),
+      from: "Ayush",
     });
 
     break;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,11 +18,9 @@ import {
   createLogtail,
   createLogtailAll,
 } from "./external/logtail/logtailUtils.js";
-import { format } from "date-fns";
 import { CacheManager } from "./external/caching/CacheManager.js";
 import { initDrizzle } from "./db/initDrizzle.js";
 import { createPosthogCli } from "./external/posthog/createPosthogCli.js";
-import pg from "pg";
 import http from "http";
 import { generateId } from "./utils/genUtils.js";
 import { subscribeToOrgUpdates } from "./external/supabase/subscribeToOrgUpdates.js";

--- a/server/src/internal/analytics/ActionService.ts
+++ b/server/src/internal/analytics/ActionService.ts
@@ -1,5 +1,5 @@
 import { DrizzleCli } from "@/db/initDrizzle.js";
-import { Action, ActionInsert, actions } from "@autumn/shared";
+import { type ActionInsert, actions } from "@autumn/shared";
 
 export class ActionService {
   static async insert(db: DrizzleCli, data: ActionInsert | ActionInsert[]) {

--- a/server/src/internal/analytics/actionUtils.ts
+++ b/server/src/internal/analytics/actionUtils.ts
@@ -1,5 +1,5 @@
 import { generateId } from "@/utils/genUtils.js";
-import { ExtendedRequest } from "@/utils/models/Request.js";
+import type { ExtendedRequest } from "@/utils/models/Request.js";
 import {
   Entity,
   Organization,

--- a/server/src/internal/analytics/handlers/handleCustomerCreated.ts
+++ b/server/src/internal/analytics/handlers/handleCustomerCreated.ts
@@ -1,5 +1,5 @@
 import { DrizzleCli } from "@/db/initDrizzle.js";
-import { ActionRequest, ExtendedRequest } from "@/utils/models/Request.js";
+import type { ExtendedRequest } from "@/utils/models/Request.js";
 import { ActionType, AppEnv, Organization } from "@autumn/shared";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
 import { JobName } from "@/queue/JobName.js";

--- a/server/src/internal/analytics/runActionHandlerTask.ts
+++ b/server/src/internal/analytics/runActionHandlerTask.ts
@@ -1,6 +1,6 @@
 import { DrizzleCli } from "@/db/initDrizzle.js";
 import { JobName } from "@/queue/JobName.js";
-import { acquireLock, getLock, releaseLock } from "@/queue/lockUtils.js";
+import { getLock, releaseLock } from "@/queue/lockUtils.js";
 import { Queue } from "bullmq";
 import { Job } from "bullmq";
 import { handleProductsUpdated } from "./handlers/handleProductsUpdated.js";

--- a/server/src/internal/api/entities/EntityService.ts
+++ b/server/src/internal/api/entities/EntityService.ts
@@ -1,4 +1,4 @@
-import { DrizzleCli } from "@/db/initDrizzle.js";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import RecaseError from "@/utils/errorUtils.js";
 import { ErrCode } from "@autumn/shared";
 import { Entity, entities } from "@autumn/shared";
@@ -108,7 +108,7 @@ export class EntityService {
     orgId: string;
     env: string;
   }) {
-    const results = await db
+    const _results = await db
       .delete(entities)
       .where(
         and(

--- a/server/src/internal/api/entities/entityRouter.ts
+++ b/server/src/internal/api/entities/entityRouter.ts
@@ -1,10 +1,7 @@
 import { Router } from "express";
 
 import { routeHandler } from "@/utils/routerUtils.js";
-import { EntityService } from "./EntityService.js";
 import { CusService } from "@/internal/customers/CusService.js";
-import RecaseError from "@/utils/errorUtils.js";
-import { ErrCode } from "@autumn/shared";
 import { handleGetEntity } from "./handlers/handleGetEntity.js";
 import { handlePostEntityRequest } from "../../entities/handlers/handleCreateEntity/handleCreateEntity.js";
 import { handleDeleteEntity } from "./handlers/handleDeleteEntity.js";
@@ -18,7 +15,7 @@ entityRouter.get("", (req, res) =>
     res,
     action: "listEntities",
     handler: async (req, res) => {
-      const customerId = req.params.customer_id as string;
+      const customerId = String(req.params.customer_id);
       let { orgId, env } = req;
 
       let customer = await CusService.getFull({

--- a/server/src/internal/api/entities/getEntityUtils.ts
+++ b/server/src/internal/api/entities/getEntityUtils.ts
@@ -1,4 +1,4 @@
-import { DrizzleCli } from "@/db/initDrizzle.js";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import {
   getCusFeaturesResponse,
@@ -8,15 +8,15 @@ import {
 import RecaseError from "@/utils/errorUtils.js";
 import { nullish } from "@/utils/genUtils.js";
 import {
-  AppEnv,
+  type AppEnv,
   CusProductStatus,
-  Entity,
+  type Entity,
   EntityExpand,
-  EntityResponse,
+  type EntityResponse,
   ErrCode,
-  FullCusProduct,
-  Organization,
-  Subscription,
+  type FullCusProduct,
+  type Organization,
+  type Subscription,
 } from "@autumn/shared";
 
 export const getEntityResponse = async ({

--- a/server/src/internal/api/entitled/checkUtils.ts
+++ b/server/src/internal/api/entitled/checkUtils.ts
@@ -4,20 +4,19 @@ import { isFeaturePriceItem } from "@/internal/products/product-items/productIte
 import {
   APIVersion,
   BillingInterval,
-  Feature,
-  FreeTrial,
-  FullCusProduct,
-  FullCustomerEntitlement,
-  Organization,
-  ProductItem,
+  type Feature,
+  type FreeTrial,
+  type FullCusProduct,
+  type FullCustomerEntitlement,
+  type Organization,
+  type ProductItem,
   SuccessCode,
   UsageModel,
 } from "@autumn/shared";
 import { getCheckPreview } from "./getCheckPreview.js";
 
-import { DrizzleCli } from "@/db/initDrizzle.js";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { getProration } from "@/internal/invoices/previewItemUtils/getItemsForNewProduct.js";
-import { formatUnixToDateTime } from "@/utils/genUtils.js";
 
 export const getBooleanEntitledResult = async ({
   db,

--- a/server/src/internal/api/entitled/entitledRouter.ts
+++ b/server/src/internal/api/entitled/entitledRouter.ts
@@ -3,10 +3,10 @@ import RecaseError, { handleRequestError } from "@/utils/errorUtils.js";
 import {
   APIVersion,
   CusProductStatus,
-  Feature,
+  type Feature,
   FeatureType,
-  FullCustomerEntitlement,
-  Organization,
+  type FullCustomerEntitlement,
+  type Organization,
 } from "@autumn/shared";
 
 import {

--- a/server/src/internal/api/entitled/getCheckPreview.ts
+++ b/server/src/internal/api/entitled/getCheckPreview.ts
@@ -1,4 +1,4 @@
-import { DrizzleCli } from "@/db/initDrizzle.js";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { fullCusProductToProduct } from "@/internal/customers/cusProducts/cusProductUtils.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import {
@@ -9,10 +9,10 @@ import {
 import { getProductResponse } from "@/internal/products/productV2Utils.js";
 import { notNullish } from "@/utils/genUtils.js";
 import {
-  Feature,
+  type Feature,
   FeaturePreviewScenario,
-  FullCusProduct,
-  FullProduct,
+  type FullCusProduct,
+  type FullProduct,
 } from "@autumn/shared";
 
 export const getCheckPreview = async ({

--- a/server/src/internal/api/entitled/handlers/attachToCheckPreview/getAttachScenario.ts
+++ b/server/src/internal/api/entitled/handlers/attachToCheckPreview/getAttachScenario.ts
@@ -24,7 +24,6 @@ export const getAttachScenario = async ({
   product: FullProduct;
 }) => {
   let branch = preview.branch;
-  let attachFunc = preview.func;
 
   if (
     branch == AttachBranch.New ||

--- a/server/src/internal/api/entitled/handlers/getFeatureCheckPreview.ts
+++ b/server/src/internal/api/entitled/handlers/getFeatureCheckPreview.ts
@@ -1,9 +1,11 @@
+export interface FeatureCheckPreviewParams {
+  customerId: string;
+  featureId: string;
+  quantity: number;
+}
+
 export const getFeatureCheckPreview = async ({
   customerId,
   featureId,
   quantity,
-}: {
-  customerId: string;
-  featureId: string;
-  quantity: number;
-}) => {};
+}: FeatureCheckPreviewParams) => {};

--- a/server/src/internal/api/entitled/handlers/getProductCheckPreview.ts
+++ b/server/src/internal/api/entitled/handlers/getProductCheckPreview.ts
@@ -1,5 +1,5 @@
 import { checkToAttachParams } from "@/internal/customers/attach/attachUtils/attachParams/checkToAttachParams.js";
-import { FullCusProduct, FullCustomer, FullProduct } from "@autumn/shared";
+import { FullCustomer, FullProduct } from "@autumn/shared";
 import { ExtendedRequest } from "@/utils/models/Request.js";
 import { AttachBody } from "@/internal/customers/attach/models/AttachBody.js";
 import { attachParamsToPreview } from "@/internal/customers/attach/handleAttachPreview/attachParamsToPreview.js";
@@ -39,7 +39,6 @@ export const attachToCheckPreview = async ({
   features: Feature[];
 }) => {
   // 1. If check
-  let branch = preview.branch;
   let attachFunc = preview.func;
 
   const noOptions = !preview.options || preview.options.length === 0;

--- a/server/src/internal/api/events/EventService.ts
+++ b/server/src/internal/api/events/EventService.ts
@@ -2,7 +2,7 @@ import { ErrCode, EventInsert } from "@autumn/shared";
 import RecaseError from "@/utils/errorUtils.js";
 import { StatusCodes } from "http-status-codes";
 import { events } from "@autumn/shared";
-import { DrizzleCli } from "@/db/initDrizzle.js";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { and, eq, desc } from "drizzle-orm";
 
 export class EventService {

--- a/server/src/internal/api/events/eventRouter.ts
+++ b/server/src/internal/api/events/eventRouter.ts
@@ -26,7 +26,7 @@ import { creditSystemContainsFeature } from "@/internal/features/creditSystemUti
 import { addTaskToQueue } from "@/queue/queueUtils.js";
 import { JobName } from "@/queue/JobName.js";
 import { orgToVersion } from "@/utils/versionUtils.js";
-import { DrizzleCli } from "@/db/initDrizzle.js";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { ExtendedRequest } from "@/utils/models/Request.js";
 import { getEventTimestamp } from "./eventUtils.js";
 

--- a/server/src/internal/api/events/usageRouter.ts
+++ b/server/src/internal/api/events/usageRouter.ts
@@ -1,10 +1,9 @@
 import { Router } from "express";
 import {
   CusProductStatus,
-  Customer,
+  type Customer,
   ErrCode,
-  Event,
-  EventInsert,
+  type EventInsert,
   FeatureType,
   FeatureUsageType,
 } from "@autumn/shared";
@@ -12,19 +11,14 @@ import RecaseError, { handleRequestError } from "@/utils/errorUtils.js";
 import { generateId, nullish } from "@/utils/genUtils.js";
 
 import { EventService } from "./EventService.js";
-import { OrgService } from "@/internal/orgs/OrgService.js";
-import { FeatureService } from "@/internal/features/FeatureService.js";
 import { StatusCodes } from "http-status-codes";
-import { QueueManager } from "@/queue/QueueManager.js";
 
 import { JobName } from "@/queue/JobName.js";
 import { getOrCreateCustomer } from "@/internal/customers/cusUtils/getOrCreateCustomer.js";
 import { creditSystemContainsFeature } from "@/internal/features/creditSystemUtils.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
-import { getOrgAndFeatures } from "@/internal/orgs/orgUtils.js";
 import { getEventTimestamp } from "./eventUtils.js";
 import { ExtendedRequest } from "@/utils/models/Request.js";
-import { runUpdateBalanceTask } from "@/trigger/updateBalanceTask.js";
 import { runUpdateUsageTask } from "@/trigger/updateUsageTask.js";
 export const eventsRouter = Router();
 export const usageRouter = Router();

--- a/server/src/internal/api/features/handlers/handleDeleteFeature.ts
+++ b/server/src/internal/api/features/handlers/handleDeleteFeature.ts
@@ -3,7 +3,7 @@ import { getCreditSystemsFromFeature } from "@/internal/features/creditSystemUti
 import { FeatureService } from "@/internal/features/FeatureService.js";
 import { EntitlementService } from "@/internal/products/entitlements/EntitlementService.js";
 import RecaseError from "@/utils/errorUtils.js";
-import { ExtendedRequest, ExtendedResponse } from "@/utils/models/Request.js";
+import type { ExtendedRequest, ExtendedResponse } from "@/utils/models/Request.js";
 import { routeHandler } from "@/utils/routerUtils.js";
 
 export const handleDeleteFeature = async (req: any, res: any) =>

--- a/server/src/internal/api/features/handlers/handleUpdateFeature.ts
+++ b/server/src/internal/api/features/handlers/handleUpdateFeature.ts
@@ -26,7 +26,6 @@ import {
   EntInterval,
   FeatureUsageType,
 } from "@autumn/shared";
-import { SupabaseClient } from "@supabase/supabase-js";
 import { ExtendedRequest, ExtendedResponse } from "@/utils/models/Request.js";
 
 const handleFeatureIdChanged = async ({

--- a/server/src/internal/metadata/metadataUtils.ts
+++ b/server/src/internal/metadata/metadataUtils.ts
@@ -4,7 +4,7 @@ import { generateId } from "@/utils/genUtils.js";
 import { addDays } from "date-fns";
 import { MetadataService } from "./MetadataService.js";
 import { AttachParams } from "../customers/cusProducts/AttachParams.js";
-import { DrizzleCli } from "@/db/initDrizzle.js";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 
 export const createCheckoutMetadata = async ({
   db,

--- a/server/src/internal/migrations/migrationSteps/sendMigrationEmail.ts
+++ b/server/src/internal/migrations/migrationSteps/sendMigrationEmail.ts
@@ -41,5 +41,6 @@ Step: Migrate customers
 2. Failed customers: 
 ${migrateStep?.failed_customers}
 `,
+    from: "Ayush"
   });
 };

--- a/server/src/middleware/publicAuthMiddleware.ts
+++ b/server/src/middleware/publicAuthMiddleware.ts
@@ -24,15 +24,17 @@ const allowedEndpoints = [
   },
 ];
 
+export interface IsAllowedEndpointProps {
+  pattern: string;
+  path: string;
+  method: string;
+}
+
 const isAllowedEndpoint = ({
   pattern,
   path,
   method,
-}: {
-  pattern: string;
-  path: string;
-  method: string;
-}) => {
+}: IsAllowedEndpointProps) => {
   // Convert pattern to regex, handling path params like :id
   const matchPath = (pattern: string, path: string) => {
     // Convert pattern to regex, handling path params like :id

--- a/server/src/queue/workersInit.ts
+++ b/server/src/queue/workersInit.ts
@@ -9,7 +9,7 @@ import { runMigrationTask } from "@/internal/migrations/runMigrationTask.js";
 import { runTriggerCheckoutReward } from "@/internal/rewards/triggerCheckoutReward.js";
 import { runSaveFeatureDisplayTask } from "@/internal/features/featureUtils.js";
 import { CacheManager } from "@/external/caching/CacheManager.js";
-import { DrizzleCli, initDrizzle } from "@/db/initDrizzle.js";
+import { type DrizzleCli, initDrizzle } from "@/db/initDrizzle.js";
 import { acquireLock, getRedisConnection, releaseLock } from "./lockUtils.js";
 import { runActionHandlerTask } from "@/internal/analytics/runActionHandlerTask.js";
 


### PR DESCRIPTION
This PR aims to remove unused imports, use type imports more often, make the resend email functions futureproof and make use of reusable interfaces and types.

This is by far not every file I just didnt want yall to have to go through hundrets of files for a code review so I will most likely split this up into multiple PRs.