### PR TITLE
fix : Block attaching products with per-entity features to entities

### DIFF
--- a/server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts
+++ b/server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts
@@ -217,6 +217,20 @@ export const handleAttachErrors = async ({
 }) => {
   const { onlyCheckout } = config;
 
+  const isEntityAttach = Boolean(attachParams.entityId || attachParams.internalEntityId);
+  if (isEntityAttach) {
+    const hasPerEntityFeature = attachParams.entitlements?.some(
+      (ent) => !!ent.entity_feature_id
+    );
+    if (hasPerEntityFeature) {
+      throw new RecaseError({
+        message: "Product contains per-entity features and cannot be attached to an entity",
+        code: ErrCode.InvalidRequest,
+        statusCode: StatusCodes.BAD_REQUEST,
+      });
+    }
+  }
+
   if (branch === AttachBranch.MultiAttach) {
     await handleMultiAttachErrors({
       attachParams,


### PR DESCRIPTION
## Summary
Adds validation in `handleAttachErrors` to detect entity-targeted attaches.
Previously, products with per-entity features (e.g. custom domain, per-org quota) could be incorrectly attached to entities.  
This caused inconsistencies and potential billing/entitlement issues.  

## Related Issues
Closes [ENG-414](https://lindie.app/share/670cc31c69f9ab7d3d1d61e0fb2cc7c3b3ada74b/ENG-414)

### How
- Before attaching, check the product’s features.
- If any feature is marked as `per_entity`, throw an error.
- Otherwise, allow normal attach flow.

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
