### PR TITLE
feat: prevent products from having both weekly and monthly price items

### DIFF
--- a/server/src/internal/products/product-items/validateProductItems.ts
+++ b/server/src/internal/products/product-items/validateProductItems.ts
@@ -276,5 +276,25 @@ export const validateProductItems = ({
 		}
 	}
 
+	// 6. Can't have both weekly and monthly price items in the same product
+	const hasWeeklyPrice = newItems.some(
+		(item) =>
+			(isPriceItem(item) || isFeaturePriceItem(item)) &&
+			item.interval === ProductItemInterval.Week
+	);
+	const hasMonthlyPrice = newItems.some(
+		(item) =>
+			(isPriceItem(item) || isFeaturePriceItem(item)) &&
+			item.interval === ProductItemInterval.Month
+	);
+
+	if (hasWeeklyPrice && hasMonthlyPrice) {
+		throw new RecaseError({
+			message: `Can't have both weekly and monthly price items in the same product`,
+			code: ErrCode.InvalidInputs,
+			statusCode: StatusCodes.BAD_REQUEST,
+		});
+	}
+
 	return { allFeatures, newFeatures };
 };


### PR DESCRIPTION
## Summary
- Added validation to prevent products from having both weekly and monthly billing intervals for price items or feature price items in the same product

## Changes
- Added validation check in `validateProductItems` that throws an error if a product attempts to include both `ProductItemInterval.Week` and `ProductItemInterval.Month` price items
- This prevents mixed weekly/monthly billing configurations that could cause billing inconsistencies

## Test plan
- [ ] Test creating a product with only weekly price items (should succeed)
- [ ] Test creating a product with only monthly price items (should succeed)  
- [ ] Test creating a product with both weekly and monthly price items (should fail with error)
- [ ] Test creating a product with feature items that have different intervals (should still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)