### PR TITLE
feat(catalog-v2): wire base price mappings and re-point on product change

### DIFF
--- a/server/src/external/stripe/createStripePrice/createStripeArrearProrated.ts
+++ b/server/src/external/stripe/createStripePrice/createStripeArrearProrated.ts
@@ -250,6 +250,7 @@ export const createStripeArrearProrated = async ({
 				slot: "stripe_price_id",
 				currency,
 				orgDefault,
+				stripeProductId,
 			}),
 		},
 	);

--- a/server/src/external/stripe/createStripePrice/createStripeFixedPrice.ts
+++ b/server/src/external/stripe/createStripePrice/createStripeFixedPrice.ts
@@ -73,6 +73,7 @@ export const createStripeFixedPrice = async ({
 				slot: "stripe_price_id",
 				currency,
 				orgDefault,
+				stripeProductId: product.processor!.id,
 			}),
 		},
 	);

--- a/server/src/external/stripe/createStripePrice/createStripeInArrear.ts
+++ b/server/src/external/stripe/createStripePrice/createStripeInArrear.ts
@@ -366,6 +366,7 @@ export const createStripeInArrearPrice = async ({
 				slot: "stripe_price_id",
 				currency,
 				orgDefault,
+				stripeProductId,
 			}),
 		},
 	);

--- a/server/src/external/stripe/createStripePrice/createStripePrepaidPriceV2.ts
+++ b/server/src/external/stripe/createStripePrice/createStripePrepaidPriceV2.ts
@@ -108,6 +108,7 @@ export const createStripePrepaidPriceV2 = async ({
 			slot: "stripe_prepaid_price_v2_id",
 			currency,
 			orgDefault,
+			stripeProductId,
 		}),
 	});
 

--- a/server/src/external/stripe/prices/utils/buildIdempotencyKey.ts
+++ b/server/src/external/stripe/prices/utils/buildIdempotencyKey.ts
@@ -20,18 +20,26 @@ const hashStripePriceIdempotencyShape = ({
 		.digest("hex")
 		.slice(0, 16);
 
+/**
+ * The Stripe product is part of the key because it is a `prices.create`
+ * parameter the hashed shape does not cover: re-minting one Autumn price under
+ * a new product is a different request, and Stripe rejects a reused key whose
+ * parameters changed.
+ */
 export const buildStripePriceIdempotencyKey = ({
 	price,
 	slot,
 	currency,
 	orgDefault,
+	stripeProductId,
 }: {
 	price: Price;
 	slot: string;
 	currency: string;
 	orgDefault: string;
+	stripeProductId: string;
 }) =>
-	`${AUTUMN_STRIPE_IDEMPOTENCY_PREFIX}price:${price.id}:${slot}:${currency}:${hashStripePriceIdempotencyShape({ price, currency, orgDefault })}`;
+	`${AUTUMN_STRIPE_IDEMPOTENCY_PREFIX}price:${price.id}:${slot}:${currency}:${stripeProductId}:${hashStripePriceIdempotencyShape({ price, currency, orgDefault })}`;
 
 export const buildStripeProductIdempotencyKey = ({
 	productInternalId,

--- a/server/src/internal/catalogV2/execute/executeInitStripeResources/initStripeResourcesForCatalog.ts
+++ b/server/src/internal/catalogV2/execute/executeInitStripeResources/initStripeResourcesForCatalog.ts
@@ -5,6 +5,7 @@ import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatal
 import { initStripeResourcesForProducts } from "@/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts";
 import { applyStripeResourceReuseForProduct } from "@/internal/products/stripeResourceUtils/applyStripeResourceReuseForProduct";
 import { hydratePlanLicenseProcessor } from "./hydratePlanLicenseProcessor";
+import { repointBasePricesToPlanProcessor } from "./repointBasePricesToPlanProcessor";
 import { validateAdoptedStripePrices } from "./validateAdoptedStripePrices";
 import {
 	catalogProductsByInternalId,
@@ -52,6 +53,8 @@ export const initStripeResourcesForCatalog = async ({
 	// Ahead of the completeness skip and the Live guard below, so a stated id
 	// is checked in every environment even when nothing needs creating.
 	await validateAdoptedStripePrices({ ctx, upsertProducts: targets });
+	// Ahead of init so a cleared price is minted under the new product below.
+	await repointBasePricesToPlanProcessor({ ctx, upsertProducts: targets });
 
 	for (const upsert of targets) {
 		const product = upsert.row.nextFullProduct;

--- a/server/src/internal/catalogV2/execute/executeInitStripeResources/repointBasePricesToPlanProcessor.ts
+++ b/server/src/internal/catalogV2/execute/executeInitStripeResources/repointBasePricesToPlanProcessor.ts
@@ -1,0 +1,90 @@
+import { isFixedPrice, type Price } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { findMatchingStripePriceForFixedPrice } from "@/internal/billing/v2/providers/stripe/utils/sync/matchUtils/stripePriceMatchesAutumnPrice";
+// Both helpers move here when the legacy mappings endpoints retire.
+import { clearDependentStripePriceFields } from "@/internal/catalog/actions/catalogMappings/catalogMappingUtils";
+import { listExistingStripePricesByProduct } from "@/internal/catalog/actions/catalogMappings/updateMappings/matchExistingStripeBasePrice";
+import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { PriceService } from "@/internal/products/prices/PriceService";
+
+type StrandedBasePrice = { price: Price; stripeProductId: string };
+
+const stripePriceIdOf = ({ price }: { price?: Price }): string | null =>
+	(price?.config as { stripe_price_id?: string | null } | undefined)
+		?.stripe_price_id ?? null;
+
+/**
+ * A base price left under the product the plan just stopped mapping to. A price
+ * the same request restated is left alone — the stated id owns it.
+ */
+const strandedBasePrice = ({
+	upsert,
+}: {
+	upsert: UpsertProductPlan;
+}): StrandedBasePrice[] => {
+	const next = upsert.row.nextFullProduct;
+	const current = upsert.row.currentFullProduct;
+	if (!current) return [];
+
+	const stripeProductId = next.processor?.id;
+	if (!stripeProductId) return [];
+	if (current.processor?.id === stripeProductId) return [];
+
+	const price = next.prices.find(isFixedPrice);
+	if (!price) return [];
+	if (price.config.stripe_product_id === stripeProductId) return [];
+
+	const currentPrice = current.prices.find(isFixedPrice);
+	if (stripePriceIdOf({ price }) !== stripePriceIdOf({ price: currentPrice })) {
+		return [];
+	}
+
+	return [{ price, stripeProductId }];
+};
+
+/**
+ * A plan is billed under the Stripe product its base price belongs to, so a
+ * changed product has to move that price as well — otherwise checkout keeps
+ * charging the old product's price and the mapping is cosmetic. Reuses a price
+ * already under the new product when one matches; otherwise clears the stale
+ * ids so init mints a fresh one.
+ */
+export const repointBasePricesToPlanProcessor = async ({
+	ctx,
+	upsertProducts,
+}: {
+	ctx: AutumnContext;
+	upsertProducts: UpsertProductPlan[];
+}) => {
+	const stranded = upsertProducts.flatMap((upsert) =>
+		strandedBasePrice({ upsert }),
+	);
+	if (stranded.length === 0) return;
+
+	const currency = ctx.org.default_currency || "usd";
+	const pricesByProduct = await listExistingStripePricesByProduct({
+		ctx,
+		stripeProductIds: stranded.map((entry) => entry.stripeProductId),
+	});
+
+	for (const { price, stripeProductId } of stranded) {
+		const matched = findMatchingStripePriceForFixedPrice({
+			price,
+			stripeProductId,
+			stripePrices: pricesByProduct.get(stripeProductId) ?? [],
+			currency,
+		});
+
+		price.config = clearDependentStripePriceFields({
+			price,
+			stripeProductId,
+			stripePriceId: matched?.id ?? null,
+		});
+
+		await PriceService.update({
+			db: ctx.db,
+			id: price.id!,
+			update: { config: price.config },
+		});
+	}
+};

--- a/server/src/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices.ts
+++ b/server/src/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices.ts
@@ -11,15 +11,34 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { PriceService } from "@/internal/products/prices/PriceService";
 
-type PriceConfigIds = {
-	stripe_prepaid_price_v2_id?: string | null;
-	stripe_product_id?: string | null;
-};
+/** Fixed prices bill from the v1 slot, prepaid from the v2 slot. */
+const PRICE_MAPPING_SLOTS = [
+	"stripe_price_id",
+	"stripe_prepaid_price_v2_id",
+] as const;
+
+type PriceConfigIds = Partial<
+	Record<(typeof PRICE_MAPPING_SLOTS)[number] | "stripe_product_id", string | null>
+>;
 
 type AdoptedPrice = { planId: string; price: Price; stripePriceId: string };
 
 const configIds = ({ price }: { price: Price }): PriceConfigIds =>
 	(price.config ?? {}) as PriceConfigIds;
+
+/** Every Stripe price the plan already holds — carried-forward ids included. */
+const knownStripePriceIds = ({
+	product,
+}: {
+	product?: FullProduct | null;
+}): Set<string> =>
+	new Set(
+		(product?.prices ?? []).flatMap((price) =>
+			PRICE_MAPPING_SLOTS.map((slot) => configIds({ price })[slot]).filter(
+				(id): id is string => Boolean(id),
+			),
+		),
+	);
 
 /** Stated ids only — an id Autumn minted earlier was real when it was written. */
 const newlyAdoptedPrices = ({
@@ -28,22 +47,14 @@ const newlyAdoptedPrices = ({
 	upsert: UpsertProductPlan;
 }): AdoptedPrice[] => {
 	const next: FullProduct = upsert.row.nextFullProduct;
-	const current = upsert.row.currentFullProduct;
+	const known = knownStripePriceIds({ product: upsert.row.currentFullProduct });
 
 	return next.prices.flatMap((price) => {
-		const stripePriceId = configIds({ price }).stripe_prepaid_price_v2_id;
+		const ids = configIds({ price });
+		const stripePriceId = PRICE_MAPPING_SLOTS.map((slot) => ids[slot])
+			.filter((id): id is string => Boolean(id))
+			.find((id) => !known.has(id));
 		if (!stripePriceId) return [];
-
-		const currentPrice = current?.prices.find(
-			(candidate) => candidate.id === price.id,
-		);
-		if (
-			currentPrice &&
-			configIds({ price: currentPrice }).stripe_prepaid_price_v2_id ===
-				stripePriceId
-		) {
-			return [];
-		}
 		return [{ planId: next.id, price, stripePriceId }];
 	});
 };

--- a/server/src/internal/orgs/handlers/stripeHandlers/handleSearchStripePrices.ts
+++ b/server/src/internal/orgs/handlers/stripeHandlers/handleSearchStripePrices.ts
@@ -1,0 +1,99 @@
+import {
+	type CatalogStripePrice,
+	Scopes,
+	StripePriceSearchParamsSchema,
+	StripePriceSearchResponseSchema,
+} from "@autumn/shared";
+import type Stripe from "stripe";
+import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { isStripeConnected } from "../../orgUtils.js";
+
+const STRIPE_PRICE_ID_PREFIX = "price_";
+const STRIPE_PRODUCT_ID_PREFIX = "prod_";
+
+const stripePriceToCatalogPrice = (
+	stripePrice: Stripe.Price,
+): CatalogStripePrice => {
+	const product = stripePrice.product;
+	const expandedProduct =
+		product &&
+		typeof product !== "string" &&
+		!("deleted" in product && product.deleted)
+			? product
+			: null;
+
+	return {
+		id: stripePrice.id,
+		nickname: stripePrice.nickname ?? null,
+		unit_amount: stripePrice.unit_amount ?? null,
+		currency: stripePrice.currency,
+		interval: stripePrice.recurring?.interval ?? null,
+		interval_count: stripePrice.recurring?.interval_count ?? null,
+		active: stripePrice.active,
+		product_id:
+			typeof product === "string" ? product : (expandedProduct?.id ?? null),
+		product_name: expandedProduct?.name ?? null,
+	};
+};
+
+/**
+ * Two lookups, no free-text search: an exact price id, or every price under a
+ * product id. Stripe cannot match price ids by substring, so anything else
+ * would return unrelated prices — those queries never reach Stripe.
+ */
+export const handleSearchStripePrices = createRoute({
+	scopes: [Scopes.Plans.Read],
+	query: StripePriceSearchParamsSchema,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { org, env, logger } = ctx;
+		const { search, limit } = c.req.valid("query");
+		const normalizedSearch = search?.trim() ?? "";
+
+		const respond = ({
+			stripeConnected,
+			stripePrices = [],
+		}: {
+			stripeConnected: boolean;
+			stripePrices?: Stripe.Price[];
+		}) =>
+			c.json(
+				StripePriceSearchResponseSchema.parse({
+					stripe_connected: stripeConnected,
+					stripe_prices: stripePrices.map(stripePriceToCatalogPrice),
+				}),
+			);
+
+		if (!isStripeConnected({ org, env })) {
+			return respond({ stripeConnected: false });
+		}
+
+		const stripeCli = createStripeCli({ org, env });
+
+		try {
+			if (normalizedSearch.startsWith(STRIPE_PRICE_ID_PREFIX)) {
+				const stripePrice = await stripeCli.prices.retrieve(normalizedSearch, {
+					expand: ["product"],
+				});
+				return respond({ stripeConnected: true, stripePrices: [stripePrice] });
+			}
+
+			if (normalizedSearch.startsWith(STRIPE_PRODUCT_ID_PREFIX)) {
+				const listed = await stripeCli.prices.list({
+					product: normalizedSearch,
+					active: true,
+					limit,
+					expand: ["data.product"],
+				});
+				return respond({ stripeConnected: true, stripePrices: listed.data });
+			}
+		} catch (error) {
+			logger.warn(
+				`[stripe.prices.search] Lookup failed for ${normalizedSearch}: ${error}`,
+			);
+		}
+
+		return respond({ stripeConnected: true });
+	},
+});

--- a/server/src/internal/orgs/orgRouter.ts
+++ b/server/src/internal/orgs/orgRouter.ts
@@ -55,6 +55,7 @@ import { handleDeleteStripe } from "./handlers/stripeHandlers/handleDeleteStripe
 import { handleGetOAuthUrl } from "./handlers/stripeHandlers/handleGetOAuthUrl.js";
 import { handleGetStripeAccount } from "./handlers/stripeHandlers/handleGetStripeAccount.js";
 import { handleResolveStripeProducts } from "./handlers/stripeHandlers/handleResolveStripeProducts.js";
+import { handleSearchStripePrices } from "./handlers/stripeHandlers/handleSearchStripePrices.js";
 import { handleSearchStripeProducts } from "./handlers/stripeHandlers/handleSearchStripeProducts.js";
 
 export const internalOrgRouter = new Hono<HonoEnv>();
@@ -108,6 +109,7 @@ honoOrgRouter.patch("/transition_rules", ...handleUpdateTransitionRules);
 honoOrgRouter.get("/stripe", ...handleGetStripeAccount);
 honoOrgRouter.get("/stripe/products/search", ...handleSearchStripeProducts);
 honoOrgRouter.post("/stripe/products/resolve", ...handleResolveStripeProducts);
+honoOrgRouter.get("/stripe/prices/search", ...handleSearchStripePrices);
 honoOrgRouter.delete("/stripe", ...handleDeleteStripe);
 honoOrgRouter.post("/stripe", ...handleConnectStripe);
 honoOrgRouter.get("/stripe/oauth_url", ...handleGetOAuthUrl);

--- a/server/src/internal/products/actions/computeEntitlementPricesPlan/buildEntitlementPricesPlan/buildEntitlementPricesPlan.ts
+++ b/server/src/internal/products/actions/computeEntitlementPricesPlan/buildEntitlementPricesPlan/buildEntitlementPricesPlan.ts
@@ -1,3 +1,4 @@
+import type { Price } from "@autumn/shared";
 import type { ClaimResult } from "../types/claimResult";
 import type { EntitlementPricesPlanMode } from "../types/computeEntitlementPricesPlanParams";
 import {
@@ -11,19 +12,54 @@ import {
 	withFreshPriceId,
 } from "./buildEntitlementPricesPlanUtils";
 
+/** Fixed prices bill from the v1 slot, prepaid from the v2 slot. */
+const PRICE_MAPPING_SLOTS = [
+	"stripe_price_id",
+	"stripe_prepaid_price_v2_id",
+] as const;
+
+type PriceMapping = Partial<
+	Record<(typeof PRICE_MAPPING_SLOTS)[number], string | null>
+>;
+
+const mappingOf = ({ price }: { price?: Price }): PriceMapping =>
+	(price?.config ?? {}) as PriceMapping;
+
 /**
  * A claim matches on price definition, which deliberately ignores Stripe ids —
  * billing depends on that. So a re-stated mapping arrives as a claimed pair and
- * would be dropped; carry it onto the row we keep instead.
+ * would be dropped; carry it onto the row we keep instead. Desired only carries
+ * a slot the request stated, so a plain edit produces nothing here.
  */
-const adoptedPriceIdOf = (
-	entitlementPrice: ClaimResult["entitlementPriceClaims"][number]["current"],
-): string | undefined =>
-	(
-		entitlementPrice.price?.config as
-			| { stripe_prepaid_price_v2_id?: string }
-			| undefined
-	)?.stripe_prepaid_price_v2_id;
+const restatedMapping = ({
+	desired,
+	current,
+}: {
+	desired?: Price;
+	current?: Price;
+}): PriceMapping | undefined => {
+	if (!current) return undefined;
+
+	const desiredMapping = mappingOf({ price: desired });
+	const currentMapping = mappingOf({ price: current });
+	const restated = PRICE_MAPPING_SLOTS.filter(
+		(slot) => desiredMapping[slot] && desiredMapping[slot] !== currentMapping[slot],
+	);
+	if (restated.length === 0) return undefined;
+
+	return Object.fromEntries(restated.map((slot) => [slot, desiredMapping[slot]]));
+};
+
+const withMapping = ({
+	price,
+	mapping,
+}: {
+	price: Price;
+	mapping: PriceMapping;
+}): Price => ({
+	...price,
+	config: { ...price.config, ...mapping } as Price["config"],
+});
 
 /**
  * Claims → same; unclaimed desired → new; unclaimed current → leave bucket by mode.
@@ -42,30 +78,22 @@ export const buildEntitlementPricesPlan = ({
 	const leaveBucket = leaveBucketForMode({ mode });
 
 	for (const { desired, current } of claims.entitlementPriceClaims) {
-		const statedPriceId = adoptedPriceIdOf(desired);
-		const mappingChanged =
-			statedPriceId !== undefined &&
-			statedPriceId !== adoptedPriceIdOf(current) &&
-			current.price !== undefined;
+		const mapping = restatedMapping({
+			desired: desired.price,
+			current: current.price,
+		});
 
-		if (!mappingChanged) {
+		if (!mapping || !current.price) {
 			pushEntitlementPrice({ plan, bucket: "same", entitlementPrice: current });
 			continue;
 		}
 
-		const keptPrice = current.price!;
 		pushEntitlementPrice({
 			plan,
 			bucket: "updated",
 			entitlementPrice: {
 				...current,
-				price: {
-					...keptPrice,
-					config: {
-						...keptPrice.config,
-						stripe_prepaid_price_v2_id: statedPriceId,
-					} as typeof keptPrice.config,
-				},
+				price: withMapping({ price: current.price, mapping }),
 			},
 		});
 	}
@@ -89,7 +117,10 @@ export const buildEntitlementPricesPlan = ({
 	}
 
 	if (claims.basePriceClaim) {
-		plan.prices.same.push(claims.basePriceClaim.current);
+		const { desired, current } = claims.basePriceClaim;
+		const mapping = restatedMapping({ desired, current });
+		if (mapping) plan.prices.updated.push(withMapping({ price: current, mapping }));
+		else plan.prices.same.push(current);
 	}
 
 	if (claims.unclaimedDesiredBasePrice) {

--- a/server/tests/integration/catalog-v2/plans/processors/base-price-adopt.test.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/base-price-adopt.test.ts
@@ -1,0 +1,197 @@
+/**
+ * catalogV2.update — a supplied Stripe price id on the BASE price is adopted.
+ *
+ * A base price is fixed, so its id belongs in `stripe_price_id`, not the
+ * prepaid v2 slot that item prices use. The schema carried `processors` here
+ * already; nothing read it, so the id was accepted and dropped.
+ *
+ * Contract:
+ *   C1  `plan.price.processors.stripe.price_id` lands in stripe_price_id and
+ *       no new price is minted
+ *   C2  the adopted price's own Stripe product is recorded on the config
+ *   C3  re-stating a different id re-points the price and its product — the
+ *       definition is unchanged, so the claim layer would otherwise drop it
+ *   C4  an id Stripe does not know is a hard error, not a silent mint
+ *
+ * Red (current): basePriceToProductItem ignores `processors`, so the id never
+ *   reaches the slot and Autumn mints its own price.
+ * Green (after): the slot holds the supplied id; a missing id 400s.
+ */
+
+import { expect, test } from "bun:test";
+import { BillingInterval, type FullProduct } from "@autumn/shared";
+import {
+	findBasePrice,
+	stripeConfigValue,
+} from "@tests/integration/utils/expectStripePriceResources.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { withCatalogPlans } from "../licenses/utils/seedLicensePlans.js";
+
+const BASE_AMOUNT = 20;
+
+const getFull = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}): Promise<FullProduct> =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+const basePrice = ({ priceId }: { priceId?: string } = {}) => ({
+	amount: BASE_AMOUNT,
+	interval: BillingInterval.Month,
+	...(priceId ? { processors: { stripe: { price_id: priceId } } } : {}),
+});
+
+const baseSlots = ({ product }: { product: FullProduct }) => {
+	const price = findBasePrice({ product });
+	return {
+		priceId: stripeConfigValue({ price, field: "stripe_price_id" }),
+		productId: stripeConfigValue({ price, field: "stripe_product_id" }),
+	};
+};
+
+/** A price Autumn did not make — the shape a real import starts from. */
+const createExternalPrice = async ({
+	stripeCli,
+	label,
+}: {
+	stripeCli: Stripe;
+	label: string;
+}) => {
+	const product = await stripeCli.products.create({
+		name: `External Base ${label}`,
+	});
+	const price = await stripeCli.prices.create({
+		product: product.id,
+		currency: "usd",
+		unit_amount: BASE_AMOUNT * 100,
+		recurring: { interval: "month" },
+	});
+	return { productId: product.id, priceId: price.id };
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors base price: a supplied price id is adopted with its product")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_base_adopt");
+		const external = await createExternalPrice({
+			stripeCli: ctx.stripeCli,
+			label: planId,
+		});
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Base Price Adopt",
+							price: basePrice({ priceId: external.priceId }),
+							items: [],
+						},
+					],
+				});
+
+				const slots = baseSlots({ product: await getFull({ ctx, planId }) });
+				// C1: the stated id landed — no freshly minted price.
+				expect(slots.priceId, "adopted base price id").toBe(external.priceId);
+				// C2: the product comes from the adopted price.
+				expect(slots.productId, "adopted price's own product").toBe(
+					external.productId,
+				);
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors base price: re-stating a different id re-points the price")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_base_remap");
+		const first = await createExternalPrice({
+			stripeCli: ctx.stripeCli,
+			label: `${planId}_a`,
+		});
+		const second = await createExternalPrice({
+			stripeCli: ctx.stripeCli,
+			label: `${planId}_b`,
+		});
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Base Price Remap",
+							price: basePrice({ priceId: first.priceId }),
+							items: [],
+						},
+					],
+				});
+				expect(
+					baseSlots({ product: await getFull({ ctx, planId }) }).priceId,
+					"first mapping",
+				).toBe(first.priceId);
+
+				// Same amount and interval, so the price definition is unchanged and
+				// the claim layer keeps the current row unless the mapping is noticed.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{ plan_id: planId, price: basePrice({ priceId: second.priceId }) },
+					],
+				});
+
+				const slots = baseSlots({ product: await getFull({ ctx, planId }) });
+				// C3: both the price and its product follow the restated id.
+				expect(slots.priceId, "re-mapped base price id").toBe(second.priceId);
+				expect(slots.productId, "product re-pointed").toBe(second.productId);
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors base price: an unknown price id errors instead of minting")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_base_bad");
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				// C4: a plausible but non-existent id must fail loudly.
+				const update = autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Base Price Bad",
+							price: basePrice({ priceId: "price_1NoSuchBasePriceAtAll" }),
+							items: [],
+						},
+					],
+				});
+				await expect(update).rejects.toThrow();
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/processors/product-repoint.test.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/product-repoint.test.ts
@@ -1,0 +1,230 @@
+/**
+ * catalogV2.update — changing a plan's Stripe product moves its base price.
+ *
+ * A plan is billed under the Stripe product its base price belongs to. The
+ * legacy mappings endpoint moved the price whenever the product changed;
+ * `processors` only stamped product.processor, so the mapping was cosmetic and
+ * checkout kept charging the old product's price.
+ *
+ * Contract:
+ *   D1  a matching price already under the new product is reused, not duplicated
+ *   D2  with nothing to match, the stale ids are cleared and a price is minted
+ *       under the new product
+ *   D3  a request that restates the price id itself wins — the re-point leaves
+ *       it alone rather than overwriting a stated mapping
+ *
+ * Red (current): applyPlanProcessorsToProduct never touches price configs, and
+ *   init skips the price because every slot is still filled.
+ * Green (after): the base price's product follows the plan's.
+ */
+
+import { expect, test } from "bun:test";
+import { BillingInterval, type FullProduct } from "@autumn/shared";
+import {
+	findBasePrice,
+	stripeConfigValue,
+} from "@tests/integration/utils/expectStripePriceResources.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { withCatalogPlans } from "../licenses/utils/seedLicensePlans.js";
+
+const BASE_AMOUNT = 20;
+
+const getFull = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}): Promise<FullProduct> =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+const baseSlots = ({ product }: { product: FullProduct }) => {
+	const price = findBasePrice({ product });
+	return {
+		priceId: stripeConfigValue({ price, field: "stripe_price_id" }),
+		productId: stripeConfigValue({ price, field: "stripe_product_id" }),
+	};
+};
+
+const seedPaidPlan = async ({
+	autumn,
+	planId,
+	name,
+}: {
+	autumn: { catalogV2: { update: (params: unknown) => Promise<unknown> } };
+	planId: string;
+	name: string;
+}) =>
+	autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				name,
+				price: { amount: BASE_AMOUNT, interval: BillingInterval.Month },
+				items: [],
+			},
+		],
+	});
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors repoint: a matching price under the new product is reused")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_repoint_match");
+		const externalProduct = await ctx.stripeCli.products.create({
+			name: `Repoint Match ${planId}`,
+		});
+		const externalPrice = await ctx.stripeCli.prices.create({
+			product: externalProduct.id,
+			currency: "usd",
+			unit_amount: BASE_AMOUNT * 100,
+			recurring: { interval: "month" },
+		});
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await seedPaidPlan({
+					autumn: autumnV2_3,
+					planId,
+					name: "Repoint Match",
+				});
+				const minted = baseSlots({ product: await getFull({ ctx, planId }) });
+				expect(minted.priceId, "autumn minted a base price").toMatch(/^price_/);
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							processors: { stripe: { product_id: externalProduct.id } },
+						},
+					],
+				});
+
+				// D1: the existing $20/mo price under the new product is adopted,
+				// rather than a second identical price being created.
+				const slots = baseSlots({ product: await getFull({ ctx, planId }) });
+				expect(slots.productId, "price product follows the plan").toBe(
+					externalProduct.id,
+				);
+				expect(slots.priceId, "reused the matching price").toBe(
+					externalPrice.id,
+				);
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors repoint: with no match the stale price is replaced")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_repoint_mint");
+		const externalProduct = await ctx.stripeCli.products.create({
+			name: `Repoint Mint ${planId}`,
+		});
+		// Deliberately a different amount, so nothing under the product matches.
+		await ctx.stripeCli.prices.create({
+			product: externalProduct.id,
+			currency: "usd",
+			unit_amount: 9900,
+			recurring: { interval: "month" },
+		});
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await seedPaidPlan({
+					autumn: autumnV2_3,
+					planId,
+					name: "Repoint Mint",
+				});
+				const minted = baseSlots({ product: await getFull({ ctx, planId }) });
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							processors: { stripe: { product_id: externalProduct.id } },
+						},
+					],
+				});
+
+				// D2: the old id must not survive — it belongs to a product this
+				// plan no longer maps to.
+				const slots = baseSlots({ product: await getFull({ ctx, planId }) });
+				expect(slots.productId, "price product follows the plan").toBe(
+					externalProduct.id,
+				);
+				expect(slots.priceId, "stale price replaced").not.toBe(minted.priceId);
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors repoint: a restated price id wins over the re-point")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_repoint_stated");
+		const statedProduct = await ctx.stripeCli.products.create({
+			name: `Repoint Stated ${planId}`,
+		});
+		const statedPrice = await ctx.stripeCli.prices.create({
+			product: statedProduct.id,
+			currency: "usd",
+			unit_amount: BASE_AMOUNT * 100,
+			recurring: { interval: "month" },
+		});
+		const planProduct = await ctx.stripeCli.products.create({
+			name: `Repoint Plan ${planId}`,
+		});
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await seedPaidPlan({
+					autumn: autumnV2_3,
+					planId,
+					name: "Repoint Stated",
+				});
+
+				// Both change at once: the plan moves to one product while the price
+				// is stated under another.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							processors: { stripe: { product_id: planProduct.id } },
+							price: {
+								amount: BASE_AMOUNT,
+								interval: BillingInterval.Month,
+								processors: { stripe: { price_id: statedPrice.id } },
+							},
+						},
+					],
+				});
+
+				// D3: feature prices already live under their own products, so a
+				// stated price is honoured rather than dragged to the plan's.
+				const slots = baseSlots({ product: await getFull({ ctx, planId }) });
+				expect(slots.priceId, "stated price kept").toBe(statedPrice.id);
+				expect(slots.productId, "stated price's own product kept").toBe(
+					statedProduct.id,
+				);
+			},
+		});
+	},
+);

--- a/server/tests/unit/external/stripe/build-stripe-price-idempotency-key.test.ts
+++ b/server/tests/unit/external/stripe/build-stripe-price-idempotency-key.test.ts
@@ -31,12 +31,21 @@ const fixed = ({ amount }: { amount: number }): Price => ({
 	proration_config: null,
 });
 
-const key = ({ price, currency = "usd" }: { price: Price; currency?: string }) =>
+const key = ({
+	price,
+	currency = "usd",
+	stripeProductId = "prod_pro",
+}: {
+	price: Price;
+	currency?: string;
+	stripeProductId?: string;
+}) =>
 	buildStripePriceIdempotencyKey({
 		price,
 		slot: "stripe_price_id",
 		currency,
 		orgDefault: "usd",
+		stripeProductId,
 	});
 
 describe("buildStripePriceIdempotencyKey", () => {
@@ -47,7 +56,19 @@ describe("buildStripePriceIdempotencyKey", () => {
 
 		expect(key({ price: ten })).toBe(key({ price: tenAgain }));
 		expect(key({ price: ten })).not.toBe(key({ price: twenty }));
-		expect(key({ price: ten })).toMatch(/^autumn:price:pr_abc:stripe_price_id:usd:[a-f0-9]{16}$/);
+		expect(key({ price: ten })).toMatch(
+			/^autumn:price:pr_abc:stripe_price_id:usd:prod_pro:[a-f0-9]{16}$/,
+		);
+	});
+
+	test("same price re-minted under a new product gets a new key", () => {
+		const ten = fixed({ amount: 10 });
+
+		// Re-pointing a plan's Stripe product remints this row under a different
+		// product; Stripe rejects a reused key whose parameters changed.
+		expect(key({ price: ten, stripeProductId: "prod_old" })).not.toBe(
+			key({ price: ten, stripeProductId: "prod_new" }),
+		);
 	});
 
 	test("same id + amount, prorated → arrear, gets a new key", () => {

--- a/shared/api/models.ts
+++ b/shared/api/models.ts
@@ -68,6 +68,7 @@ export * from "./referrals/createReferralCodeParams.js";
 export * from "./referrals/redeemReferralCodeParams.js";
 export * from "./referrals/referralOpModels.js";
 export * from "./rewards/index.js";
+export * from "./stripe/stripePriceModels.js";
 export * from "./stripe/stripeProductModels.js";
 // Helpers
 export * from "./utils/openApiHelpers.js";

--- a/shared/api/products/components/basePrice/basePriceToProductItem.ts
+++ b/shared/api/products/components/basePrice/basePriceToProductItem.ts
@@ -29,10 +29,17 @@ export const basePriceToProductItem = ({
 			: undefined;
 	const priceId =
 		"price_id" in basePrice ? (basePrice.price_id ?? undefined) : undefined;
-	const stripePriceId =
-		"stripe_price_id" in basePrice
-			? (basePrice.stripe_price_id ?? undefined)
+	// A base price is fixed, so an adopted id belongs in the v1 slot it bills
+	// from. The internal field stays as the sync flows' way in.
+	const statedStripePriceId =
+		"processors" in basePrice
+			? basePrice.processors?.stripe?.price_id
 			: undefined;
+	const stripePriceId =
+		statedStripePriceId ??
+		("stripe_price_id" in basePrice
+			? (basePrice.stripe_price_id ?? undefined)
+			: undefined);
 
 	const additionalCurrencies =
 		"additional_currencies" in basePrice

--- a/shared/api/stripe/stripePriceModels.ts
+++ b/shared/api/stripe/stripePriceModels.ts
@@ -1,0 +1,35 @@
+import { z } from "zod/v4";
+
+export const CatalogStripePriceSchema = z.object({
+	id: z.string(),
+	nickname: z.string().nullable(),
+	unit_amount: z.number().nullable(),
+	currency: z.string(),
+	interval: z.string().nullable(),
+	interval_count: z.number().nullable(),
+	active: z.boolean(),
+	product_id: z.string().nullable(),
+	product_name: z.string().nullable(),
+});
+
+/**
+ * Stripe has no substring search over price ids, so the only useful queries are
+ * an exact price id or a product id to list under. Anything else is not a lookup.
+ */
+export const StripePriceSearchParamsSchema = z.object({
+	search: z.string().optional(),
+	limit: z.coerce.number().int().min(1).max(100).default(100),
+});
+
+export const StripePriceSearchResponseSchema = z.object({
+	stripe_connected: z.boolean(),
+	stripe_prices: z.array(CatalogStripePriceSchema),
+});
+
+export type CatalogStripePrice = z.infer<typeof CatalogStripePriceSchema>;
+export type StripePriceSearchParams = z.infer<
+	typeof StripePriceSearchParamsSchema
+>;
+export type StripePriceSearchResponse = z.infer<
+	typeof StripePriceSearchResponseSchema
+>;


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires supplied Stripe price IDs into base prices and moves the base price when a plan's Stripe product changes, so billing follows the plan's product instead of charging the old product's price.

- `processors.stripe.price_id` on a base price is now mapped to `stripe_price_id`; previously the id was dropped and Autumn minted its own price.
- On a Stripe product change, the base price reuses a matching price under the new product, or clears stale ids so a new one is minted.
- Both `stripe_price_id` and `stripe_prepaid_price_v2_id` are carried through adoption validation and the claim layer, including the base price.
- Stripe price idempotency keys now include the Stripe product id, so a price re-minted under a new product gets a fresh key.
- Added `GET /orgs/:org_id/stripe/prices/search` to look up a price by exact id or list prices under a product id.

**Known gaps**
- A Stripe id already held elsewhere in the plan can be reassigned to a different price without validation, billing the wrong amount.
- If no matching price exists during a repoint, the stale id is cleared before the replacement is created, so a failed repoint leaves the stored price without a usable mapping.

<sup>Written for commit 21327212b59efb821dd222ee25d6bd44aef1dd84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR wires supplied Stripe IDs into base prices and moves base-price mappings when a plan changes Stripe products.

- **[Bug fixes, Improvements]** Preserve supplied base and prepaid Stripe price mappings through catalog validation and price claims.
- **[Bug fixes, Improvements]** Reuse or recreate a base price under a newly selected Stripe product.
- **[Improvements]** Include the Stripe product in price-creation idempotency keys.
- **[API changes]** Add an internal endpoint for retrieving a Stripe price or listing active prices for a product.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because Stripe IDs can still be reassigned without price validation, and a failed repoint can leave a plan without a usable mapping.

A simple catalog edit can map a $20 price to another row’s existing $10 Stripe price and charge the wrong amount; separately, replacement creation can fail after the old mapping has already been cleared and committed.

**Files Needing Attention:** server/src/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices.ts; server/src/internal/catalogV2/execute/executeInitStripeResources/repointBasePricesToPlanProcessor.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices.ts | Expands adoption validation to both mapping slots, but the previously reported cross-price reassignment bypass remains. |
| server/src/internal/catalogV2/execute/executeInitStripeResources/repointBasePricesToPlanProcessor.ts | Repoints base prices to new Stripe products, but still persists destructive clearing before replacement creation succeeds. |
| server/src/internal/products/actions/computeEntitlementPricesPlan/buildEntitlementPricesPlan/buildEntitlementPricesPlan.ts | Carries restated fixed and prepaid Stripe mappings through claimed price updates. |
| server/src/external/stripe/prices/utils/buildIdempotencyKey.ts | Adds the destination Stripe product to price-creation idempotency keys. |
| server/src/internal/orgs/handlers/stripeHandlers/handleSearchStripePrices.ts | Adds exact price lookup and active-price listing by Stripe product. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Catalog plan update] --> B[Validate supplied Stripe price IDs]
  B --> C[Detect changed Stripe product]
  C --> D{Matching base price exists?}
  D -->|Yes| E[Reuse matching Stripe price]
  D -->|No| F[Clear stale mapping]
  F --> G[Create replacement Stripe price]
  E --> H[Persist catalog mapping]
  G --> H
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: 🐛 wire base price stripe mappings ..."](https://github.com/useautumn/autumn/commit/21327212b59efb821dd222ee25d6bd44aef1dd84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58595940)</sub>

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)
- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)

<!-- /greptile_comment -->