### PR TITLE
Bug : Added a green confirmation message in the product attachment modal

### DIFF
--- a/vite/src/views/customers/customer/product/components/attach-preview/AttachInfo.tsx
+++ b/vite/src/views/customers/customer/product/components/attach-preview/AttachInfo.tsx
@@ -9,7 +9,7 @@ import {
   ProductItemFeatureType,
 } from "@autumn/shared";
 import { format } from "date-fns";
-import { InfoIcon } from "lucide-react";
+import { InfoIcon, CheckCircle } from "lucide-react";
 
 export const AttachInfo = () => {
   const { attachState, product } = useProductContext();
@@ -86,10 +86,38 @@ export const AttachInfo = () => {
   };
   const description = getAttachDescription();
 
+
+  const hasNoPriceChanges = () => {
+    if (preview?.branch === AttachBranch.SameCustomEnts) {
+      return true;
+    }
+    
+    if (flags.isFree) {
+      return true;
+    }
+
+    if (preview?.due_today?.total === 0) {
+      return true;
+    }
+    
+    return false;
+  };
+
   if (!description) {
     return null;
   }
 
+  if (hasNoPriceChanges()) {
+    return (
+      <div className="flex items-center p-2 bg-green-50 border-1 border-green-200 text-green-700 rounded-xs">
+        <div className="min-w-6 flex">
+          <CheckCircle size={14} />
+        </div>
+        <p className="text-sm font-medium">No changes to prices or subscriptions will be made</p>
+      </div>
+    );
+  }
+  
   return (
     <div className="flex items-center p-2 bg-blue-50 border-1 border-blue-200 text-blue-400 rounded-xs">
       <div className="min-w-6 flex">


### PR DESCRIPTION
## Summary
Added a green confirmation message in the product attachment modal to clearly indicate when customer product changes won't result in any price modifications.

## Related Issues
Found this here : https://lindie.app/share/670cc31c69f9ab7d3d1d61e0fb2cc7c3b3ada74b/ENG-502

## Changes
- Modified `AttachInfo` component to show green confirmation instead of blue info when no price changes occur
- Added `hasNoPriceChanges()` function to detect scenarios with no price impact:
  - `AttachBranch.SameCustomEnts` - entitlement-only changes
  - `flags.isFree` - free products
  - `preview?.due_today?.total === 0` - no charges due today
- Updated UI to use green styling (`bg-green-50`, `border-green-200`, `text-green-700`) with CheckCircle icon
- Maintained existing blue info styling for other scenarios

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe)

## Testing
- Verified green message appears for free products
- Verified green message appears for entitlement-only changes
- Verified green message appears when no charges are due
- Verified blue info message still appears for other scenarios

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)
