### PR TITLE
feat(customers): implement context-based filter syncing with URL support

### DIFF
--- a/vite/src/views/customers/CustomersView.tsx
+++ b/vite/src/views/customers/CustomersView.tsx
@@ -22,15 +22,15 @@ import { useSetSearchParams } from "@/utils/setSearchParams";
 
 function CustomersView({ env }: { env: AppEnv }) {
   const pageSize = 50;
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [searchQuery, setSearchQuery] = React.useState(
     searchParams.get("q") || "",
   );
 
   const [filters, setFilters] = React.useState<any>({
-    status: searchParams.get("status"),
-    product_id: searchParams.get("product_id"),
+    status: [],
+    product_id: []
   });
 
   const [pagination, setPagination] = React.useState<{
@@ -55,8 +55,8 @@ function CustomersView({ env }: { env: AppEnv }) {
     data: {
       search: searchParams.get("q") || "",
       filters: {
-        status: searchParams.get("status"),
-        product_id: searchParams.get("product_id"),
+        status: filters.status.join(","),
+        product_id: filters.product_id.join(","),
       },
 
       page: pagination.page,
@@ -110,6 +110,35 @@ function CustomersView({ env }: { env: AppEnv }) {
       setPaginationLoading(false);
     });
   }, [pagination]);
+
+  useEffect(() => {
+    const urlStatus = searchParams
+    .get("status")?.split(",")
+    .filter(Boolean) || [];
+    
+    const urlProductIds = searchParams
+    .get("product_id")?.split(",").
+    filter(Boolean) || [];
+    
+    setFilters({
+      status: urlStatus,
+      product_id: urlProductIds,
+    });
+  }, []);
+
+  useEffect(() => {
+    const params: Record<string, string> = {};
+
+    if (filters.status.length > 0) {
+      params.status = filters.status.join(",");
+    }
+
+    if (filters.product_id.length > 0) {
+      params.product_id = filters.product_id.join(",");
+    }
+
+    setSearchParams(params);
+  }, [filters]);
 
   const totalPages = Math.ceil((data?.totalCount || 0) / pageSize);
 

--- a/vite/src/views/customers/FilterButton.tsx
+++ b/vite/src/views/customers/FilterButton.tsx
@@ -12,36 +12,27 @@ import {
 import { useCustomersContext } from "./CustomersContext";
 import { keyToTitle } from "@/utils/formatUtils/formatTextUtils";
 import { Check, ListFilter, X } from "lucide-react";
-import { useSearchParams } from "react-router";
-import { useSetSearchParams } from "@/utils/setSearchParams";
-import { useEffect } from "react";
 
 function FilterButton() {
   const { setFilters } = useCustomersContext();
-  const [searchParams] = useSearchParams();
-  const setSearchParams = useSetSearchParams();
-  // useEffect(() => {
-  //   let statusParam = searchParams.get("status");
-  //   let productIdParam = searchParams.get("product_id");
-  //   setFilters({ status: statusParam, product_id: productIdParam });
-  // }, [searchParams]);
+
+  const clearFilters = () => {
+    setFilters({
+      status: [],
+      product_id: [],
+    });
+  };
 
   return (
     <DropdownMenu>
       <RenderFilterTrigger />
-
       <DropdownMenuContent className="w-56" align="start">
         <FilterStatus />
         <ProductStatus />
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
           <DropdownMenuItem
-            onClick={() =>
-              setSearchParams({
-                status: "",
-                product_id: "",
-              })
-            }
+            onClick={clearFilters}
             className="cursor-pointer"
           >
             <X size={14} className="text-t3" />
@@ -57,10 +48,21 @@ export default FilterButton;
 
 export const FilterStatus = () => {
   const { filters, setFilters } = useCustomersContext();
-  const statuses = ["canceled", "free_trial"];
 
-  const [searchParams] = useSearchParams();
-  const setSearchParams = useSetSearchParams();
+  const statuses: string[] = ["canceled", "free_trial"];
+
+  const selectedStatuses = filters.status || [];
+
+  const toggleStatus = (status: string) => {
+    const selected = filters.status || [];
+    const isSelected = selected.includes(status);
+
+    const updated = isSelected
+      ? selected.filter((s: string) => s !== status)
+      : [...selected, status];
+
+    setFilters({ ...filters, status: updated });
+  };
 
   return (
     <DropdownMenuGroup>
@@ -68,19 +70,11 @@ export const FilterStatus = () => {
         Status
       </DropdownMenuLabel>
       {statuses.map((status: any) => {
-        const isActive = searchParams.get("status") === status;
+        const isActive = selectedStatuses.includes(status);
         return (
           <DropdownMenuItem
             key={status}
-            onClick={() => {
-              if (isActive) {
-                // setFilters({ ...filters, status: undefined });
-                setSearchParams({ status: "" });
-              } else {
-                // setFilters({ ...filters, status });
-                setSearchParams({ status });
-              }
-            }}
+            onClick={() => toggleStatus(status)}
             className="flex items-center justify-between cursor-pointer text-sm"
           >
             {keyToTitle(status)}
@@ -93,26 +87,32 @@ export const FilterStatus = () => {
 };
 
 export const ProductStatus = () => {
-  const { products } = useCustomersContext();
-  const setSearchParams = useSetSearchParams();
-  const [searchParams] = useSearchParams();
+  const { products, filters, setFilters } = useCustomersContext();
+
+  const selectedProducts = filters.product_id || [];
+
+  const toggleProduct = (productId: string) => {
+    const selected = filters.product_id || [];
+    const isSelected = selected.includes(productId);
+
+    const updated = isSelected
+      ? selected.filter((s: string) => s !== productId)
+      : [...selected, productId];
+
+    setFilters({ ...filters, product_id: updated });
+  };
+
   return (
     <DropdownMenuGroup>
       <DropdownMenuLabel className="text-t3 !font-regular text-xs">
         Product
       </DropdownMenuLabel>
       {products.map((product: any) => {
-        const isActive = searchParams.get("product_id") === product.id;
+        const isActive = selectedProducts.includes(product.id);
         return (
           <DropdownMenuItem
             key={product.id}
-            onClick={() => {
-              if (isActive) {
-                setSearchParams({ product_id: "" });
-              } else {
-                setSearchParams({ product_id: product.id });
-              }
-            }}
+            onClick={() => toggleProduct(product.id)}
             className="flex items-center justify-between cursor-pointer"
           >
             {product.name}


### PR DESCRIPTION
## Summary
Refactored the Customers page to use context-based state for filters (`status`, `product_id`) while syncing the filters to the URL. This allows for better state management and UX, with filters persisting on reload and remaining shareable via URL.

- Hydrates context from URL on first mount
- Syncs context changes back to URL
- Removes direct usage of `useSearchParams` from filter components
- Prepares the system for more complex, composable filters

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<img width="700" height="41" alt="image" src="https://github.com/user-attachments/assets/8da787b4-f35d-4350-9d75-bf7ab27f568f" />

<img width="275" height="238" alt="image" src="https://github.com/user-attachments/assets/8ed68f96-4a4a-44c7-95b0-541b87822949" />

## Additional Context
None