### PR TITLE
fix(stripe-prices): recognise a round-tripped price id in any identit…

### DIFF
--- a/server/tests/unit/shared/stripePriceIdForInitializedPrice.test.ts
+++ b/server/tests/unit/shared/stripePriceIdForInitializedPrice.test.ts
@@ -12,9 +12,11 @@ import {
 const usage = ({
 	amount,
 	stripePriceId,
+	prepaidV2StripePriceId,
 }: {
 	amount: number;
 	stripePriceId?: string;
+	prepaidV2StripePriceId?: string;
 }): Price => ({
 	id: "pr_messages",
 	org_id: "org_1",
@@ -32,6 +34,9 @@ const usage = ({
 		interval: BillingInterval.Month,
 		interval_count: 1,
 		...(stripePriceId !== undefined ? { stripe_price_id: stripePriceId } : {}),
+		...(prepaidV2StripePriceId !== undefined
+			? { stripe_prepaid_price_v2_id: prepaidV2StripePriceId }
+			: {}),
 	} as UsagePriceConfig,
 	entitlement_id: "ent_messages",
 	proration_config: null,
@@ -73,6 +78,45 @@ describe("stripePriceIdForInitializedPrice", () => {
 			stripePriceIdForInitializedPrice({
 				requestedStripePriceId: "price_imported",
 				currentPrice: usage({ amount: 10, stripePriceId: "price_old" }),
+				newPrice: usage({ amount: 500 }),
+			}),
+		).toBe("price_imported");
+	});
+
+	test("drops a round-tripped prepaid v2 id when the definition drifted", () => {
+		expect(
+			stripePriceIdForInitializedPrice({
+				requestedStripePriceId: "price_old",
+				currentPrice: usage({
+					amount: 10,
+					prepaidV2StripePriceId: "price_old",
+				}),
+				newPrice: usage({ amount: 500 }),
+			}),
+		).toBeUndefined();
+	});
+
+	test("keeps a round-tripped prepaid v2 id when the definition still matches", () => {
+		expect(
+			stripePriceIdForInitializedPrice({
+				requestedStripePriceId: "price_old",
+				currentPrice: usage({
+					amount: 10,
+					prepaidV2StripePriceId: "price_old",
+				}),
+				newPrice: usage({ amount: 10 }),
+			}),
+		).toBe("price_old");
+	});
+
+	test("keeps an unowned id when the current price only fills the v2 slot", () => {
+		expect(
+			stripePriceIdForInitializedPrice({
+				requestedStripePriceId: "price_imported",
+				currentPrice: usage({
+					amount: 10,
+					prepaidV2StripePriceId: "price_old",
+				}),
 				newPrice: usage({ amount: 500 }),
 			}),
 		).toBe("price_imported");

--- a/shared/utils/productUtils/priceUtils/match/stripePriceIdForInitializedPrice.ts
+++ b/shared/utils/productUtils/priceUtils/match/stripePriceIdForInitializedPrice.ts
@@ -1,12 +1,23 @@
 import { nullish } from "../../../utils.js";
+import {
+	type CurrencyAwarePriceConfig,
+	getAllPriceStripeIds,
+} from "@models/productModels/priceModels/priceConfig/priceCurrencyView.js";
 import type { Price } from "@models/productModels/priceModels/priceModels.js";
 import { pricesAreSame } from "../comparePrice/pricesAreSame.js";
 
-const priceStripePriceId = ({ price }: { price: Price }): string | null => {
-	const id = (price.config as { stripe_price_id?: string | null })
-		.stripe_price_id;
-	return nullish(id) ? null : id;
-};
+// A prepaid price under billing V2 stores its Stripe price in
+// `stripe_prepaid_price_v2_id`, so ownership must span every identity slot.
+const priceOwnsStripePriceId = ({
+	price,
+	stripePriceId,
+}: {
+	price: Price;
+	stripePriceId: string;
+}): boolean =>
+	getAllPriceStripeIds({
+		config: price.config as CurrencyAwarePriceConfig,
+	}).includes(stripePriceId);
 
 /**
  * Stamp a requested Stripe price id onto a newly built Autumn price only when
@@ -24,7 +35,12 @@ export const stripePriceIdForInitializedPrice = ({
 }): string | undefined => {
 	if (nullish(requestedStripePriceId)) return undefined;
 	if (!currentPrice) return requestedStripePriceId;
-	if (requestedStripePriceId !== priceStripePriceId({ price: currentPrice })) {
+	if (
+		!priceOwnsStripePriceId({
+			price: currentPrice,
+			stripePriceId: requestedStripePriceId,
+		})
+	) {
 		return requestedStripePriceId;
 	}
 	if (pricesAreSame(currentPrice, newPrice)) return requestedStripePriceId;


### PR DESCRIPTION
…y slot

Ownership was read from config.stripe_price_id alone, so a prepaid price under billing V2 — whose id lives in stripe_prepaid_price_v2_id — looked unowned. A stale id round-tripped through plans.update was then kept as if imported, and promoted onto the drifted price, leaving the plan billing at the old Stripe amount. getAllPriceStripeIds spans every slot, including per-currency overlays.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes price ownership detection so a round-tripped Stripe price id is recognized even when stored in the prepaid V2 slot. Previously, only `config.stripe_price_id` was checked, so a stale id was kept and promoted onto a drifted price, leaving billing at the old amount.

<sup>Written for commit 0ca2c125339bcbec6e5b90b827ee84752b3a11f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

