### PR TITLE
feat: grant rewards scopes in the default OAuth resource set

### DIFF
--- a/shared/utils/auth/autumnOAuthScopes.test.ts
+++ b/shared/utils/auth/autumnOAuthScopes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { DEFAULT_OAUTH_RESOURCE_SCOPES } from "./autumnOAuthScopes";
 import { Scopes } from "../scopeDefinitions";
+import { DEFAULT_OAUTH_RESOURCE_SCOPES } from "./autumnOAuthScopes";
 
 describe("DEFAULT_OAUTH_RESOURCE_SCOPES", () => {
 	test("contains the exact Autumn OAuth resource allowlist", () => {
@@ -12,6 +12,8 @@ describe("DEFAULT_OAUTH_RESOURCE_SCOPES", () => {
 			Scopes.Features.Write,
 			Scopes.Plans.Read,
 			Scopes.Plans.Write,
+			Scopes.Rewards.Read,
+			Scopes.Rewards.Write,
 			Scopes.Balances.Read,
 			Scopes.Balances.Write,
 			Scopes.Billing.Read,
@@ -30,8 +32,6 @@ describe("DEFAULT_OAUTH_RESOURCE_SCOPES", () => {
 				Scopes.Migrations.Write,
 				Scopes.Platform.Read,
 				Scopes.Platform.Write,
-				Scopes.Rewards.Read,
-				Scopes.Rewards.Write,
 				Scopes.Admin,
 				Scopes.Owner,
 				Scopes.Superuser,

--- a/shared/utils/auth/autumnOAuthScopes.ts
+++ b/shared/utils/auth/autumnOAuthScopes.ts
@@ -13,6 +13,8 @@ export const DEFAULT_OAUTH_RESOURCE_SCOPES = [
 	Scopes.Features.Write,
 	Scopes.Plans.Read,
 	Scopes.Plans.Write,
+	Scopes.Rewards.Read,
+	Scopes.Rewards.Write,
 	Scopes.Balances.Read,
 	Scopes.Balances.Write,
 	Scopes.Billing.Read,
@@ -23,7 +25,5 @@ export const DEFAULT_OAUTH_RESOURCE_SCOPES = [
 export const OAUTH_PROTOCOL_SCOPES = OPENID_SCOPES;
 
 export const DEFAULT_OAUTH_RESOURCES = [
-	...new Set(
-		DEFAULT_OAUTH_RESOURCE_SCOPES.map((scope) => scope.split(":")[0]),
-	),
+	...new Set(DEFAULT_OAUTH_RESOURCE_SCOPES.map((scope) => scope.split(":")[0])),
 ] as ResourceType[];


### PR DESCRIPTION
The Slack agent mints its Autumn token from `DEFAULT_OAUTH_RESOURCE_SCOPES`, which omitted rewards entirely. Two consequences in prod:

- `listRewards` is allowlisted on the investigator, but the minted token can never satisfy the endpoint's `rewards:read`.
- `createReward` is gated on `rewards:write` (`gatedWrites.ts:42`), which no minted token can carry — so the approval would fail closed at decide time.

Adds `rewards:read` and `rewards:write` to the ceiling. 12 → 14 of the 21 defined scopes.

## Dashboard

No UI change needed. `DEFAULT_OAUTH_RESOURCES` derives from this list, `SlackScopesSheet` passes it as `BOT_RESOURCES`, and `ScopeSelector` builds each row generically. The display metadata already existed (`scopeDefinitions.ts:448` — "Referrals and reward codes"), so a Rewards row appears automatically.

## Reversal of a locked decision

The test explicitly asserted rewards was *excluded* ("does not include elevated or unrelated product scopes"). That assertion is moved, not deleted — this is a deliberate reversal, not an oversight being corrected. Still excluded: `organisation:write`, `migrations:*`, `apiKeys:*`, `platform:*`.

## Scope of impact

This constant is also the default grant for every OAuth/MCP client (consent screen, protected-resource metadata, `packages/auth/src/oauth/autumnOAuth.ts:15`) — not leaf alone. Any client relying on the default grant now receives rewards read+write.

## Rollout

Existing installations keep their current scopes until their OAuth credential is re-issued — `resolveAgentScopes` bounds requested scopes against the ceiling at mint time.

This unblocks rewards but does not enable them: `createReward` still sits only on the unwired `catalog` agent, and `orchestrator.md:21` still tells the agent rewards changes are unavailable.

## Verification

- `shared/utils/auth/` — 23 pass / 0 fail
- `server/tests/unit/auth/` (22 files) — 150 pass / 0 fail
- leaf oauth + installations + gatedWrites — 27 pass / 0 fail
- `bun ts` root + leaf — clean; biome clean

Two incidental biome reformats are included (import order in the test, a line-wrap in `DEFAULT_OAUTH_RESOURCES`) from formatting the touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grants `rewards:read` and `rewards:write` in the default OAuth resource scope set so the Slack agent can call `listRewards` and pass `createReward`'s approval gate.

- The test that asserted rewards were excluded now asserts they're included; this is a deliberate reversal, not a fix for an oversight.
- This constant is the default grant for every OAuth/MCP client, so any client using the default now receives rewards read and write.
- Existing installations keep their current scopes until their OAuth credential is re-issued.
- No dashboard change is needed; the Rewards row appears automatically from existing scope metadata.

<sup>Written for commit df4827087def932e6f4241614b18bd857f40ef33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR expands the default OAuth resource grant so OAuth and MCP clients can read and write rewards.

- **[Bug fixes, API changes]** Adds `rewards:read` and `rewards:write` to the default OAuth scope set, enabling authorized reward operations that previously failed scope checks.
- **[Improvements]** Updates the exact allowlist test to document the deliberate inclusion of reward scopes while retaining exclusions for elevated and unrelated scopes.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the expanded reward permissions are deliberate, remain bounded by existing OAuth role checks, and preserve approval gating for agent writes.

The implementation and tests consistently add both reward scopes to the shared default grant, with no concrete unacknowledged failure introduced by the changed lines.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/auth/autumnOAuthScopes.ts | Adds reward read and write permissions to the shared default OAuth grant and consequently adds rewards to the derived resource list. |
| shared/utils/auth/autumnOAuthScopes.test.ts | Updates the exact allowlist and exclusion assertions to capture the intentional scope-policy change. |

<sub>Reviews (1): Last reviewed commit: ["feat: grant rewards scopes in the defaul..."](https://github.com/useautumn/autumn/commit/df4827087def932e6f4241614b18bd857f40ef33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57879021)</sub>

**Context used:**

- Knowledge Base — [Automation and external integrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/automation-and-external-integrations.md)

<!-- /greptile_comment -->