### PR TITLE
feat(catalog-v2): unlink stripe mappings with an explicit null

### DIFF
--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/applyPlanProcessorsToProduct.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/applyPlanProcessorsToProduct.ts
@@ -4,7 +4,7 @@ import {
 	productProcessorsAreSame,
 } from "@autumn/shared";
 
-/** Stamp `plan.processors.stripe` onto `product.processor`. Omit keeps. */
+/** Stamp `plan.processors.stripe` onto `product.processor`. Omit keeps, null unlinks. */
 export const applyPlanProcessorsToProduct = ({
 	product,
 	processors,
@@ -12,19 +12,23 @@ export const applyPlanProcessorsToProduct = ({
 	product: Product;
 	processors?: ApiPlanProcessors;
 }): { product: Product; changed: boolean } => {
-	if (processors?.stripe === undefined) {
+	const stripe = processors?.stripe;
+	if (stripe === undefined) {
 		return { product, changed: false };
 	}
 
 	const next: Product = {
 		...product,
-		processor: {
-			type: "stripe",
-			id: processors.stripe.product_id,
-			...(processors.stripe.additional_product_ids?.length
-				? { additional_ids: processors.stripe.additional_product_ids }
-				: {}),
-		},
+		processor:
+			stripe === null
+				? null
+				: {
+						type: "stripe",
+						id: stripe.product_id,
+						...(stripe.additional_product_ids?.length
+							? { additional_ids: stripe.additional_product_ids }
+							: {}),
+					},
 	};
 	return {
 		product: next,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/variantSettingsPlanParams.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/variantSettingsPlanParams.ts
@@ -72,7 +72,8 @@ export const variantSettingsPlanParams = ({
 		})
 	) {
 		const nextProcessors = productToPlanProcessors({ product: next });
-		if (nextProcessors) patch.processors = nextProcessors;
+		// A cleared mapping has no next value — send the explicit unlink instead.
+		patch.processors = nextProcessors ?? { stripe: null };
 	}
 
 	return patch;

--- a/server/tests/integration/catalog-v2/plans/processors/product-id-unlink.test.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/product-id-unlink.test.ts
@@ -1,0 +1,138 @@
+/**
+ * catalogV2.update — an explicit null unlinks a Stripe mapping.
+ *
+ * Setting a mapping fans out to every row of the plan, so clearing one has to
+ * travel the same path: `omitted = unchanged, null = unlink` is the annotation
+ * rule mappings ride (wire/08, envelope rule 4).
+ *
+ * Contract:
+ *   B5  `processors: { stripe: null }` clears the mapping from every version
+ *       of the plan and from its variants
+ *   B6  preview reports the unlink, carrying the previous id
+ *
+ * Red (current):  `stripe` is optional but not nullable — null is rejected by
+ *   the schema, or read as "omitted" and the mapping survives.
+ * Green (after):  every row's processor is cleared; preview names the change.
+ */
+
+import { expect, test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	messagesItem,
+	withCatalogPlans,
+} from "../licenses/utils/seedLicensePlans.js";
+import { seedBaseWithVariant } from "../variants/utils/seedVariantPlans.js";
+import { expectVersionProcessorCorrect } from "./utils/expectPlanProcessors.js";
+
+const LINKED_PRODUCT_ID = "prod_UnlinkFixture";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors unlink: null clears the mapping from every row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_proc_unlink");
+		const variantId = uniqueTestId("cv2_proc_unlink_eu");
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId],
+			run: async () => {
+				await seedBaseWithVariant({
+					autumn: autumnV2_3,
+					baseId,
+					variantId,
+				});
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: baseId,
+							versioning: "new_version",
+							active: true,
+						},
+					],
+				});
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: baseId,
+							processors: { stripe: { product_id: LINKED_PRODUCT_ID } },
+						},
+					],
+				});
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId: baseId,
+					version: 1,
+					productId: LINKED_PRODUCT_ID,
+				});
+
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: baseId, processors: { stripe: null } }],
+				});
+
+				// B5: cleared on the addressed row, its history, and the variant.
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId: baseId,
+					version: 2,
+					productId: null,
+				});
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId: baseId,
+					version: 1,
+					productId: null,
+				});
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId: variantId,
+					version: 1,
+					productId: null,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors unlink: preview reports the cleared mapping")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_proc_unlink_prev");
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Unlink Preview",
+							items: [messagesItem(100)],
+							processors: { stripe: { product_id: LINKED_PRODUCT_ID } },
+						},
+					],
+				});
+
+				const preview = await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, processors: { stripe: null } }],
+				});
+
+				const row = preview.plans.find(
+					(plan: { plan_id: string }) => plan.plan_id === planId,
+				);
+				expect(row, `preview row for ${planId}`).toBeDefined();
+
+				// B6: the unlink is named, carrying the id being dropped.
+				const previous = row?.plan_change?.previous_attributes;
+				expect(previous, "previous_attributes present").toBeTruthy();
+				expect(
+					(previous as { processors?: { stripe?: { product_id?: string } } })
+						?.processors?.stripe?.product_id,
+					"previous stripe product_id",
+				).toBe(LINKED_PRODUCT_ID);
+			},
+		});
+	},
+);

--- a/shared/api/products/components/processors.ts
+++ b/shared/api/products/components/processors.ts
@@ -19,7 +19,8 @@ export const ApiStripePriceProcessorSchema = z.object({
 });
 
 export const ApiPlanProcessorsSchema = z.object({
-	stripe: ApiStripePlanProcessorSchema.optional(),
+	/** Omit to keep the current mapping; null unlinks it. */
+	stripe: ApiStripePlanProcessorSchema.nullish(),
 });
 
 export const ApiPriceProcessorsSchema = z.object({


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows explicit `null` to unlink a Stripe processor mapping in catalogV2, while omitting `stripe` still keeps the current mapping. Previously, `null` was rejected or treated as "no change"; now it clears the mapping from every version of the plan and its variants, and previews show the unlink as a change carrying the previous product id.

- Updates the `ApiPlanProcessorsSchema` so `stripe` accepts `null` as an explicit unlink.
- Adds integration tests covering fan-out across plan versions and variants, and that the preview reports the unlinked id.

<sup>Written for commit b9d32a3f54d972be03a3f884a10ead4e5395f36d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds an explicit way to remove a plan’s Stripe product mapping while preserving the existing mapping when the field is omitted.

- **API changes, Improvements:** Accept `stripe: null` as the explicit unlink value in plan processor inputs.
- **Bug fixes:** Carry processor removals through plan versions and variants instead of treating them as omitted updates.
- **Improvements:** Add integration coverage for unlink propagation and preview output.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/products/components/processors.ts | Extends the plan processor API schema so an explicit null represents unlinking while omission remains supported. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/applyPlanProcessorsToProduct.ts | Distinguishes omitted Stripe mappings from explicit null and clears the stored processor for the latter. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/variantSettingsPlanParams.ts | Preserves processor removal as an explicit variant update rather than dropping the change. |
| server/tests/integration/catalog-v2/plans/processors/product-id-unlink.test.ts | Covers unlinking across plan versions and variants and verifies that preview retains the previous Stripe product ID. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Catalog update input] --> B{processors.stripe}
  B -->|omitted| C[Keep existing mapping]
  B -->|object| D[Set Stripe product mapping]
  B -->|null| E[Clear Stripe product mapping]
  E --> F[Propagate through selected versions and variants]
  F --> G[Preview records previous product ID]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: 💍 cover stripe mapping unlink and..."](https://github.com/useautumn/autumn/commit/b9d32a3f54d972be03a3f884a10ead4e5395f36d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58595933)</sub>

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)

<!-- /greptile_comment -->