### PR TITLE
Update migration confirmation pop-up text

### DIFF
--- a/vite/src/views/products/product/versioning/ConfirmMigrateDialog.tsx
+++ b/vite/src/views/products/product/versioning/ConfirmMigrateDialog.tsx
@@ -49,7 +49,7 @@ export default function ConfirmNewVersionDialog({
           <DialogDescription className="text-sm flex flex-col gap-4">
             <p>
               Note: This will migrate all customers on {product.name} (version{" "}
-              {version}) to the latest version.
+              {version}) to the latest version. Custom plans and cancelled plans will not be migrated.
             </p>
             <p>
               Type <code className="font-bold">{product.id}</code> to continue.


### PR DESCRIPTION
## Summary
Updated the customer migration confirmation dialog to explicitly state that custom plans and cancelled plans will not be migrated.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (UI text update for clarity)

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
The text in the migration confirmation pop-up has been updated to provide clearer information to users about what is included in the migration process.

**Before:**
"Note: This will migrate all customers on {product.name} (version {version}) to the latest version."

**After:**
"Note: This will migrate all customers on {product.name} (version {version}) to the latest version. Custom plans and cancelled plans will not be migrated."

---

[Slack Thread](https://autumnpricing.slack.com/archives/C07NV8P9NTE/p1752245289400569?thread_ts=1752245289.400569&cid=C07NV8P9NTE)