### PR TITLE
fix: Prevent updating paid products to free products

### DIFF
--- a/server/src/internal/products/handlers/handleUpdateProduct/handleUpdateProduct.ts
+++ b/server/src/internal/products/handlers/handleUpdateProduct/handleUpdateProduct.ts
@@ -146,6 +146,14 @@ export const handleUpdateProductV2 = async (req: any, res: any) =>
 
       const { items, free_trial } = req.body;
 
+      if (fullProduct.prices?.length > 0 && (!items || items.length === 0)) {
+        throw new RecaseError({
+          message: "Cannot update a paid product to a free product. Please cancel the current product first.",
+          code: ErrCode.InvalidRequest,
+          statusCode: 400,
+        });
+      }
+
       if (free_trial !== undefined) {
         await validateOneOffTrial({
           prices: fullProduct.prices,


### PR DESCRIPTION
## Summary
Users could accidentally update a paid product (with prices) into a free product (without prices), which could cause billing and customer management issues.

## Related Issues
closes [ENG-506](https://lindie.app/share/670cc31c69f9ab7d3d1d61e0fb2cc7c3b3ada74b/ENG-506)

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues


## Additional Context

Added validation in the `handleUpdateProductV2` function to prevent this scenario:
- **Check existing product:** If the current product has prices (`fullProduct.prices?.length > 0`)
- **Check update input:** If the update request has no items (`!items || items.length === 0`)
- **Throw error:** If both conditions are true, throw a `BadRequest` error