### PR TITLE
fix(shared): gate stripe_meter_id reuse on both prices being consumable

### DIFF
--- a/server/tests/unit/shared/copyStripeResourcesToMatchingPrice.test.ts
+++ b/server/tests/unit/shared/copyStripeResourcesToMatchingPrice.test.ts
@@ -204,6 +204,40 @@ describe("copyStripeResourcesToMatchingPrice", () => {
 		expect(config.stripe_product_id).toBe("prod_ai_credits");
 	});
 
+	test("does not copy a consumable candidate's stripe_meter_id onto a prepaid target", () => {
+		const consumableCandidate = candidate({
+			id: "pr_consumable",
+			config: {
+				...baseConfig,
+				bill_when: BillWhen.EndOfPeriod,
+				stripe_product_id: "prod_ai_credits",
+				stripe_meter_id: "meter_ai_credits",
+			},
+		});
+		const newPrice = target({
+			config: {
+				...baseConfig,
+				bill_when: BillWhen.StartOfPeriod,
+				stripe_product_id: undefined,
+				stripe_price_id: undefined,
+				stripe_meter_id: undefined,
+				stripe_event_name: undefined,
+			} as UsagePriceConfig,
+		});
+
+		const result = copyStripeResourcesToMatchingPrice({
+			targetPrice: newPrice,
+			candidatePrices: [consumableCandidate],
+			targetEntitlements: [entitlement({ id: "ent_new" })],
+			candidateEntitlements: [entitlement()],
+		});
+
+		const config = newPrice.config as UsagePriceConfig;
+		expect(result.copiedFields).toEqual(["stripe_product_id"]);
+		expect(config.stripe_product_id).toBe("prod_ai_credits");
+		expect(config.stripe_meter_id).toBeUndefined();
+	});
+
 	test("returns no copied fields when nothing matches", () => {
 		const unrelatedCandidate = candidate({
 			id: "pr_unrelated",

--- a/shared/utils/productUtils/priceUtils/match/copyStripeResourcesToMatchingPrice.ts
+++ b/shared/utils/productUtils/priceUtils/match/copyStripeResourcesToMatchingPrice.ts
@@ -1,4 +1,9 @@
-import { type Entitlement, nullish, type Price } from "@autumn/shared";
+import {
+	type Entitlement,
+	isConsumablePrice,
+	nullish,
+	type Price,
+} from "@autumn/shared";
 import { getPriceStripeReuseLevel } from "./getPriceStripeReuseLevel.js";
 
 const stripeResourceFields = [
@@ -83,6 +88,13 @@ export const copyStripeResourcesToMatchingPrice = ({
 	if (productSource) {
 		const fromConfig = productSource.config as StripeResourceConfig;
 		for (const field of stripeProductOnlyFields) {
+			if (
+				field === "stripe_meter_id" &&
+				(!isConsumablePrice(targetPrice) || !isConsumablePrice(productSource))
+			) {
+				continue;
+			}
+
 			if (
 				copyField({
 					fromConfig,


### PR DESCRIPTION
Prepaid prices should never inherit a Stripe usage meter from a stripeProductOnly reuse match. Only copy stripe_meter_id when both the target and candidate prices are consumable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents prepaid prices from inheriting a Stripe usage meter from a `stripeProductOnly` reuse match. `stripe_meter_id` is now copied only when both the target and candidate prices are consumable.

<sup>Written for commit bfa7c0b4e057c648a83f3415e7a50ec83a4fd7fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

