### PR TITLE
feat(catalog-v2): complete the stripe product-id mapping story

### DIFF
--- a/server/src/internal/catalogV2/actions/buildPlanChange/fullProductToApiPlanV1Sync.ts
+++ b/server/src/internal/catalogV2/actions/buildPlanChange/fullProductToApiPlanV1Sync.ts
@@ -3,6 +3,7 @@ import {
 	type FullPlanLicense,
 	type FullProductWithoutLicenses,
 	mapToProductV2,
+	productToPlanProcessors,
 	productV2ToApiPlanV1,
 } from "@autumn/shared";
 import { toApiPlanLicenseSnapshot } from "@/internal/catalogV2/actions/buildPlanChange/buildPlanLicenseChanges/toApiPlanLicenseSnapshot";
@@ -17,7 +18,7 @@ export const fullProductToApiPlanV1Sync = ({
 	const resolvedFeatures =
 		features ?? product.entitlements.map((entitlement) => entitlement.feature);
 	const licenses = product.licenses ?? [];
-	return productV2ToApiPlanV1({
+	const plan = productV2ToApiPlanV1({
 		product: mapToProductV2({ product, features: resolvedFeatures }),
 		features: resolvedFeatures,
 		...(licenses.length > 0
@@ -28,4 +29,10 @@ export const fullProductToApiPlanV1Sync = ({
 				}
 			: {}),
 	});
+	// Carried so the plan-change diff can report mapping edits.
+	const processors = productToPlanProcessors({ product });
+	return {
+		...plan,
+		...(processors !== undefined ? { processors } : {}),
+	};
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/applyPlanProcessorsToProduct.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/applyPlanProcessorsToProduct.ts
@@ -1,0 +1,43 @@
+import type { ApiPlanProcessors, Product } from "@autumn/shared";
+
+const processorsEqual = ({
+	left,
+	right,
+}: {
+	left: Product["processor"];
+	right: Product["processor"];
+}): boolean =>
+	(left?.id ?? null) === (right?.id ?? null) &&
+	JSON.stringify(left?.additional_ids ?? []) ===
+		JSON.stringify(right?.additional_ids ?? []);
+
+/** Stamp `plan.processors.stripe` onto `product.processor`. Omit keeps. */
+export const applyPlanProcessorsToProduct = ({
+	product,
+	processors,
+}: {
+	product: Product;
+	processors?: ApiPlanProcessors;
+}): { product: Product; changed: boolean } => {
+	if (processors?.stripe === undefined) {
+		return { product, changed: false };
+	}
+
+	const next: Product = {
+		...product,
+		processor: {
+			type: "stripe",
+			id: processors.stripe.product_id,
+			...(processors.stripe.additional_product_ids?.length
+				? { additional_ids: processors.stripe.additional_product_ids }
+				: {}),
+		},
+	};
+	return {
+		product: next,
+		changed: !processorsEqual({
+			left: product.processor,
+			right: next.processor,
+		}),
+	};
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/applyPlanProcessorsToProduct.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/applyPlanProcessorsToProduct.ts
@@ -1,15 +1,8 @@
-import type { ApiPlanProcessors, Product } from "@autumn/shared";
-
-const processorsEqual = ({
-	left,
-	right,
-}: {
-	left: Product["processor"];
-	right: Product["processor"];
-}): boolean =>
-	(left?.id ?? null) === (right?.id ?? null) &&
-	JSON.stringify(left?.additional_ids ?? []) ===
-		JSON.stringify(right?.additional_ids ?? []);
+import {
+	type ApiPlanProcessors,
+	type Product,
+	productProcessorsAreSame,
+} from "@autumn/shared";
 
 /** Stamp `plan.processors.stripe` onto `product.processor`. Omit keeps. */
 export const applyPlanProcessorsToProduct = ({
@@ -35,7 +28,7 @@ export const applyPlanProcessorsToProduct = ({
 	};
 	return {
 		product: next,
-		changed: !processorsEqual({
+		changed: !productProcessorsAreSame({
 			left: product.processor,
 			right: next.processor,
 		}),

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/computeProductDetailsPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/computeProductDetailsPlan.ts
@@ -8,6 +8,7 @@ import {
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { ProductDetailsPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { isExistingRowPromote } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/isExistingRowPromote";
+import { applyPlanProcessorsToProduct } from "./applyPlanProcessorsToProduct";
 import { diffProductDetails } from "./diffProductDetails";
 import { initProductRow } from "./initProductRow";
 import { planParamsToProductRowPatch } from "./planParamsToProductRowPatch";
@@ -75,7 +76,7 @@ export const computeProductDetailsPlan = ({
 	) {
 		patch.is_default = true;
 	}
-	const next: Product = {
+	const patched: Product = {
 		...currentFullProduct,
 		...patch,
 		...(baseInternalProductId !== undefined
@@ -85,13 +86,22 @@ export const computeProductDetailsPlan = ({
 				}
 			: {}),
 	};
+	const { product: next, changed: processorChanged } =
+		applyPlanProcessorsToProduct({
+			product: patched,
+			processors: planParams.processors,
+		});
 	const previousAttributes = diffProductDetails({
 		current: currentFullProduct,
 		next,
 	});
-	if (isEmptyObject(previousAttributes)) {
+	if (isEmptyObject(previousAttributes) && !processorChanged) {
 		return { changed: false, product: currentFullProduct };
 	}
 
-	return { changed: true, product: next, previousAttributes };
+	return {
+		changed: true,
+		product: next,
+		...(isEmptyObject(previousAttributes) ? {} : { previousAttributes }),
+	};
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/initProductRow.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/initProductRow.ts
@@ -5,6 +5,7 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { generateId } from "@/utils/genUtils.js";
+import { applyPlanProcessorsToProduct } from "./applyPlanProcessorsToProduct";
 import { planParamsToProductRowPatch } from "./planParamsToProductRowPatch";
 
 /**
@@ -35,7 +36,7 @@ export const initProductRow = ({
 			current: base,
 		});
 		const willBeActive = planParams.active === true;
-		return {
+		const cloned = {
 			...base,
 			...patch,
 			version,
@@ -52,11 +53,15 @@ export const initProductRow = ({
 			base_internal_product_id:
 				baseInternalProductId ?? base.base_internal_product_id ?? null,
 		};
+		return applyPlanProcessorsToProduct({
+			product: cloned,
+			processors: planParams.processors,
+		}).product;
 	}
 
 	const patch = planParamsToProductRowPatch({ planParams, current: null });
 
-	return {
+	const created = {
 		id: planParams.plan_id,
 		name: patch.name ?? planParams.plan_id,
 		description: patch.description ?? null,
@@ -89,4 +94,8 @@ export const initProductRow = ({
 		usage_alerts: patch.usage_alerts ?? null,
 		overage_allowed: patch.overage_allowed ?? null,
 	};
+	return applyPlanProcessorsToProduct({
+		product: created,
+		processors: planParams.processors,
+	}).product;
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/creates/initVariantPlanParams.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/creates/initVariantPlanParams.ts
@@ -85,5 +85,8 @@ export const initVariantPlanParams = ({
 			: {}),
 		metadata: baseFullProduct.metadata,
 		...(licenses.length > 0 ? { licenses } : {}),
+		...(variant.processors !== undefined
+			? { processors: variant.processors }
+			: {}),
 	};
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/variantSettingsPlanParams.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/variantSettingsPlanParams.ts
@@ -3,6 +3,7 @@ import {
 	billingControlsFromColumns,
 	type Product,
 	productDetailFieldIsSame,
+	productProcessorsAreSame,
 	productToPlanProcessors,
 	type UpdateCatalogPlanParams,
 } from "@autumn/shared";
@@ -26,7 +27,8 @@ const settingsChanged = ({
 	key: "description" | "group" | "is_add_on" | "config" | "metadata";
 	current: Product;
 	next: Product;
-}): boolean => !productDetailFieldIsSame({ key, product1: current, product2: next });
+}): boolean =>
+	!productDetailFieldIsSame({ key, product1: current, product2: next });
 
 /** Base current→next settings. Name / default / archive never copy. */
 export const variantSettingsPlanParams = ({
@@ -63,14 +65,13 @@ export const variantSettingsPlanParams = ({
 		patch.billing_controls = billingControlsFromColumns(next);
 	}
 
-	const currentProcessors = productToPlanProcessors({ product: current });
-	const nextProcessors = productToPlanProcessors({ product: next });
 	if (
-		(currentProcessors?.stripe?.product_id ?? null) !==
-			(nextProcessors?.stripe?.product_id ?? null) ||
-		JSON.stringify(currentProcessors?.stripe?.additional_product_ids ?? []) !==
-			JSON.stringify(nextProcessors?.stripe?.additional_product_ids ?? [])
+		!productProcessorsAreSame({
+			left: current.processor,
+			right: next.processor,
+		})
 	) {
+		const nextProcessors = productToPlanProcessors({ product: next });
 		if (nextProcessors) patch.processors = nextProcessors;
 	}
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/variantSettingsPlanParams.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/variantSettingsPlanParams.ts
@@ -3,6 +3,7 @@ import {
 	billingControlsFromColumns,
 	type Product,
 	productDetailFieldIsSame,
+	productToPlanProcessors,
 	type UpdateCatalogPlanParams,
 } from "@autumn/shared";
 
@@ -14,6 +15,7 @@ type VariantSettingsPlanParams = Pick<
 	| "config"
 	| "metadata"
 	| "billing_controls"
+	| "processors"
 >;
 
 const settingsChanged = ({
@@ -59,6 +61,17 @@ export const variantSettingsPlanParams = ({
 		)
 	) {
 		patch.billing_controls = billingControlsFromColumns(next);
+	}
+
+	const currentProcessors = productToPlanProcessors({ product: current });
+	const nextProcessors = productToPlanProcessors({ product: next });
+	if (
+		(currentProcessors?.stripe?.product_id ?? null) !==
+			(nextProcessors?.stripe?.product_id ?? null) ||
+		JSON.stringify(currentProcessors?.stripe?.additional_product_ids ?? []) !==
+			JSON.stringify(nextProcessors?.stripe?.additional_product_ids ?? [])
+	) {
+		if (nextProcessors) patch.processors = nextProcessors;
 	}
 
 	return patch;

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/deriveVariantEdits.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/deriveVariantEdits.ts
@@ -58,7 +58,8 @@ const buildVariantEditIntent = ({
 		!editDiff &&
 		!hasSettings &&
 		!pointerChanged &&
-		target.archived === undefined
+		target.archived === undefined &&
+		target.processors === undefined
 	) {
 		return undefined;
 	}
@@ -68,7 +69,8 @@ const buildVariantEditIntent = ({
 		!editDiff &&
 		!hasSettings &&
 		pointerChanged &&
-		target.archived === undefined;
+		target.archived === undefined &&
+		target.processors === undefined;
 
 	return {
 		productKey: productToProductKey({ product: target.row }),
@@ -77,6 +79,9 @@ const buildVariantEditIntent = ({
 			version: target.row.version,
 			...settingsPatch,
 			...(target.archived !== undefined ? { archived: target.archived } : {}),
+			...(target.processors !== undefined
+				? { processors: target.processors }
+				: {}),
 			...(target.unlink ? { base_variant_id: null } : {}),
 		},
 		source: pointerIsOnlyChange

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts
@@ -34,7 +34,12 @@ export const deriveVariantMints = ({
 		: undefined;
 
 	return targets.flatMap((target): ProductUpsertIntent[] => {
-		const carriesContent = target.follow === true || target.customize != null;
+		// A mapping-only declaration is still content: without this the edit lane
+		// writes the customer-bearing row instead of minting from it.
+		const carriesContent =
+			target.follow === true ||
+			target.customize != null ||
+			target.processors !== undefined;
 		if (!carriesContent) return [];
 		if (
 			!rowHasVersionableCustomers({
@@ -71,6 +76,9 @@ export const deriveVariantMints = ({
 						? { new_version_slug: target.newVersionSlug }
 						: {}),
 					...settingsPatch,
+					...(target.processors !== undefined
+						? { processors: target.processors }
+						: {}),
 				},
 				source: "variant_propagation",
 				...(editDiff ? { editDiff } : {}),

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/targets/declaredVariantTargets.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/targets/declaredVariantTargets.ts
@@ -50,6 +50,9 @@ export const declaredVariantTargets = ({
 				row,
 				declared: true,
 				...(variant.customize ? { customize: variant.customize } : {}),
+				...(variant.processors !== undefined
+					? { processors: variant.processors }
+					: {}),
 				...(variant.archived !== undefined
 					? { archived: variant.archived }
 					: {}),

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/targets/variantEditTarget.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/targets/variantEditTarget.ts
@@ -10,6 +10,8 @@ export type VariantEditTarget = {
 	/** Nested `base_variant_id: null` — clear the pointer. */
 	unlink?: boolean;
 	customize?: CatalogVariantParams["customize"];
+	/** Stated `processors` on the variant entry — an override of the base's. */
+	processors?: CatalogVariantParams["processors"];
 	archived?: boolean;
 	newVersionSlug?: string;
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveVersionSiblingIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveVersionSiblingIntents.ts
@@ -120,7 +120,12 @@ export const deriveVersionSiblingIntents = ({
 	upsert: UpsertProductPlan;
 	projectedProductStatesContext: ProductStatesContext;
 }): ProductUpsertIntent[] => {
-	if (intent.source !== "direct") return [];
+	// A sync already carries the mapping to one row; re-deriving would loop.
+	if (intent.source === "processor_sync") return [];
+	// Mapping fan-out rides any lane: a variant reached by propagation still
+	// owes the id to its own versions. Every other edge stays direct-only.
+	const declaredProcessors = intent.planParams.processors;
+	if (intent.source !== "direct" && declaredProcessors === undefined) return [];
 	const inheritAllVersions = intent.planParams.versioning === "all_versions";
 	const explicitUnlink = intent.planParams.base_variant_id === null;
 	const versions =
@@ -139,7 +144,17 @@ export const deriveVersionSiblingIntents = ({
 				product.version === intent.productKey.version ||
 				product.base_internal_product_id == null,
 		);
-	if (!inheritAllVersions && !upsert.unlink && !firstLink) return [];
+	// Every version of a plan bills under one Stripe product, so a stated mapping
+	// replaces whatever each sibling held — declared, not diffed, since siblings
+	// can lag the addressed row.
+	if (
+		!inheritAllVersions &&
+		!upsert.unlink &&
+		!firstLink &&
+		declaredProcessors === undefined
+	) {
+		return [];
+	}
 
 	const contentEdit = inheritAllVersions
 		? contentEditFromLatest({ upsert })
@@ -149,6 +164,7 @@ export const deriveVersionSiblingIntents = ({
 		.filter((product) => {
 			if (product.version === intent.productKey.version) return false;
 			if (inheritAllVersions || explicitUnlink || firstLink) return true;
+			if (declaredProcessors !== undefined) return true;
 			return product.base_internal_product_id === currentPointer;
 		})
 		.map((product) => {
@@ -165,8 +181,18 @@ export const deriveVersionSiblingIntents = ({
 							planParams: intent.planParams,
 							version: product.version,
 						})
-					: { plan_id: product.id, version: product.version },
-				source: inheritAllVersions ? ("all_versions" as const) : "repoint",
+					: {
+							plan_id: product.id,
+							version: product.version,
+							...(declaredProcessors !== undefined
+								? { processors: declaredProcessors }
+								: {}),
+						},
+				source: inheritAllVersions
+					? ("all_versions" as const)
+					: upsert.unlink || firstLink
+						? ("repoint" as const)
+						: ("processor_sync" as const),
 				...(editDiff ? { editDiff } : {}),
 				...(upsert.unlink ? { unlink: true } : {}),
 				...(firstLink ? { baseInternalProductId: nextPointer } : {}),

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/upsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/upsertProductPlan.ts
@@ -23,6 +23,8 @@ export type UpsertProductSource =
 	| "license_pin"
 	| "license_adopt"
 	| "repoint"
+	/** Sibling version taking the plan's Stripe mapping — every version shares it. */
+	| "processor_sync"
 	| "demoted_product";
 
 /** Which product row this plan writes, and its before/after FullProduct. */

--- a/server/src/internal/catalogV2/execute/executeUpsertProducts/applyProductDetailsUpdate.ts
+++ b/server/src/internal/catalogV2/execute/executeUpsertProducts/applyProductDetailsUpdate.ts
@@ -49,6 +49,7 @@ export const applyProductDetailsUpdate = async ({
 			usage_alerts: product.usage_alerts,
 			overage_allowed: product.overage_allowed,
 			base_internal_product_id: product.base_internal_product_id,
+			processor: product.processor,
 		},
 	});
 

--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -12,7 +12,9 @@ import {
 	getProductItemDisplay,
 	itemToBillingInterval,
 	itemToBillingIntervalCount,
+	priceConfigToPriceProcessors,
 	productItemsToPlanItemsV1,
+	productToPlanProcessors,
 	productV2ToBasePrice,
 	productV2ToFeatureItems,
 	sortProductItems,
@@ -109,6 +111,9 @@ export async function getPlanResponse({
 
 	// 4. Extract base price using existing helper
 	const basePriceItem = productV2ToBasePrice({ product: productV2 as any });
+	const basePriceProcessors = priceConfigToPriceProcessors({
+		config: basePriceItem?.price_config,
+	});
 	const basePrice: ApiPlanV1["price"] | null = basePriceItem
 		? {
 				amount: basePriceItem.price,
@@ -126,6 +131,7 @@ export async function getPlanResponse({
 					features,
 					currency,
 				}),
+				...(basePriceProcessors ? { processors: basePriceProcessors } : {}),
 			}
 		: null;
 
@@ -174,6 +180,9 @@ export async function getPlanResponse({
 		: undefined;
 
 	// 9. Build Plan response
+	const planProcessors = productToPlanProcessors({
+		product,
+	});
 	const plan = {
 		id: product.id,
 		name: product.name || "",
@@ -200,6 +209,7 @@ export async function getPlanResponse({
 		metadata: product.metadata ?? {},
 
 		customer_eligibility: customerEligibility,
+		...(planProcessors ? { processors: planProcessors } : {}),
 	} satisfies ApiPlanV1;
 
 	// 10. Graph edges: up-link to the base plan, down-links to variants.

--- a/server/tests/integration/catalog-v2/plans/CASES.md
+++ b/server/tests/integration/catalog-v2/plans/CASES.md
@@ -43,6 +43,9 @@ plans/
     update-plan-free-trial.test.ts
     stripe-reuse.test.ts
     stripe-reuse-mint.test.ts
+  processors/
+    get-echo.test.ts
+    utils/expectPlanProcessors.ts
   versions/
     plan-versions.test.ts
     new-version-mint.test.ts
@@ -1482,3 +1485,35 @@ overrides the target per variant; unnamed targets fall back to `v{n}`.
 | variant target following in place → existing row's slug untouched | `versions/version-identity-propagate-slug.test.ts` |
 | target slug another version of that target holds → `DuplicateVersionSlug` | `versions/version-identity-propagate-slug.test.ts` |
 | `license_parents[].new_version_slug` with `new_version` → names the parent's minted row | `versions/version-identity-propagate-slug.test.ts` |
+
+## 27. Processors GET echo — `processors/`
+
+`catalogV2.get` maps existing Stripe ids onto `processors.stripe`. Price
+processors expose `price_id` only — Stripe product is inferred from the
+price. Currency echo waits for price stamp.
+
+| Case | Status |
+|---|---|
+| Paid + Stripe init → GET plan `product_id` / price `price_id` match DB | ✓ `processors/get-echo.test.ts` |
+| Free plan omits `processors` | ✓ `processors/get-echo.test.ts` |
+| `create_in_stripe: false` omits `processors` | ✓ `processors/get-echo.test.ts` |
+| Mapper: V2 prepaid id wins over V1; omit when unset | ✓ unit `catalogV2/processors-echo.test.ts` |
+
+## 28. Plan processor stamp + variant fan-out
+
+`plans[].processors.stripe` stamps `product.processor`. Omit keeps. Not a
+product-detail key — processor-only updates still persist. Base stamp fans
+out to latest variants (same path as description/group). `variants[].processors`
+or a direct `plans[]` entry for the variant overrides the base.
+
+Price processors, Stripe retrieve, and init-skip are later.
+
+| Case | Status |
+|---|---|
+| Stamp `product_id` onto the plan row | ✓ unit `computeProductDetailsPlan/applyPlanProcessorsToProduct.test.ts` |
+| Omit / same id is a no-op | ✓ unit `computeProductDetailsPlan/applyPlanProcessorsToProduct.test.ts` |
+| Processor is not a `PRODUCT_DETAIL_KEYS` field | ✓ unit `computeProductDetailsPlan/diffProductDetails.test.ts` |
+| Base processor change fans out to latest variant | ✓ unit `variants/derive-variant-intents.test.ts` |
+| `variants[].processors` overrides the base | ✓ unit `variants/derive-variant-intents.test.ts` |
+| Variant create copies `variants[].processors` | ✓ unit `variants/derive-variant-intents.test.ts` |
+| Direct variant `plans[]` entry overrides (first claim wins) | existing `claimNewIntents` — no extra path |

--- a/server/tests/integration/catalog-v2/plans/processors/get-echo.test.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/get-echo.test.ts
@@ -1,0 +1,184 @@
+/**
+ * catalogV2.get echoes Stripe product/price ids as `processors.stripe`.
+ *
+ * Contract:
+ *   New fields:  plan.processors.stripe.{product_id, additional_product_ids?}
+ *                price.processors.stripe.{price_id}
+ *                items[].price.processors.stripe.{price_id}
+ *   Behaviors:   paid + Stripe init → GET matches product.processor / price.config
+ *                free plan / create_in_stripe:false → processors omitted
+ *
+ * Red (current): processors is not on ApiPlanV1 / GET
+ * Green (after): GET echoes existing DB stripe ids; omit when unset
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiPlanExpandedV1,
+	BillingInterval,
+	BillingMethod,
+	type FullProduct,
+} from "@autumn/shared";
+import {
+	findBasePrice,
+	findFeaturePrice,
+	stripeConfigValue,
+} from "@tests/integration/utils/expectStripePriceResources.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import { expectApiPlanProcessorsCorrect } from "./utils/expectPlanProcessors.js";
+
+const getFull = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}): Promise<FullProduct> =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+const getApiPlan = async ({
+	autumn,
+	planId,
+}: {
+	autumn: AutumnInt;
+	planId: string;
+}): Promise<ApiPlanExpandedV1> => {
+	const catalog = await autumn.catalogV2.get({ include_archived: true });
+	const plan = catalog.plans.find((row) => row.id === planId);
+	expect(plan, `GET catalog plan ${planId}`).toBeDefined();
+	return plan!;
+};
+
+const prepaidMessagesItem = {
+	feature_id: TestFeature.Messages,
+	included: 0,
+	price: {
+		amount: 10,
+		interval: BillingInterval.Month,
+		billing_method: BillingMethod.Prepaid,
+		billing_units: 100,
+	},
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors get: paid plan echoes stripe product and price ids")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_proc_get_paid");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Processors Get Paid",
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [prepaidMessagesItem],
+					},
+				],
+			});
+
+			const db = await getFull({ ctx, planId });
+			const api = await getApiPlan({ autumn: autumnV2_3, planId });
+			const base = findBasePrice({ product: db });
+			const prepaid = findFeaturePrice({
+				product: db,
+				featureId: TestFeature.Messages,
+			});
+			const prepaidPriceId =
+				stripeConfigValue({
+					price: prepaid,
+					field: "stripe_prepaid_price_v2_id",
+				}) ?? stripeConfigValue({ price: prepaid, field: "stripe_price_id" });
+
+			expect(db.processor?.id, "db processor minted").toMatch(/^prod_/);
+			expectApiPlanProcessorsCorrect({
+				plan: api,
+				stripe: { product_id: db.processor?.id ?? "" },
+				basePriceId: stripeConfigValue({
+					price: base,
+					field: "stripe_price_id",
+				}),
+				items: {
+					[TestFeature.Messages]: prepaidPriceId,
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors get: free plan omits processors")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_proc_get_free");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Processors Get Free",
+						items: [{ feature_id: TestFeature.Dashboard }],
+					},
+				],
+			});
+
+			const api = await getApiPlan({ autumn: autumnV2_3, planId });
+			expect(api.price, "free plan price").toBeNull();
+			expectApiPlanProcessorsCorrect({
+				plan: api,
+				stripe: null,
+				items: { [TestFeature.Dashboard]: null },
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors get: create_in_stripe false omits processors")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_proc_get_skip");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Processors Get Skip",
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [prepaidMessagesItem],
+						create_in_stripe: false,
+					},
+				],
+			});
+
+			const api = await getApiPlan({ autumn: autumnV2_3, planId });
+			expectApiPlanProcessorsCorrect({
+				plan: api,
+				stripe: null,
+				basePriceId: null,
+				items: { [TestFeature.Messages]: null },
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/processors/mapping-only-mint.test.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/mapping-only-mint.test.ts
@@ -1,0 +1,91 @@
+/**
+ * catalogV2.update — a mapping-only variant declaration counts as a change.
+ *
+ * Under a base `new_version`, a variant whose active row has customers must
+ * mint its own row rather than being edited in place. The mint gate asks
+ * whether the variant declared a change, but only counts `customize` — so a
+ * variant carrying nothing but a Stripe mapping is skipped, never mints, and
+ * the mapping lands on the row customers are attached to.
+ *
+ * Contract:
+ *   B1  base new_version + variant declared with ONLY processors mints the
+ *       variant, so its lineage keeps following the base
+ *
+ * The mapping itself is plan-wide (every version bills under one Stripe
+ * product), so both rows carry it — what the mint buys is the row, not a
+ * version-specific id.
+ *
+ * Red (current):  no v2 for the variant at all; the mapping only reaches v1.
+ * Green (after):  v2 exists, and both versions carry the mapping.
+ */
+
+import { test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { withCatalogPlans } from "../licenses/utils/seedLicensePlans.js";
+import { seedVersionableCustomer } from "../migrations/utils/seedVersionableCustomer.js";
+import { expectVersionIdentityCorrect } from "../utils/expectVersionIdentity.js";
+import { seedBaseWithVariant } from "../variants/utils/seedVariantPlans.js";
+import { expectVersionProcessorCorrect } from "./utils/expectPlanProcessors.js";
+
+const MAPPED_PRODUCT_ID = "prod_MappingOnlyMint";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors mint: mapping-only variant entry mints instead of editing the live row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_proc_mom");
+		const variantId = uniqueTestId("cv2_proc_mom_eu");
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId],
+			run: async () => {
+				await seedBaseWithVariant({
+					autumn: autumnV2_3,
+					baseId,
+					variantId,
+				});
+				// Customers on the variant's active row make it mint-worthy.
+				await seedVersionableCustomer({ ctx, planId: variantId, version: 1 });
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: baseId,
+							versioning: "new_version",
+							variants: [
+								{
+									variant_plan_id: variantId,
+									processors: {
+										stripe: { product_id: MAPPED_PRODUCT_ID },
+									},
+								},
+							],
+						},
+					],
+				});
+
+				// B1: the variant minted rather than being edited in place.
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: variantId,
+					version: 2,
+				});
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId: variantId,
+					version: 2,
+					productId: MAPPED_PRODUCT_ID,
+				});
+				// The mapping is plan-wide, so the older row carries it too.
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId: variantId,
+					version: 1,
+					productId: MAPPED_PRODUCT_ID,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/processors/product-id-fanout.test.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/product-id-fanout.test.ts
@@ -1,0 +1,220 @@
+/**
+ * catalogV2.update — a plan's Stripe product id fans out across the whole plan.
+ *
+ * Every version of a plan bills under one Stripe product (a mint clones the
+ * previous row's processor), so a later correction must reach the versions
+ * that already exist — that is the import case.
+ *
+ * Contract:
+ *   B2  processors on a plan reach EVERY version of that plan, unconditionally,
+ *       replacing whatever id each version held
+ *   B3  the fan-out reaches variants and their own version histories
+ *   B4  a mapping-only change is visible in preview_update previous_attributes
+ *
+ * Red (current):  deriveVersionSiblingIntents bails unless all_versions /
+ *   unlink / pointer-change, so only the addressed row is stamped; and
+ *   previousAttributeKeys omits `processors`, so preview reports no change.
+ * Green (after):  every version + variant version carries the id, and preview
+ *   names the mapping change.
+ */
+
+import { expect, test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	messagesItem,
+	withCatalogPlans,
+} from "../licenses/utils/seedLicensePlans.js";
+import { seedBaseWithVariant } from "../variants/utils/seedVariantPlans.js";
+import { expectVersionProcessorCorrect } from "./utils/expectPlanProcessors.js";
+
+const IMPORTED_PRODUCT_ID = "prod_ImportedFanout";
+const REPLACED_PRODUCT_ID = "prod_ImportedReplacement";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors fanout: product id reaches every version of the plan")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_proc_fan_ver");
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Fanout Versions",
+							items: [messagesItem(100)],
+						},
+					],
+				});
+				// v2 takes the pointer; v1 becomes history.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							items: [messagesItem(200)],
+							versioning: "new_version",
+							active: true,
+						},
+					],
+				});
+
+				// Mapping-only edit, addressing the active row.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							processors: { stripe: { product_id: IMPORTED_PRODUCT_ID } },
+						},
+					],
+				});
+
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId,
+					version: 2,
+					productId: IMPORTED_PRODUCT_ID,
+				});
+				// B2: history follows the active row's mapping.
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId,
+					version: 1,
+					productId: IMPORTED_PRODUCT_ID,
+				});
+
+				// B2: a second mapping replaces the id on every version.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							processors: { stripe: { product_id: REPLACED_PRODUCT_ID } },
+						},
+					],
+				});
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId,
+					version: 2,
+					productId: REPLACED_PRODUCT_ID,
+				});
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId,
+					version: 1,
+					productId: REPLACED_PRODUCT_ID,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors fanout: product id reaches every variant version")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_proc_fan_var");
+		const variantId = uniqueTestId("cv2_proc_fan_var_eu");
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId],
+			run: async () => {
+				await seedBaseWithVariant({
+					autumn: autumnV2_3,
+					baseId,
+					variantId,
+				});
+				// Give the variant its own history: v2 takes the pointer.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: variantId,
+							versioning: "new_version",
+							active: true,
+						},
+					],
+				});
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: baseId,
+							processors: { stripe: { product_id: IMPORTED_PRODUCT_ID } },
+						},
+					],
+				});
+
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId: baseId,
+					version: 1,
+					productId: IMPORTED_PRODUCT_ID,
+				});
+				// B3: the variant's active row follows the base.
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId: variantId,
+					version: 2,
+					productId: IMPORTED_PRODUCT_ID,
+				});
+				// B3: so does the variant's own history.
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId: variantId,
+					version: 1,
+					productId: IMPORTED_PRODUCT_ID,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors fanout: preview reports a mapping-only change")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_proc_fan_prev");
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Fanout Preview",
+							items: [messagesItem(100)],
+							processors: { stripe: { product_id: IMPORTED_PRODUCT_ID } },
+						},
+					],
+				});
+
+				const preview = await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							processors: { stripe: { product_id: REPLACED_PRODUCT_ID } },
+						},
+					],
+				});
+
+				const row = preview.plans.find(
+					(plan: { plan_id: string }) => plan.plan_id === planId,
+				);
+				expect(row, `preview row for ${planId}`).toBeDefined();
+
+				// B4: the mapping change is named, carrying the previous id.
+				const previous = row?.plan_change?.previous_attributes;
+				expect(previous, "previous_attributes present").toBeTruthy();
+				expect(
+					(previous as { processors?: { stripe?: { product_id?: string } } })
+						?.processors?.stripe?.product_id,
+					"previous stripe product_id",
+				).toBe(IMPORTED_PRODUCT_ID);
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/processors/utils/expectPlanProcessors.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/utils/expectPlanProcessors.ts
@@ -1,5 +1,35 @@
 import { expect } from "bun:test";
 import type { ApiPlanV1 } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+/** DB-side stripe product id on one plan version. `null` asserts unset. */
+export const expectVersionProcessorCorrect = async ({
+	ctx,
+	planId,
+	version,
+	productId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	version: number;
+	productId: string | null;
+}) => {
+	const product = await ProductService.get({
+		db: ctx.db,
+		id: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		version,
+	});
+	expect(product, `missing ${planId} v${version}`).toBeDefined();
+	const label = `${planId} v${version} processor id`;
+	if (productId === null) {
+		expect(product?.processor?.id ?? null, label).toBeNull();
+		return;
+	}
+	expect(product?.processor?.id, label).toBe(productId);
+};
 
 /**
  * API-side processors asserts via catalogV2.get.
@@ -27,10 +57,9 @@ export const expectApiPlanProcessorsCorrect = ({
 	if (basePriceId === null) {
 		expect(plan.price?.processors, "base processors omitted").toBeUndefined();
 	} else if (basePriceId !== undefined) {
-		expect(
-			plan.price?.processors?.stripe?.price_id,
-			"base price_id",
-		).toBe(basePriceId);
+		expect(plan.price?.processors?.stripe?.price_id, "base price_id").toBe(
+			basePriceId,
+		);
 	}
 
 	if (items === undefined) return;

--- a/server/tests/integration/catalog-v2/plans/processors/utils/expectPlanProcessors.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/utils/expectPlanProcessors.ts
@@ -1,0 +1,54 @@
+import { expect } from "bun:test";
+import type { ApiPlanV1 } from "@autumn/shared";
+
+/**
+ * API-side processors asserts via catalogV2.get.
+ * Omit a field to skip. Pass `null` on `stripe` / a price slot to assert omitted.
+ */
+export const expectApiPlanProcessorsCorrect = ({
+	plan,
+	stripe,
+	basePriceId,
+	items,
+}: {
+	plan: ApiPlanV1;
+	stripe?: { product_id: string } | null;
+	basePriceId?: string | null;
+	items?: Record<string, string | null>;
+}) => {
+	if (stripe === null) {
+		expect(plan.processors, "plan processors omitted").toBeUndefined();
+	} else if (stripe !== undefined) {
+		expect(plan.processors?.stripe?.product_id, "plan product_id").toBe(
+			stripe.product_id,
+		);
+	}
+
+	if (basePriceId === null) {
+		expect(plan.price?.processors, "base processors omitted").toBeUndefined();
+	} else if (basePriceId !== undefined) {
+		expect(
+			plan.price?.processors?.stripe?.price_id,
+			"base price_id",
+		).toBe(basePriceId);
+	}
+
+	if (items === undefined) return;
+	for (const [featureId, expectedPriceId] of Object.entries(items)) {
+		const item = plan.items.find(
+			(candidate) => candidate.feature_id === featureId,
+		);
+		expect(item, `missing item ${featureId}`).toBeDefined();
+		if (expectedPriceId === null) {
+			expect(
+				item?.price?.processors,
+				`${featureId} processors omitted`,
+			).toBeUndefined();
+			continue;
+		}
+		expect(
+			item?.price?.processors?.stripe?.price_id,
+			`${featureId} price_id`,
+		).toBe(expectedPriceId);
+	}
+};

--- a/server/tests/unit/catalogV2/computeProductDetailsPlan/applyPlanProcessorsToProduct.test.ts
+++ b/server/tests/unit/catalogV2/computeProductDetailsPlan/applyPlanProcessorsToProduct.test.ts
@@ -21,9 +21,10 @@ describe("applyPlanProcessorsToProduct", () => {
 			product,
 			changed: false,
 		});
-		expect(
-			applyPlanProcessorsToProduct({ product, processors: {} }),
-		).toEqual({ product, changed: false });
+		expect(applyPlanProcessorsToProduct({ product, processors: {} })).toEqual({
+			product,
+			changed: false,
+		});
 	});
 
 	test("stripe object stamps id and additional ids", () => {
@@ -43,6 +44,48 @@ describe("applyPlanProcessorsToProduct", () => {
 			id: "prod_abc",
 			additional_ids: ["prod_alias"],
 		});
+	});
+
+	test("reordered additional ids are not a change", () => {
+		const product = row({
+			processor: {
+				type: "stripe",
+				id: "prod_abc",
+				additional_ids: ["prod_alias_a", "prod_alias_b"],
+			},
+		});
+		expect(
+			applyPlanProcessorsToProduct({
+				product,
+				processors: {
+					stripe: {
+						product_id: "prod_abc",
+						additional_product_ids: ["prod_alias_b", "prod_alias_a"],
+					},
+				},
+			}).changed,
+		).toBe(false);
+	});
+
+	test("a different additional id set is a change", () => {
+		const product = row({
+			processor: {
+				type: "stripe",
+				id: "prod_abc",
+				additional_ids: ["prod_alias_a"],
+			},
+		});
+		expect(
+			applyPlanProcessorsToProduct({
+				product,
+				processors: {
+					stripe: {
+						product_id: "prod_abc",
+						additional_product_ids: ["prod_alias_b"],
+					},
+				},
+			}).changed,
+		).toBe(true);
 	});
 
 	test("same id is not a change", () => {

--- a/server/tests/unit/catalogV2/computeProductDetailsPlan/applyPlanProcessorsToProduct.test.ts
+++ b/server/tests/unit/catalogV2/computeProductDetailsPlan/applyPlanProcessorsToProduct.test.ts
@@ -1,0 +1,59 @@
+/**
+ * applyPlanProcessorsToProduct — stamp plan.processors.stripe onto product.processor.
+ *
+ * Omit / processors.stripe omitted → keep. Object → set. Same id → unchanged.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Product } from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/db/products";
+import { applyPlanProcessorsToProduct } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/applyPlanProcessorsToProduct";
+
+const row = (overrides: Partial<Product> = {}): Product =>
+	({ ...products.create({ id: "pro" }), ...overrides }) as Product;
+
+describe("applyPlanProcessorsToProduct", () => {
+	test("omit keeps the existing processor", () => {
+		const product = row({
+			processor: { type: "stripe", id: "prod_existing" },
+		});
+		expect(applyPlanProcessorsToProduct({ product })).toEqual({
+			product,
+			changed: false,
+		});
+		expect(
+			applyPlanProcessorsToProduct({ product, processors: {} }),
+		).toEqual({ product, changed: false });
+	});
+
+	test("stripe object stamps id and additional ids", () => {
+		const product = row({ processor: null });
+		const { product: next, changed } = applyPlanProcessorsToProduct({
+			product,
+			processors: {
+				stripe: {
+					product_id: "prod_abc",
+					additional_product_ids: ["prod_alias"],
+				},
+			},
+		});
+		expect(changed).toBe(true);
+		expect(next.processor).toEqual({
+			type: "stripe",
+			id: "prod_abc",
+			additional_ids: ["prod_alias"],
+		});
+	});
+
+	test("same id is not a change", () => {
+		const product = row({
+			processor: { type: "stripe", id: "prod_abc" },
+		});
+		expect(
+			applyPlanProcessorsToProduct({
+				product,
+				processors: { stripe: { product_id: "prod_abc" } },
+			}),
+		).toEqual({ product, changed: false });
+	});
+});

--- a/server/tests/unit/catalogV2/computeProductDetailsPlan/diffProductDetails.test.ts
+++ b/server/tests/unit/catalogV2/computeProductDetailsPlan/diffProductDetails.test.ts
@@ -85,4 +85,14 @@ describe("productDetailsAreSame / diffProductDetails", () => {
 			true,
 		);
 	});
+
+	test("processor is not a product-detail key", () => {
+		const current = row({ processor: { type: "stripe", id: "prod_old" } });
+		const next = row({ processor: { type: "stripe", id: "prod_new" } });
+		expect(productDetailsAreSame({ product1: current, product2: next })).toBe(
+			true,
+		);
+		expect(diffProductDetails({ current, next })).toEqual({});
+	});
 });
+

--- a/server/tests/unit/catalogV2/processors-echo.test.ts
+++ b/server/tests/unit/catalogV2/processors-echo.test.ts
@@ -1,0 +1,85 @@
+/**
+ * productToPlanProcessors / priceConfigToPriceProcessors — GET echo mappers.
+ *
+ * Contract:
+ *   plan processor.id → processors.stripe.product_id
+ *   prepaid V2 id wins over V1 for price_id
+ *   omit the object when no stripe price id is set
+ *
+ * Red (current): mappers do not exist
+ * Green (after): mapping table above
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	priceConfigToPriceProcessors,
+	productToPlanProcessors,
+} from "@autumn/shared";
+
+describe("productToPlanProcessors", () => {
+	test("maps processor id and additional ids", () => {
+		expect(
+			productToPlanProcessors({
+				product: {
+					processor: {
+						type: "stripe",
+						id: "prod_abc",
+						additional_ids: ["prod_alias"],
+					},
+				},
+			}),
+		).toEqual({
+			stripe: {
+				product_id: "prod_abc",
+				additional_product_ids: ["prod_alias"],
+			},
+		});
+	});
+
+	test("omits when processor is missing", () => {
+		expect(
+			productToPlanProcessors({ product: { processor: null } }),
+		).toBeUndefined();
+		expect(
+			productToPlanProcessors({
+				product: { processor: { type: "stripe", id: "" } },
+			}),
+		).toBeUndefined();
+	});
+});
+
+describe("priceConfigToPriceProcessors", () => {
+	test("prepaid V2 id wins over V1", () => {
+		expect(
+			priceConfigToPriceProcessors({
+				config: {
+					stripe_product_id: "prod_price",
+					stripe_price_id: "price_v1",
+					stripe_prepaid_price_v2_id: "price_v2",
+				},
+			}),
+		).toEqual({
+			stripe: { price_id: "price_v2" },
+		});
+	});
+
+	test("falls back to stripe_price_id when V2 is unset", () => {
+		expect(
+			priceConfigToPriceProcessors({
+				config: { stripe_price_id: "price_v1" },
+			}),
+		).toEqual({
+			stripe: { price_id: "price_v1" },
+		});
+	});
+
+	test("omits when no stripe price id is set", () => {
+		expect(priceConfigToPriceProcessors({ config: {} })).toBeUndefined();
+		expect(priceConfigToPriceProcessors({ config: null })).toBeUndefined();
+		expect(
+			priceConfigToPriceProcessors({
+				config: { stripe_product_id: "prod_price" },
+			}),
+		).toBeUndefined();
+	});
+});

--- a/server/tests/unit/catalogV2/variants/derive-variant-intents.test.ts
+++ b/server/tests/unit/catalogV2/variants/derive-variant-intents.test.ts
@@ -362,4 +362,165 @@ describe("deriveVariantIntents", () => {
 		expect(mint).toBeDefined();
 		expect(mint?.planParams.active).toBe(true);
 	});
+
+	test("processor change fans out to latest variant", () => {
+		const current = {
+			...baseProduct,
+			processor: { type: "stripe", id: "prod_old" },
+		};
+		const next = {
+			...baseProduct,
+			processor: { type: "stripe", id: "prod_new" },
+		};
+		const variant = {
+			...baseProduct,
+			id: "team-eu",
+			internal_id: "internal_team-eu",
+			base_internal_product_id: baseProduct.internal_id,
+			processor: { type: "stripe", id: "prod_old" },
+		};
+
+		const intents = deriveVariantIntents({
+			intent: {
+				productKey: { planId: "team", version: 1 },
+				planParams: {
+					plan_id: "team",
+					version: 1,
+					processors: { stripe: { product_id: "prod_new" } },
+				},
+				source: "direct",
+			},
+			upsert: {
+				row: {
+					planId: "team",
+					version: 1,
+					op: "update",
+					source: "direct",
+					versioning: "existing",
+					currentFullProduct: current,
+					baseFullProduct: null,
+					nextFullProduct: next,
+				},
+				state: { hasCustomers: false, planHadLiveVersions: true },
+			} as UpsertProductPlan,
+			projectedProductStatesContext: {
+				...emptyStates({ planIds: ["team", "team-eu"] }),
+				versionsByPlanId: {
+					team: [next],
+					"team-eu": [variant],
+				},
+			},
+		});
+
+		expect(intents).toHaveLength(1);
+		expect(intents[0]?.source).toBe("variant_propagation");
+		expect(intents[0]?.planParams.processors).toEqual({
+			stripe: { product_id: "prod_new" },
+		});
+	});
+
+	test("variants[].processors overrides base fan-out", () => {
+		const current = {
+			...baseProduct,
+			processor: { type: "stripe", id: "prod_old" },
+		};
+		const next = {
+			...baseProduct,
+			processor: { type: "stripe", id: "prod_new" },
+		};
+		const variant = {
+			...baseProduct,
+			id: "team-eu",
+			internal_id: "internal_team-eu",
+			base_internal_product_id: baseProduct.internal_id,
+			processor: { type: "stripe", id: "prod_old" },
+		};
+
+		const intents = deriveVariantIntents({
+			intent: {
+				productKey: { planId: "team", version: 1 },
+				planParams: {
+					plan_id: "team",
+					version: 1,
+					processors: { stripe: { product_id: "prod_new" } },
+				},
+				source: "direct",
+			},
+			upsert: {
+				row: {
+					planId: "team",
+					version: 1,
+					op: "update",
+					source: "direct",
+					versioning: "existing",
+					currentFullProduct: current,
+					baseFullProduct: null,
+					nextFullProduct: next,
+				},
+				declaredVariants: [
+					{
+						variant_plan_id: "team-eu",
+						processors: { stripe: { product_id: "prod_eu" } },
+					},
+				],
+				state: { hasCustomers: false, planHadLiveVersions: true },
+			} as UpsertProductPlan,
+			projectedProductStatesContext: {
+				...emptyStates({ planIds: ["team", "team-eu"] }),
+				versionsByPlanId: {
+					team: [next],
+					"team-eu": [variant],
+				},
+			},
+		});
+
+		expect(intents).toHaveLength(1);
+		expect(intents[0]?.planParams.processors).toEqual({
+			stripe: { product_id: "prod_eu" },
+		});
+	});
+
+	test("variant_link create copies variants[].processors onto planParams", () => {
+		const next = {
+			...baseProduct,
+			processor: { type: "stripe", id: "prod_base" },
+		};
+		const intents = deriveVariantIntents({
+			intent: {
+				productKey: { planId: "team", version: 1 },
+				planParams: { plan_id: "team", version: 1 },
+				source: "direct",
+			},
+			upsert: {
+				row: {
+					planId: "team",
+					version: 1,
+					op: "none",
+					source: "direct",
+					versioning: "existing",
+					currentFullProduct: next,
+					baseFullProduct: null,
+					nextFullProduct: next,
+				},
+				declaredVariants: [
+					{
+						variant_plan_id: "team-eu",
+						name: "Team EU",
+						processors: { stripe: { product_id: "prod_eu" } },
+					},
+				],
+				state: { hasCustomers: false, planHadLiveVersions: true },
+			} as UpsertProductPlan,
+			projectedProductStatesContext: emptyStates({
+				planIds: ["team", "team-eu"],
+			}),
+		});
+
+		expect(intents).toHaveLength(1);
+		expect(intents[0]?.source).toBe("variant_link");
+		expect(intents[0]?.planParams.processors).toEqual({
+			stripe: { product_id: "prod_eu" },
+		});
+	});
 });
+

--- a/server/tests/unit/catalogV2/variants/variant-models.test.ts
+++ b/server/tests/unit/catalogV2/variants/variant-models.test.ts
@@ -138,4 +138,15 @@ previous_version_slug: null,
 		});
 		expect(parsed).not.toHaveProperty("versioning");
 	});
+
+	test("variants[] accepts processors", () => {
+		const parsed = CatalogVariantParamsSchema.parse({
+			variant_plan_id: "team-eu",
+			processors: { stripe: { product_id: "prod_eu" } },
+		});
+		expect(parsed.processors).toEqual({
+			stripe: { product_id: "prod_eu" },
+		});
+	});
 });
+

--- a/shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts
@@ -1,5 +1,6 @@
 import { FreeTrialParamsV1Schema } from "@api/common/freeTrial/freeTrialParamsV1.js";
 import { BasePriceParamsSchema } from "@api/products/components/basePrice/basePrice.js";
+import { ApiPlanProcessorsSchema } from "@api/products/components/processors.js";
 import { PlanLicenseParamsSchema } from "@api/products/crud/licenses/planLicenseParams.js";
 import { MigrationParamsSchema } from "@api/products/crud/migrationParams.js";
 import { CreatePlanItemParamsV1Schema } from "@api/products/items/crud/createPlanItemParamsV1.js";
@@ -49,6 +50,10 @@ export const UpdateCatalogPlanParamsSchema = z.object({
 	active: z.boolean().optional().meta({
 		description:
 			"Take the active pointer. On `new_version`, omit to mint a draft; `true` promotes the minted row immediately.",
+	}),
+	processors: ApiPlanProcessorsSchema.optional().meta({
+		description:
+			"Payment processors this plan is connected to. Omit to keep.",
 	}),
 	price: BasePriceParamsSchema.nullable().optional().meta({
 		description:

--- a/shared/api/catalogV2/planUpdate/params/catalogVariantParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogVariantParams.ts
@@ -1,4 +1,5 @@
 import { CustomizePlanV1Schema } from "@api/billing/common/customizePlan/customizePlanV1.js";
+import { ApiPlanProcessorsSchema } from "@api/products/components/processors.js";
 import { idRegex } from "@utils/utils.js";
 import { z } from "zod/v4";
 
@@ -37,6 +38,10 @@ export const CatalogVariantParamsSchema = z.object({
 	new_version_slug: z.string().nonempty().regex(idRegex).optional().meta({
 		description:
 			"Slug for the row this variant mints. Omit to inherit the base's `new_version_slug`, then `v{n}`. Ignored when this entry resolves to an existing row.",
+	}),
+	processors: ApiPlanProcessorsSchema.optional().meta({
+		description:
+			"Overrides the base plan's processors for this variant. Omit to inherit when the base processors change.",
 	}),
 	base_variant_id: CatalogBaseVariantIdSchema.meta({
 		description:

--- a/shared/api/products/apiPlanV1.ts
+++ b/shared/api/products/apiPlanV1.ts
@@ -9,6 +9,10 @@ import { ApiFreeTrialV2Schema } from "./components/apiFreeTrialV2.js";
 import { CustomerEligibilitySchema } from "./components/customerEligibility.js";
 import { DisplaySchema } from "./components/display.js";
 import {
+	ApiPlanProcessorsSchema,
+	ApiPriceProcessorsSchema,
+} from "./components/processors.js";
+import {
 	API_PLAN_ITEM_PREPAID_EXAMPLE,
 	API_PLAN_ITEM_USAGE_BASED_EXAMPLE,
 	ApiPlanItemV1Schema,
@@ -133,6 +137,10 @@ export const ApiPlanV1Schema = z.object({
 			display: DisplaySchema.optional().meta({
 				description: "Display text for showing this price in pricing pages.",
 			}),
+			processors: ApiPriceProcessorsSchema.optional().meta({
+				description:
+					"Payment processors this base price is connected to. Omitted when unset.",
+			}),
 		})
 		.nullable()
 		.meta({
@@ -142,6 +150,10 @@ export const ApiPlanV1Schema = z.object({
 	items: z.array(ApiPlanItemV1Schema).meta({
 		description:
 			"Feature configurations included in this plan. Each item defines included units, pricing, and reset behavior for a feature.",
+	}),
+	processors: ApiPlanProcessorsSchema.optional().meta({
+		description:
+			"Payment processors this plan is connected to. Omitted when unset.",
 	}),
 	free_trial: ApiFreeTrialV2Schema.optional().meta({
 		description:

--- a/shared/api/products/components/planChange/planPreviousAttributesV0.ts
+++ b/shared/api/products/components/planChange/planPreviousAttributesV0.ts
@@ -17,6 +17,7 @@ export const PlanPreviousAttributesV0Schema = ApiPlanV1Schema.pick({
 	config: true,
 	archived: true,
 	metadata: true,
+	processors: true,
 })
 	.partial()
 	.extend({

--- a/shared/api/products/components/processors.ts
+++ b/shared/api/products/components/processors.ts
@@ -1,0 +1,36 @@
+import { z } from "zod/v4";
+
+/** Stripe connection on a plan — the Stripe Product. */
+export const ApiStripePlanProcessorSchema = z.object({
+	product_id: z.string().meta({
+		description: "Stripe product ID this plan is billed under.",
+	}),
+	additional_product_ids: z.array(z.string()).optional().meta({
+		description: "Extra Stripe product IDs aliased to this plan.",
+	}),
+});
+
+/** Stripe connection on a price — the Stripe Price. Product is inferred from it. */
+export const ApiStripePriceProcessorSchema = z.object({
+	price_id: z.string().meta({
+		description:
+			"Stripe price ID. For prepaid with included > 0 this is the V2 price.",
+	}),
+});
+
+export const ApiPlanProcessorsSchema = z.object({
+	stripe: ApiStripePlanProcessorSchema.optional(),
+});
+
+export const ApiPriceProcessorsSchema = z.object({
+	stripe: ApiStripePriceProcessorSchema.optional(),
+});
+
+export type ApiStripePlanProcessor = z.infer<
+	typeof ApiStripePlanProcessorSchema
+>;
+export type ApiStripePriceProcessor = z.infer<
+	typeof ApiStripePriceProcessorSchema
+>;
+export type ApiPlanProcessors = z.infer<typeof ApiPlanProcessorsSchema>;
+export type ApiPriceProcessors = z.infer<typeof ApiPriceProcessorsSchema>;

--- a/shared/api/products/index.ts
+++ b/shared/api/products/index.ts
@@ -7,6 +7,7 @@ export * from "./components/apiFreeTrialV2";
 export * from "./components/basePrice/basePriceToProductItem";
 export * from "./components/billingMethod";
 export * from "./components/display";
+export * from "./components/processors";
 export * from "./components/planChange/index";
 export * from "./components/planExpand";
 export * from "./crud/index";

--- a/shared/api/products/items/apiPlanItemV1.ts
+++ b/shared/api/products/items/apiPlanItemV1.ts
@@ -7,6 +7,7 @@ import {
 } from "@api/products/components/additionalCurrencies.js";
 import { BillingMethod } from "@api/products/components/billingMethod.js";
 import { DisplaySchema } from "@api/products/components/display.js";
+import { ApiPriceProcessorsSchema } from "@api/products/components/processors.js";
 import { RolloverExpiryDurationType } from "@models/productModels/durationTypes/rolloverExpiryDurationType.js";
 import { BillingInterval } from "@models/productModels/intervals/billingInterval.js";
 import { ResetInterval } from "@models/productModels/intervals/resetInterval.js";
@@ -127,6 +128,10 @@ export const ApiPlanItemV1Schema = z
 				max_purchase: z.number().nullable().meta({
 					description:
 						"Maximum units a customer can purchase beyond included. E.g. if included=100 and max_purchase=300, customer can use up to 400 total before usage is capped. Null for no limit.",
+				}),
+				processors: ApiPriceProcessorsSchema.optional().meta({
+					description:
+						"Payment processors this item price is connected to. Omitted when unset.",
 				}),
 			})
 			.nullable()

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -56,6 +56,7 @@ export * from "./productUtils/classifyProduct/isProductPaidAndRecurring";
 export * from "./productUtils/compareProduct/productDetailsAreSame";
 export * from "./productUtils/convertProduct/productKey";
 export * from "./productUtils/convertProduct/productToEffectivePrices";
+export * from "./productUtils/convertProduct/productToPlanProcessors";
 export * from "./productUtils/convertProduct/productToProductKey";
 export * from "./productUtils/convertProduct/productToReplacementKey";
 // Product utils

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -54,6 +54,7 @@ export * from "./productUtils/classifyProduct/hasMissingStripeResourcesForProduc
 export * from "./productUtils/classifyProduct/isEligibleDefaultProduct";
 export * from "./productUtils/classifyProduct/isProductPaidAndRecurring";
 export * from "./productUtils/compareProduct/productDetailsAreSame";
+export * from "./productUtils/compareProduct/productProcessorsAreSame";
 export * from "./productUtils/convertProduct/productKey";
 export * from "./productUtils/convertProduct/productToEffectivePrices";
 export * from "./productUtils/convertProduct/productToPlanProcessors";

--- a/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
@@ -20,6 +20,7 @@ const previousAttributeKeys = [
 	"billing_controls",
 	"archived",
 	"metadata",
+	"processors",
 ] as const satisfies readonly (keyof ApiPlanV1)[];
 
 const valuesEqual = (left: unknown, right: unknown): boolean => {

--- a/shared/utils/productUtils/compareProduct/productProcessorsAreSame.ts
+++ b/shared/utils/productUtils/compareProduct/productProcessorsAreSame.ts
@@ -1,0 +1,31 @@
+import type { Product } from "../../../models/productModels/productModels.js";
+
+/** Alias ids are an unordered set, so sequence must not count as a difference. */
+const additionalIdsAreSame = ({
+	left,
+	right,
+}: {
+	left?: string[];
+	right?: string[];
+}): boolean => {
+	const leftIds = [...(left ?? [])].sort();
+	const rightIds = [...(right ?? [])].sort();
+	return (
+		leftIds.length === rightIds.length &&
+		leftIds.every((id, index) => id === rightIds[index])
+	);
+};
+
+/** Stripe mapping equality: the primary product id plus the set of alias ids. */
+export const productProcessorsAreSame = ({
+	left,
+	right,
+}: {
+	left: Product["processor"];
+	right: Product["processor"];
+}): boolean =>
+	(left?.id ?? null) === (right?.id ?? null) &&
+	additionalIdsAreSame({
+		left: left?.additional_ids,
+		right: right?.additional_ids,
+	});

--- a/shared/utils/productUtils/convertProduct/productToPlanProcessors.ts
+++ b/shared/utils/productUtils/convertProduct/productToPlanProcessors.ts
@@ -1,0 +1,19 @@
+import type { ApiPlanProcessors } from "@api/products/components/processors";
+import type { Product } from "@models/productModels/productModels";
+
+export const productToPlanProcessors = ({
+	product,
+}: {
+	product: Pick<Product, "processor">;
+}): ApiPlanProcessors | undefined => {
+	const processor = product.processor;
+	if (!processor?.id) return undefined;
+	return {
+		stripe: {
+			product_id: processor.id,
+			...(processor.additional_ids?.length
+				? { additional_product_ids: processor.additional_ids }
+				: {}),
+		},
+	};
+};

--- a/shared/utils/productUtils/priceUtils/convertPrice/priceConfigToPriceProcessors.ts
+++ b/shared/utils/productUtils/priceUtils/convertPrice/priceConfigToPriceProcessors.ts
@@ -1,0 +1,18 @@
+import type { ApiPriceProcessors } from "@api/products/components/processors";
+
+type StripePriceConfigSlots = {
+	stripe_product_id?: string | null;
+	stripe_price_id?: string | null;
+	stripe_prepaid_price_v2_id?: string | null;
+} | null;
+
+export const priceConfigToPriceProcessors = ({
+	config,
+}: {
+	config?: StripePriceConfigSlots;
+}): ApiPriceProcessors | undefined => {
+	const priceId =
+		config?.stripe_prepaid_price_v2_id || config?.stripe_price_id || undefined;
+	if (!priceId) return undefined;
+	return { stripe: { price_id: priceId } };
+};

--- a/shared/utils/productUtils/priceUtils/index.ts
+++ b/shared/utils/productUtils/priceUtils/index.ts
@@ -8,6 +8,7 @@ export * from "./classifyPriceUtils.js";
 export * from "./comparePrice/pricesAreSame.js";
 export * from "./comparePrice/priceToStripePriceIdempotencyShape.js";
 export * from "./convertAmountUtils.js";
+export * from "./convertPrice/priceConfigToPriceProcessors.js";
 export * from "./convertPrice/priceToRequiredStripeSlots.js";
 export * from "./convertPrice/priceToStripeNickname.js";
 export * from "./convertPrice/priceToStripeTiersMode.js";

--- a/shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToPlanItemV1.ts
+++ b/shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToPlanItemV1.ts
@@ -1,4 +1,5 @@
 import { PlanExpand } from "@api/products/components/planExpand.js";
+import { priceConfigToPriceProcessors } from "@utils/productUtils/priceUtils/convertPrice/priceConfigToPriceProcessors.js";
 import {
 	type ApiPlanItemV1,
 	ApiPlanItemV1Schema,
@@ -107,6 +108,10 @@ const itemToPlanFeaturePrice = ({
 		});
 	}
 
+	const processors = priceConfigToPriceProcessors({
+		config: item.price_config,
+	});
+
 	return {
 		amount: price ?? undefined,
 		additional_currencies: additionalCurrencies,
@@ -122,6 +127,7 @@ const itemToPlanFeaturePrice = ({
 		billing_units: item.billing_units ?? 1,
 		billing_method: billingMethod,
 		max_purchase: maxPurchase,
+		...(processors ? { processors } : {}),
 	};
 };
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the plan processor story so `catalogV2.update` can set a plan's Stripe product mapping once, keep every version in sync, and report the mapping on GET.

- `plans[].processors.stripe` and `variants[].processors` are new optional params; omit or repeat the current values and nothing changes.
- A mapping-only update still persists even though `processor` isn't a product-detail key.
- A mapping on any plan row replaces the Stripe id on every version of that plan and its variants, unless a variant carries its own override. Alias ids are supported and compared as an unordered set.
- Mapping-only variant declarations under `new_version` mint a new row instead of editing the live row.
- GET echoes `processors.stripe.product_id` and price `price_id`s (preferring the prepaid V2 price); free plans and `create_in_stripe: false` omit the field. `previous_attributes` includes `processors`, so preview_update shows mapping-only edits.
- Supplied product ids are stored without validating against the org's Stripe account, so a typo or foreign id can leave Stripe sync unable to resolve the intended plan.

<sup>Written for commit 0b2e1af1d80662f142c6b662098d73461f7e0ec3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Completes Stripe product-ID mapping support across catalog updates, plan versions, variants, previews, and GET responses.

- **API changes, Improvements:** Adds optional Stripe processor mappings to plan and variant request models and exposes product and price IDs in plan responses.
- **Bug fixes, Improvements:** Persists mapping-only updates and includes processor changes in update previews.
- **Improvements:** Synchronizes a plan’s mapping across its versions and variants while preserving explicit variant overrides.
- **Bug fixes:** Treats mapping-only variant declarations as version-worthy changes when existing customers require a new row.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no unacknowledged blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/applyPlanProcessorsToProduct.ts | Applies declared Stripe product mappings to product rows and detects mapping-only changes. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveVersionSiblingIntents.ts | Fans declared processor mappings out to sibling plan versions without recursively generating synchronization intents. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts | Treats mapping-only variant declarations as content requiring a new version when applicable. |
| server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts | Adds persisted Stripe product and price identifiers to catalog plan responses. |
| shared/api/products/components/processors.ts | Defines the public processor mapping schemas used by plan, price, and update contracts. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Catalog update with Stripe product ID] --> Plan[Apply mapping to selected plan]
  Plan --> Versions[Synchronize plan versions]
  Plan --> Variants[Propagate to variants]
  Variants --> Overrides[Preserve explicit variant overrides]
  Versions --> Persist[Persist processor mappings]
  Overrides --> Persist
  Persist --> Preview[Expose changes in preview]
  Persist --> Get[Echo product and price IDs on GET]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: 🐛 compare stripe alias product ids..."](https://github.com/useautumn/autumn/commit/0b2e1af1d80662f142c6b662098d73461f7e0ec3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58595928)</sub>

<!-- /greptile_comment -->