### PR TITLE
fix: 🐛 hotfix rollovers being null can crash getCustomer

### DIFF
--- a/server/src/internal/customers/cusUtils/cusFeatureResponseUtils/getCusBalances.ts
+++ b/server/src/internal/customers/cusUtils/cusFeatureResponseUtils/getCusBalances.ts
@@ -76,7 +76,7 @@ export const getRolloverFields = ({
   cusEnt: FullCustomerEntitlement;
   entityId?: string;
 }) => {
-  let hasRollover = notNullish(cusEnt.rollovers) || notNullish(cusEnt.entitlement.rollover);
+  let hasRollover = notNullish(cusEnt.rollovers) && notNullish(cusEnt.entitlement.rollover);
   if (!hasRollover) {
     return null;
   }

--- a/server/src/internal/customers/cusUtils/cusFeatureResponseUtils/getCusBalances.ts
+++ b/server/src/internal/customers/cusUtils/cusFeatureResponseUtils/getCusBalances.ts
@@ -76,7 +76,7 @@ export const getRolloverFields = ({
   cusEnt: FullCustomerEntitlement;
   entityId?: string;
 }) => {
-  let hasRollover = notNullish(cusEnt.entitlement.rollover);
+  let hasRollover = notNullish(cusEnt.rollovers) || notNullish(cusEnt.entitlement.rollover);
   if (!hasRollover) {
     return null;
   }


### PR DESCRIPTION
## Summary
Hotfix an issue where if a customer entitlement has no rollovers, it can crash the get customer route