### PR TITLE
feat : Add editable display name for members

### DIFF
--- a/server/src/internal/users/userRouter.ts
+++ b/server/src/internal/users/userRouter.ts
@@ -1,7 +1,64 @@
 import { Router } from "express";
+import { z } from "zod";
+import { routeHandler } from "@/utils/routerUtils.js";
+import { ExtendedRequest } from "@/utils/models/Request.js";
+import { ExtendedResponse } from "@/utils/models/Request.js";
+import { db } from "@/db/initDrizzle.js";
+import { user as userTable } from "@autumn/shared";
+import { eq } from "drizzle-orm";
+import RecaseError from "@/utils/errorUtils.js";
+import { ErrCode } from "@autumn/shared";
+import { StatusCodes } from "http-status-codes";
 
 export const userRouter: Router = Router();
 
 userRouter.get("", async (req: any, res) => {
   res.status(200).json({ userId: req.userId });
 });
+
+// Schema for updating user profile
+const UpdateUserSchema = z.object({
+  name: z.string()
+    .min(3, "Name must be at least 3 characters")
+    .max(50, "Name must be at most 50 characters")
+    .regex(/^[a-zA-Z0-9\s\-_]+$/, "Name can only contain letters, numbers, spaces, hyphens, and underscores"),
+});
+
+userRouter.put("/profile", async (req: any, res: any) =>
+  routeHandler({
+    req,
+    res,
+    action: "PUT/users/profile",
+    handler: async (req: ExtendedRequest, res: ExtendedResponse) => {
+      const { userId, db } = req;
+      
+      const updateData = UpdateUserSchema.parse(req.body);
+      
+      const [updatedUser] = await db
+        .update(userTable)
+        .set({
+          name: updateData.name,
+          updatedAt: new Date(),
+        })
+        .where(eq(userTable.id, userId))
+        .returning();
+      
+      if (!updatedUser) {
+        throw new RecaseError({
+          message: "User not found",
+          code: ErrCode.InvalidRequest,
+          statusCode: StatusCodes.NOT_FOUND,
+        });
+      }
+      
+      res.status(200).json({
+        success: true,
+        user: {
+          id: updatedUser.id,
+          name: updatedUser.name,
+          email: updatedUser.email,
+        },
+      });
+    },
+  })
+);

--- a/vite/src/components/general/InlineEdit.tsx
+++ b/vite/src/components/general/InlineEdit.tsx
@@ -1,0 +1,161 @@
+import { useState, useRef, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Check, X, Edit } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface InlineEditProps {
+  value: string;
+  onSave: (value: string) => Promise<void>;
+  onCancel?: () => void;
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+  validation?: (value: string) => string | null;
+  maxLength?: number;
+  minLength?: number;
+}
+
+export const InlineEdit = ({
+  value,
+  onSave,
+  onCancel,
+  placeholder = "Enter value...",
+  className,
+  disabled = false,
+  validation,
+  maxLength = 50,
+  minLength = 3,
+}: InlineEditProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(value);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  useEffect(() => {
+    setEditValue(value);
+  }, [value]);
+
+  const validateInput = (input: string): string | null => {
+    if (input.length < minLength) {
+      return `Must be at least ${minLength} characters`;
+    }
+    if (input.length > maxLength) {
+      return `Must be at most ${maxLength} characters`;
+    }
+    if (validation) {
+      return validation(input);
+    }
+    return null;
+  };
+
+  const handleStartEdit = () => {
+    if (disabled) return;
+    setIsEditing(true);
+    setError(null);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setEditValue(value);
+    setError(null);
+    onCancel?.();
+  };
+
+  const handleSave = async () => {
+    const validationError = validateInput(editValue);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    if (editValue === value) {
+      setIsEditing(false);
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await onSave(editValue);
+      setIsEditing(false);
+      setError(null);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : "Failed to save");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      handleCancel();
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <div className={cn("flex items-center gap-2", className)}>
+        <div className="flex-1">
+          <Input
+            ref={inputRef}
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            className={cn(error && "border-red-500")}
+            disabled={isSaving}
+          />
+          {error && (
+            <p className="text-xs text-red-500 mt-1">{error}</p>
+          )}
+        </div>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={handleSave}
+          disabled={isSaving}
+          className="h-8 w-8 p-0"
+        >
+          <Check className="h-4 w-4" />
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={handleCancel}
+          disabled={isSaving}
+          className="h-8 w-8 p-0"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex items-center gap-2 group", className)}>
+      <span className="flex-1">{value || placeholder}</span>
+      {!disabled && (
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={handleStartEdit}
+          className="h-8 w-8 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+        >
+          <Edit className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/vite/src/services/userService.ts
+++ b/vite/src/services/userService.ts
@@ -1,0 +1,29 @@
+import { useAxiosInstance } from "./useAxiosInstance";
+import { toast } from "sonner";
+
+export const useUserService = () => {
+  const axiosInstance = useAxiosInstance();
+
+  const updateUserProfile = async (name: string) => {
+    try {
+      const { data, status } = await axiosInstance.put("/users/profile", {
+        name,
+      });
+
+      if (status === 200) {
+        toast.success("Profile updated successfully");
+        return data.user;
+      } else {
+        throw new Error(data.message || "Failed to update profile");
+      }
+    } catch (error: any) {
+      const errorMessage = error.response?.data?.message || error.message || "Failed to update profile";
+      toast.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+  };
+
+  return {
+    updateUserProfile,
+  };
+};

--- a/vite/src/views/main-sidebar/org-dropdown/manage-org/EditableMemberName.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/manage-org/EditableMemberName.tsx
@@ -1,0 +1,62 @@
+import { InlineEdit } from "@/components/general/InlineEdit";
+import { useUserService } from "@/services/userService";
+import { useSession } from "@/lib/auth-client";
+import { Membership } from "@autumn/shared";
+
+interface EditableMemberNameProps {
+  membership: Membership;
+  onUpdate?: (updatedUser: any) => void;
+}
+
+export const EditableMemberName = ({ 
+  membership, 
+  onUpdate 
+}: EditableMemberNameProps) => {
+  const { data: session } = useSession();
+  const { updateUserProfile } = useUserService();
+
+  const canEdit = () => {
+    const currentUserId = session?.session?.userId;
+    const memberUserId = membership.user.id;
+    const memberRole = membership.member.role;
+    
+    if (currentUserId === memberUserId) {
+      return true;
+    }
+    
+    if (memberRole === "admin" || memberRole === "owner") {
+      return true;
+    }
+    
+    return false;
+  };
+
+  const validateName = (name: string): string | null => {
+    if (!/^[a-zA-Z0-9\s\-_]+$/.test(name)) {
+      return "Name can only contain letters, numbers, spaces, hyphens, and underscores";
+    }
+    return null;
+  };
+
+  const handleSave = async (newName: string) => {
+    try {
+      const updatedUser = await updateUserProfile(newName);
+      onUpdate?.(updatedUser);
+    } catch (error) {
+      throw error;
+    }
+  };
+
+  return (
+    <InlineEdit
+      value={membership.user.name}
+      onSave={handleSave}
+      placeholder="Enter name..."
+      disabled={!canEdit()}
+      validation={validateName}
+      maxLength={50}
+      minLength={3}
+      className="w-full"
+    />
+  );
+};

--- a/vite/src/views/main-sidebar/org-dropdown/manage-org/OrgMembersList.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/manage-org/OrgMembersList.tsx
@@ -8,9 +8,10 @@ import { Badge } from "@/components/ui/badge";
 import { InvitePopover } from "./InvitePopover";
 import { useSession } from "@/lib/auth-client";
 import { MemberRowToolbar } from "./MemberRowToolbar";
+import { EditableMemberName } from "./EditableMemberName";
 
 export const OrgMembersList = () => {
-  const { memberships, isLoading: isMembersLoading } = useMemberships();
+  const { memberships, isLoading: isMembersLoading, mutate } = useMemberships();
   const { data } = useSession();
 
   if (isMembersLoading) return null;
@@ -21,6 +22,10 @@ export const OrgMembersList = () => {
 
   const isAdmin =
     membership?.member.role === "admin" || membership?.member.role === "owner";
+
+  const handleMemberUpdate = () => {
+    mutate();
+  };
 
   return (
     <div className="h-full overflow-y-auto">
@@ -51,7 +56,12 @@ export const OrgMembersList = () => {
             className={cn("grid-cols-18 px-6 text-sm text-t2")}
           >
             <Item className="col-span-6">{user.email}</Item>
-            <Item className="col-span-5">{user.name}</Item>
+            <Item className="col-span-5">
+              <EditableMemberName 
+                membership={membership} 
+                onUpdate={handleMemberUpdate}
+              />
+            </Item>
             <Item className="col-span-3">
               <Badge variant="outline">{member.role}</Badge>
             </Item>


### PR DESCRIPTION
## Summary
Previously, when users signed up with Google, their Google account name/nickname was automatically set as their display name or if signed up using email and password, then no name. This caused issues where old or unwanted nicknames could not be changed.

This PR introduces an editable display name feature, allowing users (and/or admins) to update their names after account creation.

## Related Issues
fixs  #141 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
https://github.com/user-attachments/assets/0cb91578-34d7-427d-bfcb-fa4840bab154

