### PR TITLE
[Fix] Prevent removing the last Metered Feature row #175

### DIFF
--- a/vite/src/views/credits/CreditSystemConfig.tsx
+++ b/vite/src/views/credits/CreditSystemConfig.tsx
@@ -20,6 +20,7 @@ import React, { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useFeaturesContext } from "../features/FeaturesContext";
 import { X } from "lucide-react";
+import { toast } from "sonner";
 
 function CreditSystemConfig({
   creditSystem,
@@ -74,6 +75,10 @@ function CreditSystemConfig({
 
   const removeSchemaItem = (index: number) => {
     const newSchema = [...creditSystemConfig.schema];
+    if(newSchema.length == 1){
+      toast.error("At Least One Row Should Be There")
+      return
+    }
     newSchema.splice(index, 1);
     setCreditSystemConfig({ ...creditSystemConfig, schema: newSchema });
   };


### PR DESCRIPTION
## Related Issues
Fixes #175

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<img width="731" height="519" alt="Screenshot 2025-09-01 at 9 22 00 PM" src="https://github.com/user-attachments/assets/84d4bc04-9e6e-44a9-85a3-33b6380d3965" />


## Additional Context
*Problem : 
Currently, in the Create Credit System form, when the user removes the last Metered Feature + Credit Amount row, the Add button becomes disabled. This prevents users from adding new rows again without refreshing the form.

*Solution:
Added a check to prevent deletion of the last row.
If the user tries to remove the final remaining row, a toast error is shown



https://github.com/user-attachments/assets/8b2be8a5-d988-4849-9fa0-810b7d7f293d


