### PR TITLE
logic update for the components in the sidebar when not expanded

### DIFF
--- a/vite/src/views/main-sidebar/MainSidebar.tsx
+++ b/vite/src/views/main-sidebar/MainSidebar.tsx
@@ -20,6 +20,8 @@ import { Button } from "@/components/ui/button";
 import { SidebarGroup } from "./SidebarGroup";
 import { useLocalStorage } from "@/hooks/common/useLocalStorage";
 import { useAutumnFlags } from "@/hooks/common/useAutumnFlags";
+import { Link, useSearchParams } from "react-router";
+import { pushPage } from "@/utils/genUtils";
 
 export const MainSidebar = () => {
   const env = useEnv();
@@ -78,24 +80,63 @@ export const MainSidebar = () => {
           <EnvDropdown env={env} />
           <div className="flex flex-col px-2 gap-1">
             <div>
-              <NavButton
-                value="products"
-                onClick={onProductTabClick}
-                icon={<Package size={14} />}
-                title="Products"
-                env={env}
-                isOpen={expanded ? productGroupOpen : undefined}
-                isGroup
-              />
-              <SidebarGroup
-                value="products"
-                productGroup={productGroupOpen}
-                subTabs={[
-                  { title: "Products", value: "products" },
-                  { title: "Features", value: "features" },
-                  { title: "Rewards", value: "rewards" },
-                ]}
-              />
+              {expanded ? (
+                <>
+                  <NavButton
+                    value="products"
+                    onClick={() => setProductGroupOpen((prev) => !prev)}
+                    icon={<Package size={14} />}
+                    title="Products"
+                    env={env}
+                    isOpen={productGroupOpen}
+                    isGroup
+                  />
+                  <SidebarGroup
+                    value="products"
+                    productGroup={productGroupOpen}
+                    subTabs={[
+                      { title: "Products", value: "products" },
+                      { title: "Features", value: "features" },
+                      { title: "Rewards", value: "rewards" },
+                    ]}
+                  />
+                </>
+              ) : (
+                <div className="relative">
+                  <NavButton
+                    value="products"
+                    icon={<Package size={14} />}
+                    title="Products"
+                    env={env}
+                    isGroup
+                    onClick={() => setProductGroupOpen((prev) => !prev)}
+                  />
+
+                  {/* Floating card for collapsed sidebar */}
+                  {!expanded && productGroupOpen && (
+                    <div className="absolute left-full top-0 ml-2 w-48 bg-white shadow-lg border rounded-lg z-[9999] flex flex-col">
+                      {[
+                        { title: "Products", value: "products" },
+                        { title: "Features", value: "features" },
+                        { title: "Rewards", value: "rewards" },
+                      ].map((subTab) => (
+                        <Link
+                          key={subTab.value}
+                          to={pushPage({
+                            path: "/products",
+                            queryParams: { tab: subTab.value },
+                            preserveParams: false,
+                          })}
+                          className="px-3 py-2 text-left hover:bg-gray-100 text-sm"
+                          onClick={() => setProductGroupOpen(false)} // close dropdown after click
+                        >
+                          {subTab.title}
+                        </Link>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             <NavButton
@@ -111,31 +152,76 @@ export const MainSidebar = () => {
               env={env}
             />
             <div>
-              <NavButton
-                value="dev"
-                icon={<SquareTerminal size={14} />}
-                title="Developer"
-                env={env}
-                onClick={() => setDevGroupOpen((prev) => !prev)}
-                isOpen={expanded ? devGroupOpen : undefined}
-                isGroup
-              />
-              <SidebarGroup
-                value="dev"
-                productGroup={devGroupOpen}
-                subTabs={
-                  webhooks
-                    ? [
-                        { title: "API Keys", value: "api_keys" },
-                        { title: "Stripe", value: "stripe" },
-                        { title: "Webhooks", value: "webhooks" },
-                      ]
-                    : [
-                        { title: "API Keys", value: "api_keys" },
-                        { title: "Stripe", value: "stripe" },
-                      ]
-                }
-              />
+              {expanded ? (
+                <>
+                  <NavButton
+                    value="dev"
+                    icon={<SquareTerminal size={14} />}
+                    title="Developer"
+                    env={env}
+                    onClick={() => setDevGroupOpen((prev) => !prev)}
+                    isOpen={devGroupOpen}
+                    isGroup
+                  />
+                  <SidebarGroup
+                    value="dev"
+                    productGroup={devGroupOpen}
+                    subTabs={
+                      webhooks
+                        ? [
+                            { title: "API Keys", value: "api_keys" },
+                            { title: "Stripe", value: "stripe" },
+                            { title: "Webhooks", value: "webhooks" },
+                          ]
+                        : [
+                            { title: "API Keys", value: "api_keys" },
+                            { title: "Stripe", value: "stripe" },
+                          ]
+                    }
+                  />
+                </>
+              ) : (
+                <div className="relative">
+                  <NavButton
+                    value="dev"
+                    icon={<SquareTerminal size={14} />}
+                    title="Developer"
+                    env={env}
+                    isGroup
+                    onClick={() => setDevGroupOpen((prev) => !prev)}
+                  />
+
+                  {/* Floating card for collapsed sidebar */}
+                  {!expanded && devGroupOpen && (
+                    <div className="absolute left-full top-0 ml-2 w-48 bg-white shadow-lg border rounded-lg z-[9999] flex flex-col">
+                      {(webhooks
+                        ? [
+                            { title: "API Keys", value: "api_keys" },
+                            { title: "Stripe", value: "stripe" },
+                            { title: "Webhooks", value: "webhooks" },
+                          ]
+                        : [
+                            { title: "API Keys", value: "api_keys" },
+                            { title: "Stripe", value: "stripe" },
+                          ]
+                      ).map((subTab) => (
+                        <Link
+                          key={subTab.value}
+                          to={pushPage({
+                            path: "/dev",
+                            queryParams: { tab: subTab.value },
+                            preserveParams: false,
+                          })}
+                          className="px-3 py-2 text-left hover:bg-gray-100 text-sm"
+                          onClick={() => setDevGroupOpen(false)} // close after click
+                        >
+                          {subTab.title}
+                        </Link>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
             {/* <div className="flex flex-col my-1 gap-0.5 border-l border-zinc-300 ml-4 -translate-x-[1px] pl-0">
             <NavButton


### PR DESCRIPTION
## Summary
- The objective of this PR is to improve the sidebar user experience by
ensuring consistent behavior for both expanded and collapsed states.
Previously, sub-items were only shown correctly in the expanded state,
while in the collapsed state the Navigation was not shown and caused
confusion.

## Related Issues
- Fixes #211 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
- 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2f573ee3-d3c2-4286-98c3-84341917eef3" />

## Additional Context
## Changes Implemented

1.  **Products Group**
    -   When the sidebar is **expanded**, sub-items (Products, Features,
        Rewards) are shown inline using the `SidebarGroup` component.
    -   When the sidebar is **collapsed**, clicking the Products icon
        opens a **floating card** positioned to the right of the
        sidebar.
        -   This card displays all sub-items.
        -   Clicking a sub-item navigates using `pushPage` (ensuring SPA
            navigation) instead of `window.location.href` (which caused
            a full reload).
        -   The card closes automatically after a sub-item is clicked.
2.  **Developer Group**
    -   Applied the same logic as the Products group for consistency.
    -   When expanded → inline `SidebarGroup` with sub-items (API Keys,
        Stripe, Webhooks).
    -   When collapsed → floating card with the same items, navigating
        via `pushPage` and auto-closing after click.

## Outcome

-   Sidebar interaction is now **consistent** across expanded and
    collapsed states.
-   Navigation works as an SPA, avoiding full reloads.
-   User experience is improved, reducing confusion when the sidebar is
    collapsed.