### PR TITLE
Rename credit schema label to 'Credit Cost'

### DIFF
--- a/vite/src/views/credits/CreditSystemConfig.tsx
+++ b/vite/src/views/credits/CreditSystemConfig.tsx
@@ -127,7 +127,7 @@ function CreditSystemConfig({
         <div className="flex flex-col w-full">
           <div className="flex w-full gap-2">
             <FieldLabel className="w-full">Metered Feature</FieldLabel>
-            <FieldLabel className="w-full">Credit Amount</FieldLabel>
+            <FieldLabel className="w-full">Credit Cost</FieldLabel>
           </div>
 
           <div className="flex flex-col w-full gap-2 overflow-visible">


### PR DESCRIPTION
## Summary
Updates the label in the Credit System configuration modal from "Credit Amount" to "Credit Cost" to better reflect that this value represents the cost per credit. This improves clarity and reduces confusion with the separate "feature amount" field. No functional changes.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (UI copy/label change)

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
N/A — single label update.

## Additional Context
- Files changed: `vite/src/views/credits/CreditSystemConfig.tsx`
- Impact: Low. Purely a UI label change; no backend or data model changes.
- Motivation: Align terminology with user expectation (“cost” vs “amount”) and avoid ambiguity.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/task/022a88f7-4015-4b4c-8fd3-b8058e654843))