### PR TITLE
rsd eval group: Resend incident replays

### DIFF
--- a/apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts
+++ b/apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts
@@ -1,17 +1,32 @@
 import { parsePreviewPayload } from "@autumn/render";
 
+type LinePeriod = { end: number; start: number };
+
+type LineFacts = {
+	amount?: number;
+	key: string;
+	period?: LinePeriod;
+};
+
 type MoneyFacts = {
 	currency?: string;
 	incomingPlans: ReadonlyArray<string>;
-	lineItemAmounts: ReadonlyArray<number>;
+	lineFacts: ReadonlyArray<LineFacts>;
 	outgoingPlans: ReadonlyArray<string>;
 	total?: number;
 };
+
+// Each preview rounds its amounts to cents independently, so two honest
+// computes of the same write can differ by a cent per side.
+const CENT_TOLERANCE = 0.011;
 
 const asRecord = (value: unknown): Record<string, unknown> | undefined =>
 	value && typeof value === "object" && !Array.isArray(value)
 		? (value as Record<string, unknown>)
 		: undefined;
+
+const asAmount = (value: unknown): number | undefined =>
+	typeof value === "number" ? value : undefined;
 
 const planIds = (value: unknown): string[] =>
 	Array.isArray(value)
@@ -20,6 +35,29 @@ const planIds = (value: unknown): string[] =>
 				.filter((id): id is string => typeof id === "string")
 				.sort()
 		: [];
+
+const linePeriodOf = (value: unknown): LinePeriod | undefined => {
+	const period = asRecord(value);
+	const start = asAmount(period?.start);
+	const end = asAmount(period?.end);
+	return start !== undefined && end !== undefined && end > start
+		? { end, start }
+		: undefined;
+};
+
+const lineFactsOf = (item: unknown): LineFacts => {
+	const record = asRecord(item) ?? {};
+	return {
+		amount: asAmount(record.total) ?? asAmount(record.amount),
+		key: `${record.plan_id ?? ""}|${record.feature_id ?? ""}`,
+		period: linePeriodOf(record.period),
+	};
+};
+
+const byLineIdentity = (left: LineFacts, right: LineFacts): number =>
+	left.key.localeCompare(right.key) ||
+	(left.period?.end ?? 0) - (right.period?.end ?? 0) ||
+	(left.amount ?? 0) - (right.amount ?? 0);
 
 const moneyFactsOf = (preview: unknown): MoneyFacts | undefined => {
 	// Stored previews may carry the `{_display, preview}` enrichment wrapper.
@@ -33,22 +71,61 @@ const moneyFactsOf = (preview: unknown): MoneyFacts | undefined => {
 	return {
 		currency: typeof record.currency === "string" ? record.currency : undefined,
 		incomingPlans: planIds(record.incoming_plans ?? record.incoming),
-		lineItemAmounts: lineItems
-			.map((item) => asRecord(item)?.amount)
-			.filter((amount): amount is number => typeof amount === "number")
-			.sort((left, right) => left - right),
+		lineFacts: lineItems.map(lineFactsOf).sort(byLineIdentity),
 		outgoingPlans: planIds(record.outgoing_plans ?? record.outgoing),
-		total:
-			typeof record.total === "number"
-				? record.total
-				: typeof dueToday?.total === "number"
-					? dueToday.total
-					: undefined,
+		total: asAmount(record.total) ?? asAmount(dueToday?.total),
 	};
 };
 
+/** The stored amount recomputed for the current preview's period — a prorated
+ * line's period starts at server-now, so its amount decays between computes. */
+const decayAdjustedAmount = ({
+	current,
+	stored,
+}: {
+	current: LineFacts;
+	stored: LineFacts;
+}): number | undefined =>
+	stored.amount !== undefined &&
+	stored.period &&
+	current.period &&
+	stored.period.end === current.period.end
+		? (stored.amount * (current.period.end - current.period.start)) /
+			(stored.period.end - stored.period.start)
+		: undefined;
+
+const compareLineFacts = ({
+	current,
+	stored,
+}: {
+	current: ReadonlyArray<LineFacts>;
+	stored: ReadonlyArray<LineFacts>;
+}): { decayDelta: number } | { drifted: true } => {
+	if (stored.length !== current.length) return { drifted: true };
+	let decayDelta = 0;
+	for (const [index, storedLine] of stored.entries()) {
+		const currentLine = current[index];
+		if (!currentLine || storedLine.key !== currentLine.key) {
+			return { drifted: true };
+		}
+		if (storedLine.amount === undefined || currentLine.amount === undefined) {
+			if (storedLine.amount !== currentLine.amount) return { drifted: true };
+			continue;
+		}
+		const expected =
+			decayAdjustedAmount({ current: currentLine, stored: storedLine }) ??
+			storedLine.amount;
+		if (Math.abs(currentLine.amount - expected) > CENT_TOLERANCE) {
+			return { drifted: true };
+		}
+		decayDelta += expected - storedLine.amount;
+	}
+	return { decayDelta };
+};
+
 /** Whether the approved money facts still match what would execute — derived
- * facts, not raw payloads, so benign field churn never blocks approvals. */
+ * facts, not raw payloads, so benign field churn and the server-clock decay of
+ * prorated amounts never block approvals. */
 export const previewMoneyFactsDrifted = ({
 	current,
 	stored,
@@ -59,12 +136,6 @@ export const previewMoneyFactsDrifted = ({
 	const storedFacts = moneyFactsOf(stored);
 	const currentFacts = moneyFactsOf(current);
 	if (!storedFacts || !currentFacts) return { drifted: false };
-	if (storedFacts.total !== currentFacts.total) {
-		return {
-			drifted: true,
-			reason: `total ${storedFacts.total} → ${currentFacts.total}`,
-		};
-	}
 	if (
 		storedFacts.currency &&
 		currentFacts.currency &&
@@ -73,18 +144,36 @@ export const previewMoneyFactsDrifted = ({
 		return { drifted: true, reason: "currency changed" };
 	}
 	if (
-		JSON.stringify(storedFacts.lineItemAmounts) !==
-		JSON.stringify(currentFacts.lineItemAmounts)
-	) {
-		return { drifted: true, reason: "line items changed" };
-	}
-	if (
 		JSON.stringify(storedFacts.incomingPlans) !==
 			JSON.stringify(currentFacts.incomingPlans) ||
 		JSON.stringify(storedFacts.outgoingPlans) !==
 			JSON.stringify(currentFacts.outgoingPlans)
 	) {
 		return { drifted: true, reason: "plan set changed" };
+	}
+	const lineVerdict = compareLineFacts({
+		current: currentFacts.lineFacts,
+		stored: storedFacts.lineFacts,
+	});
+	if ("drifted" in lineVerdict) {
+		return { drifted: true, reason: "line items changed" };
+	}
+	if (storedFacts.total === undefined || currentFacts.total === undefined) {
+		if (storedFacts.total !== currentFacts.total) {
+			return {
+				drifted: true,
+				reason: `total ${storedFacts.total} → ${currentFacts.total}`,
+			};
+		}
+		return { drifted: false };
+	}
+	const expectedTotal = storedFacts.total + lineVerdict.decayDelta;
+	const totalTolerance = CENT_TOLERANCE * (storedFacts.lineFacts.length + 1);
+	if (Math.abs(currentFacts.total - expectedTotal) > totalTolerance) {
+		return {
+			drifted: true,
+			reason: `total ${storedFacts.total} → ${currentFacts.total}`,
+		};
 	}
 	return { drifted: false };
 };

--- a/apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts
+++ b/apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts
@@ -16,8 +16,8 @@ type MoneyFacts = {
 	total?: number;
 };
 
-// Each preview rounds its amounts to cents independently, so two honest
-// computes of the same write can differ by a cent per side.
+// Each compute rounds to cents independently, so a decay-adjusted stored
+// amount can miss the freshly rounded one by up to a cent per line.
 const CENT_TOLERANCE = 0.011;
 
 const asRecord = (value: unknown): Record<string, unknown> | undefined =>
@@ -35,6 +35,16 @@ const planIds = (value: unknown): string[] =>
 				.filter((id): id is string => typeof id === "string")
 				.sort()
 		: [];
+
+const samePlanIds = ({
+	current,
+	stored,
+}: {
+	current: ReadonlyArray<string>;
+	stored: ReadonlyArray<string>;
+}): boolean =>
+	stored.length === current.length &&
+	stored.every((id, index) => id === current[index]);
 
 const linePeriodOf = (value: unknown): LinePeriod | undefined => {
 	const period = asRecord(value);
@@ -66,14 +76,14 @@ const moneyFactsOf = (preview: unknown): MoneyFacts | undefined => {
 		: preview;
 	const record = asRecord(parsePreviewPayload(unwrapped) ?? unwrapped);
 	if (!record) return undefined;
-	const dueToday = asRecord(record.due_today);
 	const lineItems = Array.isArray(record.line_items) ? record.line_items : [];
 	return {
 		currency: typeof record.currency === "string" ? record.currency : undefined,
 		incomingPlans: planIds(record.incoming_plans ?? record.incoming),
 		lineFacts: lineItems.map(lineFactsOf).sort(byLineIdentity),
 		outgoingPlans: planIds(record.outgoing_plans ?? record.outgoing),
-		total: asAmount(record.total) ?? asAmount(dueToday?.total),
+		total:
+			asAmount(record.total) ?? asAmount(asRecord(record.due_today)?.total),
 	};
 };
 
@@ -94,33 +104,50 @@ const decayAdjustedAmount = ({
 			(stored.period.end - stored.period.start)
 		: undefined;
 
-const compareLineFacts = ({
+/** Total proration decay across matched lines, or undefined when the lines
+ * differ in identity or beyond decay — i.e. a real change. */
+const lineDecayDelta = ({
 	current,
 	stored,
 }: {
 	current: ReadonlyArray<LineFacts>;
 	stored: ReadonlyArray<LineFacts>;
-}): { decayDelta: number } | { drifted: true } => {
-	if (stored.length !== current.length) return { drifted: true };
+}): number | undefined => {
+	if (stored.length !== current.length) return undefined;
 	let decayDelta = 0;
 	for (const [index, storedLine] of stored.entries()) {
 		const currentLine = current[index];
-		if (!currentLine || storedLine.key !== currentLine.key) {
-			return { drifted: true };
-		}
+		if (!currentLine || storedLine.key !== currentLine.key) return undefined;
 		if (storedLine.amount === undefined || currentLine.amount === undefined) {
-			if (storedLine.amount !== currentLine.amount) return { drifted: true };
+			if (storedLine.amount !== currentLine.amount) return undefined;
 			continue;
 		}
 		const expected =
 			decayAdjustedAmount({ current: currentLine, stored: storedLine }) ??
 			storedLine.amount;
 		if (Math.abs(currentLine.amount - expected) > CENT_TOLERANCE) {
-			return { drifted: true };
+			return undefined;
 		}
 		decayDelta += expected - storedLine.amount;
 	}
-	return { decayDelta };
+	return decayDelta;
+};
+
+const totalWithinDecay = ({
+	currentFacts,
+	decayDelta,
+	storedFacts,
+}: {
+	currentFacts: MoneyFacts;
+	decayDelta: number;
+	storedFacts: MoneyFacts;
+}): boolean => {
+	if (storedFacts.total === undefined || currentFacts.total === undefined) {
+		return storedFacts.total === currentFacts.total;
+	}
+	const tolerance = CENT_TOLERANCE * (storedFacts.lineFacts.length + 1);
+	const expected = storedFacts.total + decayDelta;
+	return Math.abs(currentFacts.total - expected) <= tolerance;
 };
 
 /** Whether the approved money facts still match what would execute — derived
@@ -144,32 +171,25 @@ export const previewMoneyFactsDrifted = ({
 		return { drifted: true, reason: "currency changed" };
 	}
 	if (
-		JSON.stringify(storedFacts.incomingPlans) !==
-			JSON.stringify(currentFacts.incomingPlans) ||
-		JSON.stringify(storedFacts.outgoingPlans) !==
-			JSON.stringify(currentFacts.outgoingPlans)
+		!samePlanIds({
+			current: currentFacts.incomingPlans,
+			stored: storedFacts.incomingPlans,
+		}) ||
+		!samePlanIds({
+			current: currentFacts.outgoingPlans,
+			stored: storedFacts.outgoingPlans,
+		})
 	) {
 		return { drifted: true, reason: "plan set changed" };
 	}
-	const lineVerdict = compareLineFacts({
+	const decayDelta = lineDecayDelta({
 		current: currentFacts.lineFacts,
 		stored: storedFacts.lineFacts,
 	});
-	if ("drifted" in lineVerdict) {
+	if (decayDelta === undefined) {
 		return { drifted: true, reason: "line items changed" };
 	}
-	if (storedFacts.total === undefined || currentFacts.total === undefined) {
-		if (storedFacts.total !== currentFacts.total) {
-			return {
-				drifted: true,
-				reason: `total ${storedFacts.total} → ${currentFacts.total}`,
-			};
-		}
-		return { drifted: false };
-	}
-	const expectedTotal = storedFacts.total + lineVerdict.decayDelta;
-	const totalTolerance = CENT_TOLERANCE * (storedFacts.lineFacts.length + 1);
-	if (Math.abs(currentFacts.total - expectedTotal) > totalTolerance) {
+	if (!totalWithinDecay({ currentFacts, decayDelta, storedFacts })) {
 		return {
 			drifted: true,
 			reason: `total ${storedFacts.total} → ${currentFacts.total}`,

--- a/apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts
+++ b/apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts
@@ -25,7 +25,7 @@ const asRecord = (value: unknown): Record<string, unknown> | undefined =>
 		? (value as Record<string, unknown>)
 		: undefined;
 
-const asAmount = (value: unknown): number | undefined =>
+const asNumber = (value: unknown): number | undefined =>
 	typeof value === "number" ? value : undefined;
 
 const planIds = (value: unknown): string[] =>
@@ -48,8 +48,8 @@ const samePlanIds = ({
 
 const linePeriodOf = (value: unknown): LinePeriod | undefined => {
 	const period = asRecord(value);
-	const start = asAmount(period?.start);
-	const end = asAmount(period?.end);
+	const start = asNumber(period?.start);
+	const end = asNumber(period?.end);
 	return start !== undefined && end !== undefined && end > start
 		? { end, start }
 		: undefined;
@@ -58,7 +58,7 @@ const linePeriodOf = (value: unknown): LinePeriod | undefined => {
 const lineFactsOf = (item: unknown): LineFacts => {
 	const record = asRecord(item) ?? {};
 	return {
-		amount: asAmount(record.total) ?? asAmount(record.amount),
+		amount: asNumber(record.total) ?? asNumber(record.amount),
 		key: `${record.plan_id ?? ""}|${record.feature_id ?? ""}`,
 		period: linePeriodOf(record.period),
 	};
@@ -83,7 +83,7 @@ const moneyFactsOf = (preview: unknown): MoneyFacts | undefined => {
 		lineFacts: lineItems.map(lineFactsOf).sort(byLineIdentity),
 		outgoingPlans: planIds(record.outgoing_plans ?? record.outgoing),
 		total:
-			asAmount(record.total) ?? asAmount(asRecord(record.due_today)?.total),
+			asNumber(record.total) ?? asNumber(asRecord(record.due_today)?.total),
 	};
 };
 

--- a/apps/leaf/tests/evals/agent/rsd/incidentSetup.ts
+++ b/apps/leaf/tests/evals/agent/rsd/incidentSetup.ts
@@ -1,0 +1,31 @@
+import { BillingInterval } from "@autumn/shared";
+import { withCustomers } from "../../fixtures/createSetup.js";
+import { orgSetups } from "../../fixtures/orgSetups.js";
+import { plan } from "../../fixtures/plans/index.js";
+
+/** The incident customer: custom-priced Enterprise plus a transactional
+ * add-on, in an org whose Marketing ladder has no 700K size. */
+export const incidentSetup = () =>
+	withCustomers({
+		setup: orgSetups.emailPlatform(),
+		customers: ({ customers, plans, subscriptions }) => ({
+			sender: {
+				...customers.base({
+					email: "billing@corvid-interactive.example",
+					id: "rsd-customer-0001",
+					name: "Corvid Interactive",
+				}),
+				subscriptions: [
+					subscriptions.active({
+						plan: plan.customized({
+							customize: {
+								price: { amount: 720, interval: BillingInterval.Month },
+							},
+							plan: plans.enterprise,
+						}),
+					}),
+					subscriptions.active({ plan: plans.sendhubPro }),
+				],
+			},
+		}),
+	});

--- a/apps/leaf/tests/evals/agent/rsd/marketing-upgrade-wrong-plan.eval.ts
+++ b/apps/leaf/tests/evals/agent/rsd/marketing-upgrade-wrong-plan.eval.ts
@@ -1,0 +1,85 @@
+import { BillingInterval } from "@autumn/shared";
+import { withCustomers } from "../../fixtures/createSetup.js";
+import { api, billing, tools } from "../../fixtures/expectations/index.js";
+import { orgSetups } from "../../fixtures/orgSetups.js";
+import { plan } from "../../fixtures/plans/index.js";
+import { approve, initEval, user } from "../../harness/index.js";
+import { billingAttachScores } from "../../utils/scorers.js";
+
+type EvalMetadata = {
+	domain: "rsd";
+	flow: "attach";
+};
+
+const experimentName = "rsd-marketing-upgrade-wrong-plan";
+const requestedPrice = 1900;
+
+// Replays a live incident: "upgrade their marketing product to 700K contacts
+// for $1900/mo" for a customer on custom Enterprise + transactional. The
+// failure was an updateSubscription on Enterprise (wrong product, prorations
+// dropped) instead of a customized Marketing attach.
+const setup = withCustomers({
+	setup: orgSetups.emailPlatform(),
+	customers: ({ customers, plans, subscriptions }) => ({
+		sender: {
+			...customers.base({
+				email: "billing@corvid-interactive.example",
+				id: "rsd-customer-0001",
+				name: "Corvid Interactive",
+			}),
+			subscriptions: [
+				subscriptions.active({
+					plan: plan.customized({
+						customize: {
+							price: { amount: 720, interval: BillingInterval.Month },
+						},
+						plan: plans.enterprise,
+					}),
+				}),
+				subscriptions.active({ plan: plans.sendhubPro }),
+			],
+		},
+	}),
+});
+
+const customer = setup.refs.customers.sender;
+
+initEval<EvalMetadata>({
+	experimentName,
+	setup,
+	metadata: {
+		domain: "rsd",
+		flow: "attach",
+	},
+	scores: billingAttachScores(),
+	cases: [
+		{
+			name: "a marketing upgrade attaches a marketing plan, never the enterprise subscription",
+			conversation: [
+				user({
+					message: `For customer ID: ${customer.id}, can we please upgrade their account to 700K contacts for $1900/month. This would just be for their marketing product`,
+				}),
+				user({
+					message: "can you confirm the total number of contacts and pricing",
+				}),
+				approve(),
+			],
+			expect: [
+				tools.called({ toolNames: ["previewAttach", "attach"] }),
+				...billing.previewThenWrite({
+					body: {
+						customer_id: customer.id,
+						customize: {
+							price: { amount: requestedPrice, interval: "month" },
+						},
+					},
+					write: "attach",
+				}),
+				api.calledTimes({
+					call: { toolName: "updateSubscription" },
+					count: 0,
+				}),
+			],
+		},
+	],
+});

--- a/apps/leaf/tests/evals/agent/rsd/marketing-upgrade-wrong-plan.eval.ts
+++ b/apps/leaf/tests/evals/agent/rsd/marketing-upgrade-wrong-plan.eval.ts
@@ -1,10 +1,7 @@
-import { BillingInterval } from "@autumn/shared";
-import { withCustomers } from "../../fixtures/createSetup.js";
 import { api, billing, tools } from "../../fixtures/expectations/index.js";
-import { orgSetups } from "../../fixtures/orgSetups.js";
-import { plan } from "../../fixtures/plans/index.js";
 import { approve, initEval, user } from "../../harness/index.js";
 import { billingAttachScores } from "../../utils/scorers.js";
+import { incidentSetup } from "./incidentSetup.js";
 
 type EvalMetadata = {
 	domain: "rsd";
@@ -18,29 +15,7 @@ const requestedPrice = 1900;
 // for $1900/mo" for a customer on custom Enterprise + transactional. The
 // failure was an updateSubscription on Enterprise (wrong product, prorations
 // dropped) instead of a customized Marketing attach.
-const setup = withCustomers({
-	setup: orgSetups.emailPlatform(),
-	customers: ({ customers, plans, subscriptions }) => ({
-		sender: {
-			...customers.base({
-				email: "billing@corvid-interactive.example",
-				id: "rsd-customer-0001",
-				name: "Corvid Interactive",
-			}),
-			subscriptions: [
-				subscriptions.active({
-					plan: plan.customized({
-						customize: {
-							price: { amount: 720, interval: BillingInterval.Month },
-						},
-						plan: plans.enterprise,
-					}),
-				}),
-				subscriptions.active({ plan: plans.sendhubPro }),
-			],
-		},
-	}),
-});
+const setup = incidentSetup();
 
 const customer = setup.refs.customers.sender;
 

--- a/apps/leaf/tests/evals/agent/rsd/marketing-upgrade-wrong-plan.eval.ts
+++ b/apps/leaf/tests/evals/agent/rsd/marketing-upgrade-wrong-plan.eval.ts
@@ -9,7 +9,6 @@ type EvalMetadata = {
 };
 
 const experimentName = "rsd-marketing-upgrade-wrong-plan";
-const requestedPrice = 1900;
 
 // Replays a live incident: "upgrade their marketing product to 700K contacts
 // for $1900/mo" for a customer on custom Enterprise + transactional. The
@@ -45,7 +44,7 @@ initEval<EvalMetadata>({
 					body: {
 						customer_id: customer.id,
 						customize: {
-							price: { amount: requestedPrice, interval: "month" },
+							price: { amount: 1900, interval: "month" },
 						},
 					},
 					write: "attach",

--- a/apps/leaf/tests/evals/agent/rsd/question-keeps-pending-write.eval.ts
+++ b/apps/leaf/tests/evals/agent/rsd/question-keeps-pending-write.eval.ts
@@ -3,7 +3,7 @@ import { withCustomers } from "../../fixtures/createSetup.js";
 import { api, tools } from "../../fixtures/expectations/index.js";
 import { orgSetups } from "../../fixtures/orgSetups.js";
 import { plan } from "../../fixtures/plans/index.js";
-import { initEval, user } from "../../harness/index.js";
+import { approve, initEval, user } from "../../harness/index.js";
 import { billingAttachScores } from "../../utils/scorers.js";
 
 type EvalMetadata = {
@@ -54,9 +54,6 @@ initEval<EvalMetadata>({
 	cases: [
 		{
 			name: "a pricing question is answered in text without replacing the write",
-			// The harness cannot resume a park across an intermediate turn, so
-			// execution is not gated here; the incident's churn — a fresh write
-			// built per reply — is what these counts catch.
 			conversation: [
 				user({
 					message: `Attach ${marketing.id} customized to $1900/month with 700K contacts for customer ${customer.id}, prorated with a finalized invoice.`,
@@ -64,11 +61,16 @@ initEval<EvalMetadata>({
 				user({
 					message: "can you confirm the total number of contacts and pricing",
 				}),
+				approve(),
 			],
 			expect: [
-				tools.called({ toolNames: ["previewAttach"] }),
+				tools.called({ toolNames: ["previewAttach", "attach"] }),
 				api.calledTimes({
 					call: { toolName: "previewAttach" },
+					count: 1,
+				}),
+				api.calledTimes({
+					call: { toolName: "attach" },
 					count: 1,
 				}),
 				api.calledTimes({

--- a/apps/leaf/tests/evals/agent/rsd/question-keeps-pending-write.eval.ts
+++ b/apps/leaf/tests/evals/agent/rsd/question-keeps-pending-write.eval.ts
@@ -1,10 +1,7 @@
-import { BillingInterval } from "@autumn/shared";
-import { withCustomers } from "../../fixtures/createSetup.js";
 import { api, tools } from "../../fixtures/expectations/index.js";
-import { orgSetups } from "../../fixtures/orgSetups.js";
-import { plan } from "../../fixtures/plans/index.js";
 import { approve, initEval, user } from "../../harness/index.js";
 import { billingAttachScores } from "../../utils/scorers.js";
+import { incidentSetup } from "./incidentSetup.js";
 
 type EvalMetadata = {
 	domain: "rsd";
@@ -16,29 +13,7 @@ const experimentName = "rsd-question-keeps-pending-write";
 // Replays the incident's card churn: every clarifying reply superseded the
 // pending card with a fresh write. A question must be answered in text while
 // exactly one previewed write survives to approval.
-const setup = withCustomers({
-	setup: orgSetups.emailPlatform(),
-	customers: ({ customers, plans, subscriptions }) => ({
-		sender: {
-			...customers.base({
-				email: "billing@corvid-interactive.example",
-				id: "rsd-customer-0001",
-				name: "Corvid Interactive",
-			}),
-			subscriptions: [
-				subscriptions.active({
-					plan: plan.customized({
-						customize: {
-							price: { amount: 720, interval: BillingInterval.Month },
-						},
-						plan: plans.enterprise,
-					}),
-				}),
-				subscriptions.active({ plan: plans.sendhubPro }),
-			],
-		},
-	}),
-});
+const setup = incidentSetup();
 
 const customer = setup.refs.customers.sender;
 const marketing = setup.refs.plans.marketingStarter150k;

--- a/apps/leaf/tests/evals/agent/rsd/question-keeps-pending-write.eval.ts
+++ b/apps/leaf/tests/evals/agent/rsd/question-keeps-pending-write.eval.ts
@@ -1,0 +1,85 @@
+import { BillingInterval } from "@autumn/shared";
+import { withCustomers } from "../../fixtures/createSetup.js";
+import { api, tools } from "../../fixtures/expectations/index.js";
+import { orgSetups } from "../../fixtures/orgSetups.js";
+import { plan } from "../../fixtures/plans/index.js";
+import { initEval, user } from "../../harness/index.js";
+import { billingAttachScores } from "../../utils/scorers.js";
+
+type EvalMetadata = {
+	domain: "rsd";
+	flow: "attach";
+};
+
+const experimentName = "rsd-question-keeps-pending-write";
+
+// Replays the incident's card churn: every clarifying reply superseded the
+// pending card with a fresh write. A question must be answered in text while
+// exactly one previewed write survives to approval.
+const setup = withCustomers({
+	setup: orgSetups.emailPlatform(),
+	customers: ({ customers, plans, subscriptions }) => ({
+		sender: {
+			...customers.base({
+				email: "billing@corvid-interactive.example",
+				id: "rsd-customer-0001",
+				name: "Corvid Interactive",
+			}),
+			subscriptions: [
+				subscriptions.active({
+					plan: plan.customized({
+						customize: {
+							price: { amount: 720, interval: BillingInterval.Month },
+						},
+						plan: plans.enterprise,
+					}),
+				}),
+				subscriptions.active({ plan: plans.sendhubPro }),
+			],
+		},
+	}),
+});
+
+const customer = setup.refs.customers.sender;
+const marketing = setup.refs.plans.marketingStarter150k;
+
+initEval<EvalMetadata>({
+	experimentName,
+	setup,
+	metadata: {
+		domain: "rsd",
+		flow: "attach",
+	},
+	scores: billingAttachScores(),
+	cases: [
+		{
+			name: "a pricing question is answered in text without replacing the write",
+			// The harness cannot resume a park across an intermediate turn, so
+			// execution is not gated here; the incident's churn — a fresh write
+			// built per reply — is what these counts catch.
+			conversation: [
+				user({
+					message: `Attach ${marketing.id} customized to $1900/month with 700K contacts for customer ${customer.id}, prorated with a finalized invoice.`,
+				}),
+				user({
+					message: "can you confirm the total number of contacts and pricing",
+				}),
+			],
+			expect: [
+				tools.called({ toolNames: ["previewAttach"] }),
+				api.calledTimes({
+					call: { toolName: "previewAttach" },
+					count: 1,
+				}),
+				api.calledTimes({
+					call: { toolName: "updateSubscription" },
+					count: 0,
+				}),
+				api.calledTimes({
+					call: { toolName: "previewUpdateSubscription" },
+					count: 0,
+				}),
+			],
+		},
+	],
+});

--- a/apps/leaf/tests/evals/agent/rsd/typed-approve-keeps-shape.eval.ts
+++ b/apps/leaf/tests/evals/agent/rsd/typed-approve-keeps-shape.eval.ts
@@ -1,10 +1,7 @@
-import { BillingInterval } from "@autumn/shared";
-import { withCustomers } from "../../fixtures/createSetup.js";
 import { api, tools } from "../../fixtures/expectations/index.js";
-import { orgSetups } from "../../fixtures/orgSetups.js";
-import { plan } from "../../fixtures/plans/index.js";
 import { initEval, user } from "../../harness/index.js";
 import { billingAttachScores } from "../../utils/scorers.js";
+import { incidentSetup } from "./incidentSetup.js";
 
 type EvalMetadata = {
 	domain: "rsd";
@@ -16,29 +13,7 @@ const experimentName = "rsd-typed-approve-keeps-shape";
 // Replays the incident's worst step: "please approve" re-delegated the request
 // and the rebuilt write switched product and dropped prorations. A typed
 // confirmation must execute the previewed write's shape, never a re-model.
-const setup = withCustomers({
-	setup: orgSetups.emailPlatform(),
-	customers: ({ customers, plans, subscriptions }) => ({
-		sender: {
-			...customers.base({
-				email: "billing@corvid-interactive.example",
-				id: "rsd-customer-0001",
-				name: "Corvid Interactive",
-			}),
-			subscriptions: [
-				subscriptions.active({
-					plan: plan.customized({
-						customize: {
-							price: { amount: 720, interval: BillingInterval.Month },
-						},
-						plan: plans.enterprise,
-					}),
-				}),
-				subscriptions.active({ plan: plans.sendhubPro }),
-			],
-		},
-	}),
-});
+const setup = incidentSetup();
 
 const customer = setup.refs.customers.sender;
 const marketing = setup.refs.plans.marketingStarter150k;

--- a/apps/leaf/tests/evals/agent/rsd/typed-approve-keeps-shape.eval.ts
+++ b/apps/leaf/tests/evals/agent/rsd/typed-approve-keeps-shape.eval.ts
@@ -54,10 +54,10 @@ initEval<EvalMetadata>({
 	cases: [
 		{
 			name: "a typed approve executes the previewed write, not a rebuilt one",
-			// The harness cannot resume a park across an intermediate turn, so
-			// execution is not gated here; the incident's rebuild — a typed
-			// approve re-modelled onto the enterprise subscription with
-			// prorations dropped — is what these gates catch.
+			// A typed "please approve" is a text turn, not a card click, so
+			// execution is not gated; the incident's rebuild — re-modelled onto
+			// the enterprise subscription with prorations dropped — is what
+			// these counts catch.
 			conversation: [
 				user({
 					message: `Attach ${marketing.id} customized to $1900/month with 700K contacts for customer ${customer.id}, prorated with a finalized invoice.`,

--- a/apps/leaf/tests/evals/agent/rsd/typed-approve-keeps-shape.eval.ts
+++ b/apps/leaf/tests/evals/agent/rsd/typed-approve-keeps-shape.eval.ts
@@ -1,0 +1,93 @@
+import { BillingInterval } from "@autumn/shared";
+import { withCustomers } from "../../fixtures/createSetup.js";
+import { api, tools } from "../../fixtures/expectations/index.js";
+import { orgSetups } from "../../fixtures/orgSetups.js";
+import { plan } from "../../fixtures/plans/index.js";
+import { initEval, user } from "../../harness/index.js";
+import { billingAttachScores } from "../../utils/scorers.js";
+
+type EvalMetadata = {
+	domain: "rsd";
+	flow: "attach";
+};
+
+const experimentName = "rsd-typed-approve-keeps-shape";
+
+// Replays the incident's worst step: "please approve" re-delegated the request
+// and the rebuilt write switched product and dropped prorations. A typed
+// confirmation must execute the previewed write's shape, never a re-model.
+const setup = withCustomers({
+	setup: orgSetups.emailPlatform(),
+	customers: ({ customers, plans, subscriptions }) => ({
+		sender: {
+			...customers.base({
+				email: "billing@corvid-interactive.example",
+				id: "rsd-customer-0001",
+				name: "Corvid Interactive",
+			}),
+			subscriptions: [
+				subscriptions.active({
+					plan: plan.customized({
+						customize: {
+							price: { amount: 720, interval: BillingInterval.Month },
+						},
+						plan: plans.enterprise,
+					}),
+				}),
+				subscriptions.active({ plan: plans.sendhubPro }),
+			],
+		},
+	}),
+});
+
+const customer = setup.refs.customers.sender;
+const marketing = setup.refs.plans.marketingStarter150k;
+
+initEval<EvalMetadata>({
+	experimentName,
+	setup,
+	metadata: {
+		domain: "rsd",
+		flow: "attach",
+	},
+	scores: billingAttachScores(),
+	cases: [
+		{
+			name: "a typed approve executes the previewed write, not a rebuilt one",
+			// The harness cannot resume a park across an intermediate turn, so
+			// execution is not gated here; the incident's rebuild — a typed
+			// approve re-modelled onto the enterprise subscription with
+			// prorations dropped — is what these gates catch.
+			conversation: [
+				user({
+					message: `Attach ${marketing.id} customized to $1900/month with 700K contacts for customer ${customer.id}, prorated with a finalized invoice.`,
+				}),
+				user({ message: "please approve" }),
+			],
+			expect: [
+				tools.called({ toolNames: ["previewAttach"] }),
+				api.calledTimes({
+					call: {
+						body: {
+							customer_id: customer.id,
+							customize: {
+								price: { amount: 1900, interval: "month" },
+							},
+							plan_id: marketing.id,
+						},
+						toolName: "previewAttach",
+					},
+					count: 1,
+				}),
+				api.calledTimes({
+					call: { toolName: "updateSubscription" },
+					count: 0,
+				}),
+				api.calledTimes({
+					call: { toolName: "previewUpdateSubscription" },
+					count: 0,
+				}),
+			],
+		},
+	],
+});

--- a/apps/leaf/tests/evals/fixtures/orgSetups.ts
+++ b/apps/leaf/tests/evals/fixtures/orgSetups.ts
@@ -1,7 +1,9 @@
+import { emailPlatformSetup } from "./setups/emailPlatformSetup.js";
 import { knowledgePlatformSetup } from "./setups/knowledgePlatformSetup.js";
 
 export type { EvalSetup as EvalOrgSetup } from "./types.js";
 
 export const orgSetups = {
+	emailPlatform: emailPlatformSetup,
 	knowledgePlatform: knowledgePlatformSetup,
 } as const;

--- a/apps/leaf/tests/evals/fixtures/setups/emailPlatformSetup.ts
+++ b/apps/leaf/tests/evals/fixtures/setups/emailPlatformSetup.ts
@@ -103,9 +103,12 @@ export const emailPlatformSetup = () =>
 					name: "Enterprise",
 					planId: planIds.enterprise,
 				}),
-				...Object.fromEntries(
-					marketingSizes.map((size) => [size.key, marketingPlan(size)]),
-				),
+				marketingStarter: marketingPlan(marketingSizes[0]),
+				marketingStarter10k: marketingPlan(marketingSizes[1]),
+				marketingStarter25k: marketingPlan(marketingSizes[2]),
+				marketingStarter50k: marketingPlan(marketingSizes[3]),
+				marketingStarter100k: marketingPlan(marketingSizes[4]),
+				marketingStarter150k: marketingPlan(marketingSizes[5]),
 				sendhubPro: {
 					...plan.monthly({
 						basePrice: basePrice.monthly({ amount: 20 }),

--- a/apps/leaf/tests/evals/fixtures/setups/emailPlatformSetup.ts
+++ b/apps/leaf/tests/evals/fixtures/setups/emailPlatformSetup.ts
@@ -1,0 +1,125 @@
+import { createSetup } from "../createSetup.js";
+
+const featureIds = {
+	ai_credits: "ai_credits",
+	automation_runs: "automation_runs",
+	contacts: "contacts",
+	domains: "domains",
+	emails: "emails",
+	partner_channel: "partner_channel",
+	priority_support: "priority_support",
+	sso: "sso",
+} as const;
+
+const planIds = {
+	enterprise: "enterprise",
+	marketingStarter: "marketing_starter",
+	marketingStarter10k: "marketing_starter_10k",
+	marketingStarter25k: "marketing_starter_25k",
+	marketingStarter50k: "marketing_starter_50k",
+	marketingStarter100k: "marketing_starter_100k",
+	marketingStarter150k: "marketing_starter_150k",
+	sendhubPro: "sendhub_pro",
+} as const;
+
+const MARKETING_GROUP = "Marketing";
+
+const marketingSizes = [
+	{ amount: 40, contacts: 5_000, key: "marketingStarter" },
+	{ amount: 80, contacts: 10_000, key: "marketingStarter10k" },
+	{ amount: 180, contacts: 25_000, key: "marketingStarter25k" },
+	{ amount: 250, contacts: 50_000, key: "marketingStarter50k" },
+	{ amount: 450, contacts: 100_000, key: "marketingStarter100k" },
+	{ amount: 650, contacts: 150_000, key: "marketingStarter150k" },
+] as const;
+
+/** Anonymized email-platform org: a Marketing plan ladder with sized contact
+ * variants (no 700K size exists), a custom-priced Enterprise with zero
+ * contacts, and a separate transactional plan — the shape behind the
+ * "upgrade their marketing product" incident. */
+export const emailPlatformSetup = () =>
+	createSetup({
+		tag: "email-platform",
+		agentRules: ({ agentRules }) => agentRules.base({}),
+		features: ({ featureList, features }) => ({
+			ai_credits: features.consumable({
+				featureId: featureIds.ai_credits,
+				name: "AI Credits",
+			}),
+			automation_runs: features.consumable({
+				featureId: featureIds.automation_runs,
+				name: "Automation Runs",
+			}),
+			contacts: features.allocated({
+				featureId: featureIds.contacts,
+				name: "Contacts",
+			}),
+			domains: features.allocated({
+				featureId: featureIds.domains,
+				name: "Domains",
+			}),
+			emails: features.consumable({
+				featureId: featureIds.emails,
+				name: "Emails",
+			}),
+			...featureList.boolean({
+				featureIds: [
+					featureIds.partner_channel,
+					featureIds.priority_support,
+					featureIds.sso,
+				],
+			}),
+		}),
+		plans: ({ basePrice, features, items, plan }) => {
+			const marketingPlan = ({
+				amount,
+				contacts,
+				key,
+			}: (typeof marketingSizes)[number]) => ({
+				...plan.monthly({
+					basePrice: basePrice.monthly({ amount }),
+					items: [
+						items.included({ feature: features.contacts, included: contacts }),
+						items.included({ feature: features.ai_credits, included: 100 }),
+					],
+					name: `Marketing Starter ${contacts / 1_000}K`,
+					planId: planIds[key],
+				}),
+				group: MARKETING_GROUP,
+			});
+			return {
+				enterprise: plan.monthly({
+					basePrice: null,
+					items: [
+						items.included({ feature: features.contacts, included: 0 }),
+						items.included({ feature: features.ai_credits, included: 100 }),
+						items.included({
+							feature: features.automation_runs,
+							included: 10_000,
+						}),
+						items.included({ feature: features.domains, included: 1_000 }),
+						items.boolean({ feature: features.sso }),
+					],
+					name: "Enterprise",
+					planId: planIds.enterprise,
+				}),
+				...Object.fromEntries(
+					marketingSizes.map((size) => [size.key, marketingPlan(size)]),
+				),
+				sendhubPro: {
+					...plan.monthly({
+						basePrice: basePrice.monthly({ amount: 20 }),
+						items: [
+							items.included({ feature: features.emails, included: 50_000 }),
+							items.included({ feature: features.ai_credits, included: 100 }),
+							items.included({ feature: features.domains, included: 10 }),
+						],
+						name: "SendHub Pro",
+						planId: planIds.sendhubPro,
+					}),
+					group: "Transactional",
+				},
+			};
+		},
+		customers: () => ({}),
+	});

--- a/apps/leaf/tests/evals/fixtures/setups/emailPlatformSetup.ts
+++ b/apps/leaf/tests/evals/fixtures/setups/emailPlatformSetup.ts
@@ -24,15 +24,6 @@ const planIds = {
 
 const MARKETING_GROUP = "Marketing";
 
-const marketingSizes = [
-	{ amount: 40, contacts: 5_000, key: "marketingStarter" },
-	{ amount: 80, contacts: 10_000, key: "marketingStarter10k" },
-	{ amount: 180, contacts: 25_000, key: "marketingStarter25k" },
-	{ amount: 250, contacts: 50_000, key: "marketingStarter50k" },
-	{ amount: 450, contacts: 100_000, key: "marketingStarter100k" },
-	{ amount: 650, contacts: 150_000, key: "marketingStarter150k" },
-] as const;
-
 /** Anonymized email-platform org: a Marketing plan ladder with sized contact
  * variants (no 700K size exists), a custom-priced Enterprise with zero
  * contacts, and a separate transactional plan — the shape behind the
@@ -74,8 +65,12 @@ export const emailPlatformSetup = () =>
 			const marketingPlan = ({
 				amount,
 				contacts,
-				key,
-			}: (typeof marketingSizes)[number]) => ({
+				planId,
+			}: {
+				amount: number;
+				contacts: number;
+				planId: string;
+			}) => ({
 				...plan.monthly({
 					basePrice: basePrice.monthly({ amount }),
 					items: [
@@ -83,7 +78,7 @@ export const emailPlatformSetup = () =>
 						items.included({ feature: features.ai_credits, included: 100 }),
 					],
 					name: `Marketing Starter ${contacts / 1_000}K`,
-					planId: planIds[key],
+					planId,
 				}),
 				group: MARKETING_GROUP,
 			});
@@ -103,12 +98,36 @@ export const emailPlatformSetup = () =>
 					name: "Enterprise",
 					planId: planIds.enterprise,
 				}),
-				marketingStarter: marketingPlan(marketingSizes[0]),
-				marketingStarter10k: marketingPlan(marketingSizes[1]),
-				marketingStarter25k: marketingPlan(marketingSizes[2]),
-				marketingStarter50k: marketingPlan(marketingSizes[3]),
-				marketingStarter100k: marketingPlan(marketingSizes[4]),
-				marketingStarter150k: marketingPlan(marketingSizes[5]),
+				marketingStarter: marketingPlan({
+					amount: 40,
+					contacts: 5_000,
+					planId: planIds.marketingStarter,
+				}),
+				marketingStarter10k: marketingPlan({
+					amount: 80,
+					contacts: 10_000,
+					planId: planIds.marketingStarter10k,
+				}),
+				marketingStarter25k: marketingPlan({
+					amount: 180,
+					contacts: 25_000,
+					planId: planIds.marketingStarter25k,
+				}),
+				marketingStarter50k: marketingPlan({
+					amount: 250,
+					contacts: 50_000,
+					planId: planIds.marketingStarter50k,
+				}),
+				marketingStarter100k: marketingPlan({
+					amount: 450,
+					contacts: 100_000,
+					planId: planIds.marketingStarter100k,
+				}),
+				marketingStarter150k: marketingPlan({
+					amount: 650,
+					contacts: 150_000,
+					planId: planIds.marketingStarter150k,
+				}),
 				sendhubPro: {
 					...plan.monthly({
 						basePrice: basePrice.monthly({ amount: 20 }),

--- a/apps/leaf/tests/evals/harness/drivers/genericMcpAgent.ts
+++ b/apps/leaf/tests/evals/harness/drivers/genericMcpAgent.ts
@@ -150,14 +150,12 @@ export const createGenericMcpAgentDriver = ({
 			runId?: string;
 			suspension?: { toolCallId?: string };
 		}) => {
-			pendingApproval =
-				output.finishReason === "suspended" && output.runId
-					? {
-							runId: output.runId,
-							toolCallId: output.suspension?.toolCallId,
-						}
-					: null;
-			if (pendingApproval) trace.event({ type: "approval_pending" });
+			if (output.finishReason !== "suspended" || !output.runId) return;
+			pendingApproval = {
+				runId: output.runId,
+				toolCallId: output.suspension?.toolCallId,
+			};
+			trace.event({ type: "approval_pending" });
 		};
 
 		return {
@@ -172,6 +170,7 @@ export const createGenericMcpAgentDriver = ({
 					toolCallId: pendingApproval.toolCallId,
 				});
 				messages = output.messages;
+				pendingApproval = null;
 				rememberApproval(output);
 				trace.event({ text: output.text ?? "", type: "agent_text" });
 				return { text: output.text };

--- a/apps/leaf/tests/evals/harness/drivers/leafAgent.ts
+++ b/apps/leaf/tests/evals/harness/drivers/leafAgent.ts
@@ -181,14 +181,12 @@ export const createLeafAgentDriver = ({
 			runId?: string;
 			suspension?: { toolCallId?: string };
 		}) => {
-			pendingApproval =
-				output.finishReason === "suspended" && output.runId
-					? {
-							runId: output.runId,
-							toolCallId: output.suspension?.toolCallId,
-						}
-					: null;
-			if (pendingApproval) trace.event({ type: "approval_pending" });
+			if (output.finishReason !== "suspended" || !output.runId) return;
+			pendingApproval = {
+				runId: output.runId,
+				toolCallId: output.suspension?.toolCallId,
+			};
+			trace.event({ type: "approval_pending" });
 		};
 
 		return {
@@ -203,6 +201,7 @@ export const createLeafAgentDriver = ({
 					toolCallId: pendingApproval.toolCallId,
 				});
 				messages = output.messages;
+				pendingApproval = null;
 				rememberApproval(output);
 				trace.event({ text: output.text ?? "", type: "agent_text" });
 				return { text: output.text };

--- a/apps/leaf/tests/unit/approvals/previewDriftDecay.test.ts
+++ b/apps/leaf/tests/unit/approvals/previewDriftDecay.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	AppEnv,
+	type ChatApproval,
+	type ChatApprovalWrite,
+} from "@autumn/shared";
+import { previewMoneyFactsDrifted } from "../../../src/internal/approvals/utils/previewMoneyFacts.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+mock.module("../../../src/lib/env.js", () => ({ env: {} }));
+mock.module("../../../src/lib/db.js", () => ({ db: {} }));
+
+const mockLeafModule = ({
+	factory,
+	specifier,
+}: {
+	factory: () => Record<string, unknown>;
+	specifier: string;
+}) => mockModuleWithRestore({ baseUrl: import.meta.url, factory, specifier });
+
+const CYCLE_START = Date.UTC(2026, 7, 22);
+const CYCLE_END = Date.UTC(2026, 8, 22);
+const MONTHLY_PRICE = 1900;
+
+const roundToCents = (amount: number) => Math.round(amount * 100) / 100;
+
+// A prorated in-advance line the way the server computes it: the period
+// starts at server-now, so the amount decays with every re-preview.
+const previewComputedAt = (nowMs: number) => {
+	const prorated = roundToCents(
+		(MONTHLY_PRICE * (CYCLE_END - nowMs)) / (CYCLE_END - CYCLE_START),
+	);
+	return {
+		object: "billing_preview",
+		customer_id: "rsd-customer-0001",
+		currency: "usd",
+		line_items: [
+			{
+				object: "billing_preview_line_item",
+				custom: false,
+				display_name: "Marketing Starter 150K",
+				description: "Marketing Starter 150K - Base Price (prorated)",
+				subtotal: prorated,
+				total: prorated,
+				discounts: [],
+				plan_id: "marketing_starter_150k",
+				feature_id: null,
+				quantity: 1,
+				period: { start: nowMs, end: CYCLE_END },
+			},
+		],
+		subtotal: prorated,
+		total: prorated,
+		incoming: [{ plan_id: "marketing_starter_150k" }],
+		outgoing: [],
+	};
+};
+
+const CARD_SHOWN_AT = CYCLE_START + 9 * 24 * 60 * 60 * 1000;
+
+describe("proration time-decay is not drift", () => {
+	test("the same write re-previewed later does not drift", () => {
+		expect(
+			previewMoneyFactsDrifted({
+				current: previewComputedAt(CARD_SHOWN_AT + 2 * 60 * 1000),
+				stored: previewComputedAt(CARD_SHOWN_AT),
+			}),
+		).toEqual({ drifted: false });
+	});
+
+	test("the drift-refresh loop converges: a refreshed card is approvable", () => {
+		let stored = previewComputedAt(CARD_SHOWN_AT);
+		let clickedAt = CARD_SHOWN_AT;
+		for (const secondsLater of [120, 30, 30]) {
+			clickedAt += secondsLater * 1000;
+			const current = previewComputedAt(clickedAt);
+			const verdict = previewMoneyFactsDrifted({ current, stored });
+			if (!verdict.drifted) return;
+			stored = current;
+		}
+		throw new Error(
+			"Approve never executed: every retry re-previewed a freshly decayed total",
+		);
+	});
+});
+
+let serverNow = CARD_SHOWN_AT;
+let storedWrite: ChatApprovalWrite;
+const releases: string[] = [];
+
+await mockLeafModule({
+	specifier: "../../../src/lib/logger.js",
+	factory: () => ({
+		logger: {
+			debug: () => {},
+			error: () => {},
+			info: () => {},
+			warn: () => {},
+		},
+	}),
+});
+await mockLeafModule({
+	specifier:
+		"../../../src/internal/installations/actions/getOrgInstallationToken.js",
+	factory: () => ({
+		getOrgInstallationToken: async () => ({ accessToken: "tok" }),
+	}),
+});
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/repos/chatApprovalRepo.js",
+	factory: () => ({
+		chatApprovalRepo: {
+			release: async () => {
+				releases.push(storedWrite.approval_id);
+			},
+			setPreview: async () => {},
+		},
+	}),
+});
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/repos/chatApprovalWritesRepo.js",
+	factory: () => ({
+		chatApprovalWritesRepo: {
+			list: async () => [storedWrite],
+			setPreview: async ({ preview }: { preview: unknown }) => {
+				storedWrite = { ...storedWrite, preview };
+			},
+		},
+	}),
+});
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/utils/fetchApprovalPreview.js",
+	factory: () => ({
+		withWritePreviews: async () => [{ preview: previewComputedAt(serverNow) }],
+	}),
+});
+
+const { guardApprovalDrift } = await import(
+	"../../../src/internal/approvals/actions/guardApprovalDrift.js"
+);
+
+const approval = {
+	env: AppEnv.Sandbox,
+	id: "ap_rsd_1",
+	org_id: "org_rsd",
+	provider: "slack",
+	workspace_id: "T_RSD",
+} as ChatApproval;
+
+const parkCard = () => {
+	serverNow = CARD_SHOWN_AT;
+	releases.length = 0;
+	storedWrite = {
+		approval_id: approval.id,
+		created_at: CARD_SHOWN_AT,
+		deny_option_id: null,
+		id: "wr_rsd_1",
+		position: 0,
+		preview: previewComputedAt(CARD_SHOWN_AT),
+		request_id: "tc_rsd_1",
+		result: null,
+		status: "pending",
+		tool_args: { customer_id: "rsd-customer-0001" },
+		tool_name: "attach",
+		updated_at: CARD_SHOWN_AT,
+	} as ChatApprovalWrite;
+};
+
+describe("guardApprovalDrift under proration time-decay", () => {
+	test("an untouched write approved minutes later executes", async () => {
+		parkCard();
+		serverNow = CARD_SHOWN_AT + 2 * 60 * 1000;
+		const result = await guardApprovalDrift({
+			approval,
+			providerUserId: "U_RSD",
+		});
+		expect(result).toBeUndefined();
+		expect(releases).toEqual([]);
+	});
+
+	test("retrying after a drift refresh eventually executes", async () => {
+		parkCard();
+		for (const secondsLater of [120, 30, 30]) {
+			serverNow += secondsLater * 1000;
+			const result = await guardApprovalDrift({
+				approval,
+				providerUserId: "U_RSD",
+			});
+			if (result === undefined) return;
+		}
+		throw new Error(
+			"Approve never executed: every retry re-previewed a freshly decayed total",
+		);
+	});
+});

--- a/apps/leaf/tests/unit/approvals/previewDriftDecay.test.ts
+++ b/apps/leaf/tests/unit/approvals/previewDriftDecay.test.ts
@@ -57,6 +57,7 @@ const previewComputedAt = (nowMs: number) => {
 };
 
 const CARD_SHOWN_AT = CYCLE_START + 9 * 24 * 60 * 60 * 1000;
+const RETRY_CADENCE_SECONDS = [120, 30, 30];
 
 describe("proration time-decay is not drift", () => {
 	test("the same write re-previewed later does not drift", () => {
@@ -71,7 +72,7 @@ describe("proration time-decay is not drift", () => {
 	test("the drift-refresh loop converges: a refreshed card is approvable", () => {
 		let stored = previewComputedAt(CARD_SHOWN_AT);
 		let clickedAt = CARD_SHOWN_AT;
-		for (const secondsLater of [120, 30, 30]) {
+		for (const secondsLater of RETRY_CADENCE_SECONDS) {
 			clickedAt += secondsLater * 1000;
 			const current = previewComputedAt(clickedAt);
 			const verdict = previewMoneyFactsDrifted({ current, stored });
@@ -180,7 +181,7 @@ describe("guardApprovalDrift under proration time-decay", () => {
 
 	test("retrying after a drift refresh eventually executes", async () => {
 		parkCard();
-		for (const secondsLater of [120, 30, 30]) {
+		for (const secondsLater of RETRY_CADENCE_SECONDS) {
 			serverNow += secondsLater * 1000;
 			const result = await guardApprovalDrift({
 				approval,

--- a/packages/mcp/src/tools/billing.ts
+++ b/packages/mcp/src/tools/billing.ts
@@ -61,13 +61,18 @@ const { billingPreview, confirmedWrite } = createDomainTools({
 	schemas,
 });
 
+const attachTargeting =
+	"- Use when the request is about a plan or product line the customer is not on — pick a plan from that group, customized if no listed variant matches, even if the customer has other subscriptions.";
+const updateSubscriptionTargeting =
+	"- Only for changing terms of the plan the request is about; a request naming a different plan or product line is an attach, never an update to another subscription.";
+
 const domain = {
 	billingPreviews: [
 		billingPreview({
 			id: "previewAttach",
 			description: `
 - Preview attaching a plan before attach.
-- Use when the request is about a plan or product line the customer is not on — pick a plan from that group, customized if no listed variant matches, even if the customer has other subscriptions.
+${attachTargeting}
 - Follow the Billing resource.
 `.trim(),
 		}),
@@ -75,7 +80,7 @@ const domain = {
 			id: "previewUpdateSubscription",
 			description: `
 - Preview updating a subscription before updateSubscription.
-- Only for changing terms of the plan the request is about; a request naming a different plan or product line is an attach, never an update to another subscription.
+${updateSubscriptionTargeting}
 - Follow the Billing resource.
 `.trim(),
 		}),
@@ -92,7 +97,7 @@ const domain = {
 			id: "attach",
 			description: `
 - Attach a plan to a customer.
-- Use when the request is about a plan or product line the customer is not on — pick a plan from that group, customized if no listed variant matches, even if the customer has other subscriptions.
+${attachTargeting}
 - Follow the Billing resource.
 `.trim(),
 		}),
@@ -100,7 +105,7 @@ const domain = {
 			id: "updateSubscription",
 			description: `
 - Update a subscription.
-- Only for changing terms of the plan the request is about; a request naming a different plan or product line is an attach, never an update to another subscription.
+${updateSubscriptionTargeting}
 - Follow the Billing resource.
 `.trim(),
 		}),

--- a/packages/mcp/src/tools/billing.ts
+++ b/packages/mcp/src/tools/billing.ts
@@ -67,6 +67,7 @@ const domain = {
 			id: "previewAttach",
 			description: `
 - Preview attaching a plan before attach.
+- Use when the request is about a plan or product line the customer is not on — pick a plan from that group, customized if no listed variant matches, even if the customer has other subscriptions.
 - Follow the Billing resource.
 `.trim(),
 		}),
@@ -74,6 +75,7 @@ const domain = {
 			id: "previewUpdateSubscription",
 			description: `
 - Preview updating a subscription before updateSubscription.
+- Only for changing terms of the plan the request is about; a request naming a different plan or product line is an attach, never an update to another subscription.
 - Follow the Billing resource.
 `.trim(),
 		}),
@@ -90,6 +92,7 @@ const domain = {
 			id: "attach",
 			description: `
 - Attach a plan to a customer.
+- Use when the request is about a plan or product line the customer is not on — pick a plan from that group, customized if no listed variant matches, even if the customer has other subscriptions.
 - Follow the Billing resource.
 `.trim(),
 		}),
@@ -97,6 +100,7 @@ const domain = {
 			id: "updateSubscription",
 			description: `
 - Update a subscription.
+- Only for changing terms of the plan the request is about; a request naming a different plan or product line is an attach, never an update to another subscription.
 - Follow the Billing resource.
 `.trim(),
 		}),

--- a/packages/mcp/src/tools/billing.ts
+++ b/packages/mcp/src/tools/billing.ts
@@ -62,7 +62,7 @@ const { billingPreview, confirmedWrite } = createDomainTools({
 });
 
 const attachTargeting =
-	"- Use when the request is about a plan or product line the customer is not on — pick a plan from that group, customized if no listed variant matches, even if the customer has other subscriptions.";
+	"- Use when the request is about a plan or product line the customer is not on — attach from that group, customizing the closest plan when none matches the requested terms, even if the customer has other subscriptions.";
 const updateSubscriptionTargeting =
 	"- Only for changing terms of the plan the request is about; a request naming a different plan or product line is an attach, never an update to another subscription.";
 


### PR DESCRIPTION
New `rsd` group replaying the Resend incident thread (C0BJCT5FE72 / 1787948496) against an anonymized email-platform org fixture (`emailPlatformSetup`): Marketing ladder with sized variants and no 700K size, a customized $720 enterprise sub with contacts included:0, and a transactional add-on — the exact trap geometry from prod.

## Incident replications

| Replication | Incident defect | What it proves |
| --- | --- | --- |
| eval `marketing-upgrade-wrong-plan` | "upgrade their marketing product" was written as `updateSubscription` on the **enterprise** sub with `proration_behavior: "none"` | Verbatim incident thread (upgrade → pricing question → approve). Gates: previewAttach→attach with the $1900 customize, `updateSubscription` count 0. |
| eval `question-keeps-pending-write` | every clarifying reply superseded the pending card with a fresh write | A pricing question after a previewed write is answered in text, the park survives, and approve executes the same attach — exactly one `previewAttach`, one `attach`, zero `updateSubscription`. |
| eval `typed-approve-keeps-shape` | "please approve" re-delegated and rebuilt the write onto the enterprise sub | A typed approve keeps the previewed shape: exactly one correctly-bodied `previewAttach` ($1900/mo, `marketing_starter_150k`), zero re-models. |
| unit `previewDriftDecay.test.ts` | Approve button permanently unclickable — every click posted "Prices changed since this card was shown" | Full loop through the real `guardApprovalDrift` with a simulated server clock and the exact proration math: card shown, approve 2min later, and the release/refresh/re-click retry loop. Plus direct pins on `previewMoneyFactsDrifted`. Not a braintrust eval by design: the guard fires on the button click, below the model — no model behavior involved. |

## Fixes (each see-red → green in this PR)

**Wrong-plan targeting** — `packages/mcp/src/tools/billing.ts` (+4 lines). The attach/updateSubscription descriptions were bare one-liners; nothing said a request naming a plan group targets a plan in that group. Before the fix, `marketing-upgrade-wrong-plan` reproduced the prod write byte-for-byte (`plan_id: enterprise_custom`, contacts 700K swap, prorations dropped) or thrashed previews until timeout. One targeting line each on attach/updateSubscription and their previews; the replay now runs preview → park → approve cleanly.

**Proration time-decay treated as drift** — `apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts`. A prorated line's period starts at server-now, so the same untouched write re-previews to a different total every ~14s at incident prices ($1900/mo → $0.044/min). The guard compared totals with exact equality, and its refresh stored another already-decaying total — so every Approve click drifted again: the unclickable card. Money facts now carry per-line `{amount, plan/feature key, period}`; comparison decay-adjusts each stored amount to the current compute instant via the shared period end, within cent-rounding tolerance. Real changes still drift (plan set, currency, line identity, changed period end, amounts beyond rounding). Side effect: the line-item comparison now actually works for billing previews — the old code read `item.amount`, which billing preview lines don't have.

**Eval parks died on any reply** — `apps/leaf/tests/evals/harness/drivers/{leafAgent,genericMcpAgent}.ts`. The drivers nulled `pendingApproval` on every non-suspending turn, so no eval could approve after an intermediate reply — unlike prod, where cards survive the thread (`approve()` defaulting `optional: true` made this a silent skip). Parks now persist until approved or replaced by a new suspension.

Regression checks: full leaf unit suite green (487 pass); `custom-base-price` green (one $49→4900 unit flake, green on re-run); `multi-year-escalator` case 2 times out identically on clean HEAD — pre-existing.

## Remaining incident defect (separate PR)

- **Stop not cancelling turns**: the Slack decide/stop flow isn't traversed by the eval driver; needs leaf scenario tests around `session.cancel()`.








<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Resend incident replays and fixes the corresponding approval, tool-selection, and evaluation-harness behavior.
- **[Bug fixes]** Treats expected time-based proration decay as stable while continuing to detect meaningful pricing, currency, plan, and line-item changes.
- **[Bug fixes]** Keeps pending approval state across intermediate evaluation turns until the operation is approved or replaced.
- **[Improvements]** Clarifies when billing agents should attach a plan rather than update an unrelated subscription.
- **[Improvements]** Adds an anonymized email-platform fixture, three incident evaluations, and approval-drift regression coverage.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/approvals/utils/previewMoneyFacts.ts | Adds line-aware proration-decay normalization while preserving checks for material billing-preview changes. |
| apps/leaf/tests/evals/harness/drivers/genericMcpAgent.ts | Preserves pending tool approval across non-suspending conversation turns and clears it when approval begins. |
| apps/leaf/tests/evals/harness/drivers/leafAgent.ts | Aligns the Leaf evaluation driver’s pending-approval lifecycle with persistent production approval cards. |
| packages/mcp/src/tools/billing.ts | Clarifies attach-versus-update targeting in billing tool descriptions. |
| apps/leaf/tests/unit/approvals/previewDriftDecay.test.ts | Exercises delayed approval and retry behavior for time-decaying prorated previews. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Marketing upgrade request] --> Preview[Preview Marketing attachment]
  Preview --> Park[Pending approval]
  Park --> Question[Intermediate pricing question]
  Question --> Park
  Park --> Approve[Approval]
  Approve --> Drift{Money facts changed?}
  Drift -->|Only expected proration decay| Attach[Execute original attachment]
  Drift -->|Material pricing or plan change| Refresh[Refresh approval preview]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["refactor: clarify attach targeting wordi..."](https://github.com/useautumn/autumn/commit/26c6ca7e3e725aac1a72850d64a1b1e45d2f6ff1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58191695)</sub>

<!-- /greptile_comment -->