### PR TITLE
Execute approved writes directly, narrate in background

### DIFF
--- a/apps/leaf/agent/lib/autumnDirectTools.ts
+++ b/apps/leaf/agent/lib/autumnDirectTools.ts
@@ -1,5 +1,6 @@
 import { defineDynamic, defineTool } from "eve/tools";
 import { withoutApprovalSummary } from "../../src/internal/approvals/utils/approvalSummary.js";
+import { settledWriteResult } from "../../src/internal/approvals/utils/settledWriteResult.js";
 import { callAutumnMcpTool } from "../../src/internal/autumnMcp/rpcClient.js";
 import { approvalSets } from "./approvalSets.js";
 import { withApprovalSummarySchema } from "./approvalSummarySchema.js";
@@ -46,6 +47,14 @@ export const autumnDirectTools = ({
 							requiresApproval ? "user-approval" : "not-applicable",
 						description: tool.description,
 						execute: async (input, toolCtx) => {
+							if (requiresApproval) {
+								const settled = await settledWriteResult({
+									input: input as Record<string, unknown>,
+									sessionId: toolCtx.session.id,
+									toolName,
+								});
+								if (settled !== undefined) return settled;
+							}
 							const minted = await mintCachedAutumnToken(
 								toolCtx.session.auth.current?.attributes,
 							);

--- a/apps/leaf/scripts/validateDirectApprove.ts
+++ b/apps/leaf/scripts/validateDirectApprove.ts
@@ -1,0 +1,32 @@
+import { resolveApproval } from "../src/internal/approvals/actions/resolveApproval.js";
+import { chatApprovalRepo } from "../src/internal/approvals/repos/chatApprovalRepo.js";
+import { chatApprovalWritesRepo } from "../src/internal/approvals/repos/chatApprovalWritesRepo.js";
+import { db } from "../src/lib/db.js";
+
+const approvalId = process.argv[2];
+const providerUserId = process.argv[3] ?? "validate-script";
+if (!approvalId)
+	throw new Error("usage: validateDirectApprove.ts <approvalId>");
+
+const claimed = await chatApprovalRepo.claim({
+	approvalId,
+	db,
+	providerUserId,
+});
+if (!claimed) throw new Error("claim failed (not pending?)");
+
+const started = Date.now();
+const result = await resolveApproval({ approval: claimed, providerUserId });
+console.log(`resolve returned in ${Date.now() - started}ms`);
+console.log(JSON.stringify({ ...result, narration: undefined }, null, 1));
+if ("narration" in result && result.narration) {
+	const narrated = await result.narration;
+	console.log("narration:", JSON.stringify(narrated)?.slice(0, 400));
+}
+
+const writes = await chatApprovalWritesRepo.list({ approvalId, db });
+console.log(
+	"write rows:",
+	writes.map((write) => `${write.tool_name}=${write.status}`).join(", "),
+);
+process.exit(0);

--- a/apps/leaf/src/internal/approvals/actions/executeApprovalWrites.ts
+++ b/apps/leaf/src/internal/approvals/actions/executeApprovalWrites.ts
@@ -93,8 +93,8 @@ const stepOutcomes = (
 		toolName: write.tool_name,
 	}));
 
-/** Dead-session fallback: the eve session that parked these writes is gone,
- * so the stored writes run directly — the card is the only outcome surface. */
+/** Runs the approval's stored writes in order and finalizes the row — the
+ * card carries the outcome; any session resume is narration only. */
 export const executeApprovalWrites = async ({
 	approval,
 	providerUserId,
@@ -133,7 +133,7 @@ export const executeApprovalWrites = async ({
 		providerUserId,
 		status: allApplied ? "approved" : "failed",
 	});
-	logger.info("Executed approved writes without an eve session", {
+	logger.info("Executed approved writes", {
 		event: "leaf.approval_writes_executed",
 		approval_id: approval.id,
 		data: {

--- a/apps/leaf/src/internal/approvals/actions/resolveApproval.ts
+++ b/apps/leaf/src/internal/approvals/actions/resolveApproval.ts
@@ -54,10 +54,27 @@ const releaseClaim = async ({
 	}
 };
 
-/** Dead-session fallback, reached only after guardApprovalDrift passed in this
- * same resolve — Slack-only, since only a surface that rendered the group may
- * execute it. */
-const executeWithoutSession = async ({
+/** Post-execution narration resume; never throws — the card already carries
+ * the truth. */
+const narrateInBackground = ({
+	approval,
+	providerUserId,
+}: {
+	approval: ChatApproval;
+	providerUserId: string;
+}): Promise<SubmittedApprovalResult | undefined> =>
+	resumeApproval({ approval, providerUserId }).catch((error: unknown) => {
+		logger.warn("[chat] Post-execution narration failed", {
+			event: "leaf.approval_narration_failed",
+			approval_id: approval.id,
+			error,
+		});
+		return undefined;
+	});
+
+/** Deterministic executor for a surface that rendered the whole group;
+ * returns undefined when the approval has no stored writes to run. */
+const executeStoredWrites = async ({
 	approval,
 	providerUserId,
 }: {
@@ -110,12 +127,16 @@ export const resolveApproval = async ({
 			return approvalErrorResult(error, { retryable: true });
 		}
 	}
-	if (!approval.tool_call_id) {
-		const executed = await executeWithoutSession({
-			approval,
-			providerUserId,
-		});
-		if (executed) return executed;
+
+	// Writes run directly; the resumed session only narrates.
+	const executed = await executeStoredWrites({ approval, providerUserId });
+	if (executed) {
+		return approval.tool_call_id
+			? {
+					...executed,
+					narration: narrateInBackground({ approval, providerUserId }),
+				}
+			: executed;
 	}
 
 	let result: SubmittedApprovalResult;
@@ -126,18 +147,11 @@ export const resolveApproval = async ({
 		});
 	} catch (error) {
 		if (error instanceof EveSessionGoneError) {
-			// Eve lost the session this card belongs to; the deterministic
-			// executor still honors the approval from the stored writes.
 			logger.error("[chat] Approval session is gone", error, {
 				event: "leaf.approval_session_gone",
 				approval_id: approval.id,
 			});
 			await dropEveSession({ approval });
-			const executed = await executeWithoutSession({
-				approval,
-				providerUserId,
-			});
-			if (executed) return executed;
 			await chatApprovalRepo.finalize({
 				approvalId: approval.id,
 				db,

--- a/apps/leaf/src/internal/approvals/repos/chatApprovalWritesRepo.ts
+++ b/apps/leaf/src/internal/approvals/repos/chatApprovalWritesRepo.ts
@@ -5,7 +5,7 @@ import {
 	chatApprovals,
 	chatApprovalWrites,
 } from "@autumn/shared";
-import { and, asc, eq, exists } from "drizzle-orm";
+import { and, asc, eq, exists, gt, inArray, or, sql } from "drizzle-orm";
 import type { ChatDb } from "../../../lib/db.js";
 import { normalizeToolName } from "../../agentRuntime/tools/toolPolicy.js";
 
@@ -114,9 +114,44 @@ const setStepStatus = async ({
 		.where(eq(chatApprovalWrites.id, writeId));
 };
 
+/** Settled writes parked by the given eve session (root or child), newest first. */
+const listSettledForSession = async ({
+	db,
+	sessionId,
+	since,
+	toolName,
+}: {
+	db: ChatDb;
+	sessionId: string;
+	since: number;
+	toolName: string;
+}): Promise<ChatApprovalWrite[]> => {
+	const rows = await db
+		.select({ write: chatApprovalWrites })
+		.from(chatApprovalWrites)
+		.innerJoin(
+			chatApprovals,
+			eq(chatApprovalWrites.approval_id, chatApprovals.id),
+		)
+		.where(
+			and(
+				eq(chatApprovalWrites.tool_name, normalizeToolName(toolName)),
+				inArray(chatApprovalWrites.status, ["applied", "failed", "skipped"]),
+				gt(chatApprovalWrites.updated_at, since),
+				or(
+					eq(chatApprovals.run_id, sessionId),
+					sql`${sessionId} = ANY(${chatApprovals.child_session_ids})`,
+				),
+			),
+		)
+		.orderBy(asc(chatApprovalWrites.updated_at));
+	return rows.map((row) => row.write).reverse();
+};
+
 export const chatApprovalWritesRepo = {
 	insert: insertSteps,
 	list: listSteps,
+	listSettledForSession,
 	setPreview: setStepPreview,
 	setStatus: setStepStatus,
 } as const;

--- a/apps/leaf/src/internal/approvals/repos/chatApprovalWritesRepo.ts
+++ b/apps/leaf/src/internal/approvals/repos/chatApprovalWritesRepo.ts
@@ -5,7 +5,7 @@ import {
 	chatApprovals,
 	chatApprovalWrites,
 } from "@autumn/shared";
-import { and, asc, eq, exists, gt, inArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, exists, gt, inArray, or, sql } from "drizzle-orm";
 import type { ChatDb } from "../../../lib/db.js";
 import { normalizeToolName } from "../../agentRuntime/tools/toolPolicy.js";
 
@@ -144,8 +144,8 @@ const listSettledForSession = async ({
 				),
 			),
 		)
-		.orderBy(asc(chatApprovalWrites.updated_at));
-	return rows.map((row) => row.write).reverse();
+		.orderBy(desc(chatApprovalWrites.updated_at));
+	return rows.map((row) => row.write);
 };
 
 export const chatApprovalWritesRepo = {

--- a/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
@@ -511,30 +511,32 @@ export const handleApprovalActionWithDeps = async ({
 			tool: details.toolName,
 		});
 
-		// The agent's continuation is conversation — it belongs in the thread,
-		// while the card stays a compact record of what ran.
-		if (!failed && "text" in result && result.text.trim()) {
-			try {
-				await deps.postThreadReply({ event, markdown: result.text });
-			} catch (error) {
-				deps.logger.warn("Could not post approval outcome reply", {
-					event: "leaf.approval_reply_failed",
-					approval_id: approvalId,
-					error,
-				});
+		// Conversation belongs in the thread; the card stays a compact record.
+		const postConversation = async (resumed: ApprovalRunResult) => {
+			if (!isErrorResult(resumed) && "text" in resumed && resumed.text.trim()) {
+				try {
+					await deps.postThreadReply({ event, markdown: resumed.text });
+				} catch (error) {
+					deps.logger.warn("Could not post approval outcome reply", {
+						event: "leaf.approval_reply_failed",
+						approval_id: approvalId,
+						error,
+					});
+				}
 			}
-		}
-		if (event.thread) {
-			try {
-				await surfaceResumedOutcome({ resumed: result });
-			} catch (error) {
-				deps.logger.warn("Could not surface chained interaction", {
-					event: "leaf.approval_chained_surface_failed",
-					approval_id: approvalId,
-					error,
-				});
+			if (event.thread) {
+				try {
+					await surfaceResumedOutcome({ resumed });
+				} catch (error) {
+					deps.logger.warn("Could not surface chained interaction", {
+						event: "leaf.approval_chained_surface_failed",
+						approval_id: approvalId,
+						error,
+					});
+				}
 			}
-		}
+		};
+		await postConversation(result);
 
 		await deps.editActionMessage({
 			content: approvalStatusCard({
@@ -559,6 +561,11 @@ export const handleApprovalActionWithDeps = async ({
 			}),
 			event,
 		});
+
+		if ("narration" in result && result.narration) {
+			const narrated = await result.narration;
+			if (narrated) await postConversation(narrated);
+		}
 	} catch (error) {
 		deps.logger.error("[chat] Approval action failed", error, {
 			event: "leaf.approval_failed",

--- a/apps/leaf/src/internal/approvals/types.ts
+++ b/apps/leaf/src/internal/approvals/types.ts
@@ -28,6 +28,7 @@ export type ApprovalRunResult =
 			chainedApprovalId?: string;
 			error: true;
 			message: string;
+			narration?: Promise<SubmittedApprovalResult | undefined>;
 			retryable?: boolean;
 			writes?: ReadonlyArray<ApprovalWriteOutcome>;
 	  }
@@ -35,6 +36,7 @@ export type ApprovalRunResult =
 	// and needs its own card, or the session waits in silence.
 	| {
 			chainedApprovalId?: string;
+			narration?: Promise<SubmittedApprovalResult | undefined>;
 			question?: {
 				options: ReadonlyArray<Readonly<{ id?: string; label?: string }>>;
 				prompt: string;

--- a/apps/leaf/src/internal/approvals/utils/settledWriteResult.ts
+++ b/apps/leaf/src/internal/approvals/utils/settledWriteResult.ts
@@ -1,0 +1,52 @@
+import { type ChatApprovalWrite, ms } from "@autumn/shared";
+import { db } from "../../../lib/db.js";
+import { chatApprovalWritesRepo } from "../repos/chatApprovalWritesRepo.js";
+
+const SETTLED_WINDOW_MS = ms.minutes(15);
+
+const canonical = (value: unknown): string =>
+	JSON.stringify(value, (_key, node) =>
+		node && typeof node === "object" && !Array.isArray(node)
+			? Object.fromEntries(
+					Object.entries(node as Record<string, unknown>).sort(([a], [b]) =>
+						a.localeCompare(b),
+					),
+				)
+			: node,
+	);
+
+const toToolResult = ({ result, status }: ChatApprovalWrite): unknown => {
+	if (status === "applied") return result ?? {};
+	const message = (result as { message?: string } | null)?.message;
+	return {
+		content: [
+			{
+				text: message ?? `Write was not applied (${status}).`,
+				type: "text",
+			},
+		],
+		isError: true,
+	};
+};
+
+/** Approved writes run through the deterministic executor before the session
+ * resumes — a resumed park gets its stored outcome instead of a second run. */
+export const settledWriteResult = async ({
+	input,
+	sessionId,
+	toolName,
+}: {
+	input: Record<string, unknown>;
+	sessionId: string;
+	toolName: string;
+}): Promise<unknown | undefined> => {
+	const settled = await chatApprovalWritesRepo.listSettledForSession({
+		db,
+		sessionId,
+		since: Date.now() - SETTLED_WINDOW_MS,
+		toolName,
+	});
+	const wanted = canonical(input);
+	const match = settled.find((write) => canonical(write.tool_args) === wanted);
+	return match && toToolResult(match);
+};

--- a/apps/leaf/src/internal/approvals/utils/settledWriteResult.ts
+++ b/apps/leaf/src/internal/approvals/utils/settledWriteResult.ts
@@ -1,19 +1,9 @@
 import { type ChatApprovalWrite, ms } from "@autumn/shared";
 import { db } from "../../../lib/db.js";
 import { chatApprovalWritesRepo } from "../repos/chatApprovalWritesRepo.js";
+import { isSameToolRequest } from "./toolRequest.js";
 
 const SETTLED_WINDOW_MS = ms.minutes(15);
-
-const canonical = (value: unknown): string =>
-	JSON.stringify(value, (_key, node) =>
-		node && typeof node === "object" && !Array.isArray(node)
-			? Object.fromEntries(
-					Object.entries(node as Record<string, unknown>).sort(([a], [b]) =>
-						a.localeCompare(b),
-					),
-				)
-			: node,
-	);
 
 const toToolResult = ({ result, status }: ChatApprovalWrite): unknown => {
 	if (status === "applied") return result ?? {};
@@ -46,7 +36,8 @@ export const settledWriteResult = async ({
 		since: Date.now() - SETTLED_WINDOW_MS,
 		toolName,
 	});
-	const wanted = canonical(input);
-	const match = settled.find((write) => canonical(write.tool_args) === wanted);
+	const match = settled.find((write) =>
+		isSameToolRequest(write.tool_args, input),
+	);
 	return match && toToolResult(match);
 };

--- a/apps/leaf/src/ui/previewContent.ts
+++ b/apps/leaf/src/ui/previewContent.ts
@@ -118,16 +118,19 @@ const balancePreviewElements = (payload: LooseRecord): CardChild[] | null => {
 		],
 	].flatMap(([label, value]) =>
 		typeof value === "string" || typeof value === "number"
-			? [`**${label}**  ${value}`]
+			? [[String(label), String(value)]]
 			: [],
 	);
 
-	return [
-		...(fields.length ? [CardText(fields.join("\n"))] : []),
-		...(typeof payload.impact === "string"
-			? [CardText(payload.impact, { style: "muted" })]
-			: []),
-	];
+	return fields.length
+		? [
+				Table({
+					align: ["left", "right"],
+					headers: ["Item", "Value"],
+					rows: fields,
+				}),
+			]
+		: null;
 };
 
 /** Structured card body for a preview payload, or null to fall back to text. */

--- a/apps/leaf/tests/unit/ui/previewContent.test.ts
+++ b/apps/leaf/tests/unit/ui/previewContent.test.ts
@@ -76,7 +76,7 @@ describe("previewElements", () => {
 		expect(json).toContain("Cancel at end of cycle");
 	});
 
-	test("renders createBalance local previews as fields", () => {
+	test("renders createBalance local previews as a table", () => {
 		const json = JSON.stringify(
 			previewElements({
 				action: "createBalance",
@@ -89,10 +89,11 @@ describe("previewElements", () => {
 				impact: "Creates a standalone balance grant.",
 			}),
 		);
+		expect(json).toContain("table");
 		expect(json).toContain("credits");
 		expect(json).toContain("500");
 		expect(json).toContain("Expires");
-		expect(json).toContain("standalone balance grant");
+		expect(json).not.toContain("standalone balance grant");
 	});
 });
 


### PR DESCRIPTION
## Why

Approving a card resumed the eve session and trusted it to execute the parked write. That meant seconds of model-turn latency before anything happened — and on eve 0.47 the write silently never ran while the resumed turn narrated success (`chat_approval_writes` rows stuck `pending`, approval `approved`, no server write; reproduced for both `createReward` and `updateCustomer`).

## What

- **`resolveApproval`**: approve runs the stored `chat_approval_writes` rows through the deterministic executor immediately (the former dead-session fallback, promoted to the primary path). The card settles on the real execution outcome in seconds; the result is truth, not inference about what eve did.
- **Background narration**: the eve session still resumes — as a `narration` promise the Slack decide flow awaits after the card settles, posting the agent's reply and chained cards/questions through one shared `postConversation` helper.
- **No double execution**: `settledWriteResult` (approvals utils) — a resumed park's tool execute matches the settled write row (session + tool + canonical args, 15-min window) and returns the stored outcome instead of calling the server again.
- `chatApprovalWritesRepo.listSettledForSession` backs the guard; `scripts/validateDirectApprove.ts` drives an approval through the path outside Slack.

Applies to every gated write (attach, createSchedule, updateSubscription, updateCustomer, createReward). Writes execute under the org installation token, as the dead-session path always did; approver scopes are still enforced at click time.

## Testing

- `apps/leaf` unit suite: **483/483** (resolveApproval ordering tests updated for direct-first semantics).
- Live against a running stack: drove the real stuck `createReward` approval through `resolveApproval` — write row settled `applied`, approval finalized, reward `yc-20` verified present via `rewards.list`; a narration failure degraded gracefully without touching the outcome.
- `tsc --noEmit` clean.

Stacked on #3144.





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR executes approved writes directly before resuming the agent session, then uses the resumed session only to narrate the result.
- **[Bug fixes, Improvements]** Runs stored approval writes through the deterministic executor so approval cards reflect the actual outcome promptly.
- **[Bug fixes]** Adds settled-write lookup intended to prevent the resumed agent from executing an already-completed write twice.
- **[Improvements]** Posts narration and chained interactions after the approval card has settled.
- **[Improvements]** Presents balance previews as structured tables.
</details>


<h3>Confidence Score: 3/5</h3>

This PR is not yet safe to merge because duplicate writes and permanently failed approvals remain reachable.

The settled-write guard still includes narration-only summary text in its match, so a changed summary can execute an already-applied operation again; separately, a temporary MCP failure now permanently closes the approval on the primary execution path.

**Files Needing Attention:** apps/leaf/src/internal/approvals/utils/settledWriteResult.ts, apps/leaf/src/internal/approvals/actions/executeApprovalWrites.ts, apps/leaf/src/internal/approvals/actions/resolveApproval.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/approvals/actions/resolveApproval.ts | Promotes deterministic stored-write execution to the primary approval path and attaches asynchronous narration. |
| apps/leaf/src/internal/approvals/actions/executeApprovalWrites.ts | Executes stored writes sequentially and finalizes the approval from their persisted outcomes. |
| apps/leaf/src/internal/approvals/utils/settledWriteResult.ts | Looks up a recently settled write from the resumed session and converts its stored outcome into a tool result. |
| apps/leaf/src/internal/approvals/repos/chatApprovalWritesRepo.ts | Adds session-scoped lookup of recently settled approval writes. |
| apps/leaf/src/internal/approvals/surfaces/slack/decide.ts | Settles the approval card before awaiting and posting background narration. |
| apps/leaf/src/ui/previewContent.ts | Replaces the balance-preview text fields with a two-column table. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant User
  participant Slack
  participant Approval
  participant MCP
  participant Eve
  User->>Slack: Approve write
  Slack->>Approval: resolveApproval
  Approval->>MCP: Execute stored write
  MCP-->>Approval: Applied or failed outcome
  Approval-->>Slack: Settle approval card
  Approval->>Eve: Resume for narration
  Eve->>Approval: Request settled tool result
  Approval-->>Eve: Return stored outcome
  Eve-->>Slack: Narration and chained interactions
```
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor: order settled writes descendin..."](https://github.com/useautumn/autumn/commit/62c6114001585e4d1851d0ad39a1739fb1427fa4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57980549)</sub>

**Context used:**

- Knowledge Base — [Automation and external integrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/automation-and-external-integrations.md)

<!-- /greptile_comment -->