### PR TITLE
fix: drain deferred SQS producers on shutdown

### DIFF
--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -63,6 +63,7 @@ import {
 	stopMemorySpikeProbe,
 } from "./utils/memory/memorySpikeProbe.js";
 import { startMemoryMonitor } from "./utils/memoryMonitor.js";
+import { stopHttpServer } from "./utils/stopHttpServer.js";
 
 checkEnvVars();
 
@@ -183,7 +184,9 @@ async function gracefulShutdown() {
 	shuttingDown = true;
 	console.log("Shutting down worker, flushing telemetry and closing DB...");
 	try {
-		await stopHttpServer();
+		const server = httpServer;
+		httpServer = undefined;
+		if (server) await stopHttpServer({ server });
 		await shutdownSqsProducers();
 
 		// Flush any buffered OTel spans before shutting down
@@ -210,14 +213,3 @@ async function gracefulShutdown() {
 		process.exit(1);
 	}
 }
-
-const stopHttpServer = async (): Promise<void> => {
-	const server = httpServer;
-	if (!server) return;
-	httpServer = undefined;
-
-	await new Promise<void>((resolve, reject) => {
-		server.close((error) => (error ? reject(error) : resolve()));
-		server.closeIdleConnections();
-	});
-};

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -42,21 +42,21 @@ import "./internal/misc/asyncTrack/asyncTrackStore.js";
 // Side-effect: configures trigger.dev SDK to use TRIGGER_SERVER_SECRET_KEY.
 import "./trigger/configureTrigger.js";
 import { closeStripeSyncEngine } from "@autumn/stripe-sync";
-import {
-	startRedisMonitor,
-	stopRedisMonitor,
-	warmupRegionalRedis,
-} from "./external/redis/initRedis.js";
 import { primeRedisMonitor } from "./external/redis/availabilityMonitor/redisAvailability.js";
 import {
 	primeRedisV2Monitor,
 	startRedisV2Monitor,
 	stopRedisV2Monitor,
 } from "./external/redis/availabilityMonitor/redisV2Availability.js";
+import {
+	startRedisMonitor,
+	stopRedisMonitor,
+	warmupRegionalRedis,
+} from "./external/redis/initRedis.js";
 import { preWarmOrgRedisConnections } from "./external/redis/orgRedisPool.js";
 import { createHonoApp } from "./initHono.js";
 import { otelSdk } from "./instrumentation.js";
-import { shutdownSqsSendBatchers } from "./queue/queueUtils.js";
+import { shutdownSqsProducers } from "./queue/shutdownSqsProducers.js";
 import { checkEnvVars } from "./utils/initUtils.js";
 import {
 	startMemorySpikeProbe,
@@ -67,6 +67,7 @@ import { startMemoryMonitor } from "./utils/memoryMonitor.js";
 checkEnvVars();
 
 let shuttingDown = false;
+let httpServer: http.Server | undefined;
 
 const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
 	logger.info(getRedactedDatabaseUrls(), "DB URLs");
@@ -96,6 +97,7 @@ const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
 
 	const requestListener = getRequestListener(app.fetch);
 	const server = http.createServer(requestListener);
+	httpServer = server;
 
 	server.keepAliveTimeout = 120000;
 	server.headersTimeout = 120000;
@@ -177,10 +179,12 @@ function registerShutdownHandlers() {
 }
 
 async function gracefulShutdown() {
+	if (shuttingDown) return;
 	shuttingDown = true;
 	console.log("Shutting down worker, flushing telemetry and closing DB...");
 	try {
-		await shutdownSqsSendBatchers();
+		await stopHttpServer();
+		await shutdownSqsProducers();
 
 		// Flush any buffered OTel spans before shutting down
 		if (otelSdk) {
@@ -206,3 +210,14 @@ async function gracefulShutdown() {
 		process.exit(1);
 	}
 }
+
+const stopHttpServer = async (): Promise<void> => {
+	const server = httpServer;
+	if (!server) return;
+	httpServer = undefined;
+
+	await new Promise<void>((resolve, reject) => {
+		server.close((error) => (error ? reject(error) : resolve()));
+		server.closeIdleConnections();
+	});
+};

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -56,7 +56,10 @@ import {
 import { preWarmOrgRedisConnections } from "./external/redis/orgRedisPool.js";
 import { createHonoApp } from "./initHono.js";
 import { otelSdk } from "./instrumentation.js";
-import { shutdownSqsProducers } from "./queue/shutdownSqsProducers.js";
+import {
+	flushSqsProducers,
+	shutdownSqsProducers,
+} from "./queue/shutdownSqsProducers.js";
 import { checkEnvVars } from "./utils/initUtils.js";
 import {
 	startMemorySpikeProbe,
@@ -67,6 +70,7 @@ import {
 	createHttpRequestTracker,
 	stopHttpServer,
 } from "./utils/stopHttpServer.js";
+import { withTimeout } from "./utils/withTimeout.js";
 
 checkEnvVars();
 
@@ -74,6 +78,7 @@ let shuttingDown = false;
 let httpServer: http.Server | undefined;
 let hasActiveHttpRequests: (() => boolean) | undefined;
 let waitForActiveHttpRequests: (() => Promise<void>) | undefined;
+const FORCED_SQS_FLUSH_TIMEOUT_MS = 5_000;
 
 const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
 	logger.info(getRedactedDatabaseUrls(), "DB URLs");
@@ -204,8 +209,20 @@ async function gracefulShutdown() {
 			});
 			if (!requestsDrained) {
 				console.warn(
-					"HTTP shutdown deadline reached with an active handler; exiting without closing SQS producers",
+					"HTTP shutdown deadline reached with an active handler; flushing SQS producers before forced exit",
 				);
+				try {
+					await withTimeout({
+						timeoutMs: FORCED_SQS_FLUSH_TIMEOUT_MS,
+						fn: flushSqsProducers,
+						timeoutMessage: "Forced-exit SQS producer flush timed out",
+					});
+				} catch (error) {
+					console.error(
+						"Failed to flush SQS producers before forced exit:",
+						error,
+					);
+				}
 				process.exit(0);
 			}
 		}

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -78,7 +78,8 @@ let shuttingDown = false;
 let httpServer: http.Server | undefined;
 let hasActiveHttpRequests: (() => boolean) | undefined;
 let waitForActiveHttpRequests: (() => Promise<void>) | undefined;
-const FORCED_SQS_FLUSH_TIMEOUT_MS = 5_000;
+const FORCED_REQUEST_GRACE_MS = 4_000;
+const FINAL_SQS_FLUSH_TIMEOUT_MS = 1_000;
 
 const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
 	logger.info(getRedactedDatabaseUrls(), "DB URLs");
@@ -206,14 +207,15 @@ async function gracefulShutdown() {
 				server,
 				hasActiveRequests: hasActiveHttpRequests,
 				waitForActiveRequests: waitForActiveHttpRequests,
+				forcedRequestGraceMs: FORCED_REQUEST_GRACE_MS,
 			});
 			if (!requestsDrained) {
 				console.warn(
-					"HTTP shutdown deadline reached with an active handler; flushing SQS producers before forced exit",
+					"HTTP hard shutdown deadline reached with an active handler; flushing completed SQS work before forced exit",
 				);
 				try {
 					await withTimeout({
-						timeoutMs: FORCED_SQS_FLUSH_TIMEOUT_MS,
+						timeoutMs: FINAL_SQS_FLUSH_TIMEOUT_MS,
 						fn: flushSqsProducers,
 						timeoutMessage: "Forced-exit SQS producer flush timed out",
 					});

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -63,12 +63,17 @@ import {
 	stopMemorySpikeProbe,
 } from "./utils/memory/memorySpikeProbe.js";
 import { startMemoryMonitor } from "./utils/memoryMonitor.js";
-import { stopHttpServer } from "./utils/stopHttpServer.js";
+import {
+	createHttpRequestTracker,
+	stopHttpServer,
+} from "./utils/stopHttpServer.js";
 
 checkEnvVars();
 
 let shuttingDown = false;
 let httpServer: http.Server | undefined;
+let hasActiveHttpRequests: (() => boolean) | undefined;
+let waitForActiveHttpRequests: (() => Promise<void>) | undefined;
 
 const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
 	logger.info(getRedactedDatabaseUrls(), "DB URLs");
@@ -96,7 +101,12 @@ const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
 		? Number.parseInt(process.env.SERVER_PORT)
 		: 8080;
 
-	const requestListener = getRequestListener(app.fetch);
+	const requestTracker = createHttpRequestTracker({
+		requestHandler: app.fetch,
+	});
+	hasActiveHttpRequests = requestTracker.hasActiveRequests;
+	waitForActiveHttpRequests = requestTracker.waitForActiveRequests;
+	const requestListener = getRequestListener(requestTracker.requestHandler);
 	const server = http.createServer(requestListener);
 	httpServer = server;
 
@@ -186,7 +196,19 @@ async function gracefulShutdown() {
 	try {
 		const server = httpServer;
 		httpServer = undefined;
-		if (server) await stopHttpServer({ server });
+		if (server) {
+			const requestsDrained = await stopHttpServer({
+				server,
+				hasActiveRequests: hasActiveHttpRequests,
+				waitForActiveRequests: waitForActiveHttpRequests,
+			});
+			if (!requestsDrained) {
+				console.warn(
+					"HTTP shutdown deadline reached with an active handler; exiting without closing SQS producers",
+				);
+				process.exit(0);
+			}
+		}
 		await shutdownSqsProducers();
 
 		// Flush any buffered OTel spans before shutting down

--- a/server/src/internal/balances/events/EventBatchingManager.ts
+++ b/server/src/internal/balances/events/EventBatchingManager.ts
@@ -4,12 +4,29 @@ import { sendEventsToTinybird } from "@server/external/tinybird/sendEvents/sendE
 import { JobName } from "@server/queue/JobName.js";
 import { addTaskToQueue } from "@server/queue/queueUtils.js";
 
+type AddEventBatchToQueue = (args: {
+	jobName: JobName.InsertEventBatch;
+	payload: { events: EventInsert[] };
+}) => Promise<void>;
+
 export class EventBatchingManager {
 	private events: Map<string, EventInsert> = new Map();
 	private timer: NodeJS.Timeout | null = null;
 	private readonly inFlightExecutions = new Set<Promise<void>>();
-	private readonly batchWindow = 350; // 100ms batching window
+	private readonly batchWindow: number;
 	private readonly maxBatchSize = 200; // Max events per batch (~200kb per event, keep batches under 10MB for Tinybird)
+	private readonly _addTaskToQueue: AddEventBatchToQueue;
+
+	constructor({
+		addTaskToQueueFn,
+		batchWindowMs,
+	}: {
+		addTaskToQueueFn?: AddEventBatchToQueue;
+		batchWindowMs?: number;
+	} = {}) {
+		this._addTaskToQueue = addTaskToQueueFn ?? addTaskToQueue;
+		this.batchWindow = batchWindowMs ?? 350;
+	}
 
 	/** Add an event to the batch */
 	addEvent(event: EventInsert): void {
@@ -18,7 +35,7 @@ export class EventBatchingManager {
 
 		// Auto-execute if batch size is reached
 		if (this.events.size >= this.maxBatchSize) {
-			void this.startBatch();
+			this.startBatchInBackground();
 			return;
 		}
 
@@ -28,7 +45,7 @@ export class EventBatchingManager {
 		}
 
 		this.timer = setTimeout(() => {
-			void this.startBatch();
+			this.startBatchInBackground();
 		}, this.batchWindow);
 	}
 
@@ -49,6 +66,12 @@ export class EventBatchingManager {
 		return execution;
 	}
 
+	private startBatchInBackground(): void {
+		void this.startBatch().catch((error: unknown) => {
+			logger.error("[EventBatchingManager] Failed to execute batch", { error });
+		});
+	}
+
 	/** Execute the current batch - queue to SQS for Postgres and send to Tinybird */
 	private async executeBatch(): Promise<void> {
 		if (this.timer) {
@@ -67,7 +90,7 @@ export class EventBatchingManager {
 		const eventItems = Array.from(currentEvents.values());
 
 		// Queue to SQS for Postgres and publish to Tinybird in parallel
-		await addTaskToQueue({
+		await this._addTaskToQueue({
 			jobName: JobName.InsertEventBatch,
 			payload: { events: eventItems },
 		});

--- a/server/src/internal/balances/events/EventBatchingManager.ts
+++ b/server/src/internal/balances/events/EventBatchingManager.ts
@@ -4,9 +4,10 @@ import { sendEventsToTinybird } from "@server/external/tinybird/sendEvents/sendE
 import { JobName } from "@server/queue/JobName.js";
 import { addTaskToQueue } from "@server/queue/queueUtils.js";
 
-class BatchingManager {
+export class EventBatchingManager {
 	private events: Map<string, EventInsert> = new Map();
 	private timer: NodeJS.Timeout | null = null;
+	private readonly inFlightExecutions = new Set<Promise<void>>();
 	private readonly batchWindow = 350; // 100ms batching window
 	private readonly maxBatchSize = 200; // Max events per batch (~200kb per event, keep batches under 10MB for Tinybird)
 
@@ -17,7 +18,7 @@ class BatchingManager {
 
 		// Auto-execute if batch size is reached
 		if (this.events.size >= this.maxBatchSize) {
-			this.executeBatch();
+			void this.startBatch();
 			return;
 		}
 
@@ -27,8 +28,25 @@ class BatchingManager {
 		}
 
 		this.timer = setTimeout(() => {
-			this.executeBatch();
+			void this.startBatch();
 		}, this.batchWindow);
+	}
+
+	async flush(): Promise<void> {
+		await this.startBatch();
+		while (this.inFlightExecutions.size > 0) {
+			await Promise.all(Array.from(this.inFlightExecutions));
+		}
+	}
+
+	private startBatch(): Promise<void> {
+		const execution = this.executeBatch();
+		this.inFlightExecutions.add(execution);
+		void execution.then(
+			() => this.inFlightExecutions.delete(execution),
+			() => this.inFlightExecutions.delete(execution),
+		);
+		return execution;
 	}
 
 	/** Execute the current batch - queue to SQS for Postgres and send to Tinybird */
@@ -62,4 +80,4 @@ class BatchingManager {
 }
 
 // Global singleton instance
-export const globalEventBatchingManager = new BatchingManager();
+export const globalEventBatchingManager = new EventBatchingManager();

--- a/server/src/internal/balances/utils/refreshEntityAggregate/RefreshEntityAggregateBatchingManager.ts
+++ b/server/src/internal/balances/utils/refreshEntityAggregate/RefreshEntityAggregateBatchingManager.ts
@@ -42,6 +42,7 @@ interface RefreshEntry {
  */
 export class RefreshEntityAggregateBatchingManager {
 	private entries: Map<string, RefreshEntry> = new Map();
+	private readonly inFlightExecutions = new Set<Promise<void>>();
 
 	private readonly bucketMs: number;
 	private readonly settleBufferMs: number;
@@ -108,7 +109,10 @@ export class RefreshEntityAggregateBatchingManager {
 
 	async flush(): Promise<void> {
 		const keys = Array.from(this.entries.keys());
-		await Promise.all(keys.map((key) => this.fire({ key })));
+		await Promise.all(keys.map((key) => this.startFire({ key })));
+		while (this.inFlightExecutions.size > 0) {
+			await Promise.all(Array.from(this.inFlightExecutions));
+		}
 	}
 
 	getStats(): { totalPending: number } {
@@ -135,15 +139,24 @@ export class RefreshEntityAggregateBatchingManager {
 		entry: RefreshEntry;
 	}): void {
 		const nowMs = this._now();
-		const bucketEndMs =
-			(Math.floor(nowMs / this.bucketMs) + 1) * this.bucketMs;
+		const bucketEndMs = (Math.floor(nowMs / this.bucketMs) + 1) * this.bucketMs;
 		const delayMs = bucketEndMs - nowMs + this.settleBufferMs;
 
 		entry.timer = setTimeout(() => {
-			this.fire({ key });
+			void this.startFire({ key });
 		}, delayMs);
 
 		if (entry.timer.unref) entry.timer.unref();
+	}
+
+	private startFire({ key }: { key: string }): Promise<void> {
+		const execution = this.fire({ key });
+		this.inFlightExecutions.add(execution);
+		void execution.then(
+			() => this.inFlightExecutions.delete(execution),
+			() => this.inFlightExecutions.delete(execution),
+		);
+		return execution;
 	}
 
 	private async fire({ key }: { key: string }): Promise<void> {

--- a/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
+++ b/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
@@ -63,6 +63,7 @@ export type QueueSyncV4Payload = {
  */
 export class SyncBatchingManagerV3 {
 	private customerBatches: Map<string, CustomerBatch> = new Map();
+	private readonly inFlightExecutions = new Set<Promise<void>>();
 
 	private readonly BATCH_WINDOW_MS: number = 1000;
 	private readonly MAX_BATCH_SIZE = 1000;
@@ -188,8 +189,11 @@ export class SyncBatchingManagerV3 {
 	async flush(): Promise<void> {
 		const batchKeys = Array.from(this.customerBatches.keys());
 		await Promise.all(
-			batchKeys.map((batchKey) => this.executeCustomerBatch({ batchKey })),
+			batchKeys.map((batchKey) => this.startCustomerBatch({ batchKey })),
 		);
+		while (this.inFlightExecutions.size > 0) {
+			await Promise.all(Array.from(this.inFlightExecutions));
+		}
 	}
 
 	private buildBatchKey({
@@ -260,12 +264,26 @@ export class SyncBatchingManagerV3 {
 		if (!batch) return;
 
 		batch.timer = setTimeout(() => {
-			this.executeCustomerBatch({ batchKey });
+			void this.startCustomerBatch({ batchKey });
 		}, this.BATCH_WINDOW_MS);
 
 		if (batch.timer.unref) {
 			batch.timer.unref();
 		}
+	}
+
+	private startCustomerBatch({
+		batchKey,
+	}: {
+		batchKey: string;
+	}): Promise<void> {
+		const execution = this.executeCustomerBatch({ batchKey });
+		this.inFlightExecutions.add(execution);
+		void execution.then(
+			() => this.inFlightExecutions.delete(execution),
+			() => this.inFlightExecutions.delete(execution),
+		);
+		return execution;
 	}
 
 	private async executeCustomerBatch({

--- a/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
+++ b/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
@@ -164,7 +164,7 @@ export class SyncBatchingManagerV3 {
 		const totalSize =
 			batch.context.cusEntIds.size + batch.context.rolloverIds.size;
 		if (totalSize >= this.MAX_BATCH_SIZE) {
-			this.executeCustomerBatch({ batchKey });
+			void this.startCustomerBatch({ batchKey });
 		}
 	}
 

--- a/server/src/queue/SqsBatchAccumulator.ts
+++ b/server/src/queue/SqsBatchAccumulator.ts
@@ -86,8 +86,8 @@ export class SqsBatchAccumulator<TEntry extends SqsBatchAccumulatorEntry> {
 	}
 
 	async flush(): Promise<void> {
-		await this.startSend();
-		while (this.inFlightSends.size > 0) {
+		while (this.pendingEntries.length > 0 || this.inFlightSends.size > 0) {
+			await this.startSend();
 			await Promise.all(Array.from(this.inFlightSends));
 		}
 	}

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -33,7 +33,7 @@ import { initBlueGreen, shutdownBlueGreen } from "./blueGreen/initBlueGreen.js";
 import { getSqsClient, QUEUE_URL, recreateSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
 import { processMessage, type SqsJob } from "./processMessage.js";
-import { shutdownSqsProducers } from "./shutdownSqsProducers.js";
+import { shutdownSqsWorker } from "./shutdownSqsWorker.js";
 import {
 	createWorkerActivityTracker,
 	type WorkerActivityTracker,
@@ -619,18 +619,7 @@ export const initWorkers = async ({
 		for (const controller of abortControllers) {
 			controller.abort();
 		}
-		await Promise.allSettled(pollingLoops);
-		await shutdownSqsProducers();
-
-		const isProd = process.env.NODE_ENV === "production";
-		if (isProd) {
-			const shutdownTimeout = setTimeout(() => process.exit(0), 5000);
-			if (shutdownTimeout.unref) {
-				shutdownTimeout.unref();
-			}
-		} else {
-			process.exit(0);
-		}
+		await shutdownSqsWorker({ pollingLoops });
 	};
 
 	process.on("SIGTERM", shutdown);

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -33,7 +33,7 @@ import { initBlueGreen, shutdownBlueGreen } from "./blueGreen/initBlueGreen.js";
 import { getSqsClient, QUEUE_URL, recreateSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
 import { processMessage, type SqsJob } from "./processMessage.js";
-import { shutdownSqsSendBatchers } from "./queueUtils.js";
+import { shutdownSqsProducers } from "./shutdownSqsProducers.js";
 import {
 	createWorkerActivityTracker,
 	type WorkerActivityTracker,
@@ -606,8 +606,12 @@ export const initWorkers = async ({
 	await warmupRegionalRedis();
 
 	await initBlueGreen({ db, logger });
+	const pollingLoops: Promise<void>[] = [];
+	let shuttingDown = false;
 
 	const shutdown = async () => {
+		if (shuttingDown) return;
+		shuttingDown = true;
 		console.log(`[SQS Worker ${process.pid}] Shutting down...`);
 		isRunning = false;
 		stopPgPoolMonitor();
@@ -615,7 +619,8 @@ export const initWorkers = async ({
 		for (const controller of abortControllers) {
 			controller.abort();
 		}
-		await shutdownSqsSendBatchers();
+		await Promise.allSettled(pollingLoops);
+		await shutdownSqsProducers();
 
 		const isProd = process.env.NODE_ENV === "production";
 		if (isProd) {
@@ -635,7 +640,6 @@ export const initWorkers = async ({
 	console.log(
 		`[Worker ${process.pid}] ${queueImplementation} worker ready in ${startupDurationMs}ms`,
 	);
-	const pollingLoops = [];
 	const workerActivity = createWorkerActivityTracker({
 		idleAfterMs: IDLE_SELF_KILL_MS,
 	});

--- a/server/src/queue/shutdownSqsProducers.ts
+++ b/server/src/queue/shutdownSqsProducers.ts
@@ -34,13 +34,15 @@ export const flushSqsProducers = async ({
 
 export const shutdownSqsProducers = async ({
 	producers = defaultProducers,
+	flushSqsSendBatchersFn = flushSqsSendBatchers,
 	shutdownSqsSendBatchersFn = shutdownSqsSendBatchers,
 }: {
 	producers?: DeferredSqsProducer[];
+	flushSqsSendBatchersFn?: () => Promise<void>;
 	shutdownSqsSendBatchersFn?: () => Promise<void>;
 } = {}): Promise<void> => {
 	try {
-		await flushSqsProducers({ producers });
+		await flushSqsProducers({ producers, flushSqsSendBatchersFn });
 	} finally {
 		await shutdownSqsSendBatchersFn();
 	}

--- a/server/src/queue/shutdownSqsProducers.ts
+++ b/server/src/queue/shutdownSqsProducers.ts
@@ -3,14 +3,28 @@ import { globalRefreshEntityAggregateBatchingManager } from "@/internal/balances
 import { globalSyncBatchingManagerV3 } from "@/internal/balances/utils/sync/SyncBatchingManagerV3.js";
 import { shutdownSqsSendBatchers } from "./queueUtils.js";
 
-export const shutdownSqsProducers = async (): Promise<void> => {
+type DeferredSqsProducer = {
+	flush: () => Promise<void>;
+};
+
+export const shutdownSqsProducers = async ({
+	producers = [
+		globalEventBatchingManager,
+		globalRefreshEntityAggregateBatchingManager,
+		globalSyncBatchingManagerV3,
+	],
+	shutdownSqsSendBatchersFn = shutdownSqsSendBatchers,
+}: {
+	producers?: DeferredSqsProducer[];
+	shutdownSqsSendBatchersFn?: () => Promise<void>;
+} = {}): Promise<void> => {
 	try {
-		await Promise.all([
-			globalEventBatchingManager.flush(),
-			globalRefreshEntityAggregateBatchingManager.flush(),
-			globalSyncBatchingManagerV3.flush(),
-		]);
+		const results = await Promise.allSettled(
+			producers.map((producer) => producer.flush()),
+		);
+		const failure = results.find((result) => result.status === "rejected");
+		if (failure) throw failure.reason;
 	} finally {
-		await shutdownSqsSendBatchers();
+		await shutdownSqsSendBatchersFn();
 	}
 };

--- a/server/src/queue/shutdownSqsProducers.ts
+++ b/server/src/queue/shutdownSqsProducers.ts
@@ -7,23 +7,33 @@ type DeferredSqsProducer = {
 	flush: () => Promise<void>;
 };
 
+const defaultProducers: DeferredSqsProducer[] = [
+	globalEventBatchingManager,
+	globalRefreshEntityAggregateBatchingManager,
+	globalSyncBatchingManagerV3,
+];
+
+export const flushSqsProducers = async ({
+	producers = defaultProducers,
+}: {
+	producers?: DeferredSqsProducer[];
+} = {}): Promise<void> => {
+	const results = await Promise.allSettled(
+		producers.map((producer) => producer.flush()),
+	);
+	const failure = results.find((result) => result.status === "rejected");
+	if (failure) throw failure.reason;
+};
+
 export const shutdownSqsProducers = async ({
-	producers = [
-		globalEventBatchingManager,
-		globalRefreshEntityAggregateBatchingManager,
-		globalSyncBatchingManagerV3,
-	],
+	producers = defaultProducers,
 	shutdownSqsSendBatchersFn = shutdownSqsSendBatchers,
 }: {
 	producers?: DeferredSqsProducer[];
 	shutdownSqsSendBatchersFn?: () => Promise<void>;
 } = {}): Promise<void> => {
 	try {
-		const results = await Promise.allSettled(
-			producers.map((producer) => producer.flush()),
-		);
-		const failure = results.find((result) => result.status === "rejected");
-		if (failure) throw failure.reason;
+		await flushSqsProducers({ producers });
 	} finally {
 		await shutdownSqsSendBatchersFn();
 	}

--- a/server/src/queue/shutdownSqsProducers.ts
+++ b/server/src/queue/shutdownSqsProducers.ts
@@ -1,0 +1,16 @@
+import { globalEventBatchingManager } from "@/internal/balances/events/EventBatchingManager.js";
+import { globalRefreshEntityAggregateBatchingManager } from "@/internal/balances/utils/refreshEntityAggregate/RefreshEntityAggregateBatchingManager.js";
+import { globalSyncBatchingManagerV3 } from "@/internal/balances/utils/sync/SyncBatchingManagerV3.js";
+import { shutdownSqsSendBatchers } from "./queueUtils.js";
+
+export const shutdownSqsProducers = async (): Promise<void> => {
+	try {
+		await Promise.all([
+			globalEventBatchingManager.flush(),
+			globalRefreshEntityAggregateBatchingManager.flush(),
+			globalSyncBatchingManagerV3.flush(),
+		]);
+	} finally {
+		await shutdownSqsSendBatchers();
+	}
+};

--- a/server/src/queue/shutdownSqsProducers.ts
+++ b/server/src/queue/shutdownSqsProducers.ts
@@ -1,7 +1,7 @@
 import { globalEventBatchingManager } from "@/internal/balances/events/EventBatchingManager.js";
 import { globalRefreshEntityAggregateBatchingManager } from "@/internal/balances/utils/refreshEntityAggregate/RefreshEntityAggregateBatchingManager.js";
 import { globalSyncBatchingManagerV3 } from "@/internal/balances/utils/sync/SyncBatchingManagerV3.js";
-import { shutdownSqsSendBatchers } from "./queueUtils.js";
+import { flushSqsSendBatchers, shutdownSqsSendBatchers } from "./queueUtils.js";
 
 type DeferredSqsProducer = {
 	flush: () => Promise<void>;
@@ -15,13 +15,20 @@ const defaultProducers: DeferredSqsProducer[] = [
 
 export const flushSqsProducers = async ({
 	producers = defaultProducers,
+	flushSqsSendBatchersFn = flushSqsSendBatchers,
 }: {
 	producers?: DeferredSqsProducer[];
+	flushSqsSendBatchersFn?: () => Promise<void>;
 } = {}): Promise<void> => {
-	const results = await Promise.allSettled(
+	const producerResults = await Promise.allSettled(
 		producers.map((producer) => producer.flush()),
 	);
-	const failure = results.find((result) => result.status === "rejected");
+	const sendBatcherResult = await Promise.allSettled([
+		flushSqsSendBatchersFn(),
+	]);
+	const failure = [...producerResults, ...sendBatcherResult].find(
+		(result) => result.status === "rejected",
+	);
 	if (failure) throw failure.reason;
 };
 

--- a/server/src/queue/shutdownSqsWorker.ts
+++ b/server/src/queue/shutdownSqsWorker.ts
@@ -1,9 +1,13 @@
-import { shutdownSqsProducers } from "./shutdownSqsProducers.js";
+import {
+	flushSqsProducers,
+	shutdownSqsProducers,
+} from "./shutdownSqsProducers.js";
 
 type ExitProcess = (code: number) => void;
 
 export const shutdownSqsWorker = async ({
 	pollingLoops,
+	flushSqsProducersFn = flushSqsProducers,
 	shutdownSqsProducersFn = shutdownSqsProducers,
 	isProduction = process.env.NODE_ENV === "production",
 	shutdownTimeoutMs = 5000,
@@ -11,6 +15,7 @@ export const shutdownSqsWorker = async ({
 	logError = (message, error) => console.error(message, error),
 }: {
 	pollingLoops: Promise<void>[];
+	flushSqsProducersFn?: () => Promise<void>;
 	shutdownSqsProducersFn?: () => Promise<void>;
 	isProduction?: boolean;
 	shutdownTimeoutMs?: number;
@@ -20,6 +25,15 @@ export const shutdownSqsWorker = async ({
 	if (isProduction) {
 		const shutdownTimeout = setTimeout(() => exitProcess(0), shutdownTimeoutMs);
 		shutdownTimeout.unref?.();
+	}
+
+	try {
+		await flushSqsProducersFn();
+	} catch (error) {
+		logError(
+			`[SQS Worker ${process.pid}] Failed to flush SQS producers before waiting for active messages`,
+			error,
+		);
 	}
 
 	await Promise.allSettled(pollingLoops);

--- a/server/src/queue/shutdownSqsWorker.ts
+++ b/server/src/queue/shutdownSqsWorker.ts
@@ -1,0 +1,38 @@
+import { shutdownSqsProducers } from "./shutdownSqsProducers.js";
+
+type ExitProcess = (code: number) => void;
+
+export const shutdownSqsWorker = async ({
+	pollingLoops,
+	shutdownSqsProducersFn = shutdownSqsProducers,
+	isProduction = process.env.NODE_ENV === "production",
+	shutdownTimeoutMs = 5000,
+	exitProcess = (code) => process.exit(code),
+	logError = (message, error) => console.error(message, error),
+}: {
+	pollingLoops: Promise<void>[];
+	shutdownSqsProducersFn?: () => Promise<void>;
+	isProduction?: boolean;
+	shutdownTimeoutMs?: number;
+	exitProcess?: ExitProcess;
+	logError?: (message: string, error: unknown) => void;
+}): Promise<void> => {
+	if (isProduction) {
+		const shutdownTimeout = setTimeout(() => exitProcess(0), shutdownTimeoutMs);
+		shutdownTimeout.unref?.();
+	}
+
+	await Promise.allSettled(pollingLoops);
+	try {
+		await shutdownSqsProducersFn();
+	} catch (error) {
+		logError(
+			`[SQS Worker ${process.pid}] Failed to drain SQS producers`,
+			error,
+		);
+	}
+
+	if (!isProduction) {
+		exitProcess(0);
+	}
+};

--- a/server/src/utils/stopHttpServer.ts
+++ b/server/src/utils/stopHttpServer.ts
@@ -40,12 +40,14 @@ export const stopHttpServer = async ({
 	waitForActiveRequests = async () => undefined,
 	shutdownTimeoutMs = 5000,
 	activeRequestTimeoutMs = shutdownTimeoutMs,
+	forcedRequestGraceMs = 0,
 }: {
 	server: http.Server;
 	hasActiveRequests?: () => boolean;
 	waitForActiveRequests?: () => Promise<void>;
 	shutdownTimeoutMs?: number;
 	activeRequestTimeoutMs?: number;
+	forcedRequestGraceMs?: number;
 }): Promise<boolean> => {
 	const forceClosed = await new Promise<boolean>((resolve, reject) => {
 		let forced = false;
@@ -79,7 +81,7 @@ export const stopHttpServer = async ({
 	return new Promise<boolean>((resolve, reject) => {
 		const activeRequestTimeout = setTimeout(
 			() => resolve(false),
-			activeRequestTimeoutMs,
+			activeRequestTimeoutMs + forcedRequestGraceMs,
 		);
 		activeRequestTimeout.unref?.();
 		void waitForActiveRequests().then(

--- a/server/src/utils/stopHttpServer.ts
+++ b/server/src/utils/stopHttpServer.ts
@@ -1,0 +1,33 @@
+import type http from "node:http";
+
+export const stopHttpServer = async ({
+	server,
+	shutdownTimeoutMs = 5000,
+}: {
+	server: http.Server;
+	shutdownTimeoutMs?: number;
+}): Promise<void> => {
+	await new Promise<void>((resolve, reject) => {
+		const shutdownTimeout = setTimeout(() => {
+			try {
+				server.closeAllConnections();
+				resolve();
+			} catch (error) {
+				reject(error);
+			}
+		}, shutdownTimeoutMs);
+		shutdownTimeout.unref?.();
+
+		try {
+			server.close((error) => {
+				clearTimeout(shutdownTimeout);
+				if (error) reject(error);
+				else resolve();
+			});
+			server.closeIdleConnections();
+		} catch (error) {
+			clearTimeout(shutdownTimeout);
+			reject(error);
+		}
+	});
+};

--- a/server/src/utils/stopHttpServer.ts
+++ b/server/src/utils/stopHttpServer.ts
@@ -1,17 +1,59 @@
 import type http from "node:http";
 
+export const createHttpRequestTracker = <Arguments extends unknown[], Result>({
+	requestHandler,
+}: {
+	requestHandler: (...args: Arguments) => Result | Promise<Result>;
+}): {
+	requestHandler: (...args: Arguments) => Promise<Awaited<Result>>;
+	hasActiveRequests: () => boolean;
+	waitForActiveRequests: () => Promise<void>;
+} => {
+	const activeRequests = new Set<Promise<Awaited<Result>>>();
+
+	const trackedRequestHandler = (
+		...args: Arguments
+	): Promise<Awaited<Result>> => {
+		const request = Promise.resolve(requestHandler(...args));
+		activeRequests.add(request);
+		void request.then(
+			() => activeRequests.delete(request),
+			() => activeRequests.delete(request),
+		);
+		return request;
+	};
+
+	return {
+		requestHandler: trackedRequestHandler,
+		hasActiveRequests: () => activeRequests.size > 0,
+		waitForActiveRequests: async () => {
+			while (activeRequests.size > 0) {
+				await Promise.allSettled(Array.from(activeRequests));
+			}
+		},
+	};
+};
+
 export const stopHttpServer = async ({
 	server,
+	hasActiveRequests = () => false,
+	waitForActiveRequests = async () => undefined,
 	shutdownTimeoutMs = 5000,
+	activeRequestTimeoutMs = shutdownTimeoutMs,
 }: {
 	server: http.Server;
+	hasActiveRequests?: () => boolean;
+	waitForActiveRequests?: () => Promise<void>;
 	shutdownTimeoutMs?: number;
-}): Promise<void> => {
-	await new Promise<void>((resolve, reject) => {
+	activeRequestTimeoutMs?: number;
+}): Promise<boolean> => {
+	const forceClosed = await new Promise<boolean>((resolve, reject) => {
+		let forced = false;
 		const shutdownTimeout = setTimeout(() => {
 			try {
+				forced = true;
 				server.closeAllConnections();
-				resolve();
+				resolve(true);
 			} catch (error) {
 				reject(error);
 			}
@@ -20,14 +62,35 @@ export const stopHttpServer = async ({
 
 		try {
 			server.close((error) => {
+				if (forced) return;
 				clearTimeout(shutdownTimeout);
 				if (error) reject(error);
-				else resolve();
+				else resolve(false);
 			});
 			server.closeIdleConnections();
 		} catch (error) {
 			clearTimeout(shutdownTimeout);
 			reject(error);
 		}
+	});
+
+	if (!forceClosed || !hasActiveRequests()) return true;
+
+	return new Promise<boolean>((resolve, reject) => {
+		const activeRequestTimeout = setTimeout(
+			() => resolve(false),
+			activeRequestTimeoutMs,
+		);
+		activeRequestTimeout.unref?.();
+		void waitForActiveRequests().then(
+			() => {
+				clearTimeout(activeRequestTimeout);
+				resolve(true);
+			},
+			(error: unknown) => {
+				clearTimeout(activeRequestTimeout);
+				reject(error);
+			},
+		);
 	});
 };

--- a/server/tests/unit/queue/SqsBatchAccumulator.test.ts
+++ b/server/tests/unit/queue/SqsBatchAccumulator.test.ts
@@ -160,6 +160,42 @@ describe("SqsBatchAccumulator", () => {
 		}
 	});
 
+	test("flush drains entries enqueued while a send is in flight", async () => {
+		let releaseFirstSend: () => void = () => undefined;
+		const firstSendReleased = new Promise<void>((resolve) => {
+			releaseFirstSend = resolve;
+		});
+		let markFirstSendStarted: () => void = () => undefined;
+		const firstSendStarted = new Promise<void>((resolve) => {
+			markFirstSendStarted = resolve;
+		});
+		const calls: SendSqsAccumulatorBatchArgs<TestEntry>[] = [];
+		const batcher = new SqsBatchAccumulator<TestEntry>({
+			batchWindowMs: 60_000,
+			sendBatch: async (args) => {
+				calls.push(args);
+				if (calls.length === 1) {
+					markFirstSendStarted();
+					await firstSendReleased;
+				}
+				return { failures: [] };
+			},
+		});
+		const firstEntry = batcher.enqueue(createEntry({ index: 0 }));
+		const flush = batcher.flush();
+		await firstSendStarted;
+		const secondEntry = batcher.enqueue(createEntry({ index: 1 }));
+
+		releaseFirstSend();
+		try {
+			await flush;
+			expect(calls).toHaveLength(2);
+		} finally {
+			await batcher.shutdown();
+			await Promise.all([firstEntry, secondEntry]);
+		}
+	});
+
 	test("shutdown drains pending and in-flight sends before resolving", async () => {
 		let resolveSend:
 			| ((result: {

--- a/server/tests/unit/queue/deferred-sqs-producer-shutdown.test.ts
+++ b/server/tests/unit/queue/deferred-sqs-producer-shutdown.test.ts
@@ -1,15 +1,5 @@
 /**
- * Regression coverage for deferred SQS producers racing accumulator shutdown.
- *
- * Red failures:
- * - accumulator shutdown starts as soon as one concurrent producer rejects;
- * - max-size sync batches are removed from the pending map without being tracked;
- * - background event enqueue failures are silently consumed by tracking cleanup.
- *
- * Green criteria:
- * - all producer drains settle before accumulator shutdown;
- * - every started sync enqueue remains visible to flush();
- * - background event failures are emitted through the application logger.
+ * Covers deferred SQS producers draining before accumulator shutdown or forced exit.
  */
 
 import { describe, expect, spyOn, test } from "bun:test";
@@ -24,9 +14,46 @@ import {
 	type QueueSyncV4Payload,
 	SyncBatchingManagerV3,
 } from "@/internal/balances/utils/sync/SyncBatchingManagerV3.js";
-import { shutdownSqsProducers } from "@/queue/shutdownSqsProducers.js";
+import {
+	flushSqsProducers,
+	shutdownSqsProducers,
+} from "@/queue/shutdownSqsProducers.js";
 
 describe("deferred SQS producer shutdown", () => {
+	test("non-closing flush drains producers and SQS send batchers in order", async () => {
+		const calls: string[] = [];
+
+		await flushSqsProducers({
+			producers: [
+				{
+					flush: async () => {
+						calls.push("producer");
+					},
+				},
+			],
+			flushSqsSendBatchersFn: async () => {
+				calls.push("send batchers");
+			},
+		});
+
+		expect(calls).toEqual(["producer", "send batchers"]);
+	});
+
+	test("non-closing flush drains send batchers after a producer failure", async () => {
+		const producerFailure = new Error("producer failed");
+		let sendBatchersFlushed = false;
+
+		const result = await flushSqsProducers({
+			producers: [{ flush: async () => Promise.reject(producerFailure) }],
+			flushSqsSendBatchersFn: async () => {
+				sendBatchersFlushed = true;
+			},
+		}).catch((error: unknown) => error);
+
+		expect(result).toBe(producerFailure);
+		expect(sendBatchersFlushed).toBeTrue();
+	});
+
 	test("waits for every producer to settle before shutting down accumulators", async () => {
 		const producerFailure = new Error("event producer failed");
 		let releaseSlowProducer: () => void = () => undefined;

--- a/server/tests/unit/queue/deferred-sqs-producer-shutdown.test.ts
+++ b/server/tests/unit/queue/deferred-sqs-producer-shutdown.test.ts
@@ -61,12 +61,16 @@ describe("deferred SQS producer shutdown", () => {
 			releaseSlowProducer = resolve;
 		});
 		let accumulatorShutdownStarted = false;
+		let sendBatchersFlushed = false;
 
 		const shutdown = shutdownSqsProducers({
 			producers: [
 				{ flush: async () => Promise.reject(producerFailure) },
 				{ flush: async () => slowProducerReleased },
 			],
+			flushSqsSendBatchersFn: async () => {
+				sendBatchersFlushed = true;
+			},
 			shutdownSqsSendBatchersFn: async () => {
 				accumulatorShutdownStarted = true;
 			},
@@ -74,9 +78,11 @@ describe("deferred SQS producer shutdown", () => {
 
 		await Bun.sleep(5);
 		expect(accumulatorShutdownStarted).toBeFalse();
+		expect(sendBatchersFlushed).toBeFalse();
 
 		releaseSlowProducer();
 		expect(await shutdown).toBe(producerFailure);
+		expect(sendBatchersFlushed).toBeTrue();
 		expect(accumulatorShutdownStarted).toBeTrue();
 	});
 

--- a/server/tests/unit/queue/deferred-sqs-producer-shutdown.test.ts
+++ b/server/tests/unit/queue/deferred-sqs-producer-shutdown.test.ts
@@ -1,7 +1,21 @@
-/** Regression coverage for deferred SQS producers racing accumulator shutdown. */
+/**
+ * Regression coverage for deferred SQS producers racing accumulator shutdown.
+ *
+ * Red failures:
+ * - accumulator shutdown starts as soon as one concurrent producer rejects;
+ * - max-size sync batches are removed from the pending map without being tracked;
+ * - background event enqueue failures are silently consumed by tracking cleanup.
+ *
+ * Green criteria:
+ * - all producer drains settle before accumulator shutdown;
+ * - every started sync enqueue remains visible to flush();
+ * - background event failures are emitted through the application logger.
+ */
 
-import { describe, expect, test } from "bun:test";
-import { AppEnv } from "@autumn/shared";
+import { describe, expect, spyOn, test } from "bun:test";
+import { AppEnv, type EventInsert } from "@autumn/shared";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import { EventBatchingManager } from "@/internal/balances/events/EventBatchingManager.js";
 import {
 	type QueueRefreshEntityAggregatePayload,
 	RefreshEntityAggregateBatchingManager,
@@ -10,8 +24,35 @@ import {
 	type QueueSyncV4Payload,
 	SyncBatchingManagerV3,
 } from "@/internal/balances/utils/sync/SyncBatchingManagerV3.js";
+import { shutdownSqsProducers } from "@/queue/shutdownSqsProducers.js";
 
 describe("deferred SQS producer shutdown", () => {
+	test("waits for every producer to settle before shutting down accumulators", async () => {
+		const producerFailure = new Error("event producer failed");
+		let releaseSlowProducer: () => void = () => undefined;
+		const slowProducerReleased = new Promise<void>((resolve) => {
+			releaseSlowProducer = resolve;
+		});
+		let accumulatorShutdownStarted = false;
+
+		const shutdown = shutdownSqsProducers({
+			producers: [
+				{ flush: async () => Promise.reject(producerFailure) },
+				{ flush: async () => slowProducerReleased },
+			],
+			shutdownSqsSendBatchersFn: async () => {
+				accumulatorShutdownStarted = true;
+			},
+		}).catch((error: unknown) => error);
+
+		await Bun.sleep(5);
+		expect(accumulatorShutdownStarted).toBeFalse();
+
+		releaseSlowProducer();
+		expect(await shutdown).toBe(producerFailure);
+		expect(accumulatorShutdownStarted).toBeTrue();
+	});
+
 	test("sync flush waits for an enqueue already started by its timer", async () => {
 		let markEnqueueStarted: () => void = () => undefined;
 		const enqueueStarted = new Promise<void>((resolve) => {
@@ -37,6 +78,50 @@ describe("deferred SQS producer shutdown", () => {
 			modifiedCusEntIdsByFeatureId: {
 				messages: ["entitlement_1"],
 			},
+		});
+		await enqueueStarted;
+
+		let flushResolved = false;
+		const flush = manager.flush().then(() => {
+			flushResolved = true;
+		});
+
+		try {
+			await Bun.sleep(5);
+			expect(flushResolved).toBeFalse();
+		} finally {
+			releaseEnqueue();
+			await flush;
+		}
+	});
+
+	test("sync flush waits for an enqueue started by the max-size path", async () => {
+		let markEnqueueStarted: () => void = () => undefined;
+		const enqueueStarted = new Promise<void>((resolve) => {
+			markEnqueueStarted = resolve;
+		});
+		let releaseEnqueue: () => void = () => undefined;
+		const enqueueReleased = new Promise<void>((resolve) => {
+			releaseEnqueue = resolve;
+		});
+		const manager = new SyncBatchingManagerV3({
+			batchWindowMs: 60_000,
+			addTaskToQueueFn: async (_args: QueueSyncV4Payload) => {
+				markEnqueueStarted();
+				await enqueueReleased;
+			},
+		});
+		const entitlementIds = Array.from(
+			{ length: 1000 },
+			(_, index) => `entitlement_${index}`,
+		);
+
+		manager.addSyncItem({
+			customerId: "customer_max_size",
+			orgId: "org_1",
+			env: AppEnv.Live,
+			cusEntIds: entitlementIds,
+			modifiedCusEntIdsByFeatureId: { messages: entitlementIds },
 		});
 		await enqueueStarted;
 
@@ -92,6 +177,44 @@ describe("deferred SQS producer shutdown", () => {
 		} finally {
 			releaseEnqueue();
 			await flush;
+		}
+	});
+
+	test("logs background event enqueue failures", async () => {
+		const enqueueFailure = new Error("SQS unavailable");
+		let markFailureLogged: (args: unknown[]) => void = () => undefined;
+		const failureLogged = new Promise<unknown[]>((resolve) => {
+			markFailureLogged = resolve;
+		});
+		const errorSpy = spyOn(logger, "error").mockImplementation((...args) => {
+			if (args[0] === "[EventBatchingManager] Failed to execute batch") {
+				markFailureLogged(args);
+			}
+		});
+		const manager = new EventBatchingManager({
+			batchWindowMs: 0,
+			addTaskToQueueFn: async () => Promise.reject(enqueueFailure),
+		});
+		const event: EventInsert = {
+			id: "event_1",
+			org_id: "org_1",
+			org_slug: "test-org",
+			env: AppEnv.Live,
+			customer_id: "customer_1",
+			event_name: "messages",
+		};
+
+		try {
+			manager.addEvent(event);
+			const loggedArgs = await Promise.race([
+				failureLogged,
+				Bun.sleep(50).then(() => null),
+			]);
+
+			expect(loggedArgs).not.toBeNull();
+			expect(loggedArgs?.[1]).toEqual({ error: enqueueFailure });
+		} finally {
+			errorSpy.mockRestore();
 		}
 	});
 });

--- a/server/tests/unit/queue/deferred-sqs-producer-shutdown.test.ts
+++ b/server/tests/unit/queue/deferred-sqs-producer-shutdown.test.ts
@@ -1,0 +1,97 @@
+/** Regression coverage for deferred SQS producers racing accumulator shutdown. */
+
+import { describe, expect, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import {
+	type QueueRefreshEntityAggregatePayload,
+	RefreshEntityAggregateBatchingManager,
+} from "@/internal/balances/utils/refreshEntityAggregate/RefreshEntityAggregateBatchingManager.js";
+import {
+	type QueueSyncV4Payload,
+	SyncBatchingManagerV3,
+} from "@/internal/balances/utils/sync/SyncBatchingManagerV3.js";
+
+describe("deferred SQS producer shutdown", () => {
+	test("sync flush waits for an enqueue already started by its timer", async () => {
+		let markEnqueueStarted: () => void = () => undefined;
+		const enqueueStarted = new Promise<void>((resolve) => {
+			markEnqueueStarted = resolve;
+		});
+		let releaseEnqueue: () => void = () => undefined;
+		const enqueueReleased = new Promise<void>((resolve) => {
+			releaseEnqueue = resolve;
+		});
+		const manager = new SyncBatchingManagerV3({
+			batchWindowMs: 0,
+			addTaskToQueueFn: async (_args: QueueSyncV4Payload) => {
+				markEnqueueStarted();
+				await enqueueReleased;
+			},
+		});
+
+		manager.addSyncItem({
+			customerId: "customer_1",
+			orgId: "org_1",
+			env: AppEnv.Live,
+			cusEntIds: ["entitlement_1"],
+			modifiedCusEntIdsByFeatureId: {
+				messages: ["entitlement_1"],
+			},
+		});
+		await enqueueStarted;
+
+		let flushResolved = false;
+		const flush = manager.flush().then(() => {
+			flushResolved = true;
+		});
+
+		try {
+			await Bun.sleep(5);
+			expect(flushResolved).toBeFalse();
+		} finally {
+			releaseEnqueue();
+			await flush;
+		}
+	});
+
+	test("aggregate refresh flush waits for an enqueue already started by its timer", async () => {
+		let markEnqueueStarted: () => void = () => undefined;
+		const enqueueStarted = new Promise<void>((resolve) => {
+			markEnqueueStarted = resolve;
+		});
+		let releaseEnqueue: () => void = () => undefined;
+		const enqueueReleased = new Promise<void>((resolve) => {
+			releaseEnqueue = resolve;
+		});
+		const manager = new RefreshEntityAggregateBatchingManager({
+			bucketMs: 1,
+			settleBufferMs: 0,
+			now: () => 0,
+			addTaskToQueueFn: async (_args: QueueRefreshEntityAggregatePayload) => {
+				markEnqueueStarted();
+				await enqueueReleased;
+			},
+		});
+
+		manager.schedule({
+			customerId: "customer_1",
+			orgId: "org_1",
+			env: AppEnv.Live,
+			internalFeatureIds: ["feature_1"],
+		});
+		await enqueueStarted;
+
+		let flushResolved = false;
+		const flush = manager.flush().then(() => {
+			flushResolved = true;
+		});
+
+		try {
+			await Bun.sleep(5);
+			expect(flushResolved).toBeFalse();
+		} finally {
+			releaseEnqueue();
+			await flush;
+		}
+	});
+});

--- a/server/tests/unit/queue/shutdown-sqs-worker.test.ts
+++ b/server/tests/unit/queue/shutdown-sqs-worker.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { shutdownSqsWorker } from "@/queue/shutdownSqsWorker.js";
 
 describe("SQS worker shutdown", () => {
-	test("arms the forced-exit deadline before waiting for polling loops", async () => {
+	test("flushes deferred producers before waiting for polling loops", async () => {
 		let releasePollingLoop: () => void = () => undefined;
 		const pollingLoop = new Promise<void>((resolve) => {
 			releasePollingLoop = resolve;
@@ -11,17 +11,25 @@ describe("SQS worker shutdown", () => {
 		const exitCode = new Promise<number>((resolve) => {
 			markExit = resolve;
 		});
-		let producerDrainStarted = false;
+		let producerFlushStarted = false;
+		let producerShutdownStarted = false;
 
 		const shutdown = shutdownSqsWorker({
 			pollingLoops: [pollingLoop],
+			flushSqsProducersFn: async () => {
+				producerFlushStarted = true;
+			},
 			shutdownSqsProducersFn: async () => {
-				producerDrainStarted = true;
+				producerShutdownStarted = true;
 			},
 			isProduction: true,
 			shutdownTimeoutMs: 5,
 			exitProcess: markExit,
 		});
+
+		await Bun.sleep(0);
+		expect(producerFlushStarted).toBeTrue();
+		expect(producerShutdownStarted).toBeFalse();
 
 		const exitBeforePollingSettled = await Promise.race([
 			exitCode,
@@ -29,12 +37,12 @@ describe("SQS worker shutdown", () => {
 		]);
 		try {
 			expect(exitBeforePollingSettled).toBe(0);
-			expect(producerDrainStarted).toBeFalse();
+			expect(producerShutdownStarted).toBeFalse();
 		} finally {
 			releasePollingLoop();
 			await shutdown;
 		}
-		expect(producerDrainStarted).toBeTrue();
+		expect(producerShutdownStarted).toBeTrue();
 	});
 
 	test("logs producer drain failures and continues to the exit path", async () => {

--- a/server/tests/unit/queue/shutdown-sqs-worker.test.ts
+++ b/server/tests/unit/queue/shutdown-sqs-worker.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { shutdownSqsWorker } from "@/queue/shutdownSqsWorker.js";
+
+describe("SQS worker shutdown", () => {
+	test("arms the forced-exit deadline before waiting for polling loops", async () => {
+		let releasePollingLoop: () => void = () => undefined;
+		const pollingLoop = new Promise<void>((resolve) => {
+			releasePollingLoop = resolve;
+		});
+		let markExit: (code: number) => void = () => undefined;
+		const exitCode = new Promise<number>((resolve) => {
+			markExit = resolve;
+		});
+		let producerDrainStarted = false;
+
+		const shutdown = shutdownSqsWorker({
+			pollingLoops: [pollingLoop],
+			shutdownSqsProducersFn: async () => {
+				producerDrainStarted = true;
+			},
+			isProduction: true,
+			shutdownTimeoutMs: 5,
+			exitProcess: markExit,
+		});
+
+		const exitBeforePollingSettled = await Promise.race([
+			exitCode,
+			Bun.sleep(50).then(() => null),
+		]);
+		try {
+			expect(exitBeforePollingSettled).toBe(0);
+			expect(producerDrainStarted).toBeFalse();
+		} finally {
+			releasePollingLoop();
+			await shutdown;
+		}
+		expect(producerDrainStarted).toBeTrue();
+	});
+
+	test("logs producer drain failures and continues to the exit path", async () => {
+		const producerFailure = new Error("producer drain failed");
+		const loggedErrors: Array<{ message: string; error: unknown }> = [];
+		let markExit: (code: number) => void = () => undefined;
+		const exitCode = new Promise<number>((resolve) => {
+			markExit = resolve;
+		});
+
+		const shutdownResult = await shutdownSqsWorker({
+			pollingLoops: [],
+			shutdownSqsProducersFn: async () => Promise.reject(producerFailure),
+			isProduction: true,
+			shutdownTimeoutMs: 5,
+			exitProcess: markExit,
+			logError: (message, error) => loggedErrors.push({ message, error }),
+		}).then(
+			() => null,
+			(error: unknown) => error,
+		);
+		const observedExitCode = await Promise.race([
+			exitCode,
+			Bun.sleep(50).then(() => null),
+		]);
+
+		expect(shutdownResult).toBeNull();
+		expect(observedExitCode).toBe(0);
+		expect(loggedErrors).toEqual([
+			{
+				message: `[SQS Worker ${process.pid}] Failed to drain SQS producers`,
+				error: producerFailure,
+			},
+		]);
+	});
+});

--- a/server/tests/unit/utils/stop-http-server.test.ts
+++ b/server/tests/unit/utils/stop-http-server.test.ts
@@ -115,6 +115,36 @@ describe("stopHttpServer", () => {
 		expect(await shutdown).toBeTrue();
 	});
 
+	test("grants a final handler grace window before reporting forced exit", async () => {
+		let releaseHandler: () => void = () => undefined;
+		const handlerReleased = new Promise<void>((resolve) => {
+			releaseHandler = resolve;
+		});
+		const tracker = createHttpRequestTracker({
+			requestHandler: async () => {
+				await handlerReleased;
+				return new Response("done");
+			},
+		});
+		void tracker.requestHandler();
+		const server = {
+			close: () => server,
+			closeIdleConnections: mock(() => undefined),
+			closeAllConnections: mock(() => undefined),
+		} as unknown as http.Server;
+		const shutdown = stopHttpServer({
+			server,
+			shutdownTimeoutMs: 2,
+			activeRequestTimeoutMs: 2,
+			forcedRequestGraceMs: 25,
+			hasActiveRequests: tracker.hasActiveRequests,
+			waitForActiveRequests: tracker.waitForActiveRequests,
+		});
+		setTimeout(releaseHandler, 10);
+
+		expect(await shutdown).toBeTrue();
+	});
+
 	test("does not report a clean drain when a handler survives force-close", async () => {
 		const closeIdleConnections = mock(() => undefined);
 		const closeAllConnections = mock(() => undefined);

--- a/server/tests/unit/utils/stop-http-server.test.ts
+++ b/server/tests/unit/utils/stop-http-server.test.ts
@@ -1,8 +1,39 @@
 import { describe, expect, mock, test } from "bun:test";
 import type http from "node:http";
-import { stopHttpServer } from "@/utils/stopHttpServer.js";
+import {
+	createHttpRequestTracker,
+	stopHttpServer,
+} from "@/utils/stopHttpServer.js";
 
 describe("stopHttpServer", () => {
+	test("tracks the handler promise independently of the connection", async () => {
+		let releaseHandler: () => void = () => undefined;
+		const handlerReleased = new Promise<void>((resolve) => {
+			releaseHandler = resolve;
+		});
+		const tracker = createHttpRequestTracker({
+			requestHandler: async () => {
+				await handlerReleased;
+				return new Response("done");
+			},
+		});
+
+		const request = tracker.requestHandler();
+		expect(tracker.hasActiveRequests()).toBeTrue();
+		let waitResolved = false;
+		const waitForActiveRequests = tracker.waitForActiveRequests().then(() => {
+			waitResolved = true;
+		});
+		await Bun.sleep(0);
+		expect(waitResolved).toBeFalse();
+
+		releaseHandler();
+		await request;
+		await waitForActiveRequests;
+		expect(tracker.hasActiveRequests()).toBeFalse();
+		expect(waitResolved).toBeTrue();
+	});
+
 	test("does not force-close connections after graceful close completes", async () => {
 		const closeIdleConnections = mock(() => undefined);
 		const closeAllConnections = mock(() => undefined);
@@ -15,9 +46,13 @@ describe("stopHttpServer", () => {
 			closeAllConnections,
 		} as unknown as http.Server;
 
-		await stopHttpServer({ server, shutdownTimeoutMs: 5 });
+		const requestsDrained = await stopHttpServer({
+			server,
+			shutdownTimeoutMs: 5,
+		});
 		await Bun.sleep(10);
 
+		expect(requestsDrained).toBeTrue();
 		expect(closeIdleConnections).toHaveBeenCalledTimes(1);
 		expect(closeAllConnections).not.toHaveBeenCalled();
 	});
@@ -32,12 +67,72 @@ describe("stopHttpServer", () => {
 		} as unknown as http.Server;
 
 		const outcome = await Promise.race([
-			stopHttpServer({ server, shutdownTimeoutMs: 5 }).then(() => "closed"),
+			stopHttpServer({ server, shutdownTimeoutMs: 5 }),
 			Bun.sleep(50).then(() => "test-timeout"),
 		]);
 
-		expect(outcome).toBe("closed");
+		expect(outcome).toBeTrue();
 		expect(closeIdleConnections).toHaveBeenCalledTimes(1);
+		expect(closeAllConnections).toHaveBeenCalledTimes(1);
+	});
+
+	test("waits for a force-closed handler before reporting a clean drain", async () => {
+		let releaseHandler: () => void = () => undefined;
+		const handlerReleased = new Promise<void>((resolve) => {
+			releaseHandler = resolve;
+		});
+		const tracker = createHttpRequestTracker({
+			requestHandler: async () => {
+				await handlerReleased;
+				return new Response("done");
+			},
+		});
+		void tracker.requestHandler();
+		const closeAllConnections = mock(() => undefined);
+		const server = {
+			close: () => server,
+			closeIdleConnections: mock(() => undefined),
+			closeAllConnections,
+		} as unknown as http.Server;
+		let shutdownResolved = false;
+
+		const shutdown = stopHttpServer({
+			server,
+			shutdownTimeoutMs: 5,
+			activeRequestTimeoutMs: 50,
+			hasActiveRequests: tracker.hasActiveRequests,
+			waitForActiveRequests: tracker.waitForActiveRequests,
+		}).then((result) => {
+			shutdownResolved = true;
+			return result;
+		});
+
+		await Bun.sleep(10);
+		expect(closeAllConnections).toHaveBeenCalledTimes(1);
+		expect(shutdownResolved).toBeFalse();
+
+		releaseHandler();
+		expect(await shutdown).toBeTrue();
+	});
+
+	test("does not report a clean drain when a handler survives force-close", async () => {
+		const closeIdleConnections = mock(() => undefined);
+		const closeAllConnections = mock(() => undefined);
+		const server = {
+			close: () => server,
+			closeIdleConnections,
+			closeAllConnections,
+		} as unknown as http.Server;
+
+		const requestsDrained = await stopHttpServer({
+			server,
+			shutdownTimeoutMs: 5,
+			activeRequestTimeoutMs: 5,
+			hasActiveRequests: () => true,
+			waitForActiveRequests: () => new Promise(() => undefined),
+		});
+
+		expect(requestsDrained).toBeFalse();
 		expect(closeAllConnections).toHaveBeenCalledTimes(1);
 	});
 });

--- a/server/tests/unit/utils/stop-http-server.test.ts
+++ b/server/tests/unit/utils/stop-http-server.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, mock, test } from "bun:test";
+import type http from "node:http";
+import { stopHttpServer } from "@/utils/stopHttpServer.js";
+
+describe("stopHttpServer", () => {
+	test("does not force-close connections after graceful close completes", async () => {
+		const closeIdleConnections = mock(() => undefined);
+		const closeAllConnections = mock(() => undefined);
+		const server = {
+			close: (callback: (error?: Error) => void) => {
+				callback();
+				return server;
+			},
+			closeIdleConnections,
+			closeAllConnections,
+		} as unknown as http.Server;
+
+		await stopHttpServer({ server, shutdownTimeoutMs: 5 });
+		await Bun.sleep(10);
+
+		expect(closeIdleConnections).toHaveBeenCalledTimes(1);
+		expect(closeAllConnections).not.toHaveBeenCalled();
+	});
+
+	test("force-closes active connections when graceful close reaches its deadline", async () => {
+		const closeIdleConnections = mock(() => undefined);
+		const closeAllConnections = mock(() => undefined);
+		const server = {
+			close: () => server,
+			closeIdleConnections,
+			closeAllConnections,
+		} as unknown as http.Server;
+
+		const outcome = await Promise.race([
+			stopHttpServer({ server, shutdownTimeoutMs: 5 }).then(() => "closed"),
+			Bun.sleep(50).then(() => "test-timeout"),
+		]);
+
+		expect(outcome).toBe("closed");
+		expect(closeIdleConnections).toHaveBeenCalledTimes(1);
+		expect(closeAllConnections).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary
- stop HTTP and SQS worker intake before shutdown draining begins
- wait for polling loops and timer-started sync/aggregate/event producer work to finish
- close the shared SQS accumulators only after all deferred producers have flushed

## Production symptom
During blue/green shutdown, pending sync timers fired after the shared accumulator had already stopped accepting entries. This produced paired SyncDirty and SyncV4 errors with "SQS batch accumulator is shutting down".

## Tests
- bun test tests/unit/queue/deferred-sqs-producer-shutdown.test.ts tests/unit/queue/SqsBatchAccumulator.test.ts tests/unit/queue/primary-queue-batching.test.ts (14 pass)
- cd server && bun ts
- commit hook: knip and @autumn/server typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix clean shutdown to drain deferred SQS producers and active HTTP requests without closing accumulators early, and bound server/worker shutdown to prevent hangs during blue/green deploys. Intake stops first; pending timers and polling work finish; then accumulators close, with a final bounded flush on forced-exit paths after waiting for surviving handlers.

- **Bug Fixes**
  - HTTP: stop intake; gracefully close server and idle connections; on deadline, force-close, then wait for surviving handlers (short grace) and perform a final bounded SQS flush before exit.
  - Worker: arm a forced-exit timer; flush deferred producers first; await polling loops; then drain and close SQS accumulators; make shutdown idempotent.
  - Managers: add in-flight tracking and `flush()` to event/sync/aggregate managers; wait for timer- and max-size enqueues; log background event enqueue failures.
  - SQS: add `flushSqsProducers` and `shutdownSqsProducers` to flush producers and SQS send batchers, then close accumulators; ensure `SqsBatchAccumulator.flush()` drains entries queued during in-flight sends.
  - Tests: cover producer-drain races, forced-exit with an active handler, worker exit timing, and HTTP shutdown behavior.

<sup>Written for commit cfe96ddaf7a0534a58121488dc14aa499b356fcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes shutdown ordering so HTTP and worker intake stop before deferred SQS producers and shared accumulators are drained.
- **Bug fixes:** Wait for timer-started event, sync, and aggregate producers before closing shared SQS accumulators.
- **Improvements:** Track active HTTP requests and polling loops, add bounded forced-exit paths, and make worker shutdown idempotent.
- **Bug fixes:** Continue flushing send batchers after producer failures and drain entries added during an in-flight SQS send.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the HTTP forced-exit path can still terminate while an active handler creates deferred SQS work after the final flush.

The fail-fast accumulator shutdown issue is fixed by waiting for every producer to settle, but a handler that survives HTTP force-close remains executable while the shutdown path performs one bounded flush and immediately exits, leaving work scheduled after that flush undrained.

**Files Needing Attention:** server/src/init.ts, server/src/utils/stopHttpServer.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/init.ts | Adds HTTP request tracking and ordered producer shutdown, but the forced-exit branch can still exit while a surviving handler creates new deferred work. |
| server/src/queue/shutdownSqsProducers.ts | Correctly waits for all producer flushes to settle before flushing and closing the shared SQS accumulators. |
| server/src/queue/shutdownSqsWorker.ts | Stops worker intake, flushes deferred work, waits for polling loops, and performs a final producer shutdown under a bounded deadline. |
| server/src/utils/stopHttpServer.ts | Tracks handler promises independently from connections and distinguishes clean drains from handlers surviving force-close. |
| server/src/queue/SqsBatchAccumulator.ts | Rechecks pending entries after in-flight sends so a flush drains entries added during an active send. |
| server/src/internal/balances/events/EventBatchingManager.ts | Tracks timer- and size-triggered batch executions so shutdown flushing can await them. |
| server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts | Tracks active sync batch executions and includes them in producer flushing. |
| server/src/internal/balances/utils/refreshEntityAggregate/RefreshEntityAggregateBatchingManager.ts | Tracks active aggregate refresh executions and waits for them during flushing. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Signal as Shutdown signal
  participant Intake as HTTP / worker intake
  participant Work as Active handlers / polling loops
  participant Producers as Deferred producers
  participant Batcher as SQS accumulators
  Signal->>Intake: Stop accepting work
  Intake->>Work: Wait for active work
  Work->>Producers: Schedule deferred work
  Producers->>Batcher: Flush queued jobs
  Batcher->>Batcher: Drain pending and in-flight sends
  Batcher-->>Signal: Close accumulators
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix: drain requests before final SQS flu..."](https://github.com/useautumn/autumn/commit/cfe96ddaf7a0534a58121488dc14aa499b356fcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50415606)</sub>

**Context used:**

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->