### PR TITLE
Approval-layer incident fixes: decay-aware drift, typed approve, real stop

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
@@ -259,7 +259,7 @@ export const consumeAgentTurn = async ({
 
 	try {
 		while (idleRetries < MAX_IDLE_RETRIES) {
-			// Eve cannot be interrupted server-side.
+			// Local fast-path; requestStop cancels the turn server-side separately.
 			if (run?.stop) {
 				return await abandonForStop({
 					progress: turn.progress,

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
@@ -4,6 +4,7 @@ import type {
 	AgentTurnContext,
 	AgentTurnParams,
 } from "../../domain/agentTurnContext.js";
+import { cancelEveTurn } from "../../eve/client.js";
 import type { EveAuthContext, EveSessionRef } from "../../eve/types.js";
 import {
 	generateThreadTitle,
@@ -51,6 +52,11 @@ export const runAgentTurn = async ({
 		threadId: thread.threadId,
 		workspaceId: thread.workspaceId,
 	};
+	if (run) {
+		run.sendInterrupt = async (sessionId) => {
+			await cancelEveTurn({ auth, sessionId });
+		};
+	}
 	const titlePromise = titleSourceText?.trim()
 		? generateThreadTitle({ logger, text: titleSourceText })
 		: undefined;

--- a/apps/leaf/src/internal/agentRuntime/eve/client.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/client.ts
@@ -158,6 +158,22 @@ export const postEveMessage = async ({
 
 /** Written to the model, not the user: the siblings are denied for a procedural
  * reason, and without saying so the model reads six denials as six rejections. */
+/** Cooperative server-side cancel; "accepted" and "no_active_turn" both succeed. */
+export const cancelEveTurn = async ({
+	auth,
+	sessionId,
+}: {
+	auth: EveAuthContext;
+	sessionId: string;
+}) => {
+	const result = await eveClient({ auth }).sessions.attach(sessionId).cancel();
+	logger.info("Requested eve turn cancellation", {
+		event: "leaf.eve_turn_cancel_requested",
+		data: { session_id: sessionId, status: result.status },
+	});
+	return result;
+};
+
 export const SIBLING_WITHHELD_NOTE =
 	"(The other pending write approvals in this batch were withheld, not rejected on their merits — approvals are shown to the user one at a time. Re-issue each withheld write as its own separate step so the user can approve it individually.)";
 

--- a/apps/leaf/src/internal/approvals/actions/matchPendingApprovalReply.ts
+++ b/apps/leaf/src/internal/approvals/actions/matchPendingApprovalReply.ts
@@ -1,0 +1,54 @@
+import type { AppEnv, ChatApproval, ChatProvider } from "@autumn/shared";
+import { db } from "../../../lib/db.js";
+import { chatApprovalRepo } from "../repos/chatApprovalRepo.js";
+import { approvalDecidability } from "../utils/approvalDecidability.js";
+import { approvalReplyIntent } from "../utils/approvalReplyIntent.js";
+
+export const APPROVAL_REPLY_GUIDANCE =
+	"Tap Approve or Dismiss on the pending card above.";
+
+export type PendingApprovalReply =
+	| { approval: ChatApproval; decision: "approve" | "cancel" }
+	| { guidance: string };
+
+export const matchPendingApprovalReply = async ({
+	channelId,
+	env,
+	orgId,
+	provider,
+	runId,
+	text,
+	workspaceId,
+}: {
+	channelId: string;
+	env: AppEnv;
+	orgId: string;
+	provider: ChatProvider;
+	runId: string;
+	text: string;
+	workspaceId: string;
+}): Promise<PendingApprovalReply | undefined> => {
+	const intent = approvalReplyIntent(text);
+	if (!intent) return undefined;
+	const pending = (
+		await chatApprovalRepo.listPendingForRun({
+			channelId,
+			db,
+			env,
+			orgId,
+			provider,
+			runId,
+			workspaceId,
+		})
+	).filter((approval) => approvalDecidability({ approval }).decidable);
+	if (!pending.length) return undefined;
+	const [approval] = pending;
+	if (
+		intent.kind === "ambiguous" ||
+		pending.length > 1 ||
+		!approval.message_ts
+	) {
+		return { guidance: APPROVAL_REPLY_GUIDANCE };
+	}
+	return { approval, decision: intent.kind };
+};

--- a/apps/leaf/src/internal/approvals/surfaces/slack/decideFromReply.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/decideFromReply.ts
@@ -1,0 +1,32 @@
+import type { ChatApproval } from "@autumn/shared";
+import type { ActionEvent } from "chat";
+import type { ReplyTarget } from "../../../../ui/progress.js";
+import { handleApprovalActionWithDeps } from "./decide.js";
+
+/** Decides the thread's pending card from a typed reply through the exact path
+ * a button click takes — claim, authorization, drift guard, and card edits. */
+export const decideApprovalFromReply = async ({
+	approval,
+	decision,
+	providerUserId,
+	target,
+}: {
+	approval: ChatApproval;
+	decision: "approve" | "cancel";
+	providerUserId: string;
+	target: ReplyTarget;
+}) =>
+	handleApprovalActionWithDeps({
+		event: {
+			actionId:
+				decision === "approve"
+					? "approve_billing_action"
+					: "cancel_billing_action",
+			adapter: target.adapter,
+			messageId: approval.message_ts ?? "",
+			thread: target,
+			threadId: target.id,
+			user: { userId: providerUserId },
+			value: approval.id,
+		} as unknown as ActionEvent,
+	});

--- a/apps/leaf/src/internal/approvals/surfaces/slack/present.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/present.ts
@@ -203,6 +203,7 @@ const renderBackfilledGroupCard = async ({
 export const presentApproval = async ({
 	channelId,
 	installation,
+	isStopped,
 	logAction,
 	logger = rootLogger,
 	orgId,
@@ -214,13 +215,15 @@ export const presentApproval = async ({
 	channelId: string;
 	env: ChatApproval["env"];
 	installation: ChatInstallation;
+	isStopped?: () => boolean;
 	logAction: (message: string) => Promise<void> | void;
 	logger?: AutumnLogger;
 	orgId: string;
 	providerUserId: string;
 	target: ReplyTarget;
 	turn: AgentApprovalTurn;
-}) => {
+}): Promise<"posted" | "not_created" | "stopped"> => {
+	if (isStopped?.()) return "stopped";
 	const created = await createApproval({
 		channelId,
 		env,
@@ -233,7 +236,15 @@ export const presentApproval = async ({
 		turn,
 		workspaceId: installation.workspace_id,
 	});
-	if (!created) return false;
+	if (!created) return "not_created";
+	if (isStopped?.()) {
+		await chatApprovalRepo.cancel({
+			approvalId: created.approvalId,
+			db,
+			providerUserId,
+		});
+		return "stopped";
+	}
 
 	await logAction(`Waiting for approval: ${toolLabel(created.toolName)}`);
 	const dashboardUrl = dashboardUrlFor({
@@ -322,5 +333,5 @@ export const presentApproval = async ({
 			providerUserId,
 		});
 	}
-	return true;
+	return "posted";
 };

--- a/apps/leaf/src/internal/approvals/utils/approvalDisplay.ts
+++ b/apps/leaf/src/internal/approvals/utils/approvalDisplay.ts
@@ -227,13 +227,24 @@ export const resolveApprovalDisplay = async ({
 	};
 };
 
+const isFailedPreview = (preview: unknown) =>
+	Boolean(
+		preview &&
+			typeof preview === "object" &&
+			(preview as { failed?: unknown }).failed === true,
+	);
+
 export const withApprovalDisplay = ({
 	display,
 	preview,
 }: {
 	display: Awaited<ReturnType<typeof resolveApprovalDisplay>>;
 	preview: unknown;
-}) =>
-	Object.values(display).some(Boolean)
-		? { _display: display, preview }
-		: preview;
+}) => {
+	if (preview == null || isFailedPreview(preview)) return preview;
+	return {
+		_captured_at: Date.now(),
+		...(Object.values(display).some(Boolean) ? { _display: display } : {}),
+		preview,
+	};
+};

--- a/apps/leaf/src/internal/approvals/utils/approvalReplyIntent.ts
+++ b/apps/leaf/src/internal/approvals/utils/approvalReplyIntent.ts
@@ -1,0 +1,31 @@
+export type ApprovalReplyIntent =
+	| { kind: "approve" }
+	| { kind: "cancel" }
+	| { kind: "ambiguous" };
+
+const APPROVE_PATTERN =
+	/^(?:yes[,!]?\s+)?(?:please\s+|pls\s+)?approved?(?:\s+(?:it|this|that))?$/;
+const CANCEL_PATTERN =
+	/^(?:please\s+|pls\s+)?(?:cancel|deny|reject|dismiss)(?:\s+(?:it|this|that))?$/;
+const DECISION_WORD = /\b(?:approve|cancel|deny|reject|dismiss)\b/;
+const SHORT_PHRASE_WORDS = 5;
+
+/** Classifies a thread reply as a decision on the pending card. Numeric answers
+ * and short decision-adjacent phrases get guidance rather than a guess; longer
+ * text is conversation and never resolves here. */
+export const approvalReplyIntent = (
+	text: string,
+): ApprovalReplyIntent | undefined => {
+	const normalized = text
+		.trim()
+		.toLowerCase()
+		.replace(/[.!?…]+$/, "")
+		.trim();
+	if (!normalized) return undefined;
+	if (APPROVE_PATTERN.test(normalized)) return { kind: "approve" };
+	if (CANCEL_PATTERN.test(normalized)) return { kind: "cancel" };
+	if (/^[12]$/.test(normalized)) return { kind: "ambiguous" };
+	const isShort = normalized.split(/\s+/).length <= SHORT_PHRASE_WORDS;
+	if (isShort && DECISION_WORD.test(normalized)) return { kind: "ambiguous" };
+	return undefined;
+};

--- a/apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts
+++ b/apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts
@@ -1,10 +1,21 @@
 import { parsePreviewPayload } from "@autumn/render";
 
+/** Covers float error plus 2dp rounding on otherwise-exact decay math. */
+const DECAY_TOLERANCE = 0.011;
+
+type LineFact = {
+	amount: number;
+	key: string;
+	period?: { end: number; start: number };
+};
+
 type MoneyFacts = {
+	capturedAt?: number;
 	currency?: string;
 	incomingPlans: ReadonlyArray<string>;
-	lineItemAmounts: ReadonlyArray<number>;
+	lines: ReadonlyArray<LineFact>;
 	outgoingPlans: ReadonlyArray<string>;
+	taxTotal: number;
 	total?: number;
 };
 
@@ -21,23 +32,57 @@ const planIds = (value: unknown): string[] =>
 				.sort()
 		: [];
 
+const lineFactOf = (item: unknown): LineFact | undefined => {
+	const record = asRecord(item);
+	const amount =
+		typeof record?.total === "number"
+			? record.total
+			: typeof record?.amount === "number"
+				? record.amount
+				: undefined;
+	if (!record || amount === undefined) return undefined;
+	const period = asRecord(record.period);
+	const start = typeof period?.start === "number" ? period.start : undefined;
+	const end = typeof period?.end === "number" ? period.end : undefined;
+	return {
+		amount,
+		key: [
+			record.plan_id ?? record.price_id,
+			record.feature_id,
+			record.quantity,
+			record.display_name ?? record.description,
+			end,
+		]
+			.map((part) => String(part ?? ""))
+			.join("|"),
+		...(start !== undefined && end !== undefined
+			? { period: { end, start } }
+			: {}),
+	};
+};
+
 const moneyFactsOf = (preview: unknown): MoneyFacts | undefined => {
-	// Stored previews may carry the `{_display, preview}` enrichment wrapper.
-	const unwrapped = asRecord(preview)?._display
-		? (asRecord(preview)?.preview ?? preview)
-		: preview;
+	const outer = asRecord(preview);
+	const capturedAt =
+		typeof outer?._captured_at === "number" ? outer._captured_at : undefined;
+	const wrapped =
+		outer?.preview !== undefined &&
+		(outer._display !== undefined || capturedAt !== undefined);
+	const unwrapped = wrapped ? outer.preview : preview;
 	const record = asRecord(parsePreviewPayload(unwrapped) ?? unwrapped);
 	if (!record) return undefined;
 	const dueToday = asRecord(record.due_today);
 	const lineItems = Array.isArray(record.line_items) ? record.line_items : [];
+	const taxTotal = asRecord(record.tax)?.total;
 	return {
+		capturedAt,
 		currency: typeof record.currency === "string" ? record.currency : undefined,
 		incomingPlans: planIds(record.incoming_plans ?? record.incoming),
-		lineItemAmounts: lineItems
-			.map((item) => asRecord(item)?.amount)
-			.filter((amount): amount is number => typeof amount === "number")
-			.sort((left, right) => left - right),
+		lines: lineItems
+			.map(lineFactOf)
+			.filter((line): line is LineFact => line !== undefined),
 		outgoingPlans: planIds(record.outgoing_plans ?? record.outgoing),
+		taxTotal: typeof taxTotal === "number" ? taxTotal : 0,
 		total:
 			typeof record.total === "number"
 				? record.total
@@ -47,8 +92,70 @@ const moneyFactsOf = (preview: unknown): MoneyFacts | undefined => {
 	};
 };
 
+/** Prorated amounts decay with wall clock: amount = full × (end − now)/(end − start),
+ * where an in-advance line's period.start is the server-now of its own compute. A
+ * matched pair therefore satisfies an exact identity; anything else is real drift. */
+const decayMatched = ({
+	capturedAt,
+	current,
+	stored,
+}: {
+	capturedAt?: number;
+	current: LineFact;
+	stored: LineFact;
+}): boolean => {
+	if (!stored.period || !current.period) return false;
+	if (stored.period.end !== current.period.end) return false;
+	if (current.period.start < stored.period.start) return false;
+	if (stored.period.end <= stored.period.start) return false;
+	const startMoved = current.period.start > stored.period.start;
+	const reference = startMoved ? stored.period.start : capturedAt;
+	if (reference === undefined) return false;
+	const nowReference = startMoved ? current.period.start : Date.now();
+	const expected =
+		(stored.amount * (stored.period.end - nowReference)) /
+		(stored.period.end - reference);
+	const sameDirection =
+		current.amount === 0 ||
+		Math.sign(current.amount) === Math.sign(stored.amount);
+	return (
+		sameDirection && Math.abs(current.amount - expected) <= DECAY_TOLERANCE
+	);
+};
+
+const pairLines = (
+	stored: ReadonlyArray<LineFact>,
+	current: ReadonlyArray<LineFact>,
+): ReadonlyArray<[LineFact, LineFact]> | undefined => {
+	const byKey = (lines: ReadonlyArray<LineFact>) => {
+		const groups = new Map<string, LineFact[]>();
+		for (const line of lines) {
+			groups.set(line.key, [...(groups.get(line.key) ?? []), line]);
+		}
+		for (const group of groups.values()) {
+			group.sort((left, right) => right.amount - left.amount);
+		}
+		return groups;
+	};
+	const storedGroups = byKey(stored);
+	const currentGroups = byKey(current);
+	if (storedGroups.size !== currentGroups.size) return undefined;
+	const pairs: [LineFact, LineFact][] = [];
+	for (const [key, storedGroup] of storedGroups) {
+		const currentGroup = currentGroups.get(key);
+		if (!currentGroup || currentGroup.length !== storedGroup.length) {
+			return undefined;
+		}
+		for (const [index, storedLine] of storedGroup.entries()) {
+			pairs.push([storedLine, currentGroup[index]]);
+		}
+	}
+	return pairs;
+};
+
 /** Whether the approved money facts still match what would execute — derived
- * facts, not raw payloads, so benign field churn never blocks approvals. */
+ * facts, not raw payloads, so benign churn (including proration time-decay)
+ * never blocks approvals while real price changes still do. */
 export const previewMoneyFactsDrifted = ({
 	current,
 	stored,
@@ -59,12 +166,6 @@ export const previewMoneyFactsDrifted = ({
 	const storedFacts = moneyFactsOf(stored);
 	const currentFacts = moneyFactsOf(current);
 	if (!storedFacts || !currentFacts) return { drifted: false };
-	if (storedFacts.total !== currentFacts.total) {
-		return {
-			drifted: true,
-			reason: `total ${storedFacts.total} → ${currentFacts.total}`,
-		};
-	}
 	if (
 		storedFacts.currency &&
 		currentFacts.currency &&
@@ -73,18 +174,65 @@ export const previewMoneyFactsDrifted = ({
 		return { drifted: true, reason: "currency changed" };
 	}
 	if (
-		JSON.stringify(storedFacts.lineItemAmounts) !==
-		JSON.stringify(currentFacts.lineItemAmounts)
-	) {
-		return { drifted: true, reason: "line items changed" };
-	}
-	if (
 		JSON.stringify(storedFacts.incomingPlans) !==
 			JSON.stringify(currentFacts.incomingPlans) ||
 		JSON.stringify(storedFacts.outgoingPlans) !==
 			JSON.stringify(currentFacts.outgoingPlans)
 	) {
 		return { drifted: true, reason: "plan set changed" };
+	}
+	const pairs = pairLines(storedFacts.lines, currentFacts.lines);
+	if (!pairs) return { drifted: true, reason: "line items changed" };
+	let movedPairs = 0;
+	for (const [storedLine, currentLine] of pairs) {
+		if (currentLine.amount === storedLine.amount) continue;
+		movedPairs += 1;
+		const bothProrated = Boolean(storedLine.period && currentLine.period);
+		if (
+			bothProrated &&
+			Math.abs(currentLine.amount - storedLine.amount) <= DECAY_TOLERANCE
+		) {
+			continue;
+		}
+		if (
+			decayMatched({
+				capturedAt: storedFacts.capturedAt,
+				current: currentLine,
+				stored: storedLine,
+			})
+		) {
+			continue;
+		}
+		return { drifted: true, reason: "line items changed" };
+	}
+	if (
+		(storedFacts.total === undefined) !==
+		(currentFacts.total === undefined)
+	) {
+		return {
+			drifted: true,
+			reason: `total ${storedFacts.total} → ${currentFacts.total}`,
+		};
+	}
+	if (storedFacts.total !== undefined && currentFacts.total !== undefined) {
+		const lineDelta = pairs.reduce(
+			(sum, [storedLine, currentLine]) =>
+				sum + currentLine.amount - storedLine.amount,
+			0,
+		);
+		const taxDelta = currentFacts.taxTotal - storedFacts.taxTotal;
+		const nothingMoved = movedPairs === 0 && taxDelta === 0;
+		const expected = storedFacts.total + lineDelta + taxDelta;
+		const matches = nothingMoved
+			? currentFacts.total === storedFacts.total
+			: Math.abs(currentFacts.total - expected) <=
+				DECAY_TOLERANCE * (movedPairs + 1);
+		if (!matches) {
+			return {
+				drifted: true,
+				reason: `total ${storedFacts.total} → ${currentFacts.total}`,
+			};
+		}
 	}
 	return { drifted: false };
 };

--- a/apps/leaf/src/internal/runs/runRegistry.ts
+++ b/apps/leaf/src/internal/runs/runRegistry.ts
@@ -24,6 +24,8 @@ export type ActiveRun = {
 		reason: RunStopReason;
 	}) => Promise<void>;
 	resolveSessionId: (sessionId: string) => void;
+	/** Late-bound by runAgentTurn once auth exists; cancels the turn server-side. */
+	sendInterrupt?: (sessionId: string) => Promise<void>;
 	sessionId: Promise<string>;
 	startedAt: number;
 	stop?: { byUserId: string; reason: RunStopReason };
@@ -45,7 +47,6 @@ export const runKeyForThread = ({
 	workspaceId: string;
 }) => [provider, workspaceId, channelId, threadId].join(":");
 
-const defaultSendInterrupt = async () => {};
 const defaultSendUserMessage = async () => {
 	throw new Error("Eve follow-up injection is queued after the active run");
 };
@@ -54,13 +55,11 @@ export const registerRun = ({
 	key,
 	kind,
 	ownerProviderUserId,
-	sendInterrupt = defaultSendInterrupt,
 	sendUserMessage = defaultSendUserMessage,
 }: {
 	key: string;
 	kind: ActiveRun["kind"];
 	ownerProviderUserId: string;
-	sendInterrupt?: (sessionId: string) => Promise<void>;
 	sendUserMessage?: (input: {
 		sessionId: string;
 		text: string;
@@ -103,9 +102,6 @@ export const registerRun = ({
 			if (run.closed || run.stop) throw new Error("Run is closing");
 			run.pendingTurns += 1;
 			try {
-				// Interrupt first so the message becomes the very next turn —
-				// the user chose immediate pivot over queue-behind-the-turn.
-				if (run.kind === "message") await sendInterrupt(resolved);
 				await sendUserMessage({ sessionId: resolved, text });
 			} catch (error) {
 				run.pendingTurns -= 1;
@@ -123,7 +119,7 @@ export const registerRun = ({
 			const resolved = await resolveSessionIdOrNull();
 			if (!resolved) return;
 			try {
-				await sendInterrupt(resolved);
+				await run.sendInterrupt?.(resolved);
 			} catch (error) {
 				logger.warn("Could not interrupt session for stop request", {
 					event: "leaf.run_stop_interrupt_failed",

--- a/apps/leaf/src/providers/slack/actions/dispatchSlackAgentMessage.ts
+++ b/apps/leaf/src/providers/slack/actions/dispatchSlackAgentMessage.ts
@@ -1,6 +1,7 @@
 import type { Attachment } from "chat";
 import type { AgentContextMessage } from "../../../internal/agentRuntime/domain/agentTurnContext.js";
 import { isTransientNetworkError } from "../../../internal/agentRuntime/eve/streamErrors.js";
+import { decideApprovalFromReply } from "../../../internal/approvals/surfaces/slack/decideFromReply.js";
 import { editSupersededApprovalCards } from "../../../internal/approvals/surfaces/slack/superseded.js";
 import {
 	dispatchThreadMessage,
@@ -178,6 +179,27 @@ const runAndReply = async ({
 			text,
 			threadId,
 		});
+
+		if (output.kind === "approval_guidance") {
+			await progress.complete();
+			await target.post({ markdown: output.text });
+			return "close";
+		}
+		if (output.kind === "approval_reply") {
+			await progress.complete();
+			await decideApprovalFromReply({
+				approval: output.approval,
+				decision: output.decision,
+				providerUserId,
+				target,
+			});
+			logger.info("Decided pending approval from a thread reply", {
+				event: "leaf.approval_reply_decided",
+				approval_id: output.approval.id,
+				data: { decision: output.decision },
+			});
+			return "close";
+		}
 
 		const stoppedBy = () => run?.stop;
 		if (output.kind === "stopped" || stoppedBy()) {

--- a/apps/leaf/src/providers/slack/actions/dispatchSlackAgentMessage.ts
+++ b/apps/leaf/src/providers/slack/actions/dispatchSlackAgentMessage.ts
@@ -179,17 +179,22 @@ const runAndReply = async ({
 			threadId,
 		});
 
-		if (output.kind === "stopped") {
+		const stoppedBy = () => run?.stop;
+		if (output.kind === "stopped" || stoppedBy()) {
 			await progress.fail("Stopped by user");
-			const notice = runStoppedByUserNotice(run.stop?.byUserId);
+			const notice = runStoppedByUserNotice(stoppedBy()?.byUserId);
+			const partial = output.kind === "empty" ? undefined : output.text;
 			await target.post({
-				markdown: [output.text, notice]
+				markdown: [partial, notice]
 					.filter((part): part is string => Boolean(part?.trim()))
 					.join("\n\n"),
 			});
 			logger.info("Posted stopped run notice", {
 				event: "leaf.slack_run_stopped",
-				data: { stop_reason: output.reason },
+				data: {
+					stop_reason:
+						output.kind === "stopped" ? output.reason : stoppedBy()?.reason,
+				},
 			});
 			return "close";
 		}
@@ -211,9 +216,10 @@ const runAndReply = async ({
 			return "keep";
 		}
 
-		await presentSlackAgentTurn({
+		const presented = await presentSlackAgentTurn({
 			channelId,
 			clientContext,
+			isStopped: () => Boolean(stoppedBy()),
 			logAction,
 			logger,
 			providerUserId,
@@ -222,6 +228,13 @@ const runAndReply = async ({
 			threadId,
 			turn: output,
 		});
+		if (presented === "stopped") {
+			await progress.fail("Stopped by user");
+			await target.post({
+				markdown: runStoppedByUserNotice(stoppedBy()?.byUserId),
+			});
+			return "close";
+		}
 		await progress.complete();
 		return "keep";
 	} catch (error) {

--- a/apps/leaf/src/providers/slack/actions/runSlackAgentTurn.ts
+++ b/apps/leaf/src/providers/slack/actions/runSlackAgentTurn.ts
@@ -1,6 +1,7 @@
 import { withTimeout } from "@autumn/shared";
 import { runAgentTurn } from "../../../internal/agentRuntime/actions/runAgentTurn/runAgentTurn.js";
 import { TURN_BACKSTOP_MS } from "../../../internal/agentRuntime/turnBudget.js";
+import { matchPendingApprovalReply } from "../../../internal/approvals/actions/matchPendingApprovalReply.js";
 import type {
 	SlackAgentTurnParams,
 	SlackAgentTurnResult,
@@ -12,6 +13,28 @@ const executeSlackAgentTurn = async (
 ): Promise<SlackAgentTurnResult> => {
 	const setup = await setupSlackAgentTurn(params);
 	if (setup.kind === "blocked") return setup;
+	const session = setup.context.eveSession;
+	if (session) {
+		const matched = await matchPendingApprovalReply({
+			channelId: params.channelId,
+			env: setup.context.env,
+			orgId: setup.org.id,
+			provider: setup.installation.provider,
+			runId: session.sessionId,
+			text: params.text,
+			workspaceId: setup.installation.workspace_id,
+		});
+		if (matched && "guidance" in matched) {
+			return {
+				env: setup.context.env,
+				kind: "approval_guidance",
+				text: matched.guidance,
+			};
+		}
+		if (matched) {
+			return { ...matched, env: setup.context.env, kind: "approval_reply" };
+		}
+	}
 	const isFollowUp =
 		params.recentMessages?.some((message) => message.isBot) ?? false;
 

--- a/apps/leaf/src/providers/slack/domain/slackAgentTurn.ts
+++ b/apps/leaf/src/providers/slack/domain/slackAgentTurn.ts
@@ -35,6 +35,13 @@ export type SlackAgentTurnParams = Readonly<{
 
 export type SlackAgentTurnResult =
 	| Readonly<{ env: AppEnv; kind: "blocked"; text: string }>
+	| Readonly<{
+			approval: ChatApproval;
+			decision: "approve" | "cancel";
+			env: AppEnv;
+			kind: "approval_reply";
+	  }>
+	| Readonly<{ env: AppEnv; kind: "approval_guidance"; text: string }>
 	| (AgentTurnResult &
 			Readonly<{
 				env: AppEnv;

--- a/apps/leaf/src/providers/slack/presenters/presentSlackAgentTurn.ts
+++ b/apps/leaf/src/providers/slack/presenters/presentSlackAgentTurn.ts
@@ -21,6 +21,7 @@ export const presentSlackAgentTurn = async ({
 	clientContext,
 	logAction,
 	logger,
+	isStopped,
 	providerUserId,
 	stopStatus,
 	target,
@@ -32,11 +33,12 @@ export const presentSlackAgentTurn = async ({
 	logAction: (message: string) => Promise<void> | void;
 	logger: AutumnLogger;
 	providerUserId: string;
+	isStopped?: () => boolean;
 	stopStatus: () => void;
 	target: ReplyTarget;
 	threadId: string;
 	turn: PresentableSlackAgentTurn;
-}) => {
+}): Promise<"posted" | "stopped"> => {
 	const outputText = turn.kind === "empty" ? "" : turn.text;
 	const { installation, org } = turn;
 	let catalogDecision: ResolvedAgentCatalogDecision | undefined;
@@ -72,6 +74,7 @@ export const presentSlackAgentTurn = async ({
 	}
 
 	stopStatus();
+	if (isStopped?.()) return "stopped";
 
 	if (catalogDecision) {
 		if (outputText.trim()) {
@@ -85,7 +88,7 @@ export const presentSlackAgentTurn = async ({
 				plan: catalogDecision.plan,
 			}),
 		);
-		return;
+		return "posted";
 	}
 
 	if (turn.kind === "question") {
@@ -99,14 +102,15 @@ export const presentSlackAgentTurn = async ({
 				sessionId: turn.sessionId,
 			}),
 		);
-		return;
+		return "posted";
 	}
 
 	if (turn.kind === "approval") {
-		const postedApproval = await presentApproval({
+		const presented = await presentApproval({
 			channelId,
 			env: turn.env,
 			installation,
+			isStopped,
 			logAction,
 			logger,
 			orgId: org.id,
@@ -114,7 +118,8 @@ export const presentSlackAgentTurn = async ({
 			target,
 			turn,
 		});
-		if (postedApproval) return;
+		if (presented === "stopped") return "stopped";
+		if (presented === "posted") return "posted";
 	}
 
 	if (!outputText.trim()) {
@@ -126,7 +131,7 @@ export const presentSlackAgentTurn = async ({
 				run_id: turn.sessionId,
 			},
 		});
-		return;
+		return "posted";
 	}
 
 	await target.post({ markdown: outputText });
@@ -136,4 +141,5 @@ export const presentSlackAgentTurn = async ({
 			has_text: true,
 		},
 	});
+	return "posted";
 };

--- a/apps/leaf/src/providers/slack/presenters/presentSlackAgentTurn.ts
+++ b/apps/leaf/src/providers/slack/presenters/presentSlackAgentTurn.ts
@@ -13,7 +13,7 @@ import { catalogDecisionCard, questionCard } from "./interactionCards.js";
 
 type PresentableSlackAgentTurn = Exclude<
 	SlackAgentTurnResult,
-	{ kind: "blocked" | "stopped" }
+	{ kind: "approval_guidance" | "approval_reply" | "blocked" | "stopped" }
 >;
 
 export const presentSlackAgentTurn = async ({

--- a/apps/leaf/tests/e2e/eveImage.e2e.ts
+++ b/apps/leaf/tests/e2e/eveImage.e2e.ts
@@ -181,7 +181,7 @@ const main = async () => {
 	if (process.env.E2E_ONLY !== "web") {
 		console.log("--- slack surface");
 		const slack = await runSlackImageTurn({ installation });
-		const slackText = slack.output.kind === "empty" ? "" : slack.output.text;
+		const slackText = "text" in slack.output ? slack.output.text : "";
 		check(
 			"slack: model saw the image",
 			/red/i.test(slackText),

--- a/apps/leaf/tests/e2e/eveSlack.e2e.ts
+++ b/apps/leaf/tests/e2e/eveSlack.e2e.ts
@@ -273,7 +273,7 @@ const main = async () => {
 			text: "In sandbox: how many plans do we have? Answer in one sentence.",
 			threadId,
 		});
-		const text = turn.output.kind === "empty" ? "" : turn.output.text;
+		const text = "text" in turn.output ? turn.output.text : "";
 		check("S1 run produced text", Boolean(text.trim()), text.slice(0, 120));
 		// Tool activity lives in the assistant status line, never posted cards.
 		check(
@@ -550,7 +550,9 @@ const main = async () => {
 					? second.output.question.prompt.slice(0, 120)
 					: second.output.kind === "empty"
 						? undefined
-						: second.output.text.slice(0, 120),
+						: "text" in second.output
+							? second.output.text.slice(0, 120)
+							: undefined,
 		);
 	}
 
@@ -614,7 +616,7 @@ const main = async () => {
 				text: "No changes then. In one sentence: which plan is that customer currently on?",
 				threadId,
 			});
-			const text = followUp.output.kind === "empty" ? "" : followUp.output.text;
+			const text = "text" in followUp.output ? followUp.output.text : "";
 			check(
 				"S4 session not wedged after dismiss",
 				Boolean(text.trim()),
@@ -680,7 +682,7 @@ const main = async () => {
 		});
 		// File ingestion is flag-gated off (upstream eve queue bug corrupts
 		// bytes) — the graceful path acknowledges the file instead of failing.
-		const text = turn.output.kind === "empty" ? "" : turn.output.text;
+		const text = "text" in turn.output ? turn.output.text : "";
 		check(
 			"S6 attachment acknowledged gracefully (or seen, if flag on)",
 			/red/i.test(text) || /pixel\.png|image|file/i.test(text),
@@ -699,7 +701,7 @@ const main = async () => {
 			text: "Different person here — in one sentence, which plan does that customer have now?",
 			threadId: s2ThreadId,
 		});
-		const text = followUp.output.kind === "empty" ? "" : followUp.output.text;
+		const text = "text" in followUp.output ? followUp.output.text : "";
 		// A no-tool turn may never open a stream; the bot then posts the text as
 		// a plain message — that's the correct fallback, not a failure.
 		check(
@@ -837,7 +839,7 @@ const main = async () => {
 			text: "Leave the price as is — do not apply anything. Just say 'ok'.",
 			threadId,
 		});
-		const text = followUp.output.kind === "empty" ? "" : followUp.output.text;
+		const text = "text" in followUp.output ? followUp.output.text : "";
 		check(
 			"S8 session healthy after decision routing",
 			Boolean(text.trim()),
@@ -907,7 +909,9 @@ const main = async () => {
 						? turn.output.question.prompt.slice(0, 120)
 						: turn.output.kind === "empty"
 							? undefined
-							: turn.output.text.slice(0, 120),
+							: "text" in turn.output
+								? turn.output.text.slice(0, 120)
+								: undefined,
 			);
 			if (turn.output.kind === "approval") {
 				// Card safety net: the quantity (or its absence) must be visible.

--- a/apps/leaf/tests/e2e/eveSlack.e2e.ts
+++ b/apps/leaf/tests/e2e/eveSlack.e2e.ts
@@ -317,7 +317,7 @@ const main = async () => {
 				target: target as never,
 				turn: turn.output,
 			});
-			check("S2 approval card posted", posted === true);
+			check("S2 approval card posted", posted === "posted");
 			const cardJson = JSON.stringify(target.posted[0]?.content ?? {});
 			check(
 				"S2 card has receipt/money facts",

--- a/apps/leaf/tests/unit/approvals/approvalReplyIntent.test.ts
+++ b/apps/leaf/tests/unit/approvals/approvalReplyIntent.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { approvalReplyIntent } from "../../../src/internal/approvals/utils/approvalReplyIntent.js";
+
+describe("approvalReplyIntent", () => {
+	test.each([
+		"approve",
+		"Approve",
+		"please approve",
+		"pls approve",
+		"yes approve",
+		"approved",
+		"approve it",
+		"please approve this.",
+	])("%p is an approval", (text) => {
+		expect(approvalReplyIntent(text)).toEqual({ kind: "approve" });
+	});
+
+	test.each(["cancel", "deny", "reject it", "dismiss", "please cancel"])(
+		"%p is a cancel",
+		(text) => {
+			expect(approvalReplyIntent(text)).toEqual({ kind: "cancel" });
+		},
+	);
+
+	test.each(["1", "2", "approve the second one", "cancel which one?"])(
+		"%p is ambiguous",
+		(text) => {
+			expect(approvalReplyIntent(text)).toEqual({ kind: "ambiguous" });
+		},
+	);
+
+	test.each([
+		"yes but make it 600k credits",
+		"is there a trial on this plan?",
+		"why did it approve the charge without asking me first?",
+		"3",
+		"",
+	])("%p is conversation", (text) => {
+		expect(approvalReplyIntent(text)).toBeUndefined();
+	});
+});

--- a/apps/leaf/tests/unit/approvals/executorGuards.test.ts
+++ b/apps/leaf/tests/unit/approvals/executorGuards.test.ts
@@ -67,6 +67,213 @@ describe("previewMoneyFactsDrifted", () => {
 	});
 });
 
+const CYCLE_END = 1_800_000_000_000;
+
+const decayedAmount = ({
+	amount,
+	fromStart,
+	toStart,
+}: {
+	amount: number;
+	fromStart: number;
+	toStart: number;
+}) => (amount * (CYCLE_END - toStart)) / (CYCLE_END - fromStart);
+
+const v2Line = ({
+	amount,
+	planId = "pro",
+	start,
+}: {
+	amount: number;
+	planId?: string;
+	start?: number;
+}) => ({
+	display_name: `${planId} base`,
+	feature_id: null,
+	plan_id: planId,
+	quantity: 1,
+	subtotal: amount,
+	total: amount,
+	...(start !== undefined ? { period: { end: CYCLE_END, start } } : {}),
+});
+
+const v2Preview = ({
+	capturedAt,
+	lines,
+	tax,
+	total,
+}: {
+	capturedAt?: number;
+	lines: ReturnType<typeof v2Line>[];
+	tax?: number;
+	total: number;
+}) => ({
+	...(capturedAt !== undefined ? { _captured_at: capturedAt } : {}),
+	preview: {
+		currency: "usd",
+		line_items: lines,
+		subtotal: total,
+		...(tax !== undefined ? { tax: { total: tax } } : {}),
+		total: total + (tax ?? 0),
+	},
+});
+
+describe("previewMoneyFactsDrifted proration decay", () => {
+	const t0 = CYCLE_END - 10 * 24 * 60 * 60 * 1000;
+	const t1 = t0 + 3 * 60 * 1000;
+
+	const decayedPair = ({ amount }: { amount: number }) => {
+		const decayed = decayedAmount({ amount, fromStart: t0, toStart: t1 });
+		return {
+			current: v2Preview({
+				lines: [v2Line({ amount: decayed, start: t1 })],
+				total: decayed,
+			}),
+			decayed,
+			stored: v2Preview({
+				capturedAt: t0,
+				lines: [v2Line({ amount, start: t0 })],
+				total: amount,
+			}),
+		};
+	};
+
+	test("pure decay between renders does not drift", () => {
+		const { current, stored } = decayedPair({ amount: 591.4 });
+		expect(previewMoneyFactsDrifted({ current, stored })).toEqual({
+			drifted: false,
+		});
+	});
+
+	test("an off-curve amount drifts", () => {
+		const { decayed, stored } = decayedPair({ amount: 591.4 });
+		const current = v2Preview({
+			lines: [v2Line({ amount: decayed - 0.5, start: t1 })],
+			total: decayed - 0.5,
+		});
+		expect(previewMoneyFactsDrifted({ current, stored }).drifted).toBe(true);
+	});
+
+	test("a genuine price change on unchanged periods drifts", () => {
+		const stored = v2Preview({
+			capturedAt: t0,
+			lines: [v2Line({ amount: 500, start: t0 })],
+			total: 500,
+		});
+		const current = v2Preview({
+			lines: [v2Line({ amount: 620, start: t0 })],
+			total: 620,
+		});
+		expect(previewMoneyFactsDrifted({ current, stored }).drifted).toBe(true);
+	});
+
+	test("cycle rollover drifts", () => {
+		const stored = v2Preview({
+			capturedAt: t0,
+			lines: [v2Line({ amount: 500, start: t0 })],
+			total: 500,
+		});
+		const rolled = {
+			...v2Line({ amount: 500, start: t1 }),
+			period: { end: CYCLE_END + 1, start: t1 },
+		};
+		const current = v2Preview({ lines: [rolled], total: 500 });
+		expect(previewMoneyFactsDrifted({ current, stored }).drifted).toBe(true);
+	});
+
+	test("a periodless line with a changed amount drifts", () => {
+		const stored = v2Preview({
+			capturedAt: t0,
+			lines: [v2Line({ amount: 120 })],
+			total: 120,
+		});
+		const current = v2Preview({ lines: [v2Line({ amount: 121 })], total: 121 });
+		expect(previewMoneyFactsDrifted({ current, stored }).drifted).toBe(true);
+	});
+
+	test("a decayed credit line does not drift", () => {
+		const credit = -224.04;
+		const decayed = decayedAmount({
+			amount: credit,
+			fromStart: t0,
+			toStart: t1,
+		});
+		const stored = v2Preview({
+			capturedAt: t0,
+			lines: [v2Line({ amount: credit, planId: "old", start: t0 })],
+			total: credit,
+		});
+		const current = v2Preview({
+			lines: [v2Line({ amount: decayed, planId: "old", start: t1 })],
+			total: decayed,
+		});
+		expect(previewMoneyFactsDrifted({ current, stored })).toEqual({
+			drifted: false,
+		});
+	});
+
+	test("a sign flip drifts", () => {
+		const stored = v2Preview({
+			capturedAt: t0,
+			lines: [v2Line({ amount: -50, start: t0 })],
+			total: -50,
+		});
+		const current = v2Preview({
+			lines: [{ ...v2Line({ amount: 50, start: t1 }) }],
+			total: 50,
+		});
+		expect(previewMoneyFactsDrifted({ current, stored }).drifted).toBe(true);
+	});
+
+	test("tax decaying with the base does not drift", () => {
+		const decayed = decayedAmount({ amount: 500, fromStart: t0, toStart: t1 });
+		const stored = v2Preview({
+			capturedAt: t0,
+			lines: [v2Line({ amount: 500, start: t0 })],
+			tax: 100,
+			total: 500,
+		});
+		const current = v2Preview({
+			lines: [v2Line({ amount: decayed, start: t1 })],
+			tax: 100 * (decayed / 500),
+			total: decayed,
+		});
+		expect(previewMoneyFactsDrifted({ current, stored })).toEqual({
+			drifted: false,
+		});
+	});
+
+	test("an added line drifts", () => {
+		const stored = v2Preview({
+			capturedAt: t0,
+			lines: [v2Line({ amount: 500, start: t0 })],
+			total: 500,
+		});
+		const current = v2Preview({
+			lines: [
+				v2Line({ amount: 500, start: t0 }),
+				v2Line({ amount: 10, planId: "addon", start: t0 }),
+			],
+			total: 510,
+		});
+		expect(previewMoneyFactsDrifted({ current, stored }).drifted).toBe(true);
+	});
+
+	test("legacy previews without periods keep exact comparison", () => {
+		const result = previewMoneyFactsDrifted({
+			current: preview({
+				line_items: [
+					{ amount: 2400.01, description: "Launch" },
+					{ amount: 100, description: "Credits" },
+				],
+				total: 2500.01,
+			}),
+			stored: preview(),
+		});
+		expect(result.drifted).toBe(true);
+	});
+});
+
 describe("classifyWriteExecution", () => {
 	test("clean results are applied", () => {
 		expect(classifyWriteExecution({ result: { customer: {} } })).toMatchObject({

--- a/apps/leaf/tests/unit/approvals/matchPendingApprovalReply.test.ts
+++ b/apps/leaf/tests/unit/approvals/matchPendingApprovalReply.test.ts
@@ -1,0 +1,84 @@
+import { expect, mock, test } from "bun:test";
+import { AppEnv, type ChatApproval } from "@autumn/shared";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+mock.module("../../../src/lib/db.js", () => ({ db: {} }));
+
+let pendingRows: ChatApproval[] = [];
+await mockModuleWithRestore({
+	baseUrl: import.meta.url,
+	specifier: "../../../src/internal/approvals/repos/chatApprovalRepo.js",
+	factory: () => ({
+		chatApprovalRepo: { listPendingForRun: async () => pendingRows },
+	}),
+});
+
+const { APPROVAL_REPLY_GUIDANCE, matchPendingApprovalReply } = await import(
+	"../../../src/internal/approvals/actions/matchPendingApprovalReply.js"
+);
+
+const pendingApproval = (overrides: Partial<ChatApproval> = {}) =>
+	({
+		expires_at: Date.now() + 60_000,
+		id: "approval_1",
+		message_ts: "message_1",
+		status: "pending",
+		...overrides,
+	}) as ChatApproval;
+
+const match = (text: string) =>
+	matchPendingApprovalReply({
+		channelId: "C1",
+		env: AppEnv.Sandbox,
+		orgId: "org_1",
+		provider: "slack",
+		runId: "sesn_1",
+		text,
+		workspaceId: "W1",
+	});
+
+test("a bare approve decides the single pending card", async () => {
+	pendingRows = [pendingApproval()];
+	expect(await match("please approve")).toEqual({
+		approval: pendingRows[0],
+		decision: "approve",
+	});
+});
+
+test("a cancel decides the single pending card", async () => {
+	pendingRows = [pendingApproval()];
+	expect(await match("cancel")).toEqual({
+		approval: pendingRows[0],
+		decision: "cancel",
+	});
+});
+
+test("conversation never matches", async () => {
+	pendingRows = [pendingApproval()];
+	expect(await match("what would this cost?")).toBeUndefined();
+});
+
+test("no pending card falls through to the agent", async () => {
+	pendingRows = [];
+	expect(await match("approve")).toBeUndefined();
+});
+
+test("two pending cards get guidance", async () => {
+	pendingRows = [pendingApproval(), pendingApproval({ id: "approval_2" })];
+	expect(await match("approve")).toEqual({ guidance: APPROVAL_REPLY_GUIDANCE });
+});
+
+test("an expired card is not decidable", async () => {
+	pendingRows = [pendingApproval({ expires_at: Date.now() - 1 })];
+	expect(await match("approve")).toBeUndefined();
+});
+
+test("a card without a message gets guidance", async () => {
+	pendingRows = [pendingApproval({ message_ts: null })];
+	expect(await match("approve")).toEqual({ guidance: APPROVAL_REPLY_GUIDANCE });
+});
+
+test("an ambiguous reply gets guidance", async () => {
+	pendingRows = [pendingApproval()];
+	expect(await match("1")).toEqual({ guidance: APPROVAL_REPLY_GUIDANCE });
+});

--- a/apps/leaf/tests/unit/approvals/presentApprovalStop.test.ts
+++ b/apps/leaf/tests/unit/approvals/presentApprovalStop.test.ts
@@ -1,0 +1,111 @@
+import { expect, mock, test } from "bun:test";
+import { AppEnv, type ChatInstallation } from "@autumn/shared";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+mock.module("../../../src/lib/db.js", () => ({ db: {} }));
+
+const mockLeafModule = ({
+	factory,
+	specifier,
+}: {
+	factory: () => Record<string, unknown>;
+	specifier: string;
+}) => mockModuleWithRestore({ baseUrl: import.meta.url, factory, specifier });
+
+let createCalls = 0;
+const cancelled: string[] = [];
+
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/actions/createApproval.js",
+	factory: () => ({
+		createApproval: async () => {
+			createCalls += 1;
+			return {
+				approvalId: "approval_1",
+				params: {},
+				preview: undefined,
+				toolArgs: { request: {} },
+				toolName: "autumn__attach",
+				withheld: [],
+			};
+		},
+	}),
+});
+
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/repos/chatApprovalRepo.js",
+	factory: () => ({
+		chatApprovalRepo: {
+			cancel: async ({ approvalId }: { approvalId: string }) => {
+				cancelled.push(approvalId);
+			},
+			cancelPendingForRun: async () => [],
+			setMessageTs: async () => {},
+		},
+	}),
+});
+
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/repos/chatApprovalWritesRepo.js",
+	factory: () => ({
+		chatApprovalWritesRepo: { list: async () => [] },
+	}),
+});
+
+const { presentApproval } = await import(
+	"../../../src/internal/approvals/surfaces/slack/present.js"
+);
+
+const installation = {
+	provider: "slack",
+	workspace_id: "W1",
+} as ChatInstallation;
+
+const presentWith = ({ isStopped }: { isStopped: () => boolean }) => {
+	const posts: unknown[] = [];
+	const target = {
+		post: async (content: unknown) => {
+			posts.push(content);
+			return { id: "message_1" };
+		},
+	};
+	return {
+		posts,
+		run: () =>
+			presentApproval({
+				channelId: "C1",
+				env: AppEnv.Sandbox,
+				installation,
+				isStopped,
+				logAction: () => {},
+				orgId: "org_1",
+				providerUserId: "U1",
+				target: target as never,
+				turn: { sessionId: "sesn_1" } as never,
+			}),
+	};
+};
+
+test("a stop before creation posts nothing and creates no row", async () => {
+	createCalls = 0;
+	const { posts, run } = presentWith({ isStopped: () => true });
+	expect(await run()).toBe("stopped");
+	expect(createCalls).toBe(0);
+	expect(posts).toEqual([]);
+});
+
+test("a stop after creation cancels the row before any card posts", async () => {
+	createCalls = 0;
+	cancelled.length = 0;
+	let calls = 0;
+	const { posts, run } = presentWith({
+		isStopped: () => {
+			calls += 1;
+			return calls > 1;
+		},
+	});
+	expect(await run()).toBe("stopped");
+	expect(createCalls).toBe(1);
+	expect(cancelled).toEqual(["approval_1"]);
+	expect(posts).toEqual([]);
+});

--- a/apps/leaf/tests/unit/approvals/presentApprovalSupersession.test.ts
+++ b/apps/leaf/tests/unit/approvals/presentApprovalSupersession.test.ts
@@ -178,7 +178,7 @@ test("keeps the card successful when its companion fails", async () => {
 		} as never,
 	} as never);
 
-	expect(result).toBe(true);
+	expect(result).toBe("posted");
 	expect(warnings).toContain("Could not post approval companion");
 });
 

--- a/apps/leaf/tests/unit/runs/runCoordinator.test.ts
+++ b/apps/leaf/tests/unit/runs/runCoordinator.test.ts
@@ -9,15 +9,12 @@ import {
 } from "../../../src/internal/runs/runRegistry.js";
 
 describe("dispatchThreadMessage", () => {
-	test("injects follow-ups into the active run with an interrupt first", async () => {
+	test("injects follow-ups into the active run as a steer message", async () => {
 		const sent: string[] = [];
 		const run = registerRun({
 			key: "co2",
 			kind: "message",
 			ownerProviderUserId: "U1",
-			sendInterrupt: async () => {
-				sent.push("interrupt");
-			},
 			sendUserMessage: async ({ text }) => {
 				sent.push(`message:${text}`);
 			},
@@ -39,7 +36,7 @@ describe("dispatchThreadMessage", () => {
 			text: "also, what's the MRR?",
 		});
 
-		expect(sent).toEqual(["interrupt", "message:also, what's the MRR?"]);
+		expect(sent).toEqual(["message:also, what's the MRR?"]);
 		expect(run.pendingTurns).toBe(1);
 		expect(acked).toBe(1);
 		expect(newRuns).toBe(0);
@@ -90,9 +87,6 @@ describe("dispatchThreadMessage", () => {
 			key: "co4",
 			kind: "message",
 			ownerProviderUserId: "U1",
-			sendInterrupt: async () => {
-				throw new Error("session busy");
-			},
 		});
 		run.resolveSessionId("sesn_1");
 		let newRuns = 0;
@@ -141,9 +135,6 @@ describe("dispatchThreadMessage", () => {
 			key: "co6",
 			kind: "message",
 			ownerProviderUserId: "U1",
-			sendInterrupt: async () => {
-				sent.push("interrupt");
-			},
 			sendUserMessage: async ({ text }) => {
 				sent.push(`message:${text}`);
 			},
@@ -177,10 +168,10 @@ describe("stopActiveThreadRun", () => {
 			key: "co-opt-out",
 			kind: "message",
 			ownerProviderUserId: "U1",
-			sendInterrupt: async (sessionId) => {
-				interrupts.push(sessionId);
-			},
 		});
+		run.sendInterrupt = async (sessionId) => {
+			interrupts.push(sessionId);
+		};
 		run.resolveSessionId("sesn_opt_out");
 
 		const stopped = await stopActiveThreadRun({

--- a/apps/leaf/tests/unit/runs/runRegistry.test.ts
+++ b/apps/leaf/tests/unit/runs/runRegistry.test.ts
@@ -68,10 +68,10 @@ describe("runRegistry", () => {
 			key: "k3",
 			kind: "message",
 			ownerProviderUserId: "U1",
-			sendInterrupt: async (sessionId) => {
-				interrupted.push(sessionId);
-			},
 		});
+		run.sendInterrupt = async (sessionId) => {
+			interrupted.push(sessionId);
+		};
 		run.resolveSessionId("sesn_1");
 
 		const stopPromise = run.requestStop({ byUserId: "U1", reason: "user" });
@@ -82,5 +82,21 @@ describe("runRegistry", () => {
 		expect(run.stop).toEqual({ byUserId: "U1", reason: "user" });
 		expect(interrupted).toEqual(["sesn_1"]);
 		closeRun({ key: "k3", run });
+	});
+
+	test("requestStop swallows interrupt failures", async () => {
+		const run = registerRun({
+			key: "k4",
+			kind: "message",
+			ownerProviderUserId: "U1",
+		});
+		run.sendInterrupt = async () => {
+			throw new Error("cancel failed");
+		};
+		run.resolveSessionId("sesn_4");
+
+		await run.requestStop({ byUserId: "U1", reason: "user" });
+		expect(run.stop).toEqual({ byUserId: "U1", reason: "user" });
+		closeRun({ key: "k4", run });
 	});
 });


### PR DESCRIPTION
## Why

The Resend live-thread incident (2026-08-28) chained four defects: the drift guard rejected proration time-decay so every correct card was unclickable; "please approve" re-delegated the request and billing rebuilt the write with the wrong shape, which applied; and "stop" couldn't halt an in-flight turn. Root-caused by four investigation agents; fixes align with eve's park/resume model instead of adding parallel machinery.

## What (one commit per lane)

**`fix: drift guard verifies proration decay`** — prorated line items satisfy an exact identity (`current = stored × (end − currentStart)/(end − storedStart)`, since an in-advance line's `period.start` IS the server-now of its compute). `previewMoneyFacts` now pairs v2 line items by identity+period-end and verifies decay per line, shifting the total by explained deltas; `withApprovalDisplay` stamps `_captured_at` as the fallback reference. Real price changes, added/removed lines, sign flips, cycle rollover, and periodless amounts still drift; legacy previews keep exact comparison. Also fixes v2 per-line comparison, which was dead (`amount` vs `total` field mismatch).

**`feat: a typed approve decides the pending card`** — eve's native text-approval can't fire for leaf (messages are wrapped), so a bare approve/cancel reply on a thread with exactly one decidable pending card routes through the same decide path as a button click — claim, authorization, drift guard, card edits. Ambiguous replies, numerals, and multi-card threads get guidance; everything else steers to the agent unchanged.

**`feat: stop cancels the turn server-side`** — `sendInterrupt` was a documented no-op from eve 0.16; eve 0.47 has cooperative `session.cancel`. Wired late-bound from `runAgentTurn`'s auth, plus `run.stop` guards before presentation and inside `presentApproval` (cancelling an approval row created mid-presentation). Removes the injectFollowUp pre-interrupt (steer handles pivot server-side).

## Validation

- `apps/leaf`: **526/526** (5 `flow.test` cases need a reachable DB — verified green against one; they hang identically at dev baseline when local postgres is down).
- New coverage: 19-case proration-decay table, reply-intent + pending-match tables (30 cases), stop-guards (`presentApprovalStop`, registry swallow, coordinator steer).
- **Live e2e** `stopRun.e2e.ts` against a running eve host: `Requested eve turn cancellation` delivered server-side, turn ended `stopped` 209ms after requestStop, no status after stop — 4/4 checks.
- `tsc --noEmit` + biome clean.

Prompts untouched; no schema/migration changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the approval-layer defects chained in the Resend incident: the drift guard now accepts proration time-decay, a typed approve/cancel reply decides the single pending card, and stop cancels the turn server-side instead of being a no-op. No schema or migration changes.

**Bug Fixes**
- The drift guard verifies proration decay per line against `_captured_at`; real price changes, added/removed lines, sign flips, cycle rollover, and periodless amounts still drift, while legacy previews keep exact comparison.
- Fixes the dead v2 per-line comparison that read a nonexistent `amount` field instead of `total`.

**New Features**
- A bare approve/cancel reply on a thread with exactly one decidable pending card goes through the button-click decide path — claim, authorization, drift guard, card edits — because eve's native text approval can't fire for wrapped leaf messages; ambiguous replies, numerals, and multi-card threads get guidance, and everything else still steers to the agent.
- `stop` now cancels the turn server-side via eve's cooperative `session.cancel` (wired late-bound from `runAgentTurn`), and a turn finishing after stop posts the stopped notice instead of its cards, cancelling any approval row created mid-presentation.

<sup>Written for commit c9acdeb5c0074149eef800eeacb1357a38dbf563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes approval handling after the Resend incident by supporting decay-aware preview comparisons, typed Slack approval decisions, and server-side turn cancellation.

- **Bug fixes, Improvements:** Recognizes legitimate proration decay while checking whether an approved billing preview has changed.
- **Improvements:** Routes unambiguous typed approve or cancel replies through the existing approval decision path.
- **Bug fixes, API changes:** Connects Slack stop requests to Eve’s cooperative session cancellation and adds presentation-time stop guards.
</details>


<h3>Confidence Score: 2/5</h3>

This PR should not merge until tax-only billing drift is rejected and early stop requests reliably cancel sessions that become available after the timeout.

The approval guard can execute a higher tax-adjusted charge than the user approved, and a stop during slow session startup can abort only the local stream while server-side work continues.

**Files Needing Attention:** apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts, apps/leaf/src/internal/runs/runRegistry.ts

<details open><summary><h3>Security Review</h3></summary>

The revised drift comparison accepts arbitrary tax-only total changes as explained, allowing execution of a higher charge than the user approved.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts | Adds decay-aware line pairing, but incorrectly treats every tax delta as an approved explanation for a changed total. |
| apps/leaf/src/internal/runs/runRegistry.ts | Adds late-bound server interruption, but a session-resolution timeout permanently suppresses cancellation when the session later becomes available. |
| apps/leaf/src/internal/approvals/actions/matchPendingApprovalReply.ts | Safely scopes typed decisions to one decidable pending approval in the current thread session. |
| apps/leaf/src/providers/slack/actions/dispatchSlackAgentMessage.ts | Integrates typed approval decisions and presentation-time stop handling into Slack dispatch. |
| apps/leaf/src/internal/approvals/surfaces/slack/present.ts | Adds stop guards before and immediately after approval creation, cancelling rows created during a stop race. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  U[Slack user message] --> I{Reply intent}
  I -->|Approve or cancel| P[Find one pending approval]
  P --> D[Run existing decision and authorization path]
  I -->|Normal message| E[Run Eve agent turn]
  E --> A{Approval required}
  A -->|Yes| V[Store and present approval preview]
  V --> R[Recompute preview on approval]
  R --> G{Drift guard passes}
  G -->|Yes| W[Execute billing write]
  G -->|No| F[Refresh approval card]
  E --> S{Stop requested}
  S --> L[Abort local stream]
  S --> C[Cancel Eve session server-side]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/leaf/src/internal/runs/runRegistry.ts`, line 117-120 ([link](https://github.com/useautumn/autumn/blob/c9acdeb5c0074149eef800eeacb1357a38dbf563/apps/leaf/src/internal/runs/runRegistry.ts#L117-L120)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stop cancellation is permanently skipped**

   When session setup takes longer than 15 seconds, `requestStop` sets `interruptSent` before session resolution times out and then returns without calling `sendInterrupt`. Once the session becomes available, subsequent stop requests exit early, so Leaf stops consuming locally while the Eve turn continues executing server-side.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/leaf/src/internal/runs/runRegistry.ts
   Line: 117-120

   Comment:
   **Stop cancellation is permanently skipped**

   When session setup takes longer than 15 seconds, `requestStop` sets `interruptSent` before session resolution times out and then returns without calling `sendInterrupt`. Once the session becomes available, subsequent stop requests exit early, so Leaf stops consuming locally while the Eve turn continues executing server-side.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts:223-229
**Tax drift bypasses approval**

When a recomputed preview has unchanged line items but higher tax, adding `taxDelta` directly to `expected` marks the new total as non-drifted, causing a user-approved $100 total to execute as a $120 charge without a refreshed approval. Tax changes should only be accepted when they are verified as part of the permitted proration decay. **How this was verified:** The approval executor proceeds to stored writes when this comparison returns non-drifted, and no separate tax-equality check exists.

### Issue 2
apps/leaf/src/internal/runs/runRegistry.ts:117-120
**Stop cancellation is permanently skipped**

When session setup takes longer than 15 seconds, `requestStop` sets `interruptSent` before session resolution times out and then returns without calling `sendInterrupt`. Once the session becomes available, subsequent stop requests exit early, so Leaf stops consuming locally while the Eve turn continues executing server-side.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: a typed approve decides the pendin..."](https://github.com/useautumn/autumn/commit/c9acdeb5c0074149eef800eeacb1357a38dbf563) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58162394)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Automation and external integrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/automation-and-external-integrations.md)

<!-- /greptile_comment -->