### PR TITLE
fix(stripe): un-archive feature Stripe products on reuse and idempotent replay

### DIFF
--- a/server/src/external/stripe/products/utils/resolveStripeProductForFeaturePrice.ts
+++ b/server/src/external/stripe/products/utils/resolveStripeProductForFeaturePrice.ts
@@ -45,13 +45,19 @@ export const resolveStripeProductForFeaturePrice = async ({
 		},
 	);
 
+	// Stripe replays this idempotency key for 24h, so `created` can be a stale
+	// body describing a product that has since been archived.
+	const liveProduct =
+		(await retrieveLiveStripeProduct({ stripeCli, productId: created.id })) ??
+		created;
+
 	await updateFeatureStripeProductIdIfUnset({
 		db,
 		featureInternalId: feature.internal_id,
-		newId: created.id,
+		newId: liveProduct.id,
 		previousId: feature.stripe_product_id,
 	});
 
-	config.stripe_product_id = created.id;
-	return created.id;
+	config.stripe_product_id = liveProduct.id;
+	return liveProduct.id;
 };

--- a/server/src/external/stripe/products/utils/retrieveLiveStripeProduct.ts
+++ b/server/src/external/stripe/products/utils/retrieveLiveStripeProduct.ts
@@ -11,7 +11,8 @@ export const retrieveLiveStripeProduct = async ({
 
 	try {
 		const product = await stripeCli.products.retrieve(productId);
-		return product.active ? product : null;
+		if (product.active) return product;
+		return await stripeCli.products.update(product.id, { active: true });
 	} catch {
 		return null;
 	}

--- a/server/tests/unit/external/stripe/resolve-stripe-product-for-feature-price.test.ts
+++ b/server/tests/unit/external/stripe/resolve-stripe-product-for-feature-price.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import type { Feature, Price, UsagePriceConfig } from "@autumn/shared";
+import type { DrizzleCli } from "@server/db/initDrizzle.js";
+import type Stripe from "stripe";
+import { mockModuleWithRestore } from "../../utils/mockModuleWithRestore.js";
+
+await mockModuleWithRestore(
+	"@server/internal/features/repos/updateFeatureStripeProductIdIfUnset.js",
+	() => ({ updateFeatureStripeProductIdIfUnset: async () => undefined }),
+);
+
+const { resolveStripeProductForFeaturePrice } = await import(
+	"@/external/stripe/products/utils/resolveStripeProductForFeaturePrice.js"
+);
+
+type UpdateCall = { id: string; params: Stripe.ProductUpdateParams };
+
+const makeStripeCli = ({
+	createdProduct,
+	storedProducts,
+}: {
+	createdProduct: { id: string; active: boolean };
+	storedProducts: Record<string, { id: string; active: boolean }>;
+}) => {
+	const createCalls: Stripe.ProductCreateParams[] = [];
+	const updateCalls: UpdateCall[] = [];
+
+	const stripeCli = {
+		products: {
+			retrieve: async (id: string) => {
+				const stored = storedProducts[id];
+				if (!stored) throw new Error("resource_missing");
+				return stored;
+			},
+			create: async (params: Stripe.ProductCreateParams) => {
+				createCalls.push(params);
+				return createdProduct;
+			},
+			update: async (id: string, params: Stripe.ProductUpdateParams) => {
+				updateCalls.push({ id, params });
+				const stored = storedProducts[id];
+				storedProducts[id] = { ...stored, id, ...params } as {
+					id: string;
+					active: boolean;
+				};
+				return storedProducts[id];
+			},
+		},
+	} as unknown as Stripe;
+
+	return { stripeCli, createCalls, updateCalls };
+};
+
+const db = {} as DrizzleCli;
+
+const makeFeature = ({
+	stripeProductId,
+}: {
+	stripeProductId?: string | null;
+}) =>
+	({
+		internal_id: "feature_internal_1",
+		id: "messages",
+		name: "Messages",
+		stripe_product_id: stripeProductId ?? null,
+	}) as unknown as Feature;
+
+const makePrice = ({ stripeProductId }: { stripeProductId?: string | null }) =>
+	({
+		id: "price_usage_1",
+		config: { stripe_product_id: stripeProductId ?? undefined },
+	}) as unknown as Price;
+
+describe("resolveStripeProductForFeaturePrice", () => {
+	test("un-archives the product behind a stale idempotent create replay", async () => {
+		// Stripe replays the original `active: true` body for an archived product.
+		const { stripeCli, createCalls, updateCalls } = makeStripeCli({
+			createdProduct: { id: "prod_feature", active: true },
+			storedProducts: { prod_feature: { id: "prod_feature", active: false } },
+		});
+		const price = makePrice({});
+
+		const productId = await resolveStripeProductForFeaturePrice({
+			db,
+			stripeCli,
+			feature: makeFeature({}),
+			price,
+		});
+
+		expect(createCalls).toHaveLength(1);
+		expect(updateCalls).toEqual([
+			{ id: "prod_feature", params: { active: true } },
+		]);
+		expect(productId).toBe("prod_feature");
+		expect((price.config as UsagePriceConfig).stripe_product_id).toBe(
+			"prod_feature",
+		);
+	});
+
+	test("un-archives when the create response itself is inactive", async () => {
+		const { stripeCli, updateCalls } = makeStripeCli({
+			createdProduct: { id: "prod_feature", active: false },
+			storedProducts: { prod_feature: { id: "prod_feature", active: false } },
+		});
+
+		const productId = await resolveStripeProductForFeaturePrice({
+			db,
+			stripeCli,
+			feature: makeFeature({}),
+			price: makePrice({}),
+		});
+
+		expect(updateCalls).toEqual([
+			{ id: "prod_feature", params: { active: true } },
+		]);
+		expect(productId).toBe("prod_feature");
+	});
+
+	test("un-archives the feature's existing product instead of creating one", async () => {
+		const { stripeCli, createCalls, updateCalls } = makeStripeCli({
+			createdProduct: { id: "prod_new", active: true },
+			storedProducts: { prod_existing: { id: "prod_existing", active: false } },
+		});
+		const price = makePrice({});
+
+		const productId = await resolveStripeProductForFeaturePrice({
+			db,
+			stripeCli,
+			feature: makeFeature({ stripeProductId: "prod_existing" }),
+			price,
+		});
+
+		expect(createCalls).toHaveLength(0);
+		expect(updateCalls).toEqual([
+			{ id: "prod_existing", params: { active: true } },
+		]);
+		expect(productId).toBe("prod_existing");
+		expect((price.config as UsagePriceConfig).stripe_product_id).toBe(
+			"prod_existing",
+		);
+	});
+
+	test("reuses a live product on the price without touching Stripe writes", async () => {
+		const { stripeCli, createCalls, updateCalls } = makeStripeCli({
+			createdProduct: { id: "prod_new", active: true },
+			storedProducts: { prod_price: { id: "prod_price", active: true } },
+		});
+
+		const productId = await resolveStripeProductForFeaturePrice({
+			db,
+			stripeCli,
+			feature: makeFeature({}),
+			price: makePrice({ stripeProductId: "prod_price" }),
+		});
+
+		expect(createCalls).toHaveLength(0);
+		expect(updateCalls).toHaveLength(0);
+		expect(productId).toBe("prod_price");
+	});
+});

--- a/server/tests/unit/external/stripe/retrieve-live-stripe-product.test.ts
+++ b/server/tests/unit/external/stripe/retrieve-live-stripe-product.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import type Stripe from "stripe";
+import { retrieveLiveStripeProduct } from "@/external/stripe/products/utils/retrieveLiveStripeProduct.js";
+
+type UpdateCall = { id: string; params: Stripe.ProductUpdateParams };
+
+const makeStripeCli = ({
+	product,
+}: {
+	product: { id: string; active: boolean } | null;
+}) => {
+	const retrieveCalls: string[] = [];
+	const updateCalls: UpdateCall[] = [];
+
+	const stripeCli = {
+		products: {
+			retrieve: async (id: string) => {
+				retrieveCalls.push(id);
+				if (!product) throw new Error("resource_missing");
+				return product;
+			},
+			update: async (id: string, params: Stripe.ProductUpdateParams) => {
+				updateCalls.push({ id, params });
+				return { ...product, id, ...params };
+			},
+		},
+	} as unknown as Stripe;
+
+	return { stripeCli, retrieveCalls, updateCalls };
+};
+
+describe("retrieveLiveStripeProduct", () => {
+	test("returns an active product untouched", async () => {
+		const { stripeCli, updateCalls } = makeStripeCli({
+			product: { id: "prod_live", active: true },
+		});
+
+		const product = await retrieveLiveStripeProduct({
+			stripeCli,
+			productId: "prod_live",
+		});
+
+		expect(product?.id).toBe("prod_live");
+		expect(updateCalls).toHaveLength(0);
+	});
+
+	test("un-archives an inactive product and returns it live", async () => {
+		const { stripeCli, updateCalls } = makeStripeCli({
+			product: { id: "prod_archived", active: false },
+		});
+
+		const product = await retrieveLiveStripeProduct({
+			stripeCli,
+			productId: "prod_archived",
+		});
+
+		expect(updateCalls).toEqual([
+			{ id: "prod_archived", params: { active: true } },
+		]);
+		expect(product?.id).toBe("prod_archived");
+		expect(product?.active).toBe(true);
+	});
+
+	test("returns null for a missing product", async () => {
+		const { stripeCli, updateCalls } = makeStripeCli({ product: null });
+
+		const product = await retrieveLiveStripeProduct({
+			stripeCli,
+			productId: "prod_deleted",
+		});
+
+		expect(product).toBeNull();
+		expect(updateCalls).toHaveLength(0);
+	});
+
+	test("returns null without calling Stripe when no product id is set", async () => {
+		const { stripeCli, retrieveCalls } = makeStripeCli({
+			product: { id: "prod_live", active: true },
+		});
+
+		expect(
+			await retrieveLiveStripeProduct({ stripeCli, productId: null }),
+		).toBeNull();
+		expect(retrieveCalls).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Problem

An archived feature Stripe Product (the shared per-feature product that usage prices group under since #46129c66bb's grouping change) breaks attaches two ways:

1. **Permanent breakage:** `createStripePrice` un-archives a found Stripe *price* but `retrieveLiveStripeProduct` returned `null` for an inactive *product* — leaving a reactivated price on a dead product, so every attach for that feature fails with `The product prod_… is marked as inactive`. Plan products already un-archive on reuse (`productUtils`); feature products didn't.
2. **24h breakage via idempotency replay:** `resolveStripeProductForFeaturePrice` creates the feature product under the stable key `autumn:product:feature:<feature.internal_id>`. Stripe replays that key for 24h and returns the original response body — stale `active: true` — for a product that has since been archived, so new prices get minted under it and subscription creation fails. Surfaced by the tw pool (sub-accounts reused across runs, teardown archives products), but reproducible in prod by archiving a feature product in the Stripe dashboard.

## Fix

- `retrieveLiveStripeProduct`: un-archive inactive products instead of returning `null` (mirrors the plan-product path). Missing/deleted products still return `null`.
- `resolveStripeProductForFeaturePrice`: re-check the idempotent `products.create` result through `retrieveLiveStripeProduct` before using it — a replayed body can't be trusted for `active`. The idempotency key is unchanged (dropping it would reintroduce duplicate products under concurrency).

## Tests

Unit tests for both utils with stubbed `stripeCli` (red without the fix, green with): active passthrough, inactive → un-archived, missing → null, stale-replay body → un-archived, existing archived feature product reused instead of creating new.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes archived Stripe products breaking feature attaches by un-archiving them on reuse and handling stale idempotent replay responses.

- Retrieving an inactive Stripe product now un-archives it instead of returning `null`; missing or deleted products still resolve to `null`.
- After an idempotent product create replay, the returned product ID is re-checked live so a stale `active: true` response can't leave a price on an archived product.

<sup>Written for commit 26839d8ec95706860013144785e4aa36af3e7589. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

