### PR TITLE
Enforce unique API key names per user

### DIFF
--- a/server/src/internal/dev/ApiKeyService.ts
+++ b/server/src/internal/dev/ApiKeyService.ts
@@ -100,6 +100,27 @@ export class ApiKeyService {
       .where(and(eq(apiKeys.id, id), eq(apiKeys.org_id, orgId)))
       .returning();
   }
+
+  static async checkNameExists({
+    db,
+    orgId,
+    env,
+    name,
+  }: {
+    db: DrizzleCli;
+    orgId: string;
+    env: AppEnv;
+    name: string;
+  }) {
+    const existing = await db.query.apiKeys.findFirst({
+      where: and(
+        eq(apiKeys.org_id, orgId),
+        eq(apiKeys.env, env),
+        eq(apiKeys.name, name)
+      ),
+    });
+    return !!existing;
+  }
 }
 
 export class CachedKeyService {

--- a/shared/enums/ErrCode.ts
+++ b/shared/enums/ErrCode.ts
@@ -37,6 +37,7 @@ export const ErrCode = {
   DuplicateCustomerId: "duplicate_customer_id",
   StripeKeyNotFound: "stripe_key_not_found",
   DuplicateCustomerEmail: "duplicate_customer_email",
+  DuplicateApiKeyName: "duplicate_api_key_name",
 
   // Stripe
   StripeError: "stripe_error",

--- a/shared/models/devModels/apiKeyTable.ts
+++ b/shared/models/devModels/apiKeyTable.ts
@@ -30,6 +30,7 @@ export const apiKeys = pgTable(
       name: "api_keys_org_id_fkey",
     }).onDelete("cascade"),
     unique("api_keys_hashed_key_key").on(table.hashed_key),
+    unique("api_keys_org_env_name_key").on(table.org_id, table.env, table.name),
     // index("api_keys_hashed_key_key").on(table.hashed_key),
   ],
 );

--- a/vite/src/views/developer/CreateAPIKey.tsx
+++ b/vite/src/views/developer/CreateAPIKey.tsx
@@ -40,10 +40,17 @@ const CreateAPIKey = () => {
   }, [copied]);
 
   const handleCreate = async () => {
+    const keyName = apiKeyName ? apiKeyName : name;
+    
+    if (!keyName || keyName.trim() === "") {
+      toast.error("Please enter a name for your API key");
+      return;
+    }
+
     setLoading(true);
     try {
       const { api_key } = await DevService.createAPIKey(axiosInstance, {
-        name: apiKeyName ? apiKeyName : name,
+        name: keyName.trim(),
       });
 
       setApiKey(api_key);
@@ -51,9 +58,13 @@ const CreateAPIKey = () => {
         setApiCreated(true);
       }
       await mutate();
-    } catch (error) {
+    } catch (error: any) {
       console.log("Error:", error);
-      toast.error("Failed to create API key");
+      if (error?.response?.data?.code === "duplicate_api_key_name") {
+        toast.error(error.response.data.message || "API key with this name already exists");
+      } else {
+        toast.error("Failed to create API key");
+      }
     }
 
     setLoading(false);

--- a/vite/src/views/onboarding/onboarding-steps/CreateSecretKey.tsx
+++ b/vite/src/views/onboarding/onboarding-steps/CreateSecretKey.tsx
@@ -30,17 +30,28 @@ export const CreateSecretKey = ({
   const axiosInstance = useAxiosInstance({ env });
 
   const handleCreate = async () => {
-    console.log("creating api key", apiKeyName ? apiKeyName : name);
+    const keyName = apiKeyName ? apiKeyName : name;
+    
+    if (!keyName || keyName.trim() === "") {
+      toast.error("Please enter a name for your API key");
+      return;
+    }
+
+    console.log("creating api key", keyName);
     setLoading(true);
     try {
       const { api_key } = await DevService.createAPIKey(axiosInstance, {
-        name: apiKeyName ? apiKeyName : name,
+        name: keyName.trim(),
       });
 
       setApiKey(api_key);
-    } catch (error) {
+    } catch (error: any) {
       console.log("Error:", error);
-      toast.error("Failed to create API key");
+      if (error?.response?.data?.code === "duplicate_api_key_name") {
+        toast.error(error.response.data.message || "API key with this name already exists");
+      } else {
+        toast.error("Failed to create API key");
+      }
     }
 
     setLoading(false);

--- a/vite/src/views/onboarding2/integrate/integration-steps/CreateSecretKey.tsx
+++ b/vite/src/views/onboarding2/integrate/integration-steps/CreateSecretKey.tsx
@@ -35,9 +35,13 @@ export const CreateSecretKey = ({
       });
 
       setApiKey(api_key);
-    } catch (error) {
+    } catch (error: any) {
       console.log("Error:", error);
-      toast.error("Failed to create API key");
+      if (error?.response?.data?.code === "duplicate_api_key_name") {
+        toast.error(error.response.data.message || "API key with this name already exists");
+      } else {
+        toast.error("Failed to create API key");
+      }
     }
 
     setLoading(false);


### PR DESCRIPTION
## Summary
This PR ensures that users cannot create multiple API keys with the same name. Allowing duplicate names previously led to confusion when managing keys, as it was unclear which key was which.

## Why this is needed
- Prevents misinterpretation and management issues when users have multiple keys with the same name.
- Improves developer experience by making key identification clear and unambiguous.

## Related Issues
Closes #166 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

https://github.com/user-attachments/assets/ff361aae-9227-4941-a2e0-d80e61f416ed



## Changes Made
- Added validation to check for duplicate API key names during creation.
- Return a descriptive error message if the name already exists for the user.
- Updated API key creation flow to enforce uniqueness.
