### PR TITLE
feat: Add patch.bot chat widget

### DIFF
--- a/vite/src/app/layout.tsx
+++ b/vite/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { ArrowUpRightFromSquare, PanelLeft, PanelRight } from "lucide-react";
 import { AutumnProvider } from "autumn-js/react";
 import { useSession } from "@/lib/auth-client";
 import { CustomToaster } from "@/components/general/CustomToaster";
+import { ChatWidget } from "@/components/general/ChatWidget";
 import {
   SidebarContext,
   useSidebarContext,
@@ -108,6 +109,7 @@ export function MainLayout() {
             <CustomToaster />
             <MainSidebar />
             <MainContent />
+            <ChatWidget />
           </main>
         </NuqsAdapter>
       </SidebarContext.Provider>

--- a/vite/src/components/general/ChatWidget.tsx
+++ b/vite/src/components/general/ChatWidget.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSession } from '@/lib/auth-client';
+
+declare global {
+  interface Window {
+    patch?: {
+      config: {
+        organizationId: string;
+        email?: string | null;
+        name?: string | null;
+        avatar_url?: string | null;
+      };
+    };
+  }
+}
+
+let widgetInitialized = false;
+
+export function ChatWidget() {
+  const { data: session, isPending } = useSession();
+
+  useEffect(() => {
+    if (isPending || widgetInitialized) return;
+
+    widgetInitialized = true;
+
+    // Set config
+    window.patch = {
+      config: {
+        organizationId: import.meta.env.VITE_PATCH_WIDGET_KEY || "fGZL4NggKn9UJPgUs52SIw7h6Sv5IlQp",
+        email: session?.user?.email,
+        name: session?.user?.name,
+        avatar_url: session?.user?.image,
+      }
+    };
+
+    // Load script
+    const script = document.createElement('script');
+    script.src = 'https://chat.patch.bot/widget/loader.js';
+    script.async = true;
+    document.head.appendChild(script);
+
+    return
+  }, [session, isPending]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
Allow users to ask questions and provide feedback to Autumn Discord server from an in-app chat widget.
- New Discord thread is created when widget conversation is started
- Autumn user email and avatar session data are included in Discord messages

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [X] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [X] My code follows the code style of this project
- [X] I have added tests where applicable
- [X] I have tested my changes locally
- [X] I have linked relevant issues
- [X] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->
<img width="3436" height="1902" alt="Screenshot 2025-08-09 151450" src="https://github.com/user-attachments/assets/740ed817-666c-4fba-995a-2c3dc2138ced" />

<img width="3456" height="1898" alt="Screenshot 2025-08-09 151712" src="https://github.com/user-attachments/assets/a69778b8-57c8-495b-a46d-110f193bcf34" />

<img width="1713" height="1904" alt="Screenshot 2025-08-09 151812" src="https://github.com/user-attachments/assets/082c9ae5-f20c-4d23-82ba-ce52e8bce8d5" />

<img width="1712" height="1900" alt="Screenshot 2025-08-09 151831" src="https://github.com/user-attachments/assets/c2310741-e3d5-4b37-86e7-e97c59e85be0" />


## Additional Context
<!-- Add any other context or information about the PR here --> 

PR submitted per Ayush's request. Further widget branding and configuration changes can be customized without code changes.