### PR TITLE
Disabled-Create-Customer-Button-Until-Name-Id-Or-Email-isfilled-to-Pr…

### DIFF
--- a/vite/src/views/customers/components/CreateCustomer.tsx
+++ b/vite/src/views/customers/components/CreateCustomer.tsx
@@ -75,14 +75,18 @@ function CreateCustomer() {
         </DialogHeader>
         <div className="flex gap-2">
           <div>
-            <FieldLabel>Name</FieldLabel>
+            <FieldLabel>
+              Name
+            </FieldLabel>
             <Input
               value={fields.name}
               onChange={(e) => setFields({ ...fields, name: e.target.value })}
             />
           </div>
           <div>
-            <FieldLabel>ID</FieldLabel>
+            <FieldLabel>
+              ID 
+            </FieldLabel>
             <Input
               value={fields.id}
               onChange={(e) => setFields({ ...fields, id: e.target.value })}
@@ -107,12 +111,11 @@ function CreateCustomer() {
           />
         </div> */}
         <DialogFooter>
-          <Button
-            onClick={handleCreate}
-            isLoading={isLoading}
-            variant="gradientPrimary"
-          >
-            Create
+          <Button onClick={handleCreate} 
+            isLoading={isLoading} 
+            variant="gradientPrimary" 
+            disabled={ !fields.name.trim() || (!fields.id.trim() && !fields.email.trim()) } 
+          > Create 
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary
Prevented API calls when creating a new customer if the required fields are empty. The Create button is now only enabled when the user fills: name and at least one of id or email.This ensures that no API request is made with incomplete data, improving form validation and preventing unnecessary errors.

## Related Issues
Fixes #200 #199 

## Additional Context
Before this change, the Create Customer API was being called even if the form fields were empty, which could lead to invalid requests.
Now, the Create button is only enabled when:
   Name is filled and
   At least one of id or email is provided.
This ensures that:
The API is only called when valid data is present.
Users can create a new customer only if the required information is entered.
All cases are handled:
   Name + ID
   Name + Email
   Name + ID + Email
This improves form validation, prevents unnecessary API calls, and ensures a better user experience.