### PR TITLE
fix: hide RC badge for expired-only customer products

### DIFF
--- a/vite/src/views/customers2/customer/CustomerView2.tsx
+++ b/vite/src/views/customers2/customer/CustomerView2.tsx
@@ -88,7 +88,9 @@ export default function CustomerView2() {
 	}
 
 	const isRevenueCatCustomer = customer.customer_products.some(
-		(cp) => cp.processor?.type === ProcessorType.RevenueCat,
+		(cp) =>
+			cp.status !== CusProductStatus.Expired &&
+			cp.processor?.type === ProcessorType.RevenueCat,
 	);
 
 	return (


### PR DESCRIPTION
The customer page RC badge was keyed off any `customer_product` with a RevenueCat processor, including expired rows kept for plan history. After a cancel/expire, the API `processors` block correctly drops RC while the badge still rendered.

Filter expired CPs out of the check so the badge means currently RC-billed, matching the empty `processors` response.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the RevenueCat badge on the customer page when all RevenueCat-backed products are expired. Previously the badge showed if any historical RC `customer_product` existed; now it requires a non-expired RC product, aligning with the API processors after cancel/expire.

- Review/QA: `isRevenueCatCustomer` checks `cp.status !== CusProductStatus.Expired && cp.processor?.type === ProcessorType.RevenueCat`. Verify the badge is hidden when only expired RC products exist and shown when at least one active RC product exists.

<sup>Written for commit fce77e85d86471dcea81853b522dd782f1293c58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns the RevenueCat badge with the customer API’s active processor state.
- **[Bug fixes]** Excludes expired customer products when determining whether to display the RevenueCat badge.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/customer/CustomerView2.tsx | Updates RevenueCat badge detection to require at least one non-expired RevenueCat customer product. |

<sub>Reviews (2): Last reviewed commit: ["fix: hide RC badge for expired-only cust..."](https://github.com/useautumn/autumn/commit/fce77e85d86471dcea81853b522dd782f1293c58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56206634)</sub>

**Context used:**

- Knowledge Base — [Customer, subject, and entitlement operations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/customer-management.md)

<!-- /greptile_comment -->