### PR TITLE
UI: rename usage types to 'allocated' and 'consumed'

### DIFF
--- a/vite/src/views/features/FeatureTypeBadge.tsx
+++ b/vite/src/views/features/FeatureTypeBadge.tsx
@@ -11,17 +11,17 @@ export function FeatureTypeBadge(feature: Feature) {
     feature.type == FeatureType.Boolean
       ? "boolean"
       : feature.config?.usage_type === FeatureUsageType.Continuous
-        ? "continuous use"
-        : "single use";
+        ? "allocated"
+        : "consumed";
 
   return (
     <Badge
       className={cn(
         "bg-transparent border border-t1 text-t1 rounded-md px-2 pointer-events-none",
         badgeType === "boolean" && "bg-lime-50 text-lime-600 border-lime-600",
-        badgeType === "continuous use" &&
+        badgeType === "allocated" &&
           "bg-cyan-50 text-cyan-600 border-cyan-600",
-        badgeType === "single use" &&
+        badgeType === "consumed" &&
           "bg-blue-50 text-blue-600 border-blue-600",
       )}
     >

--- a/vite/src/views/features/metered-features/SelectFeatureUsageType.tsx
+++ b/vite/src/views/features/metered-features/SelectFeatureUsageType.tsx
@@ -40,7 +40,7 @@ export const SelectFeatureUsageType = ({
       <FieldLabel>Usage Type</FieldLabel>
       <div className="grid grid-cols-2 gap-2">
         <SelectType
-          title="Single"
+          title="Consumed"
           description="Features that are consumed and refilled like 'credits' or 'tokens'"
           icon={<Zap className="text-t3" size={12} />}
           isSelected={
@@ -50,7 +50,7 @@ export const SelectFeatureUsageType = ({
           onClick={() => setFeatureType(APIFeatureType.SingleUsage)}
         />
         <SelectType
-          title="Continuous"
+          title="Allocated"
           description="Features used on an ongoing basis, like 'seats' or 'storage'"
           icon={<Clock className="text-t3" size={12} />}
           isSelected={


### PR DESCRIPTION
Updates UI terminology to align with product naming.\n\nChanges:\n- Feature badges now display ‘allocated’ for continuous usage and ‘consumed’ for single usage.\n- Feature creation selector titles updated to ‘Allocated’ and ‘Consumed’.\n\nScope:\n- UI-only changes in Vite app; no backend or model changes.\n\nImpact:\n- Clarifies meaning across the app without affecting APIs or data models.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/5719e055-84af-11f0-a94e-3eef481a796b/task/c2151cf5-83ff-4f5a-9db4-709fd16f82f2))