### PR TITLE
chore: MotherDuck cache refresh cadence 5m → 20m

### DIFF
--- a/server/src/cron/cronInit.ts
+++ b/server/src/cron/cronInit.ts
@@ -140,7 +140,9 @@ new CronJob(
 );
 
 new CronJob(
-	"*/5 * * * *", // Refresh the MotherDuck balance cache every 5 minutes
+	// Each run bills full-rebuild duckling time + cross-region S3 for the whole
+	// scan, so cadence is the cost knob; 20min stays inside the sort disclaimer.
+	"*/20 * * * *",
 	mdCacheRefreshTick,
 	null, // onComplete
 	true, // start immediately


### PR DESCRIPTION
Each refresh full-rebuilds the lake cache, paying Standard-duckling wall-clock (startup + work + cooldown + 1-min minimum) on MotherDuck AND ~10.8 GB of cross-region S3 transfer on our AWS bill per run. Cadence is the dominant cost knob for both:

| | 5 min | 20 min |
|---|---|---|
| MD cron compute | ~$24–39/day | ~$6–10/day |
| AWS cross-region transfer | ~$31/day | ~$8/day |
| Worst-case totals staleness | ~6 min | ~21 min |

Staleness stays within the existing "order may be approximate while balances update" disclaimer; displayed values are always live from PG hydration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increases the MotherDuck balance cache refresh cadence from every 5 minutes to every 20 minutes to cut cron compute and cross‑region S3 costs, while keeping data freshness within our disclaimer.

- Cost impact: MotherDuck cron compute ~$24–39/day → ~$6–10/day; AWS cross‑region transfer ~$31/day → ~$8/day.
- Data freshness: worst‑case staleness ~6 → ~21 minutes; UI continues to show live values from PG hydration and remains within the “order may be approximate while balances update” disclaimer.

<sup>Written for commit 856264c14c44f30ab764ea1918c9488b6193d751. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reduces how often the MotherDuck balance cache is rebuilt to lower compute and cross-region transfer costs.
- **Improvements:** Changes the cache refresh cadence from every 5 minutes to every 20 minutes.
- **Improvements:** Documents the cost rationale beside the cron schedule.
- **Improvements:** The remaining 5-minute freshness comments should be updated to match the new cadence.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only non-blocking documentation cleanup needed for the new cache freshness window.

The cadence change intentionally widens cache staleness as described by the PR, while several related source comments still incorrectly state that the cache is approximately 5 minutes stale.

**Files Needing Attention:** server/src/cron/cronInit.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/cron/cronInit.ts | Changes the MotherDuck refresh schedule to every 20 minutes; behavior is intentional, but related freshness comments elsewhere remain outdated. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/cron/cronInit.ts:143-145
**Freshness comments remain outdated**

This schedule increases the cache interval to 20 minutes, but related source comments still describe balance filtering and sorting as approximately 5 minutes stale. That mismatch can lead engineers to rely on an incorrect freshness window, so the related comments should be updated with this cadence change.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: 🤖 MotherDuck cache refresh caden..."](https://github.com/useautumn/autumn/commit/856264c14c44f30ab764ea1918c9488b6193d751) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56330341)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Scheduled operations and trigger automation](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/scheduled-operations-and-triggers.md)
- Knowledge Base — [Analytics stores and data exports](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/analytics-and-data-exports.md)

<!-- /greptile_comment -->