### PR TITLE
Fixes/show discount on checkout page

### DIFF
--- a/server/src/internal/customers/cusRouter.ts
+++ b/server/src/internal/customers/cusRouter.ts
@@ -12,7 +12,10 @@ import { createStripeCli } from "@/external/stripe/utils.js";
 import { handleDeleteCustomer } from "./handlers/handleDeleteCustomer.js";
 import { handleUpdateBalances } from "./handlers/handleUpdateBalances.js";
 import { handleUpdateEntitlement } from "./handlers/handleUpdateEntitlement.js";
-import { handleAddCouponToCus } from "./handlers/handleAddCouponToCus.js";
+import {
+  handleAddCouponToCus,
+  handleGetCustomerCoupon,
+} from "./handlers/handleAddCouponToCus.js";
 import { handlePostCustomerRequest } from "./handlers/handlePostCustomer.js";
 import { entityRouter } from "../api/entities/entityRouter.js";
 import { handleUpdateCustomer } from "./handlers/handleUpdateCustomer.js";
@@ -160,6 +163,8 @@ cusRouter.get("/:customer_id/billing_portal", async (req: any, res: any) => {
 });
 
 cusRouter.post("/:customer_id/billing_portal", handleCreateBillingPortal);
+
+cusRouter.get("/:customer_id/coupon", handleGetCustomerCoupon);
 
 cusRouter.post("/:customer_id/coupons/:coupon_id", handleAddCouponToCus);
 

--- a/vite/src/services/customers/CusService.tsx
+++ b/vite/src/services/customers/CusService.tsx
@@ -70,4 +70,15 @@ export class CusService {
       `/v1/customers/${customer_id}/coupons/${coupon_id}`
     );
   }
+
+  static async getCustomerCoupon({
+    axiosInstance,
+    customer_id,
+  }: {
+    axiosInstance: AxiosInstance;
+    customer_id: string;
+  }) {
+    const res = await axiosInstance.get(`/v1/customers/${customer_id}/coupon`);
+    return res.data;
+  }
 }


### PR DESCRIPTION
## Summary
- This feature adds support for **fetching customer coupons from Stripe** and **showing applied
discounts in the product view (`DueToday` component)**.
## Related Issues
- https://lindie.app/share/670cc31c69f9ab7d3d1d61e0fb2cc7c3b3ada74b/ENG-570

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<img width="1240" height="698" alt="image" src="https://github.com/user-attachments/assets/c59dfe20-a37e-4a34-b34c-f1deb35b265e" />


## Additional Context
■ File Changes
Backend
- **cusRouter.ts**
- Added `/:customer_id/coupon` route.
- **handleGetCustomerCoupon.ts**
- Extracted handler logic for retrieving coupon.
Frontend
- **CusService.ts**
- Added `getCustomerCoupon` method.
- **DueToday.tsx**
- Added `useEffect` to fetch coupon on load.
- Added state to store coupon/discount.
- Extended rendering to include discount block and updated final total.
---
■ Additional Notes
- The discount block only appears when a **valid coupon** is applied on the customer in Stripe.
- Currently supports:
- **Percentage discounts** (`percent_off`).
- **Fixed amount discounts** (`amount_off`).
- Handles both **recurring discounts** (e.g. `duration_in_months`) and **one-time coupons**.
- Can be extended later to display coupon metadata (e.g. internal reward program ID).
---
■ Next Steps
- Add unit tests for the new API endpoint.
- Add UI tests to confirm discount calculations.
- (Optional) Show coupon metadata (e.g. reward program name) in the UI.