### PR TITLE
fix: validate dates before formatting to prevent Safari crashes

### DIFF
--- a/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
@@ -124,9 +124,13 @@ export function EventsBarChart({
 		formatter: {
 			x: (params: FormatterParams<any, unknown>) => {
 				if (params.type !== "category") return;
+				const date = parseUTCTimestamp(params.value as string);
+				if (!isFinite(date.getTime())) {
+					return params.value as string; // Return original value if invalid
+				}
 				return selectedInterval === "24h"
-					? hourFormatter.format(parseUTCTimestamp(params.value as string))
-					: dateFormatter.format(parseUTCTimestamp(params.value as string));
+					? hourFormatter.format(date)
+					: dateFormatter.format(date);
 			},
 		},
 		legend: {
@@ -154,9 +158,11 @@ export function EventsAGGrid({ data }: { data: any }) {
 			field: "timestamp",
 			flex: 1,
 			valueFormatter: (params: ValueFormatterParams<any, unknown>) => {
-				return timestampFormatter.format(
-					parseUTCTimestamp(params.value as string),
-				);
+				const date = parseUTCTimestamp(params.value as string);
+				if (!isFinite(date.getTime())) {
+					return params.value as string; // Return original value if invalid
+				}
+				return timestampFormatter.format(date);
 			},
 			cellStyle: {
 				paddingLeft: "2.5rem",


### PR DESCRIPTION
## Summary
- Added validation checks to prevent Safari crashes when formatting invalid dates
- Safari throws `RangeError` when `Intl.DateTimeFormat` receives invalid dates
- Used `isFinite(date.getTime())` to validate dates before formatting
- Applied fix to both bar chart x-axis formatter and events grid timestamp column

## Test plan
- [ ] Test analytics dashboard in Safari with various date ranges
- [ ] Verify invalid/malformed timestamps don't crash the page
- [ ] Confirm valid dates still format correctly
- [ ] Test both the Usage Analytics chart and Event Logs table

Fixes ENG-650

🤖 Generated with [Claude Code](https://claude.com/claude-code)