### PR TITLE
fix: 🐛 hotfix trmnl not working with dashed event names

### DIFF
--- a/server/src/internal/api/trmnl/trmnlRouter.ts
+++ b/server/src/internal/api/trmnl/trmnlRouter.ts
@@ -95,7 +95,6 @@ trmnlRouter.post("/screen", async (req: any, res: any) =>
       //   totalCustomers: numberWithCommas(totalCustomers),
       //   topEvent: topEvent[0],
       // });
-      topEvent = topEvent.replace("-", "_");
       res.status(200).json({
         rowData: `[${results.data.map((row: any) => `['${row.period}', ${row[topEvent + "_count"]}]`).join(",")}]`,
         revenue: numberWithCommas(monthlyRevenue.total_payment_volume),


### PR DESCRIPTION
## Summary
Due to the changes to the AnalyticsService to work with dashes, the TRMNL router was not working as it was still text replacing dashes with underscores.

## Type of Change
- [ x] Bug fix