### PR TITLE
fix: explicitly point to contributors file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 - [ ] Other (please describe):
 
 ## Checklist
-- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
+- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
 - [ ] My code follows the code style of this project
 - [ ] I have added tests where applicable
 - [ ] I have tested my changes locally


### PR DESCRIPTION
## Summary
This points to the right contributors file in the PR template

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (please describe):

Github change

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)