### PR TITLE
feat : Added Role-Based Invitations and Organization Permissions

### DIFF
--- a/server/src/internal/orgs/handlers/handleInvite.ts
+++ b/server/src/internal/orgs/handlers/handleInvite.ts
@@ -4,18 +4,45 @@ import {
   handleFrontendReqError,
   handleRequestError,
 } from "@/utils/errorUtils.js";
-import { ExtendedRequest, ExtendedResponse } from "@/utils/models/Request.js";
-import { user } from "@autumn/shared";
+import { user, OrgRole, ROLE_PERMISSIONS, invitation } from "@autumn/shared";
 import { eq } from "drizzle-orm";
 import { Request, Response } from "express";
+import { generateId } from "better-auth";
 
 export const handleInvite = async (
-  req: ExtendedRequest,
-  res: ExtendedResponse,
+  req: Request,
+  res: Response,
 ) => {
   try {
-    const { email, role } = req.body;
-    const { org, db } = req;
+    const { email, role = OrgRole.Member } = req.body;
+    const { org, db, userRole, userPermissions } = req as any;
+
+    // Validate role parameter
+    if (!Object.values(OrgRole).includes(role)) {
+      return res.status(400).json({
+        message: "Invalid role. Must be one of: owner, admin, member",
+      });
+    }
+
+    // Check permissions for inviting
+    if (!userPermissions?.canInviteMembers) {
+      return res.status(403).json({
+        message: "You don't have permission to invite members",
+      });
+    }
+
+    // Check if user can assign the requested role
+    if (role === OrgRole.Owner && !userPermissions?.canAssignOwner) {
+      return res.status(403).json({
+        message: "Only owners can assign the owner role",
+      });
+    }
+
+    if (role === OrgRole.Admin && !userPermissions?.canAssignAdmin) {
+      return res.status(403).json({
+        message: "You don't have permission to assign admin role",
+      });
+    }
 
     const emailUser = await db.query.user.findFirst({
       where: eq(user.email, email),
@@ -40,6 +67,27 @@ export const handleInvite = async (
       });
       return;
     }
+
+    // For new users, create invitation directly in the database
+    const invitationId = generateId();
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + 7); // 7 days from now
+
+    await db.insert(invitation).values({
+      id: invitationId,
+      organizationId: org.id,
+      email: email,
+      role: role,
+      status: "pending",
+      expiresAt: expiresAt,
+      inviterId: req.user.id,
+    });
+
+    // Send invitation email
+    await sendInvitationEmail({
+      email: email,
+      orgName: org.name,
+    });
 
     res.status(202).send({
       message: "Send invitation to user",

--- a/server/src/internal/orgs/handlers/handleUpdateMemberRole.ts
+++ b/server/src/internal/orgs/handlers/handleUpdateMemberRole.ts
@@ -1,0 +1,72 @@
+import { auth } from "@/utils/auth.js";
+import {
+  handleFrontendReqError,
+} from "@/utils/errorUtils.js";
+import { OrgRole, ROLE_PERMISSIONS } from "@autumn/shared";
+import { member } from "@autumn/shared";
+import { eq, and } from "drizzle-orm";
+import { Request, Response } from "express";
+
+export const handleUpdateMemberRole = async (
+  req: Request,
+  res: Response,
+) => {
+  try {
+    const { memberId, role } = req.body;
+    const { org, db, userPermissions } = req as any;
+
+    // Validate role parameter
+    if (!Object.values(OrgRole).includes(role)) {
+      return res.status(400).json({
+        message: "Invalid role. Must be one of: owner, admin, member",
+      });
+    }
+
+    // Check if user has permission to update member roles
+    if (!userPermissions?.canAssignAdmin && role === OrgRole.Admin) {
+      return res.status(403).json({
+        message: "You don't have permission to assign admin role",
+      });
+    }
+
+    if (!userPermissions?.canAssignOwner && role === OrgRole.Owner) {
+      return res.status(403).json({
+        message: "Only owners can assign the owner role",
+      });
+    }
+
+    // Get the member to be updated
+    const targetMember = await db.query.member.findFirst({
+      where: and(
+        eq(member.id, memberId),
+        eq(member.organizationId, org.id)
+      ),
+    });
+
+    if (!targetMember) {
+      return res.status(404).json({
+        message: "Member not found",
+      });
+    }
+
+    // Update the member role
+    await auth.api.updateMemberRole({
+      body: {
+        memberId: memberId,
+        organizationId: org.id,
+        role: role,
+      },
+    });
+
+    res.status(200).json({
+      message: "Member role updated successfully",
+    });
+  } catch (error) {
+    handleFrontendReqError({
+      req,
+      res,
+      error,
+      action: "updateMemberRole",
+    });
+  }
+};

--- a/server/src/internal/orgs/orgRouter.ts
+++ b/server/src/internal/orgs/orgRouter.ts
@@ -21,13 +21,21 @@ import { handleGetOrgMembers } from "./handlers/handleGetOrgMembers.js";
 import { handleInvite } from "./handlers/handleInvite.js";
 import { handleGetUploadUrl } from "./handlers/handleGetUploadUrl.js";
 import { handleDeleteOrg } from "./handlers/handleDeleteOrg.js";
+import { handleUpdateMemberRole } from "./handlers/handleUpdateMemberRole.js";
 import { ensureStripeProducts } from "@/external/stripe/stripeEnsureUtils.js";
+import { requirePermission, requireRole } from "@/middleware/roleMiddleware.js";
+import { OrgRole } from "@autumn/shared";
 
 export const orgRouter: Router = express.Router();
+
+// Public endpoints (no role restrictions)
 orgRouter.get("/members", handleGetOrgMembers);
 orgRouter.get("/upload_url", handleGetUploadUrl);
-orgRouter.post("/invite", handleInvite as any);
-orgRouter.delete("", handleDeleteOrg as any);
+
+// Protected endpoints with role-based access
+orgRouter.post("/invite", requirePermission("canInviteMembers"), handleInvite);
+orgRouter.put("/member/role", requirePermission("canAssignAdmin"), handleUpdateMemberRole);
+orgRouter.delete("", requireRole(OrgRole.Owner), handleDeleteOrg);
 
 orgRouter.delete("/delete-user", async (req: any, res) => {
   res.status(200).json({

--- a/server/src/middleware/roleMiddleware.ts
+++ b/server/src/middleware/roleMiddleware.ts
@@ -1,0 +1,92 @@
+import { OrgRole, ROLE_PERMISSIONS } from "@autumn/shared";
+import { ExtendedRequest } from "@/utils/models/Request.js";
+import { NextFunction, Response } from "express";
+import { member } from "@autumn/shared";
+import { eq, and } from "drizzle-orm";
+
+export const requireRole = (requiredRole: OrgRole) => {
+  return async (req: ExtendedRequest, res: Response, next: NextFunction) => {
+    try {
+      const { db, orgId, user } = req;
+
+      if (!user?.id) {
+        return res.status(401).json({ message: "Unauthorized" });
+      }
+
+      // Get user's membership in the current organization
+      const membership = await db.query.member.findFirst({
+        where: and(
+          eq(member.userId, user.id),
+          eq(member.organizationId, orgId)
+        ),
+      });
+
+      if (!membership) {
+        return res.status(403).json({ message: "Not a member of this organization" });
+      }
+
+      const userRole = membership.role as OrgRole;
+      const userPermissions = ROLE_PERMISSIONS[userRole];
+
+      // Check if user has the required role or higher
+      const roleHierarchy = {
+        [OrgRole.Owner]: 3,
+        [OrgRole.Admin]: 2,
+        [OrgRole.Member]: 1,
+      };
+
+      if (roleHierarchy[userRole] >= roleHierarchy[requiredRole]) {
+        req.userRole = userRole;
+        req.userPermissions = userPermissions;
+        next();
+      } else {
+        return res.status(403).json({ 
+          message: `Insufficient permissions. Required role: ${requiredRole}` 
+        });
+      }
+    } catch (error) {
+      console.error("Role middleware error:", error);
+      return res.status(500).json({ message: "Internal server error" });
+    }
+  };
+};
+
+export const requirePermission = (permission: keyof typeof ROLE_PERMISSIONS[OrgRole]) => {
+  return async (req: ExtendedRequest, res: Response, next: NextFunction) => {
+    try {
+      const { db, orgId, user } = req;
+
+      if (!user?.id) {
+        return res.status(401).json({ message: "Unauthorized" });
+      }
+
+      // Get user's membership in the current organization
+      const membership = await db.query.member.findFirst({
+        where: and(
+          eq(member.userId, user.id),
+          eq(member.organizationId, orgId)
+        ),
+      });
+
+      if (!membership) {
+        return res.status(403).json({ message: "Not a member of this organization" });
+      }
+
+      const userRole = membership.role as OrgRole;
+      const userPermissions = ROLE_PERMISSIONS[userRole];
+
+      if (userPermissions[permission]) {
+        req.userRole = userRole;
+        req.userPermissions = userPermissions;
+        next();
+      } else {
+        return res.status(403).json({ 
+          message: `Insufficient permissions. Required permission: ${permission}` 
+        });
+      }
+    } catch (error) {
+      console.error("Permission middleware error:", error);
+      return res.status(500).json({ message: "Internal server error" });
+    }
+  };
+};

--- a/server/src/utils/models/Request.ts
+++ b/server/src/utils/models/Request.ts
@@ -1,4 +1,4 @@
-import { AppEnv, AuthType, Feature, Organization } from "@autumn/shared";
+import { AppEnv, AuthType, Feature, Organization, OrgRole, RolePermissions } from "@autumn/shared";
 import { Logtail } from "@logtail/node";
 import type {
   Request as ExpressRequest,
@@ -23,6 +23,8 @@ export interface ExtendedRequest extends ExpressRequest {
   userId?: string;
   isPublic?: boolean;
   authType?: AuthType;
+  userRole?: OrgRole;
+  userPermissions?: RolePermissions;
 
   posthog?: PostHog;
   apiVersion?: number;

--- a/shared/enums/OrgRole.ts
+++ b/shared/enums/OrgRole.ts
@@ -1,0 +1,53 @@
+export enum OrgRole {
+  Owner = "owner",
+  Admin = "admin", 
+  Member = "member",
+}
+
+export interface RolePermissions {
+  canInviteMembers: boolean;
+  canRemoveMembers: boolean;
+  canAssignOwner: boolean;
+  canAssignAdmin: boolean;
+  canDeleteOrg: boolean;
+  canManageOrgSettings: boolean;
+}
+
+export const ROLE_PERMISSIONS: Record<OrgRole, RolePermissions> = {
+  [OrgRole.Owner]: {
+    canInviteMembers: true,
+    canRemoveMembers: true,
+    canAssignOwner: true,
+    canAssignAdmin: true,
+    canDeleteOrg: true,
+    canManageOrgSettings: true,
+  },
+  [OrgRole.Admin]: {
+    canInviteMembers: true,
+    canRemoveMembers: true,
+    canAssignOwner: false,
+    canAssignAdmin: true,
+    canDeleteOrg: false,
+    canManageOrgSettings: true,
+  },
+  [OrgRole.Member]: {
+    canInviteMembers: false,
+    canRemoveMembers: false,
+    canAssignOwner: false,
+    canAssignAdmin: false,
+    canDeleteOrg: false,
+    canManageOrgSettings: false,
+  },
+};
+
+export const ROLE_DISPLAY_NAMES: Record<OrgRole, string> = {
+  [OrgRole.Owner]: "Owner",
+  [OrgRole.Admin]: "Admin",
+  [OrgRole.Member]: "Member",
+};
+
+export const ROLE_DESCRIPTIONS: Record<OrgRole, string> = {
+  [OrgRole.Owner]: "Full control over the organization",
+  [OrgRole.Admin]: "Manage organization settings and members",
+  [OrgRole.Member]: "Basic access to organization features",
+};

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -152,3 +152,4 @@ export * from "./enums/ErrCode.js";
 export * from "./enums/LoggerAction.js";
 export * from "./enums/AttachErrCode.js";
 export * from "./enums/APIVersion.js";
+export * from "./enums/OrgRole.js";

--- a/vite/src/views/main-sidebar/org-dropdown/manage-org/InvitePopover.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/manage-org/InvitePopover.tsx
@@ -5,44 +5,84 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { authClient } from "@/lib/auth-client";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
-import { Mail, PlusIcon } from "lucide-react";
+import { Mail, PlusIcon, UserCheck } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useMemberships } from "../hooks/useMemberships";
+import { OrgRole, ROLE_DISPLAY_NAMES } from "@autumn/shared";
+import { useSession } from "@/lib/auth-client";
 
 export const InvitePopover = () => {
   const [email, setEmail] = useState("");
+  const [role, setRole] = useState<OrgRole>(OrgRole.Member);
   const [loading, setLoading] = useState(false);
   const axiosInstance = useAxiosInstance();
   const { mutate } = useMemberships();
   const [open, setOpen] = useState(false);
+  const { data: session } = useSession();
+  const { memberships } = useMemberships();
+
+  // Get current user's role to determine what roles they can assign
+  const currentUserMembership = memberships.find(
+    (membership) => membership.user.id === session?.session?.userId
+  );
+  const currentUserRole = currentUserMembership?.member.role as OrgRole;
+
+  // Filter available roles based on current user's permissions
+  const getAvailableRoles = () => {
+    const roles = Object.values(OrgRole);
+    
+    if (currentUserRole === OrgRole.Owner) {
+      return roles; // Owner can assign any role
+    } else if (currentUserRole === OrgRole.Admin) {
+      return roles.filter(r => r !== OrgRole.Owner); // Admin can't assign owner
+    } else {
+      return []; // Members can't invite anyone
+    }
+  };
+
+  const availableRoles = getAvailableRoles();
 
   const handleInvite = async () => {
+    if (!email.trim()) {
+      toast.error("Please enter an email address");
+      return;
+    }
+
+    if (availableRoles.length === 0) {
+      toast.error("You don't have permission to invite members");
+      return;
+    }
+
     try {
       setLoading(true);
       const { data, status } = await axiosInstance.post(
         "/organization/invite",
         {
-          email: email,
-          role: "member",
+          email: email.trim(),
+          role: role,
         },
       );
 
-      if (status === 202) {
-        await authClient.organization.inviteMember({
-          email: email,
-          role: "admin",
-          resend: true,
-        });
+      if (status === 200 || status === 202) {
         toast.success(`Successfully sent invitation to ${email}`);
+        await mutate();
+        setOpen(false);
+        setEmail("");
+        setRole(OrgRole.Member);
       } else {
-        toast.success(data.message);
+        toast.error("Failed to send invitation");
       }
-      await mutate();
-      setOpen(false);
     } catch (error) {
       console.error(error);
       toast.error(getBackendErr(error, "Failed to invite user"));
@@ -51,6 +91,11 @@ export const InvitePopover = () => {
     }
   };
 
+  // Don't show invite button if user can't invite
+  if (availableRoles.length === 0) {
+    return null;
+  }
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -58,28 +103,53 @@ export const InvitePopover = () => {
       </PopoverTrigger>
       <PopoverContent
         align="end"
-        className="border border-zinc-200 bg-stone-50 flex flex-col gap-2 pt-3"
+        className="w-72 p-4 bg-white border border-gray-200 rounded-lg shadow-lg"
+        style={{ zIndex: 1000 }}
       >
-        <div className="flex items-center gap-1 text-t3">
-          <Mail size={12} />
-          <p className="text-t3 text-sm">Invite by email</p>
-        </div>
+        <div className="space-y-3">
+          {/* Email Input */}
+          <div>
+            <Input
+              className="h-8 text-sm"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </div>
 
-        <div className="flex items-center gap-2">
-          <Input
-            className="h-7"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
+          {/* Role Selection */}
+          <div>
+            <Select value={role} onValueChange={(value) => setRole(value as OrgRole)}>
+              <SelectTrigger className="h-8 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent 
+                className="z-[1001] min-w-[120px]"
+                position="popper"
+                side="bottom"
+                align="start"
+              >
+                {availableRoles.map((availableRole) => (
+                  <SelectItem 
+                    key={availableRole} 
+                    value={availableRole}
+                    className="text-sm py-1.5"
+                  >
+                    {ROLE_DISPLAY_NAMES[availableRole]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Send Button */}
           <Button
-            variant="gradientPrimary"
-            className="!h-6.5 !mt-0"
-            startIcon={<PlusIcon size={10} />}
             onClick={handleInvite}
             isLoading={loading}
+            disabled={!email.trim()}
+            className="w-full h-8 text-sm"
           >
-            Add
+            Send
           </Button>
         </div>
       </PopoverContent>

--- a/vite/src/views/main-sidebar/org-dropdown/manage-org/MemberRowToolbar.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/manage-org/MemberRowToolbar.tsx
@@ -5,14 +5,17 @@ import {
   DropdownMenuItem,
   DropdownMenuContent,
   DropdownMenuTrigger,
+  DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { useOrg } from "@/hooks/useOrg";
 import { authClient } from "@/lib/auth-client";
-import { Invite, Membership } from "@autumn/shared";
-import { TrashIcon } from "lucide-react";
+import { Invite, Membership, OrgRole, ROLE_DISPLAY_NAMES } from "@autumn/shared";
+import { TrashIcon, UserCog, Crown, Shield, User } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useMemberships } from "../hooks/useMemberships";
+import { useSession } from "@/lib/auth-client";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
 
 export const MemberRowToolbar = ({
   membership,
@@ -22,9 +25,63 @@ export const MemberRowToolbar = ({
   invite?: Invite;
 }) => {
   const [deleteLoading, setDeleteLoading] = useState(false);
+  const [roleLoading, setRoleLoading] = useState(false);
   const [open, setOpen] = useState(false);
+  const [roleMenuOpen, setRoleMenuOpen] = useState(false);
   const { org } = useOrg();
   const { mutate } = useMemberships();
+  const { data: session } = useSession();
+  const { memberships } = useMemberships();
+  const axiosInstance = useAxiosInstance();
+
+  // Get current user's role and permissions
+  const currentUserMembership = memberships.find(
+    (m: any) => m.user.id === session?.session?.userId
+  );
+  const currentUserRole = currentUserMembership?.member.role as OrgRole;
+
+  // Check if current user can manage this member
+  const canManageMember = () => {
+    if (!membership || !currentUserRole) return false;
+    
+    const memberRole = membership.member.role as OrgRole;
+    
+    // Can't manage yourself
+    if (membership.user.id === session?.session?.userId) return false;
+    
+    // Owner can manage everyone
+    if (currentUserRole === OrgRole.Owner) return true;
+    
+    // Admin can manage members but not other admins or owners
+    if (currentUserRole === OrgRole.Admin) {
+      return memberRole === OrgRole.Member;
+    }
+    
+    return false;
+  };
+
+  // Get available roles for this member
+  const getAvailableRoles = () => {
+    if (!canManageMember()) return [];
+    
+    const memberRole = membership?.member.role as OrgRole;
+    
+    if (currentUserRole === OrgRole.Owner) {
+      // Owner can assign any role except to themselves
+      if (membership?.user.id === session?.session?.userId) {
+        return []; // Can't change own role
+      }
+      return Object.values(OrgRole);
+    } else if (currentUserRole === OrgRole.Admin) {
+      // Admin can only promote members to admin
+      if (memberRole === OrgRole.Member) {
+        return [OrgRole.Admin];
+      }
+      return [];
+    }
+    
+    return [];
+  };
 
   const handleDeleteMember = async (e: any) => {
     e.preventDefault();
@@ -70,12 +127,70 @@ export const MemberRowToolbar = ({
     setDeleteLoading(false);
   };
 
+  const handleRoleChange = async (newRole: OrgRole) => {
+    if (!membership) return;
+    
+    setRoleLoading(true);
+    try {
+      // Update member role via API
+      const response = await axiosInstance.put(
+        "/organization/member/role",
+        {
+          memberId: membership.member.id,
+          role: newRole,
+        }
+      );
+
+      if (response.status === 200) {
+        await mutate();
+        toast.success(`Role updated to ${ROLE_DISPLAY_NAMES[newRole]}`);
+      } else {
+        toast.error("Failed to update role");
+      }
+    } catch (error) {
+      toast.error("Failed to update role");
+    }
+    setRoleLoading(false);
+    setRoleMenuOpen(false);
+  };
+
+  const getRoleIcon = (role: OrgRole) => {
+    switch (role) {
+      case OrgRole.Owner:
+        return <Crown size={12} className="text-yellow-600" />;
+      case OrgRole.Admin:
+        return <Shield size={12} className="text-blue-600" />;
+      case OrgRole.Member:
+        return <User size={12} className="text-gray-600" />;
+      default:
+        return <User size={12} />;
+    }
+  };
+
+  const availableRoles = getAvailableRoles();
+  const canManage = canManageMember();
+
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
         <ToolbarButton />
       </DropdownMenuTrigger>
       <DropdownMenuContent>
+        {membership && canManage && availableRoles.length > 0 && (
+          <>
+            <DropdownMenuItem
+              className="flex justify-between text-t2"
+              onClick={() => setRoleMenuOpen(true)}
+            >
+              <div className="flex justify-between items-center w-full">
+                <span>Change Role</span>
+                <UserCog size={12} />
+              </div>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
+        
         <DropdownMenuItem
           shimmer={deleteLoading}
           className="flex justify-between text-t2"
@@ -88,11 +203,32 @@ export const MemberRowToolbar = ({
           }}
         >
           <div className="flex justify-between items-center w-full">
-            <span>Remove</span>
+            <span>{membership ? "Remove" : "Cancel Invite"}</span>
             <TrashIcon size={12} />
           </div>
         </DropdownMenuItem>
       </DropdownMenuContent>
+
+      {/* Role selection submenu */}
+      {roleMenuOpen && (
+        <DropdownMenu open={roleMenuOpen} onOpenChange={setRoleMenuOpen}>
+          <DropdownMenuContent>
+            {availableRoles.map((role) => (
+              <DropdownMenuItem
+                key={role}
+                className="flex justify-between items-center"
+                onClick={() => handleRoleChange(role)}
+                disabled={roleLoading}
+              >
+                <div className="flex items-center gap-2">
+                  {getRoleIcon(role)}
+                  <span>{ROLE_DISPLAY_NAMES[role]}</span>
+                </div>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </DropdownMenu>
   );
 };

--- a/vite/src/views/main-sidebar/org-dropdown/manage-org/OrgInvitesList.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/manage-org/OrgInvitesList.tsx
@@ -1,11 +1,12 @@
 import { useMemberships } from "../hooks/useMemberships";
-import { Invite, Membership } from "@autumn/shared";
+import { Invite, Membership, OrgRole, ROLE_DISPLAY_NAMES } from "@autumn/shared";
 import { Item, Row } from "@/components/general/TableGrid";
 import { cn } from "@/lib/utils";
 import { formatDateStr } from "@/utils/formatUtils/formatDateUtils";
 import { Badge } from "@/components/ui/badge";
 import { useSession } from "@/lib/auth-client";
 import { MemberRowToolbar } from "./MemberRowToolbar";
+import { Crown, Shield, User } from "lucide-react";
 
 export const OrgInvitesList = () => {
   const {
@@ -21,6 +22,32 @@ export const OrgInvitesList = () => {
   );
   const isAdmin =
     membership?.member.role === "admin" || membership?.member.role === "owner";
+
+  const getRoleIcon = (role: string) => {
+    switch (role) {
+      case OrgRole.Owner:
+        return <Crown size={12} className="text-yellow-600" />;
+      case OrgRole.Admin:
+        return <Shield size={12} className="text-blue-600" />;
+      case OrgRole.Member:
+        return <User size={12} className="text-gray-600" />;
+      default:
+        return <User size={12} />;
+    }
+  };
+
+  const getRoleBadgeVariant = (role: string) => {
+    switch (role) {
+      case OrgRole.Owner:
+        return "default";
+      case OrgRole.Admin:
+        return "secondary";
+      case OrgRole.Member:
+        return "outline";
+      default:
+        return "outline";
+    }
+  };
 
   return (
     <div className="h-full overflow-y-auto">
@@ -41,7 +68,10 @@ export const OrgInvitesList = () => {
             <Item className="col-span-6">{invite.email}</Item>
             <Item className="col-span-3">{invite.status}</Item>
             <Item className="col-span-3">
-              <Badge variant="outline">{invite.role}</Badge>
+              <Badge variant={getRoleBadgeVariant(invite.role || "member")} className="flex items-center gap-1">
+                {getRoleIcon(invite.role || "member")}
+                {ROLE_DISPLAY_NAMES[invite.role as OrgRole] || invite.role || "Member"}
+              </Badge>
             </Item>
             <Item className="col-span-2"></Item>
             <Item className="col-span-3">

--- a/vite/src/views/main-sidebar/org-dropdown/manage-org/OrgMembersList.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/manage-org/OrgMembersList.tsx
@@ -1,5 +1,5 @@
 import { useMemberships } from "../hooks/useMemberships";
-import { Membership } from "@autumn/shared";
+import { Membership, OrgRole, ROLE_DISPLAY_NAMES } from "@autumn/shared";
 import { PageSectionHeader } from "@/components/general/PageSectionHeader";
 import { Item, Row } from "@/components/general/TableGrid";
 import { cn } from "@/lib/utils";
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { InvitePopover } from "./InvitePopover";
 import { useSession } from "@/lib/auth-client";
 import { MemberRowToolbar } from "./MemberRowToolbar";
+import { Crown, Shield, User } from "lucide-react";
 
 export const OrgMembersList = () => {
   const { memberships, isLoading: isMembersLoading } = useMemberships();
@@ -21,6 +22,32 @@ export const OrgMembersList = () => {
 
   const isAdmin =
     membership?.member.role === "admin" || membership?.member.role === "owner";
+
+  const getRoleIcon = (role: string) => {
+    switch (role) {
+      case OrgRole.Owner:
+        return <Crown size={12} className="text-yellow-600" />;
+      case OrgRole.Admin:
+        return <Shield size={12} className="text-blue-600" />;
+      case OrgRole.Member:
+        return <User size={12} className="text-gray-600" />;
+      default:
+        return <User size={12} />;
+    }
+  };
+
+  const getRoleBadgeVariant = (role: string) => {
+    switch (role) {
+      case OrgRole.Owner:
+        return "default";
+      case OrgRole.Admin:
+        return "secondary";
+      case OrgRole.Member:
+        return "outline";
+      default:
+        return "outline";
+    }
+  };
 
   return (
     <div className="h-full overflow-y-auto">
@@ -53,9 +80,11 @@ export const OrgMembersList = () => {
             <Item className="col-span-6">{user.email}</Item>
             <Item className="col-span-5">{user.name}</Item>
             <Item className="col-span-3">
-              <Badge variant="outline">{member.role}</Badge>
+            <Badge variant={getRoleBadgeVariant(member.role)} className="flex items-center gap-1">
+                {getRoleIcon(member.role)}
+                {ROLE_DISPLAY_NAMES[member.role as OrgRole] || member.role}
+              </Badge>
             </Item>
-            {/* <Item className="col-span-0"></Item> */}
             <Item className="col-span-3">
               {formatDateStr(member.createdAt)}
             </Item>


### PR DESCRIPTION
## Summary
This PR introduces role-based access control (RBAC) for organization members. (shared in discord)
Previously, all invited users were automatically assigned as `admin`. Now, users with sufficient privileges can choose the role (`Owner`, `Admin`, `Member`) when sending an invite, and the backend enforces permissions accordingly.

## Related Issues
Closes #161 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

https://github.com/user-attachments/assets/37c40217-afcd-4b3c-bd01-d2e898b87c5c

