### PR TITLE
bun p/s use the local Slack app credentials

### DIFF
--- a/apps/leaf/scripts/printLocalSlackBotToken.ts
+++ b/apps/leaf/scripts/printLocalSlackBotToken.ts
@@ -1,0 +1,18 @@
+// Prints the local Slack app's bot token, decrypted from this env's
+// installation row. Run under DEV infisical; dev.ts pipes the output into
+// seedSlackAdminInstall when auto-seeding a non-dev run.
+import { decrypt } from "../src/lib/crypto.js";
+import { env } from "../src/lib/env.js";
+import { findInstallation } from "../src/providers/slack/installations.js";
+
+const workspaceId = process.env.SLACK_ADMIN_WORKSPACE_ID;
+if (!workspaceId) throw new Error("SLACK_ADMIN_WORKSPACE_ID is not set");
+
+const installation =
+	(await findInstallation(`slack_admin:${env.SLACK_CLIENT_ID}`, workspaceId)) ??
+	(await findInstallation("slack", workspaceId));
+if (!installation) {
+	throw new Error(`no slack installation for workspace ${workspaceId}`);
+}
+console.log(decrypt(installation.bot_access_token));
+process.exit(0);

--- a/apps/leaf/scripts/seedSlackAdminInstall.ts
+++ b/apps/leaf/scripts/seedSlackAdminInstall.ts
@@ -17,7 +17,10 @@ import { DEFAULT_SLACK_BOT_SCOPES } from "@autumn/shared/utils/auth/slackScopes"
 import { eq } from "drizzle-orm";
 import { db } from "../src/lib/db.js";
 import { env } from "../src/lib/env.js";
-import { replaceInstallation } from "../src/providers/slack/installations.js";
+import {
+	findInstallation,
+	replaceInstallation,
+} from "../src/providers/slack/installations.js";
 
 const ADMIN_ORG_SLUG = process.env.SEED_ADMIN_ORG_SLUG ?? "autumn";
 
@@ -29,11 +32,24 @@ const required = (key: string) => {
 	return value;
 };
 
+/** With --if-missing: exit 0 when the row exists, 42 when a token is needed. */
 const main = async () => {
-	const botToken = required("SLACK_BOT_TOKEN");
 	const clientId = required("SLACK_CLIENT_ID");
 	const adminWorkspaceId = env.SLACK_ADMIN_WORKSPACE_ID;
 	if (!adminWorkspaceId) throw new Error("SLACK_ADMIN_WORKSPACE_ID is not set");
+
+	if (process.argv.includes("--if-missing")) {
+		const existing = await findInstallation(
+			`slack_admin:${clientId}`,
+			adminWorkspaceId,
+		);
+		if (existing) {
+			log(`slack_admin:${clientId} already installed`);
+			process.exit(0);
+		}
+		if (!process.env.SLACK_BOT_TOKEN) process.exit(42);
+	}
+	const botToken = required("SLACK_BOT_TOKEN");
 
 	const response = await fetch("https://slack.com/api/auth.test", {
 		headers: { Authorization: `Bearer ${botToken}` },

--- a/apps/leaf/scripts/seedSlackAdminInstall.ts
+++ b/apps/leaf/scripts/seedSlackAdminInstall.ts
@@ -1,0 +1,100 @@
+// Seed a `slack_admin:<client id>` installation for the internal Autumn
+// workspace so a locally-run bot (bun p/s) gets the admin org+env flow against
+// the target DB. Coexists with the deployed bot's row — providers are keyed by
+// Slack app client id.
+//
+//   SLACK_CLIENT_ID=<local app> SLACK_BOT_TOKEN=<local xoxb> \
+//   ENV_FILE=.env.prod infisical run --env=prod --recursive -- \
+//     bun apps/leaf/scripts/seedSlackAdminInstall.ts
+import crypto from "node:crypto";
+import {
+	AppEnv,
+	type ChatInstallState,
+	member,
+	organizations,
+} from "@autumn/shared";
+import { DEFAULT_SLACK_BOT_SCOPES } from "@autumn/shared/utils/auth/slackScopes";
+import { eq } from "drizzle-orm";
+import { db } from "../src/lib/db.js";
+import { env } from "../src/lib/env.js";
+import { replaceInstallation } from "../src/providers/slack/installations.js";
+
+const ADMIN_ORG_SLUG = process.env.SEED_ADMIN_ORG_SLUG ?? "autumn";
+
+const log = (message: string) => console.log(`[seed-slack-admin] ${message}`);
+
+const required = (key: string) => {
+	const value = process.env[key];
+	if (!value) throw new Error(`${key} is required`);
+	return value;
+};
+
+const main = async () => {
+	const botToken = required("SLACK_BOT_TOKEN");
+	const clientId = required("SLACK_CLIENT_ID");
+	const adminWorkspaceId = env.SLACK_ADMIN_WORKSPACE_ID;
+	if (!adminWorkspaceId) throw new Error("SLACK_ADMIN_WORKSPACE_ID is not set");
+
+	const response = await fetch("https://slack.com/api/auth.test", {
+		headers: { Authorization: `Bearer ${botToken}` },
+		method: "POST",
+	});
+	const auth = (await response.json()) as {
+		ok: boolean;
+		error?: string;
+		team_id?: string;
+		team?: string;
+		user_id?: string;
+	};
+	if (!auth.ok || !auth.team_id) {
+		throw new Error(`Slack auth.test failed (${auth.error ?? "unknown"})`);
+	}
+	if (auth.team_id !== adminWorkspaceId) {
+		throw new Error(
+			`bot workspace ${auth.team_id} is not SLACK_ADMIN_WORKSPACE_ID ${adminWorkspaceId}`,
+		);
+	}
+
+	const [org] = await db
+		.select({ id: organizations.id, slug: organizations.slug })
+		.from(organizations)
+		.where(eq(organizations.slug, ADMIN_ORG_SLUG))
+		.limit(1);
+	if (!org) throw new Error(`org '${ADMIN_ORG_SLUG}' not found in target DB`);
+
+	const [memberRow] = await db
+		.select({ userId: member.userId })
+		.from(member)
+		.where(eq(member.organizationId, org.id))
+		.limit(1);
+	if (!memberRow) throw new Error(`org '${ADMIN_ORG_SLUG}' has no members`);
+
+	const provider = `slack_admin:${clientId}` as const;
+	const state: ChatInstallState = {
+		env: AppEnv.Sandbox,
+		expiresAt: Date.now() + 600_000,
+		nonce: crypto.randomUUID(),
+		orgId: org.id,
+		provider,
+		userId: memberRow.userId,
+	};
+	await replaceInstallation({
+		botAccessToken: botToken,
+		botUserId: auth.user_id,
+		provider,
+		scopes: [...DEFAULT_SLACK_BOT_SCOPES],
+		state,
+		workspaceId: auth.team_id,
+		workspaceName: auth.team ?? auth.team_id,
+	});
+	log(`seeded ${provider} for org ${org.slug} (workspace ${auth.team_id})`);
+};
+
+main()
+	.then(() => process.exit(0))
+	.catch((error) => {
+		console.error(
+			`[seed-slack-admin] failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		process.exit(1);
+	});

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isCloudAgent } from "@autumn/env";
+import { parseEnvFile } from "./dw/helpers/env-files.ts";
 import { resolveTriggerDevBranch } from "./triggerDevBranch.ts";
 
 function spawnTriggerDevBranchReaper({
@@ -72,6 +73,29 @@ const AUTUMN_PUBLIC_API_URL =
 const publicApiUrl = AUTUMN_PUBLIC_API_URL.replace(/\/$/, "");
 const CHAT_URL = process.env.CHAT_URL ?? publicApiUrl;
 const SLACK_BOT_URL = process.env.SLACK_BOT_URL ?? publicApiUrl;
+
+/** Slack only delivers events for the LOCAL dev app to a laptop (via the
+ * chat tunnel), so non-dev runs must verify with the local app's credentials
+ * from server/.env — the injected prod/staging ones belong to the deployed
+ * bot. */
+const localSlackAppEnv = (): Record<string, string> => {
+	if (viteAppEnv === "dev") return {};
+	const envPath = join(
+		dirname(fileURLToPath(import.meta.url)),
+		"../server/.env",
+	);
+	if (!existsSync(envPath)) return {};
+	const { values } = parseEnvFile(readFileSync(envPath, "utf8"));
+	const overrides = Object.fromEntries(
+		["SLACK_CLIENT_ID", "SLACK_CLIENT_SECRET", "SLACK_SIGNING_SECRET"].flatMap(
+			(key) => (values[key] ? [[key, values[key]]] : []),
+		),
+	);
+	if (Object.keys(overrides).length) {
+		console.log("[dev] using local Slack app credentials from server/.env");
+	}
+	return overrides;
+};
 const TRIGGER_API_URL =
 	(process.env.TRIGGER_API_URL ?? "https://api.trigger.dev")
 		.trim()
@@ -394,6 +418,7 @@ async function startDev() {
 
 		const spawnEnv: Record<string, string> = {
 			...process.env,
+			...localSlackAppEnv(),
 			TRIGGER_DEV_BRANCH: triggerDevBranch,
 			TRIGGER_API_URL,
 			// Sandbox key only. `stripe listen` reads STRIPE_API_KEY, so no

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -96,6 +96,63 @@ const localSlackAppEnv = (): Record<string, string> => {
 	}
 	return overrides;
 };
+
+/** Ensures the local app's slack_admin installation exists in the target DB
+ * so a non-dev run gets the admin org+env flow. The bot token lives encrypted
+ * in the dev DB, so a missing row is seeded via a dev-env token fetch.
+ * Best-effort: failures log a hint and never block startup. */
+const ensureLocalSlackAdminInstall = ({
+	spawnEnv,
+}: {
+	spawnEnv: Record<string, string>;
+}) => {
+	const seed = (extraEnv: Record<string, string>) =>
+		Bun.spawnSync(
+			["bun", "apps/leaf/scripts/seedSlackAdminInstall.ts", "--if-missing"],
+			{ env: { ...spawnEnv, ...extraEnv }, stderr: "pipe", stdout: "pipe" },
+		);
+	const probe = seed({});
+	if (probe.exitCode === 0) return;
+	if (probe.exitCode !== 42) {
+		console.log(
+			`[dev] slack_admin seed probe failed: ${probe.stderr.toString().trim().slice(0, 200)}`,
+		);
+		return;
+	}
+	const tokenProc = Bun.spawnSync(
+		[
+			"infisical",
+			"run",
+			"--env=dev",
+			"--recursive",
+			"--",
+			"bun",
+			"apps/leaf/scripts/printLocalSlackBotToken.ts",
+		],
+		{
+			env: {
+				HOME: process.env.HOME ?? "",
+				PATH: process.env.PATH ?? "",
+				SLACK_ADMIN_WORKSPACE_ID: spawnEnv.SLACK_ADMIN_WORKSPACE_ID ?? "",
+			},
+			stderr: "pipe",
+			stdout: "pipe",
+		},
+	);
+	const token = tokenProc.stdout.toString().trim().split("\n").at(-1) ?? "";
+	if (!token.startsWith("xoxb")) {
+		console.log(
+			"[dev] could not fetch the local Slack bot token from the dev DB — run apps/leaf/scripts/seedSlackAdminInstall.ts manually with SLACK_BOT_TOKEN set",
+		);
+		return;
+	}
+	const seeded = seed({ SLACK_BOT_TOKEN: token });
+	console.log(
+		seeded.exitCode === 0
+			? "[dev] seeded the local slack_admin installation"
+			: `[dev] slack_admin seed failed: ${seeded.stderr.toString().trim().slice(0, 200)}`,
+	);
+};
 const TRIGGER_API_URL =
 	(process.env.TRIGGER_API_URL ?? "https://api.trigger.dev")
 		.trim()
@@ -487,6 +544,9 @@ async function startDev() {
 		};
 		if (useLocalMiscCache) {
 			delete spawnEnv.MISC_CACHE_DRAGONFLY_PRIVATE_URL;
+		}
+		if (viteAppEnv !== "dev" && spawnEnv.SLACK_SIGNING_SECRET) {
+			ensureLocalSlackAdminInstall({ spawnEnv });
 		}
 
 		const concurrentlyProc = Bun.spawn(shellArgs, {

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -100,26 +100,35 @@ const localSlackAppEnv = (): Record<string, string> => {
 /** Ensures the local app's slack_admin installation exists in the target DB
  * so a non-dev run gets the admin org+env flow. The bot token lives encrypted
  * in the dev DB, so a missing row is seeded via a dev-env token fetch.
- * Best-effort: failures log a hint and never block startup. */
-const ensureLocalSlackAdminInstall = ({
+ * Fire-and-forget: failures log a hint and never block or delay startup. */
+const ensureLocalSlackAdminInstall = async ({
 	spawnEnv,
 }: {
 	spawnEnv: Record<string, string>;
 }) => {
+	const run = async (cmd: string[], env: Record<string, string>) => {
+		const proc = Bun.spawn(cmd, { env, stderr: "pipe", stdout: "pipe" });
+		const [exitCode, stdout, stderr] = await Promise.all([
+			proc.exited,
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		return { exitCode, stderr: stderr.trim(), stdout: stdout.trim() };
+	};
 	const seed = (extraEnv: Record<string, string>) =>
-		Bun.spawnSync(
-			["bun", "apps/leaf/scripts/seedSlackAdminInstall.ts", "--if-missing"],
-			{ env: { ...spawnEnv, ...extraEnv }, stderr: "pipe", stdout: "pipe" },
-		);
-	const probe = seed({});
+		run(["bun", "apps/leaf/scripts/seedSlackAdminInstall.ts", "--if-missing"], {
+			...spawnEnv,
+			...extraEnv,
+		});
+	const probe = await seed({});
 	if (probe.exitCode === 0) return;
 	if (probe.exitCode !== 42) {
 		console.log(
-			`[dev] slack_admin seed probe failed: ${probe.stderr.toString().trim().slice(0, 200)}`,
+			`[dev] slack_admin seed probe failed: ${probe.stderr.slice(0, 200)}`,
 		);
 		return;
 	}
-	const tokenProc = Bun.spawnSync(
+	const fetched = await run(
 		[
 			"infisical",
 			"run",
@@ -130,27 +139,23 @@ const ensureLocalSlackAdminInstall = ({
 			"apps/leaf/scripts/printLocalSlackBotToken.ts",
 		],
 		{
-			env: {
-				HOME: process.env.HOME ?? "",
-				PATH: process.env.PATH ?? "",
-				SLACK_ADMIN_WORKSPACE_ID: spawnEnv.SLACK_ADMIN_WORKSPACE_ID ?? "",
-			},
-			stderr: "pipe",
-			stdout: "pipe",
+			HOME: process.env.HOME ?? "",
+			PATH: process.env.PATH ?? "",
+			SLACK_ADMIN_WORKSPACE_ID: spawnEnv.SLACK_ADMIN_WORKSPACE_ID ?? "",
 		},
 	);
-	const token = tokenProc.stdout.toString().trim().split("\n").at(-1) ?? "";
+	const token = fetched.stdout.split("\n").at(-1) ?? "";
 	if (!token.startsWith("xoxb")) {
 		console.log(
 			"[dev] could not fetch the local Slack bot token from the dev DB — run apps/leaf/scripts/seedSlackAdminInstall.ts manually with SLACK_BOT_TOKEN set",
 		);
 		return;
 	}
-	const seeded = seed({ SLACK_BOT_TOKEN: token });
+	const seeded = await seed({ SLACK_BOT_TOKEN: token });
 	console.log(
 		seeded.exitCode === 0
 			? "[dev] seeded the local slack_admin installation"
-			: `[dev] slack_admin seed failed: ${seeded.stderr.toString().trim().slice(0, 200)}`,
+			: `[dev] slack_admin seed failed: ${seeded.stderr.slice(0, 200)}`,
 	);
 };
 const TRIGGER_API_URL =
@@ -473,9 +478,10 @@ async function startDev() {
 			];
 		}
 
+		const localSlackEnv = localSlackAppEnv();
 		const spawnEnv: Record<string, string> = {
 			...process.env,
-			...localSlackAppEnv(),
+			...localSlackEnv,
 			TRIGGER_DEV_BRANCH: triggerDevBranch,
 			TRIGGER_API_URL,
 			// Sandbox key only. `stripe listen` reads STRIPE_API_KEY, so no
@@ -545,8 +551,10 @@ async function startDev() {
 		if (useLocalMiscCache) {
 			delete spawnEnv.MISC_CACHE_DRAGONFLY_PRIVATE_URL;
 		}
-		if (viteAppEnv !== "dev" && spawnEnv.SLACK_SIGNING_SECRET) {
-			ensureLocalSlackAdminInstall({ spawnEnv });
+		if (localSlackEnv.SLACK_CLIENT_ID && localSlackEnv.SLACK_SIGNING_SECRET) {
+			void ensureLocalSlackAdminInstall({ spawnEnv }).catch((error) => {
+				console.log(`[dev] slack_admin seed errored: ${error}`);
+			});
 		}
 
 		const concurrentlyProc = Bun.spawn(shellArgs, {


### PR DESCRIPTION
## Why

Slack only delivers events for the LOCAL dev app to a laptop (via the chat tunnel) — the `SLACK_*` credentials infisical injects for prod/staging belong to the deployed bot, so local `bun p`/`bun s` runs rejected every event on signature verification and Slack testing against prod/staging data silently didn't work.

## What

`scripts/dev.ts` overrides `SLACK_CLIENT_ID`/`SLACK_CLIENT_SECRET`/`SLACK_SIGNING_SECRET` in the child env from `server/.env` (the local app's canonical home per `apps/leaf/README.md`) whenever `ENV_FILE` is not the dev one. Dev runs and deploys are untouched; logs one line when the override applies.

With the chat tunnel up, `bun p` now receives local-app Slack events against the prod DB with no manual env juggling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes local `bun p`/`bun s` runs so Slack events are accepted again, and auto-seeds the local bot's admin installation so the admin org+env flow works against target databases.

- Non-dev runs now override `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, and `SLACK_SIGNING_SECRET` from `server/.env`; dev runs and deploys are unchanged.
- When these credentials are present and the local app's `slack_admin:<client id>` row is missing in the target DB, the run fetches the local bot token from the dev DB and seeds it before startup; failures log a hint and never block startup.
- The new `seedSlackAdminInstall.ts` script can also be run manually; it validates the bot's workspace against `SLACK_ADMIN_WORKSPACE_ID` and pins the org slug (default `autumn`) and sandbox env.

<sup>Written for commit e6f9b803595315fc83747e146f58fc0d87a5e4eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR configures local non-dev runs to use the local Slack application and seeds its administrative installation in the selected database.
- **Bug fixes:** Overrides Slack credentials from server/.env for local runs connected to staging or production data.
- **Improvements:** Retrieves the local bot token from the development database and seeds a missing administrative installation without blocking startup.
- **Improvements:** Adds standalone scripts for retrieving and seeding local Slack installation data.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because valid local environment files can still produce unusable or mixed Slack credentials.

The override accepts incomplete credential sets and interprets server/.env differently from dotenv, so realistic local configurations still cause OAuth or event-signature verification to fail.

**Files Needing Attention:** scripts/dev.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/dev.ts | Adds local Slack credential overrides and asynchronous installation seeding, but partial credentials and non-dotenv parsing still leave Slack authentication broken for valid configurations. |
| apps/leaf/scripts/printLocalSlackBotToken.ts | Retrieves and decrypts the local Slack bot token from the development installation. |
| apps/leaf/scripts/seedSlackAdminInstall.ts | Validates the bot workspace and seeds a sandbox administrative Slack installation for the selected organization. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Start non-dev local run] --> B[Read local Slack credentials]
  B --> C[Build child environment]
  C --> D[Probe target database]
  D -->|Installation exists| G[Start Leaf]
  D -->|Installation missing| E[Fetch token from dev database]
  E --> F[Seed target database]
  F --> G
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/dev.ts:89-93
**Mixed Slack credential set**

If `server/.env` contains only some of the three Slack credentials, this code overrides those keys independently while retaining the deployed app's values for the missing keys. The resulting mixed credential set causes OAuth or event-signature verification to fail.

### Issue 2
scripts/dev.ts:88
**Dotenv values parsed incorrectly**

If `server/.env` contains a valid quoted or inline-commented value such as `SLACK_SIGNING_SECRET="abc"`, `parseEnvFile` retains the extra characters and injects a different secret than dotenv would load. Leaf then rejects valid Slack events during signature verification.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: gate the slack\_admin seed on local ..."](https://github.com/useautumn/autumn/commit/e6f9b803595315fc83747e146f58fc0d87a5e4eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58000290)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->