### PR TITLE
[FIX]: prevent negative included_usage values in product items

### DIFF
--- a/server/src/internal/products/product-items/validateProductItems.ts
+++ b/server/src/internal/products/product-items/validateProductItems.ts
@@ -102,6 +102,15 @@ const validateProductItem = ({
 		if (nullish(item.included_usage)) {
 			item.included_usage = 0;
 		}
+
+		// 4a. Check if included usage is negative
+		if (typeof item.included_usage === "number" && item.included_usage < 0) {
+			throw new RecaseError({
+				message: `Included usage must be 0 or greater`,
+				code: ErrCode.InvalidInputs,
+				statusCode: StatusCodes.BAD_REQUEST,
+			});
+		}
 	}
 
 	// 5. If it's a price, can't have day, minute or hour interval

--- a/vite/src/utils/product/product-item/validateProductItem.ts
+++ b/vite/src/utils/product/product-item/validateProductItem.ts
@@ -49,6 +49,12 @@ export const validateProductItem = ({
 		item.included_usage = null;
 	} else if (!invalidNumber(item.included_usage)) {
 		item.included_usage = Number(item.included_usage);
+		
+		// Check if included usage is negative
+		if (item.included_usage < 0) {
+			toast.error("Included usage must be 0 or greater");
+			return null;
+		}
 	}
 
 	if (isFeaturePriceItem(item) && nullish(item.usage_model)) {


### PR DESCRIPTION
## Summary
Fixed a bug where users could set negative values for `included_usage` when creating or updating product items. Added proper validation in both frontend and backend to prevent negative values and provide clear error messages.

## Related Issues
ENG-568

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
[Screencast from 2025-09-24 18-16-45.webm](https://github.com/user-attachments/assets/15a1c464-cf16-4eb0-b8b8-b15d506cf05e)

## Additional Context
Should I also add a check constraint to the entitlements table to prevent negative allowance values at the database level?

<!-- Add any other context or information about the PR here --> 