### PR TITLE
feat: show expired balances in dashboard

### DIFF
--- a/scripts/tw/helpers/preflight.ts
+++ b/scripts/tw/helpers/preflight.ts
@@ -61,6 +61,28 @@ const checkSecrets = (): PreflightProblem | undefined => {
 	};
 };
 
+/**
+ * Workers run `bun install --frozen-lockfile`; a bun.lock that drifted from
+ * package.json (typically after a dev merge) fails EVERY worker at provision.
+ * WARN-ONLY: bun's frozen check has known false positives in workspaces and
+ * differs across platforms (oven-sh/bun#20913, #19088), so a local dry-run
+ * cannot be a fatal gate — it just flags the likely cause before a fanout dies.
+ */
+const warnLockfileDrift = (): void => {
+	const proc = Bun.spawnSync(
+		["bun", "install", "--frozen-lockfile", "--dry-run"],
+		{ stdout: "pipe", stderr: "pipe" },
+	);
+	if (proc.exitCode === 0) {
+		return;
+	}
+	console.warn(
+		chalk.yellow(
+			"[tw] warning: `bun install --frozen-lockfile --dry-run` failed locally — if workers die at provision with 'lockfile had changes', run `bun install`, commit bun.lock, and push. (Local check can false-positive: oven-sh/bun#20913.)",
+		),
+	);
+};
+
 const checkGit = (ref: string): PreflightProblem | undefined => {
 	const dirty = git("status", "--porcelain", "--", ".", ":(exclude)ai");
 	if (dirty) {
@@ -115,7 +137,13 @@ export const runPreflight = ({
 	}
 	push(checkSecrets());
 	if (!allowDirty) {
-		push(checkGit(ref));
+		const gitProblem = checkGit(ref);
+		push(gitProblem);
+		// Lockfile state reflects what workers will clone only when the tree
+		// matches origin, which the git gate just proved.
+		if (!gitProblem) {
+			warnLockfileDrift();
+		}
 	}
 
 	if (problems.length === 0) {

--- a/server/src/internal/balances/deleteBalance/deleteBalance.ts
+++ b/server/src/internal/balances/deleteBalance/deleteBalance.ts
@@ -2,6 +2,7 @@ import {
 	cusEntsToUsage,
 	type DeleteBalanceParamsV0,
 	fullCustomerToCustomerEntitlements,
+	isCusEntExpired,
 	isPaidCustomerEntitlement,
 	isPooledBalanceSourceCustomerEntitlement,
 	isSyntheticPooledBalanceCustomerEntitlement,
@@ -94,9 +95,13 @@ export const deleteBalance = async ({
 		}
 	}
 
+	// Recalculation redistributes usage onto live balances, so an expired row's
+	// historical usage must never enter the input.
 	const usageToRecalculate = recalculate_balances
 		? cusEntsToUsage({
-				cusEnts: customerEntitlements,
+				cusEnts: customerEntitlements.filter(
+					(cusEnt) => !isCusEntExpired({ cusEnt }),
+				),
 				entityId: fullCustomer.entity?.id ?? undefined,
 			})
 		: 0;

--- a/server/src/internal/balances/deleteBalance/deleteBalance.ts
+++ b/server/src/internal/balances/deleteBalance/deleteBalance.ts
@@ -2,6 +2,7 @@ import {
 	cusEntsToUsage,
 	type DeleteBalanceParamsV0,
 	fullCustomerToCustomerEntitlements,
+	isCusEntExpired,
 	isPaidCustomerEntitlement,
 	isPooledBalanceSourceCustomerEntitlement,
 	isSyntheticPooledBalanceCustomerEntitlement,
@@ -23,9 +24,13 @@ import {
 export const deleteBalance = async ({
 	ctx,
 	params,
+	includeExpired = false,
 }: {
 	ctx: AutumnContext;
 	params: DeleteBalanceParamsV0;
+	/** Dashboard-only: allow deleting EXPIRED loose balances (the only cleanup
+	 *  mechanism for them — the selector below filters them out otherwise). */
+	includeExpired?: boolean;
 }) => {
 	const { customer_id, entity_id, feature_id, recalculate_balances } = params;
 
@@ -43,15 +48,31 @@ export const deleteBalance = async ({
 		entityId: entity_id,
 		withEntities: true,
 		withSubs: true,
+		includeExpiredLooseEntitlements: includeExpired,
 	});
 
 	// 2. Get balance
-	const customerEntitlements = fullCustomerToCustomerEntitlements({
+	let customerEntitlements = fullCustomerToCustomerEntitlements({
 		fullCustomer,
 		featureId: feature_id,
 		entity: fullCustomer.entity,
 		customerEntitlementFilters: buildCustomerEntitlementFilters({ params }),
 	});
+
+	// The selector excludes expired rows; match the target among expired loose
+	// entitlements directly so they stay deletable from the dashboard.
+	if (customerEntitlements.length === 0 && includeExpired) {
+		const filters = buildCustomerEntitlementFilters({ params });
+		customerEntitlements = (fullCustomer.extra_customer_entitlements ?? [])
+			.filter(
+				(cusEnt) =>
+					isCusEntExpired({ cusEnt }) &&
+					(!feature_id || cusEnt.feature_id === feature_id) &&
+					(!filters?.cusEntIds || filters.cusEntIds.includes(cusEnt.id)) &&
+					(!filters?.balanceId || cusEnt.entitlement_id === filters.balanceId),
+			)
+			.map((cusEnt) => ({ ...cusEnt, customer_product: null }));
+	}
 
 	if (customerEntitlements.length === 0) {
 		throw new RecaseError({

--- a/server/src/internal/balances/deleteBalance/deleteBalance.ts
+++ b/server/src/internal/balances/deleteBalance/deleteBalance.ts
@@ -28,8 +28,6 @@ export const deleteBalance = async ({
 }: {
 	ctx: AutumnContext;
 	params: DeleteBalanceParamsV0;
-	/** Dashboard-only: allow deleting EXPIRED loose balances (the only cleanup
-	 *  mechanism for them — the selector below filters them out otherwise). */
 	includeExpired?: boolean;
 }) => {
 	const { customer_id, entity_id, feature_id, recalculate_balances } = params;
@@ -51,8 +49,6 @@ export const deleteBalance = async ({
 		includeExpiredLooseEntitlements: includeExpired,
 	});
 
-	// 2. Get balance. includeExpired keeps expired loose rows in the selection so
-	// the dashboard can delete them — every other filter still applies.
 	const customerEntitlements = fullCustomerToCustomerEntitlements({
 		fullCustomer,
 		featureId: feature_id,
@@ -95,8 +91,7 @@ export const deleteBalance = async ({
 		}
 	}
 
-	// Recalculation redistributes usage onto live balances, so an expired row's
-	// historical usage must never enter the input.
+	// Expired usage must never be redistributed onto live balances.
 	const usageToRecalculate = recalculate_balances
 		? cusEntsToUsage({
 				cusEnts: customerEntitlements.filter(

--- a/server/src/internal/balances/deleteBalance/deleteBalance.ts
+++ b/server/src/internal/balances/deleteBalance/deleteBalance.ts
@@ -2,7 +2,6 @@ import {
 	cusEntsToUsage,
 	type DeleteBalanceParamsV0,
 	fullCustomerToCustomerEntitlements,
-	isCusEntExpired,
 	isPaidCustomerEntitlement,
 	isPooledBalanceSourceCustomerEntitlement,
 	isSyntheticPooledBalanceCustomerEntitlement,
@@ -51,28 +50,15 @@ export const deleteBalance = async ({
 		includeExpiredLooseEntitlements: includeExpired,
 	});
 
-	// 2. Get balance
-	let customerEntitlements = fullCustomerToCustomerEntitlements({
+	// 2. Get balance. includeExpired keeps expired loose rows in the selection so
+	// the dashboard can delete them — every other filter still applies.
+	const customerEntitlements = fullCustomerToCustomerEntitlements({
 		fullCustomer,
 		featureId: feature_id,
 		entity: fullCustomer.entity,
 		customerEntitlementFilters: buildCustomerEntitlementFilters({ params }),
+		includeExpired,
 	});
-
-	// The selector excludes expired rows; match the target among expired loose
-	// entitlements directly so they stay deletable from the dashboard.
-	if (customerEntitlements.length === 0 && includeExpired) {
-		const filters = buildCustomerEntitlementFilters({ params });
-		customerEntitlements = (fullCustomer.extra_customer_entitlements ?? [])
-			.filter(
-				(cusEnt) =>
-					isCusEntExpired({ cusEnt }) &&
-					(!feature_id || cusEnt.feature_id === feature_id) &&
-					(!filters?.cusEntIds || filters.cusEntIds.includes(cusEnt.id)) &&
-					(!filters?.balanceId || cusEnt.entitlement_id === filters.balanceId),
-			)
-			.map((cusEnt) => ({ ...cusEnt, customer_product: null }));
-	}
 
 	if (customerEntitlements.length === 0) {
 		throw new RecaseError({

--- a/server/src/internal/balances/handlers/handleDeleteBalance.ts
+++ b/server/src/internal/balances/handlers/handleDeleteBalance.ts
@@ -1,4 +1,5 @@
 import {
+	AuthType,
 	DeleteBalanceParamsV0Schema,
 	RouteGroup,
 	Scopes,
@@ -17,6 +18,9 @@ export const handleDeleteBalance = createRoute({
 		await deleteBalance({
 			ctx,
 			params,
+			// Dashboard sessions may delete expired loose balances (their only
+			// cleanup path); API-key behavior is unchanged.
+			includeExpired: ctx.authType === AuthType.Dashboard,
 		});
 
 		return c.json({ success: true });

--- a/server/src/internal/balances/handlers/handleDeleteBalance.ts
+++ b/server/src/internal/balances/handlers/handleDeleteBalance.ts
@@ -18,8 +18,6 @@ export const handleDeleteBalance = createRoute({
 		await deleteBalance({
 			ctx,
 			params,
-			// Dashboard sessions may delete expired loose balances (their only
-			// cleanup path); API-key behavior is unchanged.
 			includeExpired: ctx.authType === AuthType.Dashboard,
 		});
 

--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -102,10 +102,7 @@ export class CusService {
 		skipReset?: boolean;
 		/** Overrides the org-configured customer-product page size. */
 		cusProductLimit?: number;
-		/**
-		 * Internal dashboard only: also hydrate EXPIRED loose entitlements into
-		 * extra_customer_entitlements. Must stay false for public API paths.
-		 */
+		/** Must stay false on public API paths. */
 		includeExpiredLooseEntitlements?: boolean;
 	}): Promise<FullCustomer> {
 		const { db, org, env } = ctx;
@@ -146,8 +143,7 @@ export class CusService {
 					!withTrialsUsed &&
 					!withEvents &&
 					!entityId &&
-					// The flat-model query has no expired-loose hydration; fall back to
-					// the legacy query so the flag takes effect.
+					// The flat-model query has no expired-loose hydration.
 					!includeExpiredLooseEntitlements;
 
 				const query = useFlatModel

--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -87,6 +87,7 @@ export class CusService {
 		explain = false,
 		skipReset = false,
 		cusProductLimit: cusProductLimitOverride,
+		includeExpiredLooseEntitlements = false,
 	}: {
 		ctx: AutumnContext;
 		idOrInternalId: string;
@@ -101,6 +102,11 @@ export class CusService {
 		skipReset?: boolean;
 		/** Overrides the org-configured customer-product page size. */
 		cusProductLimit?: number;
+		/**
+		 * Internal dashboard only: also hydrate EXPIRED loose entitlements into
+		 * extra_customer_entitlements. Must stay false for public API paths.
+		 */
+		includeExpiredLooseEntitlements?: boolean;
 	}): Promise<FullCustomer> {
 		const { db, org, env } = ctx;
 		const orgId = org.id;
@@ -139,7 +145,10 @@ export class CusService {
 					}) &&
 					!withTrialsUsed &&
 					!withEvents &&
-					!entityId;
+					!entityId &&
+					// The flat-model query has no expired-loose hydration; fall back to
+					// the legacy query so the flag takes effect.
+					!includeExpiredLooseEntitlements;
 
 				const query = useFlatModel
 					? getCursorPaginatedFullCusQuery({
@@ -168,6 +177,7 @@ export class CusService {
 							entityId,
 							cusProductLimit,
 							entitiesLimit,
+							includeExpiredLooseEntitlements,
 						});
 
 				if (explain) {

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -400,9 +400,6 @@ const buildSubscriptionsCTE = (
   `;
 };
 
-// Expiry predicate for LOOSE (extra) customer entitlements only. Internal
-// dashboard reads can bypass it to surface expired loose balances; public
-// hydration paths always keep it.
 const looseEntitlementExpiryFilterSql = ({
 	includeExpiredLooseEntitlements,
 }: {
@@ -417,8 +414,7 @@ const buildExtraEntitlementsCTE = ({
 }: {
 	includeExpiredLooseEntitlements?: boolean;
 } = {}) => {
-	// Expired loose ents ride a SEPARATE budget (20) so they can never crowd
-	// active ones out of the shared active limit (30).
+	// A separate budget, so expired rows can never crowd out active ones.
 	const expiredBranch = includeExpiredLooseEntitlements
 		? sql`
         UNION ALL
@@ -549,7 +545,6 @@ export const getFullCusQuery = ({
 	entityId?: string;
 	cusProductLimit: number;
 	entitiesLimit?: number;
-	/** Internal dashboard only: also hydrate EXPIRED loose entitlements. */
 	includeExpiredLooseEntitlements?: boolean;
 }) => {
 	const sqlChunks: SQL[] = [];

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -21,6 +21,7 @@ const RECURRING_BILLING_INTERVALS = [
 ] as const;
 
 export const EXTRA_CUSTOMER_ENTITLEMENT_LIMIT = 30;
+export const EXPIRED_EXTRA_CUSTOMER_ENTITLEMENT_LIMIT = 20;
 export const POOLED_CUSTOMER_ENTITLEMENT_LIMIT = 100;
 
 const buildFullCustomerEntitlementJson = ({
@@ -399,7 +400,44 @@ const buildSubscriptionsCTE = (
   `;
 };
 
-const buildExtraEntitlementsCTE = () => {
+// Expiry predicate for LOOSE (extra) customer entitlements only. Internal
+// dashboard reads can bypass it to surface expired loose balances; public
+// hydration paths always keep it.
+const looseEntitlementExpiryFilterSql = ({
+	includeExpiredLooseEntitlements,
+}: {
+	includeExpiredLooseEntitlements: boolean;
+}) =>
+	includeExpiredLooseEntitlements
+		? sql``
+		: sql`AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)`;
+
+const buildExtraEntitlementsCTE = ({
+	includeExpiredLooseEntitlements = false,
+}: {
+	includeExpiredLooseEntitlements?: boolean;
+} = {}) => {
+	// Expired loose ents ride a SEPARATE budget (20) so they can never crowd
+	// active ones out of the shared active limit (30).
+	const expiredBranch = includeExpiredLooseEntitlements
+		? sql`
+        UNION ALL
+        SELECT *
+        FROM (
+          SELECT *
+          FROM customer_entitlements ce
+          WHERE ce.internal_customer_id = (SELECT internal_id FROM customer_record)
+            AND ce.customer_product_id IS NULL
+            AND ce.pooled_balance_id IS NULL
+            AND ce.pooled_contribution_id IS NULL
+            AND ce.expires_at IS NOT NULL
+            AND ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000
+            AND ${looseEntitlementIsLiveSql()}
+          ORDER BY ce.id DESC
+          LIMIT ${EXPIRED_EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
+        ) expired_ce`
+		: sql``;
+
 	return sql`
     extra_customer_entitlements AS (
       SELECT
@@ -412,15 +450,19 @@ const buildExtraEntitlementsCTE = () => {
         ) AS extra_customer_entitlements
       FROM (
         SELECT *
-        FROM customer_entitlements ce
-        WHERE ce.internal_customer_id = (SELECT internal_id FROM customer_record)
-          AND ce.customer_product_id IS NULL
-		  AND ce.pooled_balance_id IS NULL
-		  AND ce.pooled_contribution_id IS NULL
-          AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
-          AND ${looseEntitlementIsLiveSql()}
-        ORDER BY ce.id DESC
-		LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
+        FROM (
+          SELECT *
+          FROM customer_entitlements ce
+          WHERE ce.internal_customer_id = (SELECT internal_id FROM customer_record)
+            AND ce.customer_product_id IS NULL
+            AND ce.pooled_balance_id IS NULL
+            AND ce.pooled_contribution_id IS NULL
+            AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
+            AND ${looseEntitlementIsLiveSql()}
+          ORDER BY ce.id DESC
+          LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
+        ) active_ce
+        ${expiredBranch}
       ) ce
     )
   `;
@@ -493,6 +535,7 @@ export const getFullCusQuery = ({
 	entityId,
 	cusProductLimit,
 	entitiesLimit = 300,
+	includeExpiredLooseEntitlements = false,
 }: {
 	idOrInternalId: string;
 	orgId: string;
@@ -506,6 +549,8 @@ export const getFullCusQuery = ({
 	entityId?: string;
 	cusProductLimit: number;
 	entitiesLimit?: number;
+	/** Internal dashboard only: also hydrate EXPIRED loose entitlements. */
+	includeExpiredLooseEntitlements?: boolean;
 }) => {
 	const sqlChunks: SQL[] = [];
 
@@ -556,7 +601,9 @@ export const getFullCusQuery = ({
 
 	// Unconditionally add extra entitlements CTE
 	sqlChunks.push(sql`, `);
-	sqlChunks.push(buildExtraEntitlementsCTE());
+	sqlChunks.push(
+		buildExtraEntitlementsCTE({ includeExpiredLooseEntitlements }),
+	);
 
 	// Unconditionally add synthetic pooled customer entitlements.
 	sqlChunks.push(sql`, `);
@@ -786,7 +833,7 @@ export const getPaginatedFullCusQuery = ({
         AND ce.customer_product_id IS NULL
 		AND ce.pooled_balance_id IS NULL
 		AND ce.pooled_contribution_id IS NULL
-        AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
+        ${looseEntitlementExpiryFilterSql({ includeExpiredLooseEntitlements: false })}
         AND ${looseEntitlementIsLiveSql()}
         ${customerLevelOnly("ce")}
       ORDER BY ce.id DESC

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -389,7 +389,23 @@ const buildSubscriptionsCTE = (
   `;
 };
 
-const buildExtraEntitlementsCTE = () => {
+// Expiry predicate for LOOSE (extra) customer entitlements only. Internal
+// dashboard reads can bypass it to surface expired loose balances; public
+// hydration paths always keep it.
+const looseEntitlementExpiryFilterSql = ({
+	includeExpiredLooseEntitlements,
+}: {
+	includeExpiredLooseEntitlements: boolean;
+}) =>
+	includeExpiredLooseEntitlements
+		? sql``
+		: sql`AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)`;
+
+const buildExtraEntitlementsCTE = ({
+	includeExpiredLooseEntitlements = false,
+}: {
+	includeExpiredLooseEntitlements?: boolean;
+} = {}) => {
 	return sql`
     extra_customer_entitlements AS (
       SELECT
@@ -407,7 +423,7 @@ const buildExtraEntitlementsCTE = () => {
           AND ce.customer_product_id IS NULL
 		  AND ce.pooled_balance_id IS NULL
 		  AND ce.pooled_contribution_id IS NULL
-          AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
+          ${looseEntitlementExpiryFilterSql({ includeExpiredLooseEntitlements })}
           AND ${looseEntitlementIsLiveSql()}
         ORDER BY ce.id DESC
 		LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
@@ -481,6 +497,7 @@ export const getFullCusQuery = ({
 	entityId,
 	cusProductLimit,
 	entitiesLimit = 300,
+	includeExpiredLooseEntitlements = false,
 }: {
 	idOrInternalId: string;
 	orgId: string;
@@ -494,6 +511,8 @@ export const getFullCusQuery = ({
 	entityId?: string;
 	cusProductLimit: number;
 	entitiesLimit?: number;
+	/** Internal dashboard only: also hydrate EXPIRED loose entitlements. */
+	includeExpiredLooseEntitlements?: boolean;
 }) => {
 	const sqlChunks: SQL[] = [];
 
@@ -544,7 +563,9 @@ export const getFullCusQuery = ({
 
 	// Unconditionally add extra entitlements CTE
 	sqlChunks.push(sql`, `);
-	sqlChunks.push(buildExtraEntitlementsCTE());
+	sqlChunks.push(
+		buildExtraEntitlementsCTE({ includeExpiredLooseEntitlements }),
+	);
 
 	// Unconditionally add synthetic pooled customer entitlements.
 	sqlChunks.push(sql`, `);
@@ -766,7 +787,7 @@ export const getPaginatedFullCusQuery = ({
         AND ce.customer_product_id IS NULL
 		AND ce.pooled_balance_id IS NULL
 		AND ce.pooled_contribution_id IS NULL
-        AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
+        ${looseEntitlementExpiryFilterSql({ includeExpiredLooseEntitlements: false })}
         AND ${looseEntitlementIsLiveSql()}
       ORDER BY ce.id DESC
 	  LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}

--- a/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
+++ b/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
@@ -29,6 +29,8 @@ export const handleGetCustomer = createRoute({
 
 		const expandParam = c.req.query("expand");
 		const entityId = c.req.query("entity_id");
+		const includeExpiredLooseEntitlements =
+			c.req.query("include_expired_loose") === "true";
 		const extraExpands = expandParam
 			? (expandParam.split(",").filter(Boolean) as CustomerExpand[])
 			: [];
@@ -41,6 +43,7 @@ export const handleGetCustomer = createRoute({
 			expand,
 			inStatuses: ALL_STATUSES,
 			entityId: entityId || undefined,
+			includeExpiredLooseEntitlements,
 		});
 
 		const [

--- a/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
+++ b/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
@@ -29,6 +29,9 @@ export const handleGetCustomer = createRoute({
 
 		const expandParam = c.req.query("expand");
 		const entityId = c.req.query("entity_id");
+		// Query middleware coerces "true" to boolean true, so compare via String.
+		const includeExpiredLooseEntitlements =
+			String(c.req.query("include_expired_loose")) === "true";
 		const extraExpands = expandParam
 			? (expandParam.split(",").filter(Boolean) as CustomerExpand[])
 			: [];
@@ -41,6 +44,7 @@ export const handleGetCustomer = createRoute({
 			expand,
 			inStatuses: ALL_STATUSES,
 			entityId: entityId || undefined,
+			includeExpiredLooseEntitlements,
 		});
 
 		const [

--- a/server/tests/balances/check/loose/expired-balances-visibility.test.ts
+++ b/server/tests/balances/check/loose/expired-balances-visibility.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Canonical fixture + contract for expired-balance visibility (dashboard-only):
+ *   - Expired PLAN balances: an expired (canceled) product's cusEnts still
+ *     hydrate under ALL_STATUSES and are classified display-expired via the
+ *     product status (their own expires_at is null).
+ *   - Expired LOOSE balances: hydrate only with includeExpiredLooseEntitlements
+ *     and are classified display-expired via their own expires_at.
+ *   - Public selection (fullCustomerToCustomerEntitlements + default statuses)
+ *     never sees either.
+ *
+ * Leaves customer "expired-balances-visibility" behind for manual dashboard QA:
+ * one live plan (Messages 80), one expired plan (Messages 50), one live loose
+ * (Messages 100), one expired loose (Messages 200).
+ */
+
+import { expect, test } from "bun:test";
+import {
+	ALL_STATUSES,
+	ApiVersion,
+	CusProductStatus,
+	fullCustomerToCustomerEntitlements,
+	isCusEntDisplayExpired,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { CusService } from "@/internal/customers/CusService.js";
+
+function sleepUntil(epochMs: number): Promise<void> {
+	const delay = epochMs - Date.now();
+	if (delay <= 0) return Promise.resolve();
+	return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
+const testCase = "expired-balances-visibility";
+
+test.concurrent(
+	chalk.yellowBright(
+		`${testCase}: expired plan + loose balances hydrate internally and classify display-expired`,
+	),
+	async () => {
+		const customerId = testCase;
+		const churnedProd = products.base({
+			id: "churned",
+			items: [items.monthlyMessages({ includedUsage: 50 })],
+		});
+		const liveProd = products.base({
+			id: "live",
+			items: [items.monthlyMessages({ includedUsage: 80 })],
+		});
+
+		// Attaching liveProd second replaces churnedProd (same main group), so
+		// churnedProd's cusEnts become expired-plan balances.
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [churnedProd, liveProd] }),
+			],
+			actions: [
+				s.attach({ productId: churnedProd.id }),
+				s.attach({ productId: liveProd.id }),
+			],
+		});
+
+		const autumnV1 = new AutumnInt({
+			version: ApiVersion.V1_2,
+			secretKey: ctx.orgSecretKey,
+		});
+
+		const expiresAt = Date.now() + 3000;
+		await autumnV1.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			granted_balance: 200,
+			expires_at: expiresAt,
+		});
+		await autumnV1.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			granted_balance: 100,
+		});
+		await sleepUntil(expiresAt + 1000);
+
+		// Internal hydration (dashboard): everything present.
+		const internalFullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+			inStatuses: ALL_STATUSES,
+			includeExpiredLooseEntitlements: true,
+		});
+
+		const expiredProduct = internalFullCustomer.customer_products.find(
+			(customerProduct) => customerProduct.status === CusProductStatus.Expired,
+		);
+		expect(expiredProduct).toBeDefined();
+		expect(expiredProduct?.customer_entitlements).toHaveLength(1);
+		const expiredPlanEnt = expiredProduct?.customer_entitlements[0];
+		expect(expiredPlanEnt?.balance).toBe(50);
+		// Plan cusEnts carry no expires_at — display-expiry comes from the product.
+		expect(
+			isCusEntDisplayExpired({
+				cusEnt: { ...expiredPlanEnt!, customer_product: expiredProduct! },
+			}),
+		).toBe(true);
+
+		const looseEnts = internalFullCustomer.extra_customer_entitlements ?? [];
+		expect(looseEnts).toHaveLength(2);
+		const expiredLoose = looseEnts.find(
+			(customerEntitlement) => customerEntitlement.expires_at != null,
+		);
+		expect(expiredLoose?.balance).toBe(200);
+		expect(
+			isCusEntDisplayExpired({
+				cusEnt: { ...expiredLoose!, customer_product: null },
+			}),
+		).toBe(true);
+
+		const liveLoose = looseEnts.find(
+			(customerEntitlement) => customerEntitlement.expires_at == null,
+		);
+		expect(
+			isCusEntDisplayExpired({
+				cusEnt: { ...liveLoose!, customer_product: null },
+			}),
+		).toBe(false);
+
+		// Public-shaped read: default statuses + no flag — expired plan and
+		// expired loose are both invisible.
+		const publicFullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		expect(
+			publicFullCustomer.customer_products.some(
+				(customerProduct) =>
+					customerProduct.status === CusProductStatus.Expired,
+			),
+		).toBe(false);
+		expect(publicFullCustomer.extra_customer_entitlements ?? []).toHaveLength(
+			1,
+		);
+
+		// Selection layer over the internal hydration still excludes both.
+		const selected = fullCustomerToCustomerEntitlements({
+			fullCustomer: internalFullCustomer,
+			featureIds: [TestFeature.Messages],
+		});
+		expect(
+			selected.every(
+				(customerEntitlement) =>
+					customerEntitlement.expires_at == null &&
+					customerEntitlement.customer_product?.status !==
+						CusProductStatus.Expired,
+			),
+		).toBe(true);
+	},
+);

--- a/server/tests/balances/check/loose/loose-expired-internal-visibility.test.ts
+++ b/server/tests/balances/check/loose/loose-expired-internal-visibility.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test";
+import { ApiVersion, fullCustomerToCustomerEntitlements } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { CusService } from "@/internal/customers/CusService.js";
+
+function sleepUntil(epochMs: number): Promise<void> {
+	const delay = epochMs - Date.now();
+	if (delay <= 0) return Promise.resolve();
+	return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
+const testCase = "loose-expired-internal-visibility";
+
+test.concurrent(
+	chalk.yellowBright(
+		`${testCase}: includeExpiredLooseEntitlements hydrates expired loose ents for internal reads only`,
+	),
+	async () => {
+		const customerId = testCase;
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const freeProd = products.base({ id: "free", items: [messagesItem] });
+
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [],
+		});
+
+		const autumnV1 = new AutumnInt({
+			version: ApiVersion.V1_2,
+			secretKey: ctx.orgSecretKey,
+		});
+
+		const expiresAt = Date.now() + 3000;
+
+		// One loose balance that expires shortly, one that never expires.
+		await autumnV1.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			granted_balance: 200,
+			expires_at: expiresAt,
+		});
+
+		await autumnV1.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			granted_balance: 100,
+		});
+
+		await sleepUntil(expiresAt + 1000);
+
+		// Default (public) hydration: the expired loose entitlement is dropped in SQL.
+		const publicFullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+
+		const publicLooseEnts =
+			publicFullCustomer.extra_customer_entitlements ?? [];
+		expect(publicLooseEnts).toHaveLength(1);
+		expect(publicLooseEnts[0]?.expires_at).toBeNull();
+		expect(publicLooseEnts[0]?.balance).toBe(100);
+
+		// Internal dashboard hydration: the expired loose entitlement is included.
+		const internalFullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			includeExpiredLooseEntitlements: true,
+		});
+
+		const internalLooseEnts =
+			internalFullCustomer.extra_customer_entitlements ?? [];
+		expect(internalLooseEnts).toHaveLength(2);
+
+		const expiredLooseEnt = internalLooseEnts.find(
+			(customerEntitlement) => customerEntitlement.expires_at != null,
+		);
+		expect(expiredLooseEnt).toBeDefined();
+		expect(expiredLooseEnt?.expires_at).toBe(expiresAt);
+		expect(expiredLooseEnt?.balance).toBe(200);
+
+		// Even with the expired row hydrated, the TS selection layer still filters
+		// it out — public read paths stay byte-identical.
+		const selectedCustomerEntitlements = fullCustomerToCustomerEntitlements({
+			fullCustomer: internalFullCustomer,
+			featureIds: [TestFeature.Messages],
+		});
+
+		expect(
+			selectedCustomerEntitlements.every(
+				(customerEntitlement) => customerEntitlement.expires_at == null,
+			),
+		).toBe(true);
+		expect(
+			selectedCustomerEntitlements.some(
+				(customerEntitlement) => customerEntitlement.balance === 100,
+			),
+		).toBe(true);
+	},
+);

--- a/server/tests/balances/check/loose/max-limits-horror.test.ts
+++ b/server/tests/balances/check/loose/max-limits-horror.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Stress fixture + bounds contract for loose entitlement hydration budgets:
+ *   - Active loose ents share a single LIMIT 30 (EXTRA_CUSTOMER_ENTITLEMENT_LIMIT).
+ *   - Expired loose ents ride a SEPARATE LIMIT 20 bucket (dashboard flag only),
+ *     so they can never crowd active ones out.
+ *
+ * Seeds customer "max-limits-horror" with 35 live + 25 expired loose Messages
+ * balances and leaves it behind for manual dashboard QA of the bounded view.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	ALL_STATUSES,
+	ApiVersion,
+	CusProductStatus,
+	isCusEntExpired,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import {
+	EXPIRED_EXTRA_CUSTOMER_ENTITLEMENT_LIMIT,
+	EXTRA_CUSTOMER_ENTITLEMENT_LIMIT,
+} from "@/internal/customers/getFullCusQuery.js";
+
+function sleepUntil(epochMs: number): Promise<void> {
+	const delay = epochMs - Date.now();
+	if (delay <= 0) return Promise.resolve();
+	return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
+const testCase = "max-limits-horror";
+const LIVE_COUNT = EXTRA_CUSTOMER_ENTITLEMENT_LIMIT + 5;
+const EXPIRED_COUNT = EXPIRED_EXTRA_CUSTOMER_ENTITLEMENT_LIMIT + 5;
+// Default cusProductLimit is 15; 16 sequential attaches of the same main
+// product leave 15 expired + 1 active, pressing the plan hydration bound too.
+const ATTACH_COUNT = 16;
+const CUS_PRODUCT_LIMIT = 15;
+
+test.concurrent(
+	chalk.yellowBright(
+		`${testCase}: loose hydration caps at 30 active + 20 expired`,
+	),
+	async () => {
+		const customerId = testCase;
+		const planA = products.base({
+			id: "horror-a",
+			items: [items.monthlyMessages({ includedUsage: 10 })],
+		});
+		const planB = products.base({
+			id: "horror-b",
+			items: [items.monthlyMessages({ includedUsage: 10 })],
+		});
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [planA, planB] }),
+			],
+			actions: [],
+		});
+
+		// Alternating attaches of two main plans: each attach expires the other,
+		// leaving ATTACH_COUNT - 1 expired + 1 active.
+		for (let i = 0; i < ATTACH_COUNT; i++) {
+			await autumnV2_3.attach({
+				customer_id: customerId,
+				product_id: i % 2 === 0 ? planA.id : planB.id,
+			});
+		}
+
+		const autumnV1 = new AutumnInt({
+			version: ApiVersion.V1_2,
+			secretKey: ctx.orgSecretKey,
+		});
+
+		const expiresAt = Date.now() + 8000;
+		for (let i = 0; i < EXPIRED_COUNT; i++) {
+			await autumnV1.balances.create({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				granted_balance: 1000 + i,
+				expires_at: expiresAt,
+			});
+		}
+		for (let i = 0; i < LIVE_COUNT; i++) {
+			await autumnV1.balances.create({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				granted_balance: i + 1,
+			});
+		}
+		await sleepUntil(expiresAt + 1000);
+
+		// Flag off: exactly the active budget, no expired rows.
+		const publicFullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const publicLoose = publicFullCustomer.extra_customer_entitlements ?? [];
+		expect(publicLoose).toHaveLength(EXTRA_CUSTOMER_ENTITLEMENT_LIMIT);
+		expect(publicLoose.every((cusEnt) => !isCusEntExpired({ cusEnt }))).toBe(
+			true,
+		);
+
+		// Flag on: active budget untouched PLUS the separate expired budget.
+		const internalFullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			includeExpiredLooseEntitlements: true,
+		});
+		const internalLoose =
+			internalFullCustomer.extra_customer_entitlements ?? [];
+		const activeCount = internalLoose.filter(
+			(cusEnt) => !isCusEntExpired({ cusEnt }),
+		).length;
+		const expiredCount = internalLoose.filter((cusEnt) =>
+			isCusEntExpired({ cusEnt }),
+		).length;
+
+		expect(activeCount).toBe(EXTRA_CUSTOMER_ENTITLEMENT_LIMIT);
+		expect(expiredCount).toBe(EXPIRED_EXTRA_CUSTOMER_ENTITLEMENT_LIMIT);
+
+		// Plan side: hydration bounded by cusProductLimit, active plan always
+		// survives (relevant statuses sort ahead of expired before the LIMIT).
+		const dashboardFullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+			inStatuses: ALL_STATUSES,
+			includeExpiredLooseEntitlements: true,
+		});
+		const customerProducts = dashboardFullCustomer.customer_products;
+		expect(customerProducts.length).toBeLessThanOrEqual(CUS_PRODUCT_LIMIT);
+		expect(
+			customerProducts.filter(
+				(customerProduct) => customerProduct.status === CusProductStatus.Active,
+			),
+		).toHaveLength(1);
+		expect(
+			customerProducts.some(
+				(customerProduct) =>
+					customerProduct.status === CusProductStatus.Expired,
+			),
+		).toBe(true);
+	},
+	{ timeout: 180_000 },
+);

--- a/server/tests/scenarios/balances/expired-balances-scenario.test.ts
+++ b/server/tests/scenarios/balances/expired-balances-scenario.test.ts
@@ -1,0 +1,113 @@
+import { test } from "bun:test";
+import { ApiVersion } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+const sleepUntil = (epochMs: number): Promise<void> =>
+	new Promise((resolve) =>
+		setTimeout(resolve, Math.max(epochMs - Date.now(), 0)),
+	);
+
+/**
+ * Seeds a customer with every expired-balance shape the dashboard can render,
+ * so the greyed-out rows, their sort order and their disabled actions can be
+ * checked by hand. Left behind on purpose.
+ */
+test(
+	`${chalk.yellowBright("scenario: expired balances for dashboard QA")}`,
+	async () => {
+		const customerId = "expired-balances-qa";
+
+		const churned = products.base({
+			id: "expired-qa-churned",
+			items: [
+				items.monthlyMessages({ includedUsage: 50 }),
+				items.monthlyWords({ includedUsage: 500 }),
+			],
+		});
+		const live = products.base({
+			id: "expired-qa-live",
+			items: [
+				items.monthlyMessages({ includedUsage: 80 }),
+				items.monthlyWords({ includedUsage: 900 }),
+			],
+		});
+
+		// Attaching live second replaces churned (same main group), so churned's
+		// entitlements become expired-plan balances.
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [churned, live] }),
+			],
+			actions: [
+				s.attach({ productId: churned.id }),
+				s.attach({ productId: live.id }),
+			],
+		});
+
+		const autumnV1 = new AutumnInt({
+			version: ApiVersion.V1_2,
+			secretKey: ctx.orgSecretKey,
+		});
+
+		const expiresAt = Date.now() + 3_000;
+
+		// Two loose balances that will expire, on different features.
+		await autumnV1.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			granted_balance: 200,
+			expires_at: expiresAt,
+		});
+		await autumnV1.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Words,
+			granted_balance: 1_000,
+			expires_at: expiresAt,
+		});
+
+		// Live loose balances alongside them, so the table mixes both states.
+		await autumnV1.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			granted_balance: 100,
+		});
+		await autumnV1.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Words,
+			granted_balance: 250,
+		});
+
+		// Usage on the live plan, so active rows show a partially filled bar.
+		await autumnV1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 30,
+		});
+
+		await sleepUntil(expiresAt + 1_000);
+
+		console.log(chalk.bold("\n─── seeded for dashboard QA ───"));
+		console.log({
+			customerId,
+			expiredPlan: `${churned.id} (Messages 50, Words 500)`,
+			livePlan: `${live.id} (Messages 80, Words 900)`,
+			expiredLoose: "Messages 200, Words 1000",
+			liveLoose: "Messages 100, Words 250",
+			tracked: "30 messages against the live plan",
+			checkInDashboard: [
+				"Plans filter → include Expired: the churned plan and its balances appear, greyed",
+				"Expired rows sort last and never change the totals or usage bars",
+				"Expired plan rows: no edit, no record usage, no delete",
+				"Expired loose rows: delete is the only action left",
+			],
+		});
+	},
+	{ timeout: 180_000 },
+);

--- a/shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts
+++ b/shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts
@@ -1,0 +1,14 @@
+import type { FullCusEntWithFullCusProduct } from "../../../models/cusProductModels/cusEntModels/cusEntWithProduct.js";
+import { CusProductStatus } from "../../../models/cusProductModels/cusProductEnums.js";
+import { isCusEntExpired } from "./isCusEntExpired.js";
+
+/** Expired by its own clock, or orphaned by a churned (expired) plan. */
+export const isCusEntDisplayExpired = ({
+	cusEnt,
+	now,
+}: {
+	cusEnt: Pick<FullCusEntWithFullCusProduct, "expires_at" | "customer_product">;
+	now?: number;
+}): boolean =>
+	isCusEntExpired({ cusEnt, now }) ||
+	cusEnt.customer_product?.status === CusProductStatus.Expired;

--- a/shared/utils/cusEntUtils/classifyCusEnt/isCusEntExpired.ts
+++ b/shared/utils/cusEntUtils/classifyCusEnt/isCusEntExpired.ts
@@ -1,0 +1,9 @@
+import type { FullCustomerEntitlement } from "../../../models/cusProductModels/cusEntModels/cusEntModels.js";
+
+export const isCusEntExpired = ({
+	cusEnt,
+	now = Date.now(),
+}: {
+	cusEnt: Pick<FullCustomerEntitlement, "expires_at">;
+	now?: number;
+}) => cusEnt.expires_at != null && cusEnt.expires_at <= now;

--- a/shared/utils/cusEntUtils/index.ts
+++ b/shared/utils/cusEntUtils/index.ts
@@ -28,6 +28,8 @@ export * from "./balanceUtils/rollovers/cusEntsToRolloverUsage";
 export * from "./classifyCusEnt/cusEntsHaveUnlimited";
 export * from "./classifyCusEnt/cusEntsHaveUsageAllowed";
 export * from "./classifyCusEnt/customerEntitlementFundsFeature";
+export * from "./classifyCusEnt/isCusEntDisplayExpired";
+export * from "./classifyCusEnt/isCusEntExpired";
 export * from "./classifyCusEnt/isPooledBalanceCustomerEntitlement";
 // Classify utils
 export * from "./classifyCusEntUtils";

--- a/shared/utils/cusEntUtils/index.ts
+++ b/shared/utils/cusEntUtils/index.ts
@@ -27,6 +27,7 @@ export * from "./balanceUtils/rollovers/cusEntsToRolloverUsage";
 export * from "./balanceUtils/rollovers/cusEntsToRolloverUsage";
 export * from "./classifyCusEnt/cusEntsHaveUnlimited";
 export * from "./classifyCusEnt/cusEntsHaveUsageAllowed";
+export * from "./classifyCusEnt/isCusEntExpired";
 export * from "./classifyCusEnt/isPooledBalanceCustomerEntitlement";
 // Classify utils
 export * from "./classifyCusEntUtils";

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts
@@ -22,6 +22,7 @@ export const fullCustomerToCustomerEntitlements = ({
 	entity,
 	customerEntitlementFilters,
 	isRefund = false,
+	includeExpired = false,
 }: {
 	fullCustomer: FullCustomer;
 	inStatuses?: CusProductStatus[];
@@ -34,6 +35,8 @@ export const fullCustomerToCustomerEntitlements = ({
 	entity?: Entity;
 	customerEntitlementFilters?: CustomerEntitlementFilters;
 	isRefund?: boolean;
+	/** Dashboard-only: keep expired loose rows so they stay deletable. */
+	includeExpired?: boolean;
 }) => {
 	const cusProducts = fullCustomer.customer_products;
 	let cusEnts: FullCusEntWithFullCusProduct[] = [];
@@ -107,10 +110,11 @@ export const fullCustomerToCustomerEntitlements = ({
 		);
 	}
 
-	// Filter out expired entitlements (applies to loose entitlements with expires_at)
-	// This is necessary because cached fullCustomer may contain entitlements that have since expired
+	// A cached fullCustomer can hold rows that have since expired.
 	const now = Date.now();
-	cusEnts = cusEnts.filter((cusEnt) => !isCusEntExpired({ cusEnt, now }));
+	if (!includeExpired) {
+		cusEnts = cusEnts.filter((cusEnt) => !isCusEntExpired({ cusEnt, now }));
+	}
 
 	sortCusEntsForDeduction({
 		cusEnts,

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts
@@ -5,6 +5,7 @@ import type { FullCustomer } from "../../../models/cusModels/fullCusModel.js";
 import type { CustomerEntitlementFilters } from "../../../models/cusProductModels/cusEntModels/cusEntModels.js";
 import type { FullCusEntWithFullCusProduct } from "../../../models/cusProductModels/cusEntModels/cusEntWithProduct.js";
 import { CusProductStatus } from "../../../models/cusProductModels/cusProductEnums.js";
+import { isCusEntExpired } from "../../cusEntUtils/classifyCusEnt/isCusEntExpired.js";
 import { isPooledBalanceSourceCustomerEntitlement } from "../../cusEntUtils/classifyCusEnt/isPooledBalanceCustomerEntitlement.js";
 import { cusEntMatchesEntity } from "../../cusEntUtils/filterCusEntUtils.js";
 import { sortCusEntsForDeduction } from "../../cusEntUtils/sortCusEntsForDeduction.js";
@@ -95,9 +96,7 @@ export const fullCustomerToCustomerEntitlements = ({
 	// Filter out expired entitlements (applies to loose entitlements with expires_at)
 	// This is necessary because cached fullCustomer may contain entitlements that have since expired
 	const now = Date.now();
-	cusEnts = cusEnts.filter(
-		(cusEnt) => !cusEnt.expires_at || cusEnt.expires_at > now,
-	);
+	cusEnts = cusEnts.filter((cusEnt) => !isCusEntExpired({ cusEnt, now }));
 
 	sortCusEntsForDeduction({
 		cusEnts,

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts
@@ -35,7 +35,6 @@ export const fullCustomerToCustomerEntitlements = ({
 	entity?: Entity;
 	customerEntitlementFilters?: CustomerEntitlementFilters;
 	isRefund?: boolean;
-	/** Dashboard-only: keep expired loose rows so they stay deletable. */
 	includeExpired?: boolean;
 }) => {
 	const cusProducts = fullCustomer.customer_products;
@@ -110,7 +109,6 @@ export const fullCustomerToCustomerEntitlements = ({
 		);
 	}
 
-	// A cached fullCustomer can hold rows that have since expired.
 	const now = Date.now();
 	if (!includeExpired) {
 		cusEnts = cusEnts.filter((cusEnt) => !isCusEntExpired({ cusEnt, now }));

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts
@@ -6,6 +6,7 @@ import type { FullCustomer } from "../../../models/cusModels/fullCusModel.js";
 import type { CustomerEntitlementFilters } from "../../../models/cusProductModels/cusEntModels/cusEntModels.js";
 import type { FullCusEntWithFullCusProduct } from "../../../models/cusProductModels/cusEntModels/cusEntWithProduct.js";
 import { CusProductStatus } from "../../../models/cusProductModels/cusProductEnums.js";
+import { isCusEntExpired } from "../../cusEntUtils/classifyCusEnt/isCusEntExpired.js";
 import { isPooledBalanceSourceCustomerEntitlement } from "../../cusEntUtils/classifyCusEnt/isPooledBalanceCustomerEntitlement.js";
 import { cusEntMatchesEntity } from "../../cusEntUtils/filterCusEntUtils.js";
 import { sortCusEntsForDeduction } from "../../cusEntUtils/sortCusEntsForDeduction.js";
@@ -109,9 +110,7 @@ export const fullCustomerToCustomerEntitlements = ({
 	// Filter out expired entitlements (applies to loose entitlements with expires_at)
 	// This is necessary because cached fullCustomer may contain entitlements that have since expired
 	const now = Date.now();
-	cusEnts = cusEnts.filter(
-		(cusEnt) => !cusEnt.expires_at || cusEnt.expires_at > now,
-	);
+	cusEnts = cusEnts.filter((cusEnt) => !isCusEntExpired({ cusEnt, now }));
 
 	sortCusEntsForDeduction({
 		cusEnts,

--- a/shared/utils/fullSubjectUtils/fullSubjectToCustomerEntitlements.ts
+++ b/shared/utils/fullSubjectUtils/fullSubjectToCustomerEntitlements.ts
@@ -4,6 +4,7 @@ import type { CustomerEntitlementFilters } from "../../models/cusProductModels/c
 import type { FullCusEntWithFullCusProduct } from "../../models/cusProductModels/cusEntModels/cusEntWithProduct.js";
 import { CusProductStatus } from "../../models/cusProductModels/cusProductEnums.js";
 import { customerEntitlementFundsFeature } from "../cusEntUtils/classifyCusEnt/customerEntitlementFundsFeature.js";
+import { isCusEntExpired } from "../cusEntUtils/classifyCusEnt/isCusEntExpired.js";
 import { isPooledBalanceSourceCustomerEntitlement } from "../cusEntUtils/classifyCusEnt/isPooledBalanceCustomerEntitlement.js";
 import { cusEntMatchesEntity } from "../cusEntUtils/filterCusEntUtils.js";
 import { sortCusEntsForDeduction } from "../cusEntUtils/sortCusEntsForDeduction.js";
@@ -68,12 +69,11 @@ export const fullSubjectToCustomerEntitlements = ({
 	}
 
 	if (fundsFeatureId) {
-		customerEntitlements = customerEntitlements.filter(
-			(customerEntitlement) =>
-				customerEntitlementFundsFeature({
-					customerEntitlement,
-					featureId: fundsFeatureId,
-				}),
+		customerEntitlements = customerEntitlements.filter((customerEntitlement) =>
+			customerEntitlementFundsFeature({
+				customerEntitlement,
+				featureId: fundsFeatureId,
+			}),
 		);
 	}
 
@@ -87,7 +87,7 @@ export const fullSubjectToCustomerEntitlements = ({
 	const now = Date.now();
 	customerEntitlements = customerEntitlements.filter(
 		(customerEntitlement) =>
-			!customerEntitlement.expires_at || customerEntitlement.expires_at > now,
+			!isCusEntExpired({ cusEnt: customerEntitlement, now }),
 	);
 
 	sortCusEntsForDeduction({

--- a/shared/utils/fullSubjectUtils/fullSubjectToCustomerEntitlements.ts
+++ b/shared/utils/fullSubjectUtils/fullSubjectToCustomerEntitlements.ts
@@ -3,6 +3,7 @@ import type { FullSubject } from "../../models/cusModels/fullSubject/fullSubject
 import type { CustomerEntitlementFilters } from "../../models/cusProductModels/cusEntModels/cusEntModels.js";
 import type { FullCusEntWithFullCusProduct } from "../../models/cusProductModels/cusEntModels/cusEntWithProduct.js";
 import { CusProductStatus } from "../../models/cusProductModels/cusProductEnums.js";
+import { isCusEntExpired } from "../cusEntUtils/classifyCusEnt/isCusEntExpired.js";
 import { isPooledBalanceSourceCustomerEntitlement } from "../cusEntUtils/classifyCusEnt/isPooledBalanceCustomerEntitlement.js";
 import { cusEntMatchesEntity } from "../cusEntUtils/filterCusEntUtils.js";
 import { sortCusEntsForDeduction } from "../cusEntUtils/sortCusEntsForDeduction.js";
@@ -72,7 +73,7 @@ export const fullSubjectToCustomerEntitlements = ({
 	const now = Date.now();
 	customerEntitlements = customerEntitlements.filter(
 		(customerEntitlement) =>
-			!customerEntitlement.expires_at || customerEntitlement.expires_at > now,
+			!isCusEntExpired({ cusEnt: customerEntitlement, now }),
 	);
 
 	sortCusEntsForDeduction({

--- a/vite/src/views/customers/customer/hooks/useCusQuery.tsx
+++ b/vite/src/views/customers/customer/hooks/useCusQuery.tsx
@@ -66,6 +66,9 @@ export const useCusQuery = ({
 	const fetcher = async () => {
 		try {
 			const searchParams = new URLSearchParams();
+			// Detail page always shows expired loose entitlements (rendered greyed
+			// out, excluded from all balance math on the client).
+			searchParams.set("include_expired_loose", "true");
 			if (effectiveEntityId) searchParams.set("entity_id", effectiveEntityId);
 			const query = searchParams.toString();
 			const { data } = await axiosInstance.get(

--- a/vite/src/views/customers/customer/hooks/useCusQuery.tsx
+++ b/vite/src/views/customers/customer/hooks/useCusQuery.tsx
@@ -8,6 +8,7 @@ import {
 	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
+import { parseAsArrayOf, parseAsStringEnum, useQueryState } from "nuqs";
 import { useMemo } from "react";
 import { useParams } from "react-router";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
@@ -16,6 +17,10 @@ import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useEntity } from "@/hooks/stores/useSubscriptionStore";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { throwBackendError } from "@/utils/genUtils";
+import {
+	type CustomerProductsStatusOption,
+	DEFAULT_PRODUCT_STATUSES,
+} from "@/views/customers2/hooks/useCustomerProductsTableState";
 import { useCachedCustomer } from "./useCachedCustomer";
 
 type UseCusQueryOptions = {
@@ -63,9 +68,22 @@ export const useCusQuery = ({
 
 	const effectiveEntityId = entityAlreadyLoaded ? null : entityId;
 
+	// Same nuqs key as the Plans filter: expired rows are fetched only when
+	// "Expired" is among the selected statuses.
+	const [productStatuses] = useQueryState(
+		"customerProductsStatuses",
+		parseAsArrayOf(
+			parseAsStringEnum<CustomerProductsStatusOption>(["active", "expired"]),
+		).withDefault(DEFAULT_PRODUCT_STATUSES),
+	);
+	const includeExpiredLoose = productStatuses.includes("expired");
+
 	const fetcher = async () => {
 		try {
 			const searchParams = new URLSearchParams();
+			if (includeExpiredLoose) {
+				searchParams.set("include_expired_loose", "true");
+			}
 			if (effectiveEntityId) searchParams.set("entity_id", effectiveEntityId);
 			const query = searchParams.toString();
 			const { data } = await axiosInstance.get(
@@ -85,7 +103,12 @@ export const useCusQuery = ({
 		error,
 		refetch,
 	} = useQuery({
-		queryKey: buildKey(["customer", customer_id, effectiveEntityId]),
+		queryKey: buildKey([
+			"customer",
+			customer_id,
+			effectiveEntityId,
+			includeExpiredLoose,
+		]),
 		queryFn: fetcher,
 		enabled: enabled && !!customer_id,
 		retry: false,

--- a/vite/src/views/customers/customer/hooks/useCusQuery.tsx
+++ b/vite/src/views/customers/customer/hooks/useCusQuery.tsx
@@ -68,8 +68,7 @@ export const useCusQuery = ({
 
 	const effectiveEntityId = entityAlreadyLoaded ? null : entityId;
 
-	// Same nuqs key as the Plans filter: expired rows are fetched only when
-	// "Expired" is among the selected statuses.
+	// Same nuqs key as the Plans filter.
 	const [productStatuses] = useQueryState(
 		"customerProductsStatuses",
 		parseAsArrayOf(

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceFeatureCell.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceFeatureCell.tsx
@@ -2,6 +2,7 @@ import {
 	type Entity,
 	type FullCusEntWithFullCusProduct,
 	type FullCustomer,
+	isCusEntDisplayExpired,
 	isSyntheticPooledBalanceCustomerEntitlement,
 } from "@autumn/shared";
 import { CaretRightIcon } from "@phosphor-icons/react";
@@ -42,7 +43,12 @@ export function CustomerBalanceFeatureCell({
 	});
 
 	return (
-		<div className="flex items-center gap-2 min-w-0">
+		<div
+			className={cn(
+				"flex items-center gap-2 min-w-0",
+				isCusEntDisplayExpired({ cusEnt: balance }) && "opacity-50",
+			)}
+		>
 			{canExpand && (
 				<span
 					className={cn(

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceSourceCell.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceSourceCell.tsx
@@ -1,9 +1,11 @@
-import type {
-	Entity,
-	FullCusEntWithFullCusProduct,
-	FullCustomer,
+import {
+	type Entity,
+	type FullCusEntWithFullCusProduct,
+	type FullCustomer,
+	isCusEntDisplayExpired,
 } from "@autumn/shared";
 import { AdminHover } from "@/components/general/AdminHover";
+import { cn } from "@/lib/utils";
 import { getCusEntHoverTexts } from "@/views/admin/adminUtils";
 import { CustomerBalanceBillingIcon } from "./CustomerBalanceBillingIcon";
 import { getCustomerBalanceSourceParts } from "./customerBalanceUtils";
@@ -21,10 +23,13 @@ export function CustomerBalanceSourceCell({
 		getCustomerBalanceSourceParts({ balance, entities, fullCustomer });
 	const hasPlan = productName !== "No plan";
 	const metaParts = [intervalLabel, entityName].filter(Boolean).join(" · ");
+	const expiredClass = isCusEntDisplayExpired({ cusEnt: balance })
+		? "opacity-50"
+		: undefined;
 
 	if (!hasPlan) {
 		return (
-			<div className="flex items-center gap-2 min-w-0">
+			<div className={cn("flex items-center gap-2 min-w-0", expiredClass)}>
 				<CustomerBalanceBillingIcon balance={balance} />
 				<AdminHover
 					texts={getCusEntHoverTexts({

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceSourceCell.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceSourceCell.tsx
@@ -46,7 +46,7 @@ export function CustomerBalanceSourceCell({
 	}
 
 	return (
-		<div className="flex flex-col gap-0.5 min-w-0">
+		<div className={cn("flex flex-col gap-0.5 min-w-0", expiredClass)}>
 			<div className="flex items-center gap-2">
 				<CustomerBalanceBillingIcon balance={balance} />
 				<AdminHover

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
@@ -119,12 +119,8 @@ export function CustomerBalanceTable({
 			return;
 		}
 
-		// Expired balances are view-only — never open the edit sheet for them
-		// (expanding aggregated sub-rows above stays available).
 		if (isCusEntDisplayExpired({ cusEnt: ent })) return;
 
-		// Single balance or sub-row: open edit sheet directly. Expired
-		// entitlements are excluded — the sheet only ever edits active balances.
 		const featureId = ent.entitlement.feature.id;
 		const ents = (aggregatedMap.get(featureId) || [ent]).filter(
 			(aggregatedEnt) => !isCusEntDisplayExpired({ cusEnt: aggregatedEnt }),
@@ -164,8 +160,7 @@ export function CustomerBalanceTable({
 					mobileCards: true,
 					selectedItemId: getSelectedRowId(),
 					rowClassName: "h-10 py-0",
-					// An expired row without sub-rows has no click target, so it must
-					// not inherit the table's default pointer.
+					// No click target, so it must not inherit the table's pointer.
 					getRowClassName: (balance: CustomerBalanceRowData) =>
 						isCusEntDisplayExpired({ cusEnt: balance }) &&
 						(balance.subRows?.length ?? 0) === 0

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
@@ -1,4 +1,7 @@
-import type { FullCusEntWithFullCusProduct } from "@autumn/shared";
+import {
+	type FullCusEntWithFullCusProduct,
+	isCusEntDisplayExpired,
+} from "@autumn/shared";
 import { type ExpandedState, getExpandedRowModel } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import { Table } from "@/components/general/table";
@@ -116,9 +119,16 @@ export function CustomerBalanceTable({
 			return;
 		}
 
-		// Single balance or sub-row: open edit sheet directly
+		// Expired balances are view-only — never open the edit sheet for them
+		// (expanding aggregated sub-rows above stays available).
+		if (isCusEntDisplayExpired({ cusEnt: ent })) return;
+
+		// Single balance or sub-row: open edit sheet directly. Expired
+		// entitlements are excluded — the sheet only ever edits active balances.
 		const featureId = ent.entitlement.feature.id;
-		const ents = aggregatedMap.get(featureId) || [ent];
+		const ents = (aggregatedMap.get(featureId) || [ent]).filter(
+			(aggregatedEnt) => !isCusEntDisplayExpired({ cusEnt: aggregatedEnt }),
+		);
 
 		setBalanceSheet({
 			type: "edit-balance",

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
@@ -164,6 +164,13 @@ export function CustomerBalanceTable({
 					mobileCards: true,
 					selectedItemId: getSelectedRowId(),
 					rowClassName: "h-10 py-0",
+					// An expired row without sub-rows has no click target, so it must
+					// not inherit the table's default pointer.
+					getRowClassName: (balance: CustomerBalanceRowData) =>
+						isCusEntDisplayExpired({ cusEnt: balance }) &&
+						(balance.subRows?.length ?? 0) === 0
+							? "cursor-default!"
+							: undefined,
 				}}
 			>
 				<Table.Container>

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
@@ -1,4 +1,7 @@
-import type { FullCusEntWithFullCusProduct } from "@autumn/shared";
+import {
+	type FullCusEntWithFullCusProduct,
+	isCusEntExpired,
+} from "@autumn/shared";
 import { type ExpandedState, getExpandedRowModel } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import { Table } from "@/components/general/table";
@@ -116,9 +119,16 @@ export function CustomerBalanceTable({
 			return;
 		}
 
-		// Single balance or sub-row: open edit sheet directly
+		// Expired balances are view-only — never open the edit sheet for them
+		// (expanding aggregated sub-rows above stays available).
+		if (isCusEntExpired({ cusEnt: ent })) return;
+
+		// Single balance or sub-row: open edit sheet directly. Expired
+		// entitlements are excluded — the sheet only ever edits active balances.
 		const featureId = ent.entitlement.feature.id;
-		const ents = aggregatedMap.get(featureId) || [ent];
+		const ents = (aggregatedMap.get(featureId) || [ent]).filter(
+			(aggregatedEnt) => !isCusEntExpired({ cusEnt: aggregatedEnt }),
+		);
 
 		setBalanceSheet({
 			type: "edit-balance",

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -458,8 +458,14 @@ function BalanceActionsCell({
 			: [row.original]
 	).filter((ent) => !isCusEntDisplayExpired({ cusEnt: ent }));
 
+	// A row with no actions still reserves the slot, so the column edge stays
+	// straight rather than going ragged down the table.
 	if (!canDelete && !canRecordUsage && !canCheckBalance && !canRecalculate)
-		return null;
+		return (
+			<div className="flex justify-end" aria-hidden>
+				<ToolbarButton className="invisible" tabIndex={-1} />
+			</div>
+		);
 
 	return (
 		<div className="flex justify-end">

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -9,6 +9,7 @@ import {
 	cusEntsToPrepaidQuantity,
 	cusEntsToUnlimitedUsage,
 	getRolloverFields,
+	isCusEntDisplayExpired,
 	nullish,
 } from "@autumn/shared";
 import {
@@ -41,6 +42,16 @@ import {
 	canDeleteCustomerBalance,
 	canRecalculateCustomerBalances,
 } from "./customerBalanceUtils";
+
+/** Expired entitlements are display-only: they must never feed sums or usage bars. */
+function getActiveRowEntitlements(
+	row: Row<CustomerBalanceRowData>,
+): FullCusEntWithFullCusProduct[] {
+	const ents = row.original.subRows?.length
+		? row.original.subRows
+		: [row.original];
+	return ents.filter((ent) => !isCusEntDisplayExpired({ cusEnt: ent }));
+}
 
 /** Computes balance values from a single entitlement (for sub-rows) */
 function getIndividualEntValues({
@@ -171,6 +182,28 @@ function SubRowUsageCell({
 	);
 }
 
+/** Frozen balance, greyed out — no aggregation hooks run for an expired row. */
+function ExpiredUsageCell({
+	ent,
+	entityId,
+}: {
+	ent: FullCusEntWithFullCusProduct;
+	entityId: string | null;
+}) {
+	if (ent.unlimited) {
+		return (
+			<span className="text-tertiary-foreground opacity-50">Unlimited</span>
+		);
+	}
+	const { balance, allowance } = getIndividualEntValues({ ent, entityId });
+	const format = new Intl.NumberFormat().format;
+	return (
+		<span className="text-tertiary-foreground opacity-50">
+			{format(balance)} / {format(allowance)} left
+		</span>
+	);
+}
+
 function UsageCell({
 	row,
 	fullCustomer,
@@ -182,6 +215,9 @@ function UsageCell({
 	entityId: string | null;
 	customerEntitlements?: FullCusEntWithFullCusProduct[];
 }) {
+	if (isCusEntDisplayExpired({ cusEnt: row.original })) {
+		return <ExpiredUsageCell ent={row.original} entityId={entityId} />;
+	}
 	if (row.depth > 0) {
 		return <SubRowUsageCell ent={row.original} entityId={entityId} />;
 	}
@@ -205,17 +241,35 @@ const formatChipDate = (timestamp: number | null | undefined) => {
 
 function BalanceExpiryIcon({
 	expiresAt,
+	forceExpired = false,
 }: {
 	expiresAt: number | null | undefined;
+	/** A churned plan's row is dead even if its own expires_at is in the future. */
+	forceExpired?: boolean;
 }) {
+	const expiredByClock = expiresAt != null && expiresAt <= Date.now();
+	const hasExpired = forceExpired || expiredByClock;
+	// A row expired only by its plan has no meaningful date of its own.
+	const label = hasExpired ? "Expired" : "Expires";
+	const date =
+		expiredByClock || !hasExpired ? ` ${formatChipDate(expiresAt)}` : "";
+
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
-				<div className="shrink-0 text-amber-500">
+				<div
+					className={cn(
+						"shrink-0",
+						hasExpired ? "text-tertiary-foreground" : "text-amber-500",
+					)}
+				>
 					<ClockCountdownIcon size={14} weight="duotone" />
 				</div>
 			</TooltipTrigger>
-			<TooltipContent>Expires {formatChipDate(expiresAt)}</TooltipContent>
+			<TooltipContent>
+				{label}
+				{date}
+			</TooltipContent>
 		</Tooltip>
 	);
 }
@@ -322,6 +376,18 @@ function SubRowBarCell({
 	);
 }
 
+/** Keeps the layout slot for an expired row: expiry icon only, no bar or chip. */
+function ExpiredBarCell({ ent }: { ent: FullCusEntWithFullCusProduct }) {
+	return (
+		<div className="flex gap-3 items-center opacity-50">
+			<div className="flex items-center justify-end gap-1.5 shrink-0 min-w-44">
+				<BalanceExpiryIcon expiresAt={ent.expires_at} forceExpired />
+			</div>
+			<div className="w-full max-w-50 min-w-16" />
+		</div>
+	);
+}
+
 function BarCell({
 	row,
 	fullCustomer,
@@ -333,6 +399,9 @@ function BarCell({
 	entityId: string | null;
 	customerEntitlements?: FullCusEntWithFullCusProduct[];
 }) {
+	if (isCusEntDisplayExpired({ cusEnt: row.original })) {
+		return <ExpiredBarCell ent={row.original} />;
+	}
 	if (row.depth > 0) {
 		return <SubRowBarCell ent={row.original} entityId={entityId} />;
 	}
@@ -363,12 +432,19 @@ function BalanceActionsCell({
 	onCheckBalanceClick?: (balance: FullCusEntWithFullCusProduct) => void;
 	onRecalculateClick?: (balance: FullCusEntWithFullCusProduct) => void;
 }) {
+	// Delete is the only cleanup path for an expired loose row.
+	const expired = isCusEntDisplayExpired({ cusEnt: row.original });
+
 	const isParentRow = row.depth === 0;
+	// Plan balances are strictly view-only; only loose rows keep delete.
 	const canDelete =
-		!row.getCanExpand() && canDeleteCustomerBalance({ balance: row.original });
-	const canRecordUsage = isParentRow && !!onRecordUsageClick;
-	const canCheckBalance = isParentRow && !!onCheckBalanceClick;
+		!row.getCanExpand() &&
+		canDeleteCustomerBalance({ balance: row.original }) &&
+		(!expired || !row.original.customer_product);
+	const canRecordUsage = !expired && isParentRow && !!onRecordUsageClick;
+	const canCheckBalance = !expired && isParentRow && !!onCheckBalanceClick;
 	const canRecalculate =
+		!expired &&
 		isParentRow &&
 		!!onRecalculateClick &&
 		canRecalculateCustomerBalances({
@@ -376,10 +452,11 @@ function BalanceActionsCell({
 			featureId: row.original.entitlement.feature.id,
 			entityId,
 		});
-	const customerEntitlements =
+	const customerEntitlements = (
 		row.subRows.length > 0
 			? row.subRows.map((subRow) => subRow.original)
-			: [row.original];
+			: [row.original]
+	).filter((ent) => !isCusEntDisplayExpired({ cusEnt: ent }));
 
 	if (!canDelete && !canRecordUsage && !canCheckBalance && !canRecalculate)
 		return null;
@@ -475,6 +552,28 @@ function MobileBalanceBar({
 	entityId: string | null;
 	customerEntitlements: FullCusEntWithFullCusProduct[];
 }) {
+	if (isCusEntDisplayExpired({ cusEnt: ent })) return null;
+	return (
+		<MobileBalanceBarContent
+			ent={ent}
+			fullCustomer={fullCustomer}
+			entityId={entityId}
+			customerEntitlements={customerEntitlements}
+		/>
+	);
+}
+
+function MobileBalanceBarContent({
+	ent,
+	fullCustomer,
+	entityId,
+	customerEntitlements,
+}: {
+	ent: FullCusEntWithFullCusProduct;
+	fullCustomer: FullCustomer | null | undefined;
+	entityId: string | null;
+	customerEntitlements: FullCusEntWithFullCusProduct[];
+}) {
 	const { allowance, balance, quantity } = useFeatureUsageBalance({
 		fullCustomer,
 		featureId: ent.entitlement.feature.id,
@@ -505,9 +604,7 @@ function MobileUsageWithBar({
 	fullCustomer: FullCustomer | null | undefined;
 	entityId: string | null;
 }) {
-	const customerEntitlements = row.original.subRows?.length
-		? row.original.subRows
-		: [row.original];
+	const customerEntitlements = getActiveRowEntitlements(row);
 
 	return (
 		<div className="flex items-center justify-between gap-3">
@@ -577,9 +674,7 @@ export const CustomerBalanceTableColumns = ({
 				row={row}
 				fullCustomer={fullCustomer}
 				entityId={entityId}
-				customerEntitlements={
-					row.original.subRows?.length ? row.original.subRows : [row.original]
-				}
+				customerEntitlements={getActiveRowEntitlements(row)}
 			/>
 		),
 	},
@@ -593,9 +688,7 @@ export const CustomerBalanceTableColumns = ({
 				row={row}
 				fullCustomer={fullCustomer}
 				entityId={entityId}
-				customerEntitlements={
-					row.original.subRows?.length ? row.original.subRows : [row.original]
-				}
+				customerEntitlements={getActiveRowEntitlements(row)}
 			/>
 		),
 	},

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -43,7 +43,6 @@ import {
 	canRecalculateCustomerBalances,
 } from "./customerBalanceUtils";
 
-/** Expired entitlements are display-only: they must never feed sums or usage bars. */
 function getActiveRowEntitlements(
 	row: Row<CustomerBalanceRowData>,
 ): FullCusEntWithFullCusProduct[] {
@@ -182,7 +181,6 @@ function SubRowUsageCell({
 	);
 }
 
-/** Frozen balance, greyed out — no aggregation hooks run for an expired row. */
 function ExpiredUsageCell({
 	ent,
 	entityId,
@@ -249,7 +247,6 @@ function BalanceExpiryIcon({
 }) {
 	const expiredByClock = expiresAt != null && expiresAt <= Date.now();
 	const hasExpired = forceExpired || expiredByClock;
-	// A row expired only by its plan has no meaningful date of its own.
 	const label = hasExpired ? "Expired" : "Expires";
 	const date =
 		expiredByClock || !hasExpired ? ` ${formatChipDate(expiresAt)}` : "";
@@ -376,7 +373,6 @@ function SubRowBarCell({
 	);
 }
 
-/** Keeps the layout slot for an expired row: expiry icon only, no bar or chip. */
 function ExpiredBarCell({ ent }: { ent: FullCusEntWithFullCusProduct }) {
 	return (
 		<div className="flex gap-3 items-center opacity-50">
@@ -432,11 +428,9 @@ function BalanceActionsCell({
 	onCheckBalanceClick?: (balance: FullCusEntWithFullCusProduct) => void;
 	onRecalculateClick?: (balance: FullCusEntWithFullCusProduct) => void;
 }) {
-	// Delete is the only cleanup path for an expired loose row.
 	const expired = isCusEntDisplayExpired({ cusEnt: row.original });
 
 	const isParentRow = row.depth === 0;
-	// Plan balances are strictly view-only; only loose rows keep delete.
 	const canDelete =
 		!row.getCanExpand() &&
 		canDeleteCustomerBalance({ balance: row.original }) &&
@@ -458,8 +452,7 @@ function BalanceActionsCell({
 			: [row.original]
 	).filter((ent) => !isCusEntDisplayExpired({ cusEnt: ent }));
 
-	// A row with no actions still reserves the slot, so the column edge stays
-	// straight rather than going ragged down the table.
+	// Reserve the slot, or the column edge goes ragged.
 	if (!canDelete && !canRecordUsage && !canCheckBalance && !canRecalculate)
 		return (
 			<div className="flex justify-end" aria-hidden>

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -9,6 +9,7 @@ import {
 	cusEntsToPrepaidQuantity,
 	cusEntsToUnlimitedUsage,
 	getRolloverFields,
+	isCusEntExpired,
 	isFreeCustomerEntitlement,
 	isPrepaidCustomerEntitlement,
 	isSyntheticPooledBalanceCustomerEntitlement,
@@ -50,6 +51,19 @@ import {
 	canRecalculateCustomerBalances,
 	getCustomerBalanceSourceParts,
 } from "./customerBalanceUtils";
+
+/**
+ * The entitlements a row's aggregation math may see: expired entitlements are
+ * display-only and must never feed useFeatureUsageBalance or any sums.
+ */
+function getActiveRowEntitlements(
+	row: Row<CustomerBalanceRowData>,
+): FullCusEntWithFullCusProduct[] {
+	const ents = row.original.subRows?.length
+		? row.original.subRows
+		: [row.original];
+	return ents.filter((ent) => !isCusEntExpired({ cusEnt: ent }));
+}
 
 function getBalanceBillingIcon({
 	balance,
@@ -226,6 +240,20 @@ function SubRowUsageCell({
 	);
 }
 
+/**
+ * View-only cell for expired balances: shows the frozen balance greyed out,
+ * without running any of the aggregation hooks.
+ */
+function ExpiredUsageCell({ ent }: { ent: FullCusEntWithFullCusProduct }) {
+	return (
+		<span className="text-tertiary-foreground opacity-50">
+			{ent.unlimited
+				? "Unlimited"
+				: new Intl.NumberFormat().format(ent.balance ?? 0)}
+		</span>
+	);
+}
+
 function UsageCell({
 	row,
 	fullCustomer,
@@ -237,6 +265,9 @@ function UsageCell({
 	entityId: string | null;
 	customerEntitlements?: FullCusEntWithFullCusProduct[];
 }) {
+	if (isCusEntExpired({ cusEnt: row.original })) {
+		return <ExpiredUsageCell ent={row.original} />;
+	}
 	if (row.depth > 0) {
 		return <SubRowUsageCell ent={row.original} entityId={entityId} />;
 	}
@@ -263,14 +294,23 @@ function BalanceExpiryIcon({
 }: {
 	expiresAt: number | null | undefined;
 }) {
+	const hasExpired = expiresAt != null && expiresAt <= Date.now();
+
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
-				<div className="shrink-0 text-amber-500">
+				<div
+					className={cn(
+						"shrink-0",
+						hasExpired ? "text-tertiary-foreground" : "text-amber-500",
+					)}
+				>
 					<ClockCountdownIcon size={14} weight="duotone" />
 				</div>
 			</TooltipTrigger>
-			<TooltipContent>Expires {formatChipDate(expiresAt)}</TooltipContent>
+			<TooltipContent>
+				{hasExpired ? "Expired" : "Expires"} {formatChipDate(expiresAt)}
+			</TooltipContent>
 		</Tooltip>
 	);
 }
@@ -377,6 +417,21 @@ function SubRowBarCell({
 	);
 }
 
+/**
+ * View-only bar cell for expired balances: just the greyed expiry icon in the
+ * same layout slot, no reset chip and no usage bar.
+ */
+function ExpiredBarCell({ ent }: { ent: FullCusEntWithFullCusProduct }) {
+	return (
+		<div className="flex gap-3 items-center opacity-50">
+			<div className="flex items-center justify-end gap-1.5 shrink-0 min-w-44">
+				<BalanceExpiryIcon expiresAt={ent.expires_at} />
+			</div>
+			<div className="w-full max-w-50 min-w-16" />
+		</div>
+	);
+}
+
 function BarCell({
 	row,
 	fullCustomer,
@@ -388,6 +443,9 @@ function BarCell({
 	entityId: string | null;
 	customerEntitlements?: FullCusEntWithFullCusProduct[];
 }) {
+	if (isCusEntExpired({ cusEnt: row.original })) {
+		return <ExpiredBarCell ent={row.original} />;
+	}
 	if (row.depth > 0) {
 		return <SubRowBarCell ent={row.original} entityId={entityId} />;
 	}
@@ -418,6 +476,9 @@ function BalanceActionsCell({
 	onCheckBalanceClick?: (balance: FullCusEntWithFullCusProduct) => void;
 	onRecalculateClick?: (balance: FullCusEntWithFullCusProduct) => void;
 }) {
+	// Expired balances are view-only: no record/check/recalculate/delete
+	if (isCusEntExpired({ cusEnt: row.original })) return null;
+
 	const isParentRow = row.depth === 0;
 	const canDelete =
 		!row.getCanExpand() && canDeleteCustomerBalance({ balance: row.original });
@@ -431,10 +492,11 @@ function BalanceActionsCell({
 			featureId: row.original.entitlement.feature.id,
 			entityId,
 		});
-	const customerEntitlements =
+	const customerEntitlements = (
 		row.subRows.length > 0
 			? row.subRows.map((subRow) => subRow.original)
-			: [row.original];
+			: [row.original]
+	).filter((ent) => !isCusEntExpired({ cusEnt: ent }));
 
 	if (!canDelete && !canRecordUsage && !canCheckBalance && !canRecalculate)
 		return null;
@@ -530,6 +592,28 @@ function MobileBalanceBar({
 	entityId: string | null;
 	customerEntitlements: FullCusEntWithFullCusProduct[];
 }) {
+	if (isCusEntExpired({ cusEnt: ent })) return null;
+	return (
+		<MobileBalanceBarContent
+			ent={ent}
+			fullCustomer={fullCustomer}
+			entityId={entityId}
+			customerEntitlements={customerEntitlements}
+		/>
+	);
+}
+
+function MobileBalanceBarContent({
+	ent,
+	fullCustomer,
+	entityId,
+	customerEntitlements,
+}: {
+	ent: FullCusEntWithFullCusProduct;
+	fullCustomer: FullCustomer | null | undefined;
+	entityId: string | null;
+	customerEntitlements: FullCusEntWithFullCusProduct[];
+}) {
 	const { allowance, balance, quantity } = useFeatureUsageBalance({
 		fullCustomer,
 		featureId: ent.entitlement.feature.id,
@@ -560,9 +644,7 @@ function MobileUsageWithBar({
 	fullCustomer: FullCustomer | null | undefined;
 	entityId: string | null;
 }) {
-	const customerEntitlements = row.original.subRows?.length
-		? row.original.subRows
-		: [row.original];
+	const customerEntitlements = getActiveRowEntitlements(row);
 
 	return (
 		<div className="flex items-center justify-between gap-3">
@@ -609,6 +691,7 @@ export const CustomerBalanceTableColumns = ({
 		cell: ({ row }: { row: Row<CustomerBalanceRowData> }) => {
 			const ent = row.original;
 			const isSubRow = row.depth > 0;
+			const isExpired = isCusEntExpired({ cusEnt: ent });
 
 			if (isSubRow) {
 				const isPooledBalance = isSyntheticPooledBalanceCustomerEntitlement({
@@ -624,7 +707,12 @@ export const CustomerBalanceTableColumns = ({
 
 				if (!hasPlan && !isPooledBalance) {
 					return (
-						<div className="flex items-center gap-2 min-w-0">
+						<div
+							className={cn(
+								"flex items-center gap-2 min-w-0",
+								isExpired && "opacity-50",
+							)}
+						>
 							<BalanceBillingIcon balance={ent} />
 							<AdminHover
 								texts={getCusEntHoverTexts({
@@ -641,7 +729,12 @@ export const CustomerBalanceTableColumns = ({
 				}
 
 				return (
-					<div className="flex flex-col gap-0.5 min-w-0">
+					<div
+						className={cn(
+							"flex flex-col gap-0.5 min-w-0",
+							isExpired && "opacity-50",
+						)}
+					>
 						<div className="flex items-center gap-2">
 							<BalanceBillingIcon balance={ent} />
 							<AdminHover
@@ -666,7 +759,9 @@ export const CustomerBalanceTableColumns = ({
 			const isExpanded = row.getIsExpanded();
 
 			return (
-				<div className="flex items-center gap-2">
+				<div
+					className={cn("flex items-center gap-2", isExpired && "opacity-50")}
+				>
 					{canExpand && (
 						<span
 							className={cn(
@@ -709,9 +804,7 @@ export const CustomerBalanceTableColumns = ({
 				row={row}
 				fullCustomer={fullCustomer}
 				entityId={entityId}
-				customerEntitlements={
-					row.original.subRows?.length ? row.original.subRows : [row.original]
-				}
+				customerEntitlements={getActiveRowEntitlements(row)}
 			/>
 		),
 	},
@@ -725,9 +818,7 @@ export const CustomerBalanceTableColumns = ({
 				row={row}
 				fullCustomer={fullCustomer}
 				entityId={entityId}
-				customerEntitlements={
-					row.original.subRows?.length ? row.original.subRows : [row.original]
-				}
+				customerEntitlements={getActiveRowEntitlements(row)}
 			/>
 		),
 	},

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
@@ -3,7 +3,11 @@ import type {
 	FullCusEntWithFullCusProduct,
 	FullCustomerEntitlement,
 } from "@autumn/shared";
-import { FeatureType, type FullCusProduct } from "@autumn/shared";
+import {
+	FeatureType,
+	type FullCusProduct,
+	isCusEntExpired,
+} from "@autumn/shared";
 import { Button, SectionTag } from "@autumn/ui";
 import { LegoIcon, PlusIcon } from "@phosphor-icons/react";
 import { type ExpandedState, getExpandedRowModel } from "@tanstack/react-table";
@@ -117,6 +121,10 @@ export function CustomerFeatureUsageTable() {
 				cusEnts: deduplicatedCusEnts,
 				featuresMap,
 			}).sort((a, b) => {
+				// Expired (view-only) rows sink to the bottom of the table
+				const aExpired = isCusEntExpired({ cusEnt: a });
+				const bExpired = isCusEntExpired({ cusEnt: b });
+				if (aExpired !== bExpired) return aExpired ? 1 : -1;
 				const aAllowance = a.entitlement.allowance ?? 0;
 				const bAllowance = b.entitlement.allowance ?? 0;
 				if (aAllowance > 0 && bAllowance <= 0) return -1;
@@ -157,10 +165,14 @@ export function CustomerFeatureUsageTable() {
 		[meteredEnts],
 	);
 
+	// Expired entitlements never surface as flags — the flags section has no
+	// greyed-out state, and an expired boolean grant should read as not granted.
 	const booleanEnts = useMemo(
 		() =>
 			deduplicatedCusEnts.filter(
-				(ent) => ent.entitlement.feature.type === FeatureType.Boolean,
+				(ent) =>
+					ent.entitlement.feature.type === FeatureType.Boolean &&
+					!isCusEntExpired({ cusEnt: ent }),
 			),
 		[deduplicatedCusEnts],
 	);

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
@@ -3,15 +3,24 @@ import type {
 	FullCusEntWithFullCusProduct,
 	FullCustomerEntitlement,
 } from "@autumn/shared";
-import { FeatureType, type FullCusProduct } from "@autumn/shared";
+import {
+	FeatureType,
+	type FullCusProduct,
+	isCusEntDisplayExpired,
+} from "@autumn/shared";
 import { Button, SectionTag } from "@autumn/ui";
 import { LegoIcon, PlusIcon } from "@phosphor-icons/react";
 import { type ExpandedState, getExpandedRowModel } from "@tanstack/react-table";
+import { parseAsArrayOf, parseAsStringEnum, useQueryState } from "nuqs";
 import { useMemo, useState } from "react";
 import { Table } from "@/components/general/table";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useEntity } from "@/hooks/stores/useSubscriptionStore";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import {
+	type CustomerProductsStatusOption,
+	DEFAULT_PRODUCT_STATUSES,
+} from "@/views/customers2/hooks/useCustomerProductsTableState";
 import { useCustomerTable } from "@/views/customers2/hooks/useCustomerTable";
 import { CustomerBalanceTable } from "../customer-balance/CustomerBalanceTable";
 import { EmptyState } from "../EmptyState";
@@ -96,13 +105,21 @@ export function CustomerFeatureUsageTable() {
 		[features],
 	);
 
+	// Same nuqs key as the Plans table filter: one Status filter drives both.
+	const [productStatuses] = useQueryState(
+		"customerProductsStatuses",
+		parseAsArrayOf(
+			parseAsStringEnum<CustomerProductsStatusOption>(["active", "expired"]),
+		).withDefault(DEFAULT_PRODUCT_STATUSES),
+	);
+
 	const filteredCusEnts = useMemo(
 		() =>
 			filterCustomerFeatureUsage({
 				entitlements: cusEnts,
-				showExpired: false,
+				statuses: productStatuses,
 			}),
-		[cusEnts],
+		[cusEnts, productStatuses],
 	);
 
 	const { entitlements: deduplicatedCusEnts, aggregatedMap } = useMemo(
@@ -117,6 +134,10 @@ export function CustomerFeatureUsageTable() {
 				cusEnts: deduplicatedCusEnts,
 				featuresMap,
 			}).sort((a, b) => {
+				// Expired (view-only) rows sink to the bottom of the table
+				const aExpired = isCusEntDisplayExpired({ cusEnt: a });
+				const bExpired = isCusEntDisplayExpired({ cusEnt: b });
+				if (aExpired !== bExpired) return aExpired ? 1 : -1;
 				const aAllowance = a.entitlement.allowance ?? 0;
 				const bAllowance = b.entitlement.allowance ?? 0;
 				if (aAllowance > 0 && bAllowance <= 0) return -1;
@@ -157,10 +178,14 @@ export function CustomerFeatureUsageTable() {
 		[meteredEnts],
 	);
 
+	// Expired entitlements never surface as flags — the flags section has no
+	// greyed-out state, and an expired boolean grant should read as not granted.
 	const booleanEnts = useMemo(
 		() =>
 			deduplicatedCusEnts.filter(
-				(ent) => ent.entitlement.feature.type === FeatureType.Boolean,
+				(ent) =>
+					ent.entitlement.feature.type === FeatureType.Boolean &&
+					!isCusEntDisplayExpired({ cusEnt: ent }),
 			),
 		[deduplicatedCusEnts],
 	);

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
@@ -105,7 +105,7 @@ export function CustomerFeatureUsageTable() {
 		[features],
 	);
 
-	// Same nuqs key as the Plans table filter: one Status filter drives both.
+	// Same nuqs key as the Plans table filter.
 	const [productStatuses] = useQueryState(
 		"customerProductsStatuses",
 		parseAsArrayOf(
@@ -134,7 +134,6 @@ export function CustomerFeatureUsageTable() {
 				cusEnts: deduplicatedCusEnts,
 				featuresMap,
 			}).sort((a, b) => {
-				// Expired (view-only) rows sink to the bottom of the table
 				const aExpired = isCusEntDisplayExpired({ cusEnt: a });
 				const bExpired = isCusEntDisplayExpired({ cusEnt: b });
 				if (aExpired !== bExpired) return aExpired ? 1 : -1;
@@ -178,8 +177,7 @@ export function CustomerFeatureUsageTable() {
 		[meteredEnts],
 	);
 
-	// Expired entitlements never surface as flags — the flags section has no
-	// greyed-out state, and an expired boolean grant should read as not granted.
+	// The flags section has no greyed state, so an expired flag reads as ungranted.
 	const booleanEnts = useMemo(
 		() =>
 			deduplicatedCusEnts.filter(

--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts
@@ -1,16 +1,22 @@
 import {
 	CusProductStatus,
 	type FullCusEntWithFullCusProduct,
+	isCusEntExpired,
 	isPooledBalanceSourceCustomerEntitlement,
 } from "@autumn/shared";
+import type { CustomerProductsStatusOption } from "@/views/customers2/hooks/useCustomerProductsTableState";
 
 export function filterCustomerFeatureUsage({
 	entitlements,
-	showExpired,
+	statuses,
 }: {
 	entitlements: FullCusEntWithFullCusProduct[];
-	showExpired: boolean;
+	/** Mirrors the Plans table's status filter (nuqs customerProductsStatuses). */
+	statuses: CustomerProductsStatusOption[];
 }): FullCusEntWithFullCusProduct[] {
+	const showActive = statuses.includes("active");
+	const showExpired = statuses.includes("expired");
+
 	return entitlements
 		.filter((ent: FullCusEntWithFullCusProduct) => {
 			if (
@@ -20,18 +26,18 @@ export function filterCustomerFeatureUsage({
 			) {
 				return false;
 			}
-			if (showExpired) {
-				return true;
-			}
-			// Extra entitlements (no customer_product) are always shown
+			// Loose ents: live ones follow "active", time-expired ones follow "expired"
 			if (!ent.customer_product) {
-				return true;
+				return isCusEntExpired({ cusEnt: ent }) ? showExpired : showActive;
 			}
-			// Exclude expired and scheduled products from balance calculations
-			return (
-				ent.customer_product.status !== CusProductStatus.Expired &&
-				ent.customer_product.status !== CusProductStatus.Scheduled
-			);
+			if (ent.customer_product.status === CusProductStatus.Expired) {
+				return showExpired;
+			}
+			// Scheduled products stay hidden from balance views regardless
+			if (ent.customer_product.status === CusProductStatus.Scheduled) {
+				return false;
+			}
+			return showActive;
 		})
 		.sort(
 			(a: FullCusEntWithFullCusProduct, b: FullCusEntWithFullCusProduct) => {

--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts
@@ -26,14 +26,13 @@ export function filterCustomerFeatureUsage({
 			) {
 				return false;
 			}
-			// Loose ents: live ones follow "active", time-expired ones follow "expired"
 			if (!ent.customer_product) {
 				return isCusEntExpired({ cusEnt: ent }) ? showExpired : showActive;
 			}
 			if (ent.customer_product.status === CusProductStatus.Expired) {
 				return showExpired;
 			}
-			// Scheduled products stay hidden from balance views regardless
+			// Scheduled products stay hidden from balance views.
 			if (ent.customer_product.status === CusProductStatus.Scheduled) {
 				return false;
 			}

--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts
@@ -5,7 +5,7 @@ import type {
 	FullCusProduct,
 	FullCustomerEntitlement,
 } from "@autumn/shared";
-import { FeatureType } from "@autumn/shared";
+import { FeatureType, isCusEntExpired } from "@autumn/shared";
 import type { FullCusEntWithSubRows } from "./customerFeatureUsageTypes";
 
 /**
@@ -92,32 +92,46 @@ export function deduplicateEntitlements({
 				combined.push(ent);
 			}
 		} else {
-			// Combine multiple entitlements
-			const first = ents[0];
+			// Combine multiple entitlements. Expired entitlements stay visible as
+			// sub-rows (via aggregatedMap) but must not contribute to any sums —
+			// only active entitlements feed the combined parent row's math.
+			const activeEnts = ents.filter(
+				(ent) => !isCusEntExpired({ cusEnt: ent }),
+			);
+			const expiredEnts = ents.filter((ent) =>
+				isCusEntExpired({ cusEnt: ent }),
+			);
 
-			// Store the original entitlements for this aggregated feature
-			aggregatedMap.set(featureId, ents);
+			// When every entitlement for the feature is expired, the parent row is
+			// itself expired (view-only, greyed out) and just mirrors the expired
+			// values for display.
+			const mathEnts = activeEnts.length > 0 ? activeEnts : expiredEnts;
+			const first = mathEnts[0];
+
+			// Store the original entitlements for this aggregated feature,
+			// active first so expired sub-rows render last.
+			aggregatedMap.set(featureId, [...activeEnts, ...expiredEnts]);
 
 			// When entityId is present, use entity-specific balances
 			let summedBalance: number;
 			if (entityId) {
-				summedBalance = ents.reduce((sum, e) => {
+				summedBalance = mathEnts.reduce((sum, e) => {
 					const entityBalance = e.entities?.[entityId]?.balance;
 					return sum + (entityBalance ?? e.balance ?? 0);
 				}, 0);
 			} else {
-				summedBalance = ents.reduce((sum, e) => sum + (e.balance ?? 0), 0);
+				summedBalance = mathEnts.reduce((sum, e) => sum + (e.balance ?? 0), 0);
 			}
 
-			const summedAllowance = ents.reduce(
+			const summedAllowance = mathEnts.reduce(
 				(sum, e) => sum + (e.entitlement.allowance ?? 0),
 				0,
 			);
-			const summedQuantity = ents.reduce(
+			const summedQuantity = mathEnts.reduce(
 				(sum, e) => sum + (e.customer_product?.quantity ?? 1),
 				0,
 			);
-			const earliestReset = ents.reduce(
+			const earliestReset = mathEnts.reduce(
 				(earliest, e) => {
 					if (!e.next_reset_at) return earliest;
 					if (!earliest) return e.next_reset_at;

--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts
@@ -92,7 +92,6 @@ export function deduplicateEntitlements({
 				combined.push(ent);
 			}
 		} else {
-			// Expired entitlements stay visible as sub-rows but never feed the sums.
 			const activeEnts = ents.filter(
 				(ent) => !isCusEntDisplayExpired({ cusEnt: ent }),
 			);
@@ -100,11 +99,10 @@ export function deduplicateEntitlements({
 				isCusEntDisplayExpired({ cusEnt: ent }),
 			);
 
-			// An all-expired feature mirrors its expired values rather than showing zero.
+			// An all-expired feature mirrors its values rather than showing zero.
 			const mathEnts = activeEnts.length > 0 ? activeEnts : expiredEnts;
 			const first = mathEnts[0];
 
-			// Active first, so expired sub-rows sort to the bottom.
 			aggregatedMap.set(featureId, [...activeEnts, ...expiredEnts]);
 
 			// When entityId is present, use entity-specific balances

--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts
@@ -5,7 +5,7 @@ import type {
 	FullCusProduct,
 	FullCustomerEntitlement,
 } from "@autumn/shared";
-import { FeatureType } from "@autumn/shared";
+import { FeatureType, isCusEntDisplayExpired } from "@autumn/shared";
 import type { FullCusEntWithSubRows } from "./customerFeatureUsageTypes";
 
 /**
@@ -92,32 +92,41 @@ export function deduplicateEntitlements({
 				combined.push(ent);
 			}
 		} else {
-			// Combine multiple entitlements
-			const first = ents[0];
+			// Expired entitlements stay visible as sub-rows but never feed the sums.
+			const activeEnts = ents.filter(
+				(ent) => !isCusEntDisplayExpired({ cusEnt: ent }),
+			);
+			const expiredEnts = ents.filter((ent) =>
+				isCusEntDisplayExpired({ cusEnt: ent }),
+			);
 
-			// Store the original entitlements for this aggregated feature
-			aggregatedMap.set(featureId, ents);
+			// An all-expired feature mirrors its expired values rather than showing zero.
+			const mathEnts = activeEnts.length > 0 ? activeEnts : expiredEnts;
+			const first = mathEnts[0];
+
+			// Active first, so expired sub-rows sort to the bottom.
+			aggregatedMap.set(featureId, [...activeEnts, ...expiredEnts]);
 
 			// When entityId is present, use entity-specific balances
 			let summedBalance: number;
 			if (entityId) {
-				summedBalance = ents.reduce((sum, e) => {
+				summedBalance = mathEnts.reduce((sum, e) => {
 					const entityBalance = e.entities?.[entityId]?.balance;
 					return sum + (entityBalance ?? e.balance ?? 0);
 				}, 0);
 			} else {
-				summedBalance = ents.reduce((sum, e) => sum + (e.balance ?? 0), 0);
+				summedBalance = mathEnts.reduce((sum, e) => sum + (e.balance ?? 0), 0);
 			}
 
-			const summedAllowance = ents.reduce(
+			const summedAllowance = mathEnts.reduce(
 				(sum, e) => sum + (e.entitlement.allowance ?? 0),
 				0,
 			);
-			const summedQuantity = ents.reduce(
+			const summedQuantity = mathEnts.reduce(
 				(sum, e) => sum + (e.customer_product?.quantity ?? 1),
 				0,
 			);
-			const earliestReset = ents.reduce(
+			const earliestReset = mathEnts.reduce(
 				(earliest, e) => {
 					if (!e.next_reset_at) return earliest;
 					if (!earliest) return e.next_reset_at;

--- a/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
@@ -11,7 +11,6 @@ import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { useCustomerProductsPageQuery } from "@/views/customers2/hooks/useCustomerProductsPageQuery";
 import {
 	CUSTOMER_PRODUCTS_PAGE_SIZES,
-	isDefaultProductStatuses,
 	useCustomerProductsTableState,
 } from "@/views/customers2/hooks/useCustomerProductsTableState";
 import { useCustomerTable } from "@/views/customers2/hooks/useCustomerTable";
@@ -91,11 +90,6 @@ export function CustomerProductsTable() {
 
 	const totalPages = totalCount > 0 ? Math.ceil(totalCount / pageSize) : null;
 	const showFooter = totalCount >= CUSTOMER_PRODUCTS_PAGE_SIZES[0];
-
-	const hasActiveFilters =
-		kind !== "all" || !isDefaultProductStatuses(statuses);
-	const hasAnyProducts = customer.customer_products.length > 0;
-	const showFilter = hasAnyProducts || hasActiveFilters;
 
 	const [transferOpen, setTransferOpen] = useState(false);
 	const [selectedProduct, setSelectedProduct] = useState<FullCusProduct | null>(
@@ -226,14 +220,12 @@ export function CustomerProductsTable() {
 							Plans
 						</Table.Heading>
 						<Table.Actions>
-							{showFilter && (
-								<CustomerProductsFilterButton
-									kind={kind}
-									setKind={setKind}
-									statuses={statuses}
-									setStatuses={setStatuses}
-								/>
-							)}
+							<CustomerProductsFilterButton
+								kind={kind}
+								setKind={setKind}
+								statuses={statuses}
+								setStatuses={setStatuses}
+							/>
 							<AttachProductSheetTrigger />
 						</Table.Actions>
 					</Table.Toolbar>

--- a/vite/tests/views/customers2/customer-feature-usage.test.ts
+++ b/vite/tests/views/customers2/customer-feature-usage.test.ts
@@ -47,7 +47,7 @@ describe("customer feature usage pooled balances", () => {
 
 		const filtered = filterCustomerFeatureUsage({
 			entitlements: [ordinary, contributionSource, syntheticPool],
-			showExpired: false,
+			statuses: ["active"],
 		});
 
 		expect(filtered.map(({ id }) => id)).toEqual(["ordinary", "pool"]);


### PR DESCRIPTION
Shows expired balances in the dashboard without changing public or API behaviour.
Previously hidden entirely; now they render greyed out, view-only, and never
affect usage maths or public selectors.

## Behaviour

- Expired **plan** balances appear when the Plans status filter includes
  "Expired", and are non-editable and non-deletable.
- Expired **loose** balances hydrate only when `include_expired_loose` is set.
  They render greyed, don't affect sums, usage bars or booleans, and sort last.
- Dashboard sessions may delete expired loose balances — the only cleanup path
  for them. API-key behaviour is unchanged.
- Public hydration and selection helpers still exclude expired rows, so API
  responses are byte-identical.

## Implementation

- **Backend:** `CusService.getFull` accepts `includeExpiredLooseEntitlements`;
  the SQL unions a separate expired-loose bucket (LIMIT 20) alongside the active
  limit (30), so expired rows can never evict active ones.
- **Shared:** two predicates, `isCusEntExpired` (own clock) and
  `isCusEntDisplayExpired` (own clock, or orphaned by a churned plan).
  `fullCustomerToCustomerEntitlements` takes an `includeExpired` flag so
  expired rows can be selected without a second, divergent filter path.
- **Frontend:** the Plans status filter drives `include_expired_loose`; balance
  and feature-usage tables treat display-expired rows as view-only and exclude
  them from every calculation.

## Known gap

With more than `cusProductLimit` (10) plans on one customer, the products CTE
orders active/past-due/scheduled first and applies its limit, so expired
products can fall outside the window — the Plans table may then list an expired
plan whose balances are absent. Fixing it means letting the selected statuses
drive product-entitlement hydration, which is a change to
`buildOptimizedCusProductsCTE`'s windowing rather than to this feature.

## QA

`server/tests/scenarios/balances/expired-balances-scenario.test.ts` seeds
customer `expired-balances-qa` with both expired kinds across two features,
alongside live equivalents, for checking the greying, sort order and disabled
actions by hand.





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds dashboard-only visibility and cleanup support for expired balances while preserving public API selection behavior.
- **[Improvements]** Hydrates expired loose balances in a separate bounded query bucket so active balances retain their existing capacity.
- **[Improvements]** Displays expired loose and plan balances as greyed-out, view-only rows and excludes them from totals, usage bars, and active-state calculations.
- **[Bug fixes]** Routes expired loose-balance deletion through the canonical entitlement selector, preserving standard identifier, interval, entity, and feature filtering.
- **[API changes]** Adds an internal `include_expired_loose` query option without changing default public hydration or selection behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/deleteBalance/deleteBalance.ts | Uses canonical entitlement filtering for dashboard cleanup of expired loose balances and prevents expired usage from being redistributed. |
| server/src/internal/customers/getFullCusQuery.ts | Adds a separately limited expired-loose entitlement query branch without reducing the active entitlement budget. |
| shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts | Adds an opt-in expired-entitlement selection mode while retaining expiration filtering by default. |
| vite/src/views/customers/customer/hooks/useCusQuery.tsx | Keys and requests customer hydration according to whether the dashboard Plans filter includes expired records. |
| vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx | Separates expired rows from active calculations and disables usage-related actions while retaining loose-balance cleanup. |
| vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx | Excludes display-expired entitlements from active feature-usage aggregation and interaction paths. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Dashboard
    participant API as Internal customer endpoint
    participant Service as CusService
    participant DB as Entitlement query
    UI->>API: "Request customer with include_expired_loose=true"
    API->>Service: "getFull(includeExpiredLooseEntitlements=true)"
    Service->>DB: Load active loose balances (limit 30)
    Service->>DB: Load expired loose balances separately (limit 20)
    DB-->>Service: Active and expired rows
    Service-->>UI: Full customer dashboard data
    Note over UI: Expired rows render greyed out and do not affect usage calculations
    UI->>API: Delete expired loose balance
    API->>Service: "Select using canonical filters with includeExpired=true"
    Service->>DB: Delete matching loose entitlement
```
</details>

<sub>Reviews (8): Last reviewed commit: ["refactor: cut comments that restate the ..."](https://github.com/useautumn/autumn/commit/dff9bf46684e764831668f06b6b9b3adeb01b63f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56691235)</sub>

<!-- /greptile_comment -->