### PR TITLE
feat: 🎸 allow deleting customers in both autumn and stripe

### DIFF
--- a/server/src/internal/customers/handlers/cusDeleteHandlers.ts
+++ b/server/src/internal/customers/handlers/cusDeleteHandlers.ts
@@ -15,7 +15,7 @@ export const deleteCusById = async ({
   env,
   logger,
   deleteInStripe = false,
-  forceDeleteInStripe = false,
+  forceDelete = false,
 }: {
   db: DrizzleCli;
   org: Organization;
@@ -23,7 +23,7 @@ export const deleteCusById = async ({
   env: AppEnv;
   logger: any;
   deleteInStripe?: boolean;
-  forceDeleteInStripe?: boolean;
+  forceDelete?: boolean;
 }) => {
   const orgId = org.id;
 
@@ -42,10 +42,10 @@ export const deleteCusById = async ({
     });
   }
 
-  if (deleteInStripe || forceDeleteInStripe) {
+  if (deleteInStripe) {
     try {
-      // Only delete stripe customer in sandbox or if forceDeleteInStripe is true
-      if (customer.processor?.id && (env === AppEnv.Sandbox || forceDeleteInStripe)) {
+      // Only delete stripe customer in sandbox or if forceDelete is true
+      if (customer.processor?.id && (env === AppEnv.Sandbox || forceDelete)) {
         await deleteStripeCustomer({
           org,
           env: env,
@@ -82,7 +82,7 @@ export const handleDeleteCustomer = async (req: any, res: any) =>
     action: "delete customer",
     handler: async (req: ExtendedRequest, res: ExtendedResponse) => {
       const { env, logtail: logger, db, org } = req;
-      const { forceDeleteInStripe } = req.query;
+      const { forceDelete } = req.query;
 
       const data = await deleteCusById({
         db,
@@ -91,7 +91,7 @@ export const handleDeleteCustomer = async (req: any, res: any) =>
         env,
         logger,
         deleteInStripe: req.query.delete_in_stripe === "true",
-        forceDeleteInStripe: forceDeleteInStripe === "true",
+        forceDelete: forceDelete === "true",
       });
 
       res.status(200).json(data);

--- a/server/src/internal/customers/handlers/cusDeleteHandlers.ts
+++ b/server/src/internal/customers/handlers/cusDeleteHandlers.ts
@@ -42,7 +42,12 @@ export const deleteCusById = async ({
     });
   }
 
-  if (deleteInStripe) {
+  let response = {
+    customer,
+    success: true,
+  }
+
+  if (deleteInStripe || forceDelete) {
     try {
       // Only delete stripe customer in sandbox or if forceDelete is true
       if (customer.processor?.id && (env === AppEnv.Sandbox || forceDelete)) {
@@ -59,6 +64,8 @@ export const deleteCusById = async ({
         }`,
         error?.message || error
       );
+
+      response.success = false;
     }
   }
 
@@ -69,10 +76,7 @@ export const deleteCusById = async ({
     env: env,
   });
 
-  return {
-    success: true,
-    customer,
-  };
+  return response;
 };
 
 export const handleDeleteCustomer = async (req: any, res: any) =>

--- a/vite/src/views/customers/CustomerRowToolbar.tsx
+++ b/vite/src/views/customers/CustomerRowToolbar.tsx
@@ -67,13 +67,8 @@ export const CustomerRowToolbar = ({
             onClick={async (e) => {
               e.stopPropagation();
               e.preventDefault();
-
-              if (env == AppEnv.Sandbox) {
-                await handleDelete();
-              } else {
-                setDeleteOpen(true);
-                setDropdownOpen(false);
-              }
+              setDeleteOpen(true);
+              setDropdownOpen(false);
             }}
           >
             <div className="flex items-center justify-between w-full gap-2">

--- a/vite/src/views/customers/customer/components/DeleteCustomer.tsx
+++ b/vite/src/views/customers/customer/components/DeleteCustomer.tsx
@@ -25,22 +25,35 @@ export const DeleteCustomerDialog = ({
   open: boolean;
   setOpen: (open: boolean) => void;
 }) => {
-  const [loading, setLoading] = useState(false);
+  const [loadingStates, setLoadingStates] = useState({
+    deleteStripe: false,
+    deleteCustomer: false,
+  });
 
   const axiosInstance = useAxiosInstance();
 
-  const handleClicked = async () => {
-    setLoading(true);
+  const handleClicked = async ({
+    deleteStripe = false,
+  }: {
+    deleteStripe?: boolean;
+  }) => {
+    setLoadingStates({
+      deleteStripe: deleteStripe,
+      deleteCustomer: !deleteStripe,
+    });
 
     try {
-      await axiosInstance.delete(`/v1/customers/${customer.id}`);
+      await axiosInstance.delete(`/v1/customers/${customer.id}?forceDeleteInStripe=${deleteStripe}`);
       await onDelete();
       setOpen(false);
       toast.success("Customer deleted");
     } catch (error) {
       toast.error("Failed to delete customer");
     } finally {
-      setLoading(false);
+      setLoadingStates({
+        deleteStripe: false,
+        deleteCustomer: false,
+      });
       setOpen(false);
     }
   };
@@ -54,8 +67,8 @@ export const DeleteCustomerDialog = ({
 
         <div className="mb-2 text-sm">
           <p className="text-t2">
-            Are you sure you want to delete this customer? This action cannot be
-            undone.
+            Are you sure you want to delete this customer in Autumn? This action cannot be
+            undone. You can also delete the customer in Stripe aswell.
           </p>
         </div>
 
@@ -63,10 +76,19 @@ export const DeleteCustomerDialog = ({
           <div className="flex gap-2">
             <Button
               variant="destructive"
-              onClick={() => handleClicked()}
-              isLoading={loading}
+              onClick={() => handleClicked({ deleteStripe: true })}
+              isLoading={loadingStates.deleteStripe}
+              disabled={loadingStates.deleteCustomer}
             >
-              Delete customer
+              Delete in both
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => handleClicked({ deleteStripe: false })}
+              isLoading={loadingStates.deleteCustomer}
+              disabled={loadingStates.deleteStripe}
+            >
+              Delete in Autumn only
             </Button>
           </div>
         </DialogFooter>

--- a/vite/src/views/customers/customer/components/DeleteCustomer.tsx
+++ b/vite/src/views/customers/customer/components/DeleteCustomer.tsx
@@ -43,7 +43,7 @@ export const DeleteCustomerDialog = ({
     });
 
     try {
-      await axiosInstance.delete(`/v1/customers/${customer.id}?forceDeleteInStripe=${deleteStripe}`);
+      await axiosInstance.delete(`/v1/customers/${customer.id}?forceDelete=${deleteStripe}`);
       await onDelete();
       setOpen(false);
       toast.success("Customer deleted");

--- a/vite/src/views/customers/customer/components/DeleteCustomer.tsx
+++ b/vite/src/views/customers/customer/components/DeleteCustomer.tsx
@@ -4,7 +4,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { CusProductStatus, Customer, FullCusProduct } from "@autumn/shared";
+import { AppEnv, CusProductStatus, Customer, FullCusProduct } from "@autumn/shared";
 import { Dialog, DialogTrigger } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
@@ -13,6 +13,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { useCustomerContext } from "../CustomerContext";
 import { notNullish } from "@/utils/genUtils";
+import { useEnv } from "@/utils/envUtils";
 
 export const DeleteCustomerDialog = ({
   customer,
@@ -31,7 +32,7 @@ export const DeleteCustomerDialog = ({
   });
 
   const axiosInstance = useAxiosInstance();
-
+  const env = useEnv();
   const handleClicked = async ({
     deleteStripe = false,
   }: {
@@ -43,7 +44,7 @@ export const DeleteCustomerDialog = ({
     });
 
     try {
-      await axiosInstance.delete(`/v1/customers/${customer.id}?forceDelete=${deleteStripe}`);
+      await axiosInstance.delete(`/v1/customers/${customer.id}?${env === AppEnv.Sandbox ? "delete_in_stripe" : "force_delete"}=${deleteStripe}`);
       await onDelete();
       setOpen(false);
       toast.success("Customer deleted");
@@ -88,7 +89,7 @@ export const DeleteCustomerDialog = ({
               isLoading={loadingStates.deleteCustomer}
               disabled={loadingStates.deleteStripe}
             >
-              Delete in Autumn only
+              Delete only in Autumn
             </Button>
           </div>
         </DialogFooter>


### PR DESCRIPTION
## Summary
- Allow users to delete Autumn customers in Stripe at the same time as deleting them in Autumn

## Related Issues
- [ENG-451](https://linear.app/useautumn/issue/ENG-451/customer-can-choose-whether-to-delete-customer-in-autumn-only-or-in)

## Type of Change
- [x] New feature

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<img width="492" height="219" alt="image" src="https://github.com/user-attachments/assets/1523524d-3f5f-470e-8139-1bc82852e65a" />