### PR TITLE
fix: prevent Create Reward API call without required id and name (#186)

### DIFF
--- a/vite/src/views/products/rewards/CreateReward.tsx
+++ b/vite/src/views/products/rewards/CreateReward.tsx
@@ -35,6 +35,10 @@ function CreateReward() {
   }, [open]);
 
   const handleCreate = async () => {
+    if (!reward?.id && !reward?.name) {
+      toast.error("Reward ID and Name are required!");
+      return;
+    }
     setIsLoading(true);
     try {
       await RewardService.createReward({


### PR DESCRIPTION
## Related Issues
(#186) 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

https://github.com/user-attachments/assets/412b7299-1ddf-448a-ab2d-02d878cc8bbe
