### PR TITLE
Refactor : Convert Better Auth endpoints to accept camelCase params

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -71,6 +71,35 @@ const init = async () => {
     })
   );
 
+  app.use("/api/auth", express.json());
+  app.use("/api/auth", (req: any, _res: any, next: any) => {
+    const toCamel = (str: string) =>
+      str.replace(/_([a-z])/g, (_: string, c: string) => c.toUpperCase());
+
+    const toCamelOnly = (value: any): any => {
+      if (Array.isArray(value)) return value.map(toCamelOnly);
+      if (value && typeof value === "object") {
+        const out: any = {};
+        for (const key of Object.keys(value)) {
+          const v = toCamelOnly(value[key]);
+          const camelKey = toCamel(key);
+          if (out[camelKey] === undefined) {
+            out[camelKey] = v;
+          } else {
+            if (key === camelKey) out[camelKey] = v;
+          }
+        }
+        return out;
+      }
+      return value;
+    };
+
+    if (req.body && typeof req.body === "object") {
+      req.body = toCamelOnly(req.body);
+    }
+    next();
+  });
+
   app.all("/api/auth/*", toNodeHandler(auth));
 
   const server = http.createServer(app);


### PR DESCRIPTION
## Summary
This PR updates Better Auth authentication endpoints to normalize all request parameters to camelCase. This change aligns Autumn’s API with frontend conventions and improves developer experience.

## Related Issues
Closes [ENG-511](https://lindie.app/share/670cc31c69f9ab7d3d1d61e0fb2cc7c3b3ada74b/ENG-511)

## Type of Change
- [x] Refactor

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues

## Example
Input:
```json
{ "user_id": "123", "auth_token": "abc" }
```
Normalized output to handlers:
```json
{ "userId": "123", "authToken": "abc" }
```