### PR TITLE
fix: 🐛 ensure stripe products on disconnect and reconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,56 +1,49 @@
 {
-	"name": "autumn",
-	"private": true,
-	"workspaces": [
-		"server",
-		"shared",
-		"vite"
-	],
-	"type": "module",
-	"scripts": {
-		"vite:build": "bun -F @autumn/shared build && bun -F @autumn/vite build:bun",
-		"vite:start": "bun -F @autumn/vite start:bun",
-
-		"shared": "bun -F @autumn/shared build",
-
-		"server": "bun -F @autumn/shared build && bun -F @autumn/server start",
-		"workers": "bun -F @autumn/shared build && bun -F @autumn/server workers",
-		"cron": "bun -F @autumn/shared build && bun -F @autumn/server cron",
-		"check": "bun -F @autumn/shared build && bun -F @autumn/server check",
-
-		"server:cron": "pnpm -F server cron:start",
-		"server:check": "NODE_ENV=production pnpm -F server check",
-		"dev": "concurrently \"cd server && npm run dev\" \"cd vite && npm run dev\" \"redis-server\"",
-		"dev:wsl": "concurrently \"cd server && npm run dev\" \"cd vite && npm run dev\" \"cd shared && npm run dev\"",
-		"setup": "node setup.js",
-		"setupci": "node setupci",
-		"db:push": " pnpm -F shared db:push",
-		"db:generate": "pnpm -F shared db:generate",
-		"db:migrate": " pnpm -F shared db:migrate",
-		"docker:up": "docker compose -f docker-compose.dev.yml up --build",
-		"docker:up:unix": "docker compose -f docker-compose.unix.yml up --build",
-		"docker:up:ci": "docker compose -f docker-compose.ci.yml up --build",
-		"build:all": "pnpm -F shared build && pnpm -F server prod:build && pnpm -F vite build",
-
-
-		"vite:build:bun": "bun -F @autumn/shared build && bun -F @autumn/vite build:bun",
-		"vite:start:bun": "bun -F @autumn/shared build && bun -F @autumn/vite start:bun",
-
-
-		"dev:bun": "concurrently \"cd server && bun run dev\" \"cd vite && bun run dev:bun\" \"bun -F @autumn/shared dev:bun\"",
-		"build:all:bun": "bun run -F @autumn/shared build:bun && bun run -F @autumn/server prod:build:bun && bun run -F @autumn/vite build:bun"
-	},
-	"dependencies": {
-		"@wooorm/starry-night": "^3.8.0",
-		"ag-charts-react": "^12.0.1",
-		"chalk": "^5.3.0",
-		"drizzle-kit": "^0.31.1",
-		"tailwind-scrollbar-hide": "^4.0.0"
-	},
-	"devDependencies": {
-		"@types/node": "^24.0.3",
-		"dotenv": "^16.5.0",
-		"inquirer": "^12.6.3",
-		"concurrently": "^9.1.2"
-	}
+  "name": "autumn",
+  "private": true,
+  "workspaces": [
+    "server",
+    "shared",
+    "vite"
+  ],
+  "type": "module",
+  "scripts": {
+    "vite:build": "bun -F @autumn/shared build && bun -F @autumn/vite build:bun",
+    "vite:start": "bun -F @autumn/vite start:bun",
+    "shared": "bun -F @autumn/shared build",
+    "server": "bun -F @autumn/shared build && bun -F @autumn/server start",
+    "workers": "bun -F @autumn/shared build && bun -F @autumn/server workers",
+    "cron": "bun -F @autumn/shared build && bun -F @autumn/server cron",
+    "check": "bun -F @autumn/shared build && bun -F @autumn/server check",
+    "server:cron": "pnpm -F server cron:start",
+    "server:check": "NODE_ENV=production pnpm -F server check",
+    "dev": "concurrently \"cd server && npm run dev\" \"cd vite && npm run dev\" \"redis-server\"",
+    "dev:wsl": "concurrently \"cd server && npm run dev\" \"cd vite && npm run dev\" \"cd shared && npm run dev\"",
+    "setup": "node setup.js",
+    "setupci": "node setupci",
+    "db:push": " pnpm -F shared db:push",
+    "db:generate": "pnpm -F shared db:generate",
+    "db:migrate": " pnpm -F shared db:migrate",
+    "docker:up": "docker compose -f docker-compose.dev.yml up --build",
+    "docker:up:unix": "docker compose -f docker-compose.unix.yml up --build",
+    "docker:up:ci": "docker compose -f docker-compose.ci.yml up --build",
+    "build:all": "pnpm -F shared build && pnpm -F server prod:build && pnpm -F vite build",
+    "vite:build:bun": "bun -F @autumn/shared build && bun -F @autumn/vite build:bun",
+    "vite:start:bun": "bun -F @autumn/shared build && bun -F @autumn/vite start:bun",
+    "dev:bun": "concurrently \"cd server && bun run dev\" \"cd vite && bun run dev\" \"bun -F @autumn/shared dev:bun\"",
+    "build:all:bun": "bun run -F @autumn/shared build:bun && bun run -F @autumn/server prod:build:bun && bun run -F @autumn/vite build:bun"
+  },
+  "dependencies": {
+    "@wooorm/starry-night": "^3.8.0",
+    "ag-charts-react": "^12.0.1",
+    "chalk": "^5.3.0",
+    "drizzle-kit": "^0.31.1",
+    "tailwind-scrollbar-hide": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.3",
+    "dotenv": "^16.5.0",
+    "inquirer": "^12.6.3",
+    "concurrently": "^9.1.2"
+  }
 }

--- a/server/src/external/stripe/stripeEnsureUtils.ts
+++ b/server/src/external/stripe/stripeEnsureUtils.ts
@@ -80,7 +80,7 @@ export async function ensureStripeProductsWithEnv({
 			} else {
 				await initProductInStripe({
 					db,
-					org: updatedOrg, // Use updated org instead of req.org
+					org: updatedOrg,
 					env,
 					logger,
 					product: existingOrgProduct,

--- a/server/src/external/stripe/stripeEnsureUtils.ts
+++ b/server/src/external/stripe/stripeEnsureUtils.ts
@@ -1,0 +1,87 @@
+import { DrizzleCli } from "@/db/initDrizzle.js";
+import { Stripe } from "stripe";
+import { checkKeyValid } from "./stripeOnboardingUtils.js";
+import { ExtendedRequest } from "@/utils/models/Request.js";
+import { AppEnv, products } from "@autumn/shared";
+import { and, eq } from "drizzle-orm";
+import { createStripeProduct } from "./stripeProductUtils.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { initProductInStripe } from "@/internal/products/productUtils.js";
+import { createStripeCli } from "./utils.js";
+
+export async function ensureStripeProducts({
+  db,
+  logger,
+  req,
+}: {
+  db: DrizzleCli;
+  logger: any;
+  req: ExtendedRequest;
+}) {
+  await ensureStripeProductsWithEnv({
+    db,
+    logger,
+    req,
+    env: AppEnv.Sandbox,
+  });
+
+  await ensureStripeProductsWithEnv({
+    db,
+    logger,
+    req,
+    env: AppEnv.Live,
+  });
+}
+export async function ensureStripeProductsWithEnv({
+	db,
+	logger,
+	req,
+	env,
+}: {
+	db: DrizzleCli;
+	logger: any;
+	req: ExtendedRequest;
+	env: AppEnv;
+}) {
+	let stripe = createStripeCli({
+		org: req.org,
+		env,
+	});
+
+	let existingStripeProducts = await stripe.products.list();
+	let existingOrgProducts = await ProductService.listFull({
+		db,
+		orgId: req.org.id,
+		env,
+	});
+
+  console.log("existingOrgProducts", existingOrgProducts.map((p) => p.id));
+  console.log("existingStripeProducts", existingStripeProducts.data.map((p) => p.id));
+
+	for (let existingOrgProduct of existingOrgProducts) {
+		try {
+			let matchFound = existingStripeProducts.data.find(
+				(p) => p.id === existingOrgProduct.processor?.id
+			);
+      console.log("matchFound", matchFound, existingOrgProduct.processor?.id);
+
+			if (matchFound) {
+				continue;
+			} else {
+				await initProductInStripe({
+					db,
+					org: req.org,
+					env,
+					logger,
+					product: existingOrgProduct,
+				});
+
+        console.log("created product", existingOrgProduct.id);
+			}
+		} catch (error) {
+			logger.error(
+				`Error ensuring product ${existingOrgProduct.id} in Stripe: ${error}`
+			);
+		}
+	}
+}

--- a/server/src/external/stripe/utils.ts
+++ b/server/src/external/stripe/utils.ts
@@ -37,6 +37,18 @@ export const createStripeCli = ({
   return new Stripe(decrypted);
 };
 
+export const createDecryptedStripeCli = ({
+  org,
+  env,
+  apiKey,
+}: {
+  org: Organization;
+  env: AppEnv;
+  apiKey: string;
+}) => {
+  return new Stripe(apiKey);
+};
+
 export const calculateMetered1Price = ({
   product,
   numEvents,

--- a/server/src/internal/orgs/orgRouter.ts
+++ b/server/src/internal/orgs/orgRouter.ts
@@ -144,17 +144,15 @@ orgRouter.post("/stripe", async (req: any, res) => {
 			},
 		});
 
-    await clearOrgCache({
-      db,
-      orgId: req.orgId,
-      logger,
-    });
-
 		// 2. Ensure products are created in Stripe (after org is updated)
 		await ensureStripeProducts({
 			db,
 			logger,
 			req,
+      apiKeys: {
+        live: liveApiKey,
+        test: testApiKey,
+      }
 		});
 
 		res.status(200).json({

--- a/server/src/internal/orgs/orgRouter.ts
+++ b/server/src/internal/orgs/orgRouter.ts
@@ -7,8 +7,8 @@ import { encryptData } from "@/utils/encryptUtils.js";
 import { ErrCode } from "@/errors/errCodes.js";
 
 import {
-  checkKeyValid,
-  createWebhookEndpoint,
+	checkKeyValid,
+	createWebhookEndpoint,
 } from "@/external/stripe/stripeOnboardingUtils.js";
 
 import { OrgService } from "./OrgService.js";
@@ -21,6 +21,7 @@ import { handleGetOrgMembers } from "./handlers/handleGetOrgMembers.js";
 import { handleInvite } from "./handlers/handleInvite.js";
 import { handleGetUploadUrl } from "./handlers/handleGetUploadUrl.js";
 import { handleDeleteOrg } from "./handlers/handleDeleteOrg.js";
+import { ensureStripeProducts } from "@/external/stripe/stripeEnsureUtils.js";
 
 export const orgRouter: Router = express.Router();
 orgRouter.get("/members", handleGetOrgMembers);
@@ -29,183 +30,200 @@ orgRouter.post("/invite", handleInvite as any);
 orgRouter.delete("", handleDeleteOrg as any);
 
 orgRouter.delete("/delete-user", async (req: any, res) => {
-  res.status(200).json({
-    message: "User deleted",
-  });
+	res.status(200).json({
+		message: "User deleted",
+	});
 });
 
 orgRouter.get("", async (req: any, res) => {
-  try {
-    if (!req.orgId) {
-      res.status(400).json({
-        message: "Missing orgId",
-      });
-      return;
-    }
+	try {
+		if (!req.orgId) {
+			res.status(400).json({
+				message: "Missing orgId",
+			});
+			return;
+		}
 
-    const org = await OrgService.getFromReq(req);
+		const org = await OrgService.getFromReq(req);
 
-    res.status(200).json(createOrgResponse(org));
-  } catch (error) {
-    handleRequestError({
-      req,
-      error,
-      res,
-      action: "get org",
-    });
-  }
+		res.status(200).json(createOrgResponse(org));
+	} catch (error) {
+		handleRequestError({
+			req,
+			error,
+			res,
+			action: "get org",
+		});
+	}
 });
 
 orgRouter.post("/stripe", async (req: any, res) => {
-  try {
-    let { testApiKey, liveApiKey, successUrl, defaultCurrency } = req.body;
-    let { db, orgId, logtail: logger } = req;
-    if (!testApiKey || !liveApiKey || !successUrl) {
-      throw new RecaseError({
-        message: "Missing required fields",
-        code: ErrCode.StripeKeyInvalid,
-        statusCode: 400,
-      });
-    }
+	try {
+		let { testApiKey, liveApiKey, successUrl, defaultCurrency } = req.body;
+		let { db, orgId, logtail: logger } = req;
+		if (!testApiKey || !liveApiKey || !successUrl) {
+			throw new RecaseError({
+				message: "Missing required fields",
+				code: ErrCode.StripeKeyInvalid,
+				statusCode: 400,
+			});
+		}
 
-    // 1. Check if API keys are valid
-    try {
-      await clearOrgCache({
-        db,
-        orgId,
-        logger,
-      });
+		// 1. Check if API keys are valid
+		try {
+			await clearOrgCache({
+				db,
+				orgId,
+				logger,
+			});
 
-      await checkKeyValid(testApiKey);
-      await checkKeyValid(liveApiKey);
+			await checkKeyValid(testApiKey);
+			await checkKeyValid(liveApiKey);
 
-      // Get default currency from Stripe
-      let stripe = new Stripe(testApiKey);
-      let account = await stripe.accounts.retrieve();
-      if (nullish(defaultCurrency) && nullish(account.default_currency)) {
-        throw new RecaseError({
-          message: "Default currency not set",
-          code: ErrCode.StripeKeyInvalid,
-          statusCode: 500,
-        });
-      } else if (nullish(defaultCurrency)) {
-        defaultCurrency = account.default_currency;
-      }
-    } catch (error: any) {
-      throw new RecaseError({
-        message: error.message || "Invalid Stripe API keys",
-        code: ErrCode.StripeKeyInvalid,
-        statusCode: 500,
-        data: error,
-      });
-    }
-    // 2. Create webhook endpoint
-    let testWebhook: Stripe.WebhookEndpoint;
-    let liveWebhook: Stripe.WebhookEndpoint;
-    try {
-      testWebhook = await createWebhookEndpoint(
-        testApiKey,
-        AppEnv.Sandbox,
-        req.orgId,
-      );
-      liveWebhook = await createWebhookEndpoint(
-        liveApiKey,
-        AppEnv.Live,
-        req.orgId,
-      );
-    } catch (error) {
-      throw new RecaseError({
-        message: "Error creating stripe webhook",
-        code: ErrCode.StripeKeyInvalid,
-        statusCode: 500,
-        data: error,
-      });
-    }
+			// Get default currency from Stripe
+			let stripe = new Stripe(testApiKey);
+			let account = await stripe.accounts.retrieve();
+			if (nullish(defaultCurrency) && nullish(account.default_currency)) {
+				throw new RecaseError({
+					message: "Default currency not set",
+					code: ErrCode.StripeKeyInvalid,
+					statusCode: 500,
+				});
+			} else if (nullish(defaultCurrency)) {
+				defaultCurrency = account.default_currency;
+			}
+		} catch (error: any) {
+			throw new RecaseError({
+				message: error.message || "Invalid Stripe API keys",
+				code: ErrCode.StripeKeyInvalid,
+				statusCode: 500,
+				data: error,
+			});
+		}
+		// 2. Create webhook endpoint
+		let testWebhook: Stripe.WebhookEndpoint;
+		let liveWebhook: Stripe.WebhookEndpoint;
+		try {
+			testWebhook = await createWebhookEndpoint(
+				testApiKey,
+				AppEnv.Sandbox,
+				req.orgId
+			);
+			liveWebhook = await createWebhookEndpoint(
+				liveApiKey,
+				AppEnv.Live,
+				req.orgId
+			);
+		} catch (error) {
+			throw new RecaseError({
+				message: "Error creating stripe webhook",
+				code: ErrCode.StripeKeyInvalid,
+				statusCode: 500,
+				data: error,
+			});
+		}
 
-    // 1. Update org in Supabase
-    await OrgService.update({
-      db,
-      orgId: req.orgId,
-      updates: {
-        stripe_connected: true,
-        default_currency: defaultCurrency,
-        stripe_config: {
-          test_api_key: encryptData(testApiKey),
-          live_api_key: encryptData(liveApiKey),
-          test_webhook_secret: encryptData(testWebhook.secret as string),
-          live_webhook_secret: encryptData(liveWebhook.secret as string),
-          success_url: successUrl,
-        },
-      },
-    });
+		// 1. Update org in Supabase first
+		await OrgService.update({
+			db,
+			orgId: req.orgId,
+			updates: {
+				stripe_connected: true,
+				default_currency: defaultCurrency,
+				stripe_config: {
+					test_api_key: encryptData(testApiKey),
+					live_api_key: encryptData(liveApiKey),
+					test_webhook_secret: encryptData(
+						testWebhook.secret as string
+					),
+					live_webhook_secret: encryptData(
+						liveWebhook.secret as string
+					),
+					success_url: successUrl,
+				},
+			},
+		});
 
-    res.status(200).json({
-      message: "Stripe connected",
-    });
-  } catch (error: any) {
-    handleRequestError({
-      req,
-      error,
-      res,
-      action: "connect stripe",
-    });
-  }
-});
-
-orgRouter.delete("/stripe", async (req: any, res) => {
-  // 1. Get org
-  try {
-    const org = await OrgService.getFromReq(req);
-
-    let { db, orgId, logtail: logger } = req;
     await clearOrgCache({
       db,
-      orgId,
+      orgId: req.orgId,
       logger,
     });
 
-    // 2. Delete webhook endpoint
-    try {
-      const testStripeCli = createStripeCli({ org, env: AppEnv.Sandbox });
-      const liveStripeCli = createStripeCli({ org, env: AppEnv.Live });
+		// 2. Ensure products are created in Stripe (after org is updated)
+		await ensureStripeProducts({
+			db,
+			logger,
+			req,
+		});
 
-      const testWebhooks = await testStripeCli.webhookEndpoints.list();
-      for (const webhook of testWebhooks.data) {
-        if (webhook.url.includes(org.id)) {
-          await testStripeCli.webhookEndpoints.del(webhook.id);
-        }
-      }
+		res.status(200).json({
+			message: "Stripe connected",
+		});
+	} catch (error: any) {
+		handleRequestError({
+			req,
+			error,
+			res,
+			action: "connect stripe",
+		});
+	}
+});
 
-      const liveWebhooks = await liveStripeCli.webhookEndpoints.list();
-      for (const webhook of liveWebhooks.data) {
-        if (webhook.url.includes(org.id)) {
-          await liveStripeCli.webhookEndpoints.del(webhook.id);
-        }
-      }
-    } catch (error: any) {
-      console.error("Error deleting stripe webhook(s)");
-      console.error(error.message);
-    }
+orgRouter.delete("/stripe", async (req: any, res) => {
+	// 1. Get org
+	try {
+		const org = await OrgService.getFromReq(req);
 
-    await OrgService.update({
-      db,
-      orgId: req.orgId,
-      updates: {
-        stripe_connected: false,
-        stripe_config: null,
-        default_currency: undefined,
-      },
-    });
+		let { db, orgId, logtail: logger } = req;
+		await clearOrgCache({
+			db,
+			orgId,
+			logger,
+		});
 
-    res.status(200).json({
-      message: "Stripe disconnected",
-    });
-  } catch (error) {
-    handleRequestError({
-      req,
-      error,
-      res,
-      action: "delete stripe",
-    });
-  }
+		// 2. Delete webhook endpoint
+		try {
+			const testStripeCli = createStripeCli({ org, env: AppEnv.Sandbox });
+			const liveStripeCli = createStripeCli({ org, env: AppEnv.Live });
+
+			const testWebhooks = await testStripeCli.webhookEndpoints.list();
+			for (const webhook of testWebhooks.data) {
+				if (webhook.url.includes(org.id)) {
+					await testStripeCli.webhookEndpoints.del(webhook.id);
+				}
+			}
+
+			const liveWebhooks = await liveStripeCli.webhookEndpoints.list();
+			for (const webhook of liveWebhooks.data) {
+				if (webhook.url.includes(org.id)) {
+					await liveStripeCli.webhookEndpoints.del(webhook.id);
+				}
+			}
+		} catch (error: any) {
+			console.error("Error deleting stripe webhook(s)");
+			console.error(error.message);
+		}
+
+		await OrgService.update({
+			db,
+			orgId: req.orgId,
+			updates: {
+				stripe_connected: false,
+				stripe_config: null,
+				default_currency: undefined,
+			},
+		});
+
+		res.status(200).json({
+			message: "Stripe disconnected",
+		});
+	} catch (error) {
+		handleRequestError({
+			req,
+			error,
+			res,
+			action: "delete stripe",
+		});
+	}
 });


### PR DESCRIPTION
## Summary
- When Stripe is disconnected and reconnected, or connected for the first time it will now map existing Autumn products to existing Stripe products, and if there are any gaps - it will create Stripe products and link them.
- Small change to package.json where bun dev script can fail

## Related Issues
- [ENG-445](https://lindie.app/share/670cc31c69f9ab7d3d1d61e0fb2cc7c3b3ada74b/ENG-445)

## To Do:
- [x] Fix a bug where Stripe keys aren't saved before the ensure function is called, causing a "Stripe keys not found" error to occur.

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)