### PR TITLE
fix: match Stripe dashboard scopes & clarify read/write (fixes #229)

### DIFF
--- a/vite/src/views/developer/configure-stripe/ConfigureStripe.tsx
+++ b/vite/src/views/developer/configure-stripe/ConfigureStripe.tsx
@@ -132,15 +132,21 @@ export const ConfigureStripe = () => {
 							</span>
 							<InfoTooltip>
 								<div className="max-w-xs">
-									<p className="mb-2">The following scopes are needed:</p>
-									<ul className="list-disc list-inside space-y-0.5">
-										<li>Core</li>
-										<li>Checkout</li>
-										<li>Billing</li>
-										<li>All webhook</li>
-										<li>Accounts</li>
+                                    <p className="mb-2">The following scopes are needed:</p>
+                                    <ul className="list-disc list-inside space-y-0.5">
+										<li>Core (read & write)</li>
+										<li>Checkout (read & write)</li>
+										<li>Billing (read & write)</li>
+										<li>All webhooks (write)</li>
+										<li>Connect → Account Links (write)</li>
 									</ul>
-								</div>
+
+									<p className="mt-2 mb-2 text-xs">
+										In your Stripe dashboard, go to <strong>Developers → API keys</strong>, click {" "}
+										<strong>Create restricted key</strong>, and enable the scopes above with the 
+										listed permissions.
+									</p>
+                                </div>
 							</InfoTooltip>
 						</div>
 					)}


### PR DESCRIPTION
## Summary
Update Stripe scopes in the developer dashboard UI to match the actual required scopes and clarify which permissions are read/write. This ensures users creating restricted keys in Stripe follow the correct configuration.

## Related Issues
Fixes #229

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
Before:
<img width="227" height="151" alt="Screenshot 2025-10-06 at 05 43 21" src="https://github.com/user-attachments/assets/0b65c703-d10f-405d-9a85-6783fffdd7f2" />

After:
<img width="227" height="261" alt="Screenshot 2025-10-06 at 05 42 28" src="https://github.com/user-attachments/assets/b3e72c5d-8f20-4bb1-9fa1-4d8b7fb28e6c" />

## Additional Context
This PR updates the `ConfigureStripe.tsx` component so the instructions in the tooltip match the exact Stripe scopes and permissions required.