### PR TITLE
License pooled balances: lifecycle, batch transitions, and runtime

### DIFF
--- a/server/src/internal/billing/v2/actions/attachLicense/compute/computeAttachLicensePlan.ts
+++ b/server/src/internal/billing/v2/actions/attachLicense/compute/computeAttachLicensePlan.ts
@@ -5,6 +5,7 @@ import {
 	findFeatureById,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { computePooledBalanceTransitionPlan } from "@/internal/billing/v2/pooledBalances/compute/computePooledBalanceTransitionPlan.js";
 import { initFullCustomerProductFromCustomerLicense } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProductFromCustomerLicense.js";
 import { constructEntity } from "@/internal/entities/entityUtils/entityUtils.js";
 import type { AttachLicenseContext, AttachLicensePlan } from "../types.js";
@@ -86,12 +87,20 @@ export const computeAttachLicensePlan = ({
 			}),
 		}));
 
+	const incomingCustomerProducts = insertedAssignments.map(
+		(assignment) => assignment.customerProduct,
+	);
+	const { pooledBalancePlan } = computePooledBalanceTransitionPlan({
+		ctx,
+		fullCustomer,
+		incomingCustomerProducts,
+		now: context.currentEpochMs,
+	});
+
 	const billingPlan: AutumnBillingPlan = {
 		customerId: fullCustomer.id ?? fullCustomer.internal_id,
 		insertEntities: newEntities,
-		insertCustomerProducts: insertedAssignments.map(
-			(assignment) => assignment.customerProduct,
-		),
+		insertCustomerProducts: incomingCustomerProducts,
 		updateCustomerProducts: computeReusedCustomerProductUpdates({
 			reusedAssignments,
 		}),
@@ -101,6 +110,7 @@ export const computeAttachLicensePlan = ({
 				remainingChange: -assignmentEntities.length,
 			},
 		],
+		pooledBalancePlan,
 	};
 
 	return {

--- a/server/src/internal/billing/v2/actions/batchTransition/compute/operations/entitlementPriceOperations/computeEntitlementPriceOperations.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/compute/operations/entitlementPriceOperations/computeEntitlementPriceOperations.ts
@@ -1,9 +1,13 @@
 import {
+	EntInterval,
 	type EntitlementPrice,
 	type EntitlementWithFeature,
+	entToPooledBalanceIdentity,
 	entsAreSame,
+	entsHaveSamePooledIdentity,
 	type InitCustomerEntitlementContext,
 	type InitFullCustomerProductOptions,
+	PooledBalanceResetMode,
 } from "@autumn/shared";
 import { initCustomerEntitlementFields } from "@/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlementFields";
 import type {
@@ -16,7 +20,10 @@ import type {
 	ComputedEntitlementPriceTransitions,
 	EntitlementPriceTransition,
 } from "../../transitions/computeEntitlementPriceTransitions";
-import { computeCustomerEntitlementPatch } from "./computeCustomerEntitlementPatch";
+import {
+	computeCustomerEntitlementInitialState,
+	computeCustomerEntitlementPatch,
+} from "./computeCustomerEntitlementPatch";
 
 const findCandidateEntitlementIds = ({
 	candidateOutgoingEntitlements,
@@ -57,16 +64,39 @@ const computeReplaceOperation = ({
 	);
 	if (fromEntitlementIds.length === 0) return undefined;
 
+	const customerEntitlementPatch = computeCustomerEntitlementPatch({
+		fromEntitlement,
+		toEntitlement,
+	});
+	const fromIsPooled = fromEntitlement.pooled === true;
+	const toIsPooled = toEntitlement.pooled === true;
+	const isPooledReplace = fromIsPooled && toIsPooled;
+	if (!isPooledReplace) {
+		return {
+			type: "replace",
+			fromEntitlementIds,
+			toEntitlementId: toEntitlement.id,
+			fromEntitlementPrice,
+			toEntitlementPrice,
+			customerEntitlementPatch,
+		};
+	}
+
+	const incrementAmount =
+		customerEntitlementPatch.balance?.type === "increment"
+			? customerEntitlementPatch.balance.amount
+			: 0;
+
 	return {
 		type: "replace",
 		fromEntitlementIds,
 		toEntitlementId: toEntitlement.id,
 		fromEntitlementPrice,
 		toEntitlementPrice,
-		customerEntitlementPatch: computeCustomerEntitlementPatch({
-			fromEntitlement,
-			toEntitlement,
-		}),
+		customerEntitlementPatch: {
+			unlimited: customerEntitlementPatch.unlimited,
+		},
+		pooledContributionPatch: { type: "increment", amount: incrementAmount },
 	};
 };
 
@@ -87,15 +117,61 @@ const computeAddOperation = ({
 	});
 	existingEntitlementIds.push(entitlementPrice.entitlement.id);
 
+	const entitlement = entitlementPrice.entitlement;
+	const customerEntitlement = initCustomerEntitlementFields({
+		initContext,
+		initOptions,
+		entitlement,
+	});
+	if (entitlement.pooled !== true) {
+		return {
+			type: "add",
+			entitlementPrice,
+			existingEntitlementIds: [...new Set(existingEntitlementIds)],
+			customerEntitlement,
+		};
+	}
+
+	const customerLicenseLinkId = initOptions.customerLicenseLinkId;
+	if (!customerLicenseLinkId) {
+		throw new Error(
+			"Pooled entitlement addition requires a customer license link",
+		);
+	}
+
+	const initialState = computeCustomerEntitlementInitialState({ entitlement });
+	const entIdentity = entToPooledBalanceIdentity({ entitlement });
+	const resetMode =
+		entIdentity.interval === EntInterval.Lifetime
+			? PooledBalanceResetMode.Lifetime
+			: PooledBalanceResetMode.Lazy;
+	const isLifetimeReset = resetMode === PooledBalanceResetMode.Lifetime;
 	return {
 		type: "add",
 		entitlementPrice,
 		existingEntitlementIds: [...new Set(existingEntitlementIds)],
-		customerEntitlement: initCustomerEntitlementFields({
-			initContext,
-			initOptions,
-			entitlement: entitlementPrice.entitlement,
-		}),
+		customerEntitlement: {
+			...customerEntitlement,
+			balance: 0,
+		},
+		pooledAdd: {
+			contributionAmount: initialState.granted,
+			nextResetAt: isLifetimeReset
+				? null
+				: (customerEntitlement.next_reset_at ?? null),
+			featureId: entitlement.feature.id,
+			rollover: entitlement.rollover ?? null,
+			identity: {
+				...entIdentity,
+				internalCustomerId: customerEntitlement.internal_customer_id,
+				resetCycleAnchor: isLifetimeReset
+					? null
+					: (customerEntitlement.reset_cycle_anchor ?? null),
+				resetMode,
+				stripeSubscriptionId: null,
+				customerLicenseLinkId,
+			},
+		},
 	};
 };
 
@@ -113,6 +189,51 @@ const computeRemoveOperation = ({
 	if (fromEntitlementIds.length === 0) return undefined;
 
 	return { type: "remove", entitlementPrice, fromEntitlementIds };
+};
+
+const computeTransitionOperations = ({
+	candidateOutgoingEntitlements,
+	transition,
+	initContext,
+	initOptions,
+}: {
+	candidateOutgoingEntitlements: EntitlementWithFeature[];
+	transition: EntitlementPriceTransition;
+	initContext: InitCustomerEntitlementContext;
+	initOptions: InitFullCustomerProductOptions;
+}): EntitlementPriceOperation[] => {
+	const fromEntitlement = transition.fromEntitlementPrice.entitlement;
+	const toEntitlement = transition.toEntitlementPrice.entitlement;
+	const fromIsPooled = fromEntitlement.pooled === true;
+	const toIsPooled = toEntitlement.pooled === true;
+	const isPooledAmountChange =
+		fromIsPooled &&
+		toIsPooled &&
+		entsHaveSamePooledIdentity(fromEntitlement, toEntitlement);
+
+	if (isPooledAmountChange || (!fromIsPooled && !toIsPooled)) {
+		const operation = computeReplaceOperation({
+			candidateOutgoingEntitlements,
+			transition,
+		});
+		return operation ? [operation] : [];
+	}
+
+	const operations: EntitlementPriceOperation[] = [];
+	const remove = computeRemoveOperation({
+		candidateOutgoingEntitlements,
+		entitlementPrice: transition.fromEntitlementPrice,
+	});
+	if (remove) operations.push(remove);
+	operations.push(
+		computeAddOperation({
+			candidateOutgoingEntitlements,
+			entitlementPrice: transition.toEntitlementPrice,
+			initContext,
+			initOptions,
+		}),
+	);
+	return operations;
 };
 
 const hasPrice = (entitlementPrice: EntitlementPrice) =>
@@ -148,11 +269,14 @@ export const computeEntitlementPriceOperations = ({
 			continue;
 		}
 
-		const operation = computeReplaceOperation({
-			candidateOutgoingEntitlements,
-			transition,
-		});
-		if (operation) operations.push(operation);
+		operations.push(
+			...computeTransitionOperations({
+				candidateOutgoingEntitlements,
+				transition,
+				initContext: customerEntitlementInitContext,
+				initOptions: customerEntitlementInitOptions,
+			}),
+		);
 	}
 
 	for (const entitlementPrice of entitlementPriceTransitions.added) {

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/executeCustomerEntitlementOperations.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/executeCustomerEntitlementOperations.ts
@@ -12,6 +12,7 @@ import { BATCH_TRANSITION_OPERATION_CONCURRENCY } from "../utils/batchTransition
 import { executeBatchedMutation } from "./executeBatchedMutation";
 import { addCustomerEntitlementsBatch } from "./sql/addCustomerEntitlementsBatch";
 import { deleteCustomerEntitlementsBatch } from "./sql/deleteCustomerEntitlementsBatch";
+import { insertPooledBalanceGraph } from "./sql/insertPooledBalanceGraph";
 import { replaceCustomerEntitlementsBatch } from "./sql/replaceCustomerEntitlementsBatch";
 
 const executeReplacement = async ({
@@ -55,8 +56,19 @@ const executeAddition = async ({
 	return executeBatchedMutation({
 		db: ctx.db,
 		operationName: "Customer entitlement addition",
-		executeBatch: ({ db, batchSize }) =>
-			addCustomerEntitlementsBatch({
+		executeBatch: async ({ db, batchSize }) => {
+			const pooledBalanceId = operation.pooledAdd
+				? await insertPooledBalanceGraph({
+						db,
+						pooledAdd: operation.pooledAdd,
+						customerId: operation.customerEntitlement.customer_id ?? null,
+						orgId: ctx.org.id,
+						env: ctx.env,
+						now: Date.now(),
+					})
+				: undefined;
+
+			return addCustomerEntitlementsBatch({
 				db,
 				customerLicenseLinkId: batchTransition.customerLicenseLinkId,
 				assignmentCutoffMs: batchTransition.assignmentCutoffMs,
@@ -65,7 +77,14 @@ const executeAddition = async ({
 				),
 				operation,
 				batchSize,
-			}),
+				pooledBalanceId,
+				contributionIds: pooledBalanceId
+					? Array.from({ length: batchSize }, () =>
+							generateId("pool_contribution"),
+						)
+					: undefined,
+			});
+		},
 	});
 };
 

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/addCustomerEntitlementsBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/addCustomerEntitlementsBatch.ts
@@ -1,8 +1,84 @@
-import { sql } from "drizzle-orm";
+import { type SQL, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AddEntitlementPriceOperation } from "../../types/entitlementPriceOperationTypes";
 import type { BatchMutationResult } from "../../types/types";
 import { activeStatusesSql, sqlList } from "./batchTransitionSqlUtils";
+
+const generatedContributionIdsCte = ({
+	contributionIds,
+}: {
+	contributionIds: string[];
+}): SQL => sql`,
+		generated_contribution_ids AS MATERIALIZED (
+			SELECT generated.id, generated.ordinality
+			FROM JSONB_ARRAY_ELEMENTS_TEXT(${JSON.stringify(contributionIds)}::jsonb)
+				WITH ORDINALITY AS generated(id, ordinality)
+		)`;
+
+// Same-statement UPDATE cannot see rows from `inserted` (CTE snapshot).
+// Write pooled_contribution_id on INSERT; never gate the granted bump on that UPDATE.
+const addPooledContributionsCtes = ({
+	pooledBalanceId,
+	contributionAmount,
+	now,
+}: {
+	pooledBalanceId: string;
+	contributionAmount: number;
+	now: number;
+}): SQL => sql`,
+		inserted_contributions AS (
+			INSERT INTO pooled_balance_contributions (
+				id,
+				pooled_balance_id,
+				source_customer_product_id,
+				source_customer_entitlement_id,
+				current_contribution,
+				next_cycle_contribution,
+				effective_at,
+				created_at,
+				updated_at
+			)
+			SELECT
+				contribution_id.id,
+				${pooledBalanceId},
+				inserted.customer_product_id,
+				inserted.id,
+				${contributionAmount},
+				${contributionAmount},
+				NULL,
+				${now},
+				${now}
+			FROM inserted
+			INNER JOIN generated_ids
+				ON generated_ids.id = inserted.id
+			INNER JOIN generated_contribution_ids AS contribution_id
+				ON contribution_id.ordinality = generated_ids.ordinality
+			ON CONFLICT (source_customer_entitlement_id) DO NOTHING
+			RETURNING id, source_customer_entitlement_id
+		),
+		pool_deltas AS (
+			SELECT COUNT(*)::int AS contribution_count
+			FROM inserted_contributions
+		),
+		updated_pools AS (
+			UPDATE pooled_balances AS pool
+			SET
+				granted = pool.granted + (${contributionAmount} * pool_deltas.contribution_count),
+				updated_at = ${now}
+			FROM pool_deltas
+			WHERE pool.id = ${pooledBalanceId}
+			RETURNING 1
+		),
+		updated_synthetic AS (
+			UPDATE customer_entitlements AS synthetic
+			SET
+				balance = COALESCE(synthetic.balance, 0) + (${contributionAmount} * pool_deltas.contribution_count),
+				cache_version = COALESCE(synthetic.cache_version, 0) + 1
+			FROM pool_deltas, updated_pools
+			WHERE synthetic.pooled_balance_id = ${pooledBalanceId}
+				AND synthetic.customer_product_id IS NULL
+			RETURNING 1
+		)`;
 
 export const addCustomerEntitlementsBatch = async ({
 	db,
@@ -11,6 +87,8 @@ export const addCustomerEntitlementsBatch = async ({
 	customerEntitlementIds,
 	operation,
 	batchSize,
+	pooledBalanceId,
+	contributionIds,
 }: {
 	db: DrizzleCli;
 	customerLicenseLinkId: string;
@@ -18,6 +96,8 @@ export const addCustomerEntitlementsBatch = async ({
 	customerEntitlementIds: string[];
 	operation: AddEntitlementPriceOperation;
 	batchSize: number;
+	pooledBalanceId?: string;
+	contributionIds?: string[];
 }): Promise<BatchMutationResult> => {
 	if (operation.existingEntitlementIds.length === 0) {
 		throw new Error("Customer entitlement addition requires candidate IDs");
@@ -25,8 +105,24 @@ export const addCustomerEntitlementsBatch = async ({
 	if (customerEntitlementIds.length !== batchSize) {
 		throw new Error("Customer entitlement addition requires one ID per row");
 	}
+	if (
+		pooledBalanceId &&
+		(!contributionIds || contributionIds.length !== batchSize)
+	) {
+		throw new Error(
+			"Pooled entitlement addition requires one contribution ID per row",
+		);
+	}
 
 	const customerEntitlement = operation.customerEntitlement;
+	const pooledAdd =
+		pooledBalanceId && contributionIds && operation.pooledAdd
+			? {
+					pooledBalanceId,
+					contributionIds,
+					contributionAmount: operation.pooledAdd.contributionAmount,
+				}
+			: undefined;
 	const [result] = await db.execute<BatchMutationResult>(sql`
 		WITH candidate_rows AS MATERIALIZED (
 			SELECT seat.id, seat.created_at
@@ -55,7 +151,8 @@ export const addCustomerEntitlementsBatch = async ({
 			SELECT generated.id, generated.ordinality
 			FROM JSONB_ARRAY_ELEMENTS_TEXT(${JSON.stringify(customerEntitlementIds)}::jsonb)
 				WITH ORDINALITY AS generated(id, ordinality)
-		),
+		)
+		${pooledAdd ? generatedContributionIdsCte({ contributionIds: pooledAdd.contributionIds }) : sql``},
 		inserted AS (
 			INSERT INTO customer_entitlements (
 				id,
@@ -79,6 +176,7 @@ export const addCustomerEntitlementsBatch = async ({
 				customer_id,
 				feature_id,
 				external_id
+				${pooledAdd ? sql`, pooled_contribution_id` : sql``}
 			)
 			SELECT
 				generated.id,
@@ -102,12 +200,28 @@ export const addCustomerEntitlementsBatch = async ({
 				${customerEntitlement.customer_id},
 				${customerEntitlement.feature_id},
 				${customerEntitlement.external_id}
+				${pooledAdd ? sql`, contribution_id.id` : sql``}
 			FROM target_rows AS target
 			INNER JOIN generated_ids AS generated
 				ON generated.ordinality = target.ordinal
+			${
+				pooledAdd
+					? sql`INNER JOIN generated_contribution_ids AS contribution_id
+				ON contribution_id.ordinality = generated.ordinality`
+					: sql``
+			}
 			ON CONFLICT (id) DO NOTHING
-			RETURNING 1
+			RETURNING id, customer_product_id
 		)
+		${
+			pooledAdd
+				? addPooledContributionsCtes({
+						pooledBalanceId: pooledAdd.pooledBalanceId,
+						contributionAmount: pooledAdd.contributionAmount,
+						now: Date.now(),
+					})
+				: sql``
+		}
 		SELECT
 			(SELECT COUNT(*)::int FROM inserted) AS affected,
 			(

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/deleteCustomerEntitlementsBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/deleteCustomerEntitlementsBatch.ts
@@ -1,8 +1,49 @@
-import { sql } from "drizzle-orm";
+import { type SQL, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { RemoveEntitlementPriceOperation } from "../../types/entitlementPriceOperationTypes";
 import type { BatchMutationResult } from "../../types/types";
 import { activeStatusesSql, sqlList } from "./batchTransitionSqlUtils";
+import { pooledRemoveBatchCtes } from "./pooledRemoveBatchCtes";
+
+const assignedSeatFilter = (
+	operation: RemoveEntitlementPriceOperation,
+): SQL =>
+	operation.entitlementPrice.entitlement.pooled === true
+		? sql``
+		: sql`AND seat.internal_entity_id IS NOT NULL`;
+
+const pooledRemoveCtes = ({
+	operation,
+	now,
+}: {
+	operation: RemoveEntitlementPriceOperation;
+	now: number;
+}): SQL =>
+	operation.entitlementPrice.entitlement.pooled === true
+		? pooledRemoveBatchCtes({ now })
+		: sql``;
+
+const deletedCte = ({
+	operation,
+}: {
+	operation: RemoveEntitlementPriceOperation;
+}): SQL =>
+	operation.entitlementPrice.entitlement.pooled === true
+		? sql`
+		deleted AS (
+			DELETE FROM customer_entitlements AS customer_entitlement
+			USING target_rows
+			WHERE customer_entitlement.id = target_rows.target_id
+				AND (SELECT COALESCE(COUNT(*), 0) FROM updated_synthetic) >= 0
+			RETURNING 1
+		)`
+		: sql`
+		deleted AS (
+			DELETE FROM customer_entitlements AS customer_entitlement
+			USING target_rows
+			WHERE customer_entitlement.ctid = target_rows.target_ctid
+			RETURNING 1
+		)`;
 
 export const deleteCustomerEntitlementsBatch = async ({
 	db,
@@ -15,14 +56,17 @@ export const deleteCustomerEntitlementsBatch = async ({
 	operation: RemoveEntitlementPriceOperation;
 	batchSize: number;
 }): Promise<BatchMutationResult> => {
+	const now = Date.now();
 	const [result] = await db.execute<BatchMutationResult>(sql`
 		WITH candidate_rows AS MATERIALIZED (
-			SELECT customer_entitlement.ctid AS target_ctid
+			SELECT
+				customer_entitlement.ctid AS target_ctid,
+				customer_entitlement.id AS target_id
 			FROM customer_products AS seat
 			INNER JOIN customer_entitlements AS customer_entitlement
 				ON customer_entitlement.customer_product_id = seat.id
 			WHERE seat.customer_license_link_id = ${customerLicenseLinkId}
-				AND seat.internal_entity_id IS NOT NULL
+				${assignedSeatFilter(operation)}
 				AND seat.status IN (${activeStatusesSql})
 				AND customer_entitlement.entitlement_id IN (${sqlList({ values: operation.fromEntitlementIds })})
 			ORDER BY seat.created_at, seat.id, customer_entitlement.id
@@ -30,16 +74,12 @@ export const deleteCustomerEntitlementsBatch = async ({
 			LIMIT ${batchSize + 1}
 		),
 		target_rows AS MATERIALIZED (
-			SELECT target_ctid
+			SELECT target_ctid, target_id
 			FROM candidate_rows
 			LIMIT ${batchSize}
-		),
-		deleted AS (
-			DELETE FROM customer_entitlements AS customer_entitlement
-			USING target_rows
-			WHERE customer_entitlement.ctid = target_rows.target_ctid
-			RETURNING 1
 		)
+		${pooledRemoveCtes({ operation, now })}
+		, ${deletedCte({ operation })}
 		SELECT
 			(SELECT COUNT(*)::int FROM deleted) AS affected,
 			(SELECT COUNT(*) > ${batchSize} FROM candidate_rows) AS "hasMore"

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/insertPooledBalanceGraph.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/insertPooledBalanceGraph.ts
@@ -1,0 +1,150 @@
+import {
+	AllowanceType,
+	customerEntitlements,
+	entitlements,
+	pooledBalances,
+} from "@autumn/shared";
+import { and, eq, isNull } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { isUniqueConstraintError } from "@/db/dbUtils.js";
+import { generateId } from "@/utils/genUtils.js";
+import type {
+	PooledAddIdentity,
+	PooledAddSpec,
+} from "../../types/entitlementPriceOperationTypes";
+
+const findLivePooledBalanceId = async ({
+	db,
+	identity,
+}: {
+	db: DrizzleCli;
+	identity: PooledAddIdentity;
+}): Promise<string | undefined> => {
+	const [existing] = await db
+		.select({ id: pooledBalances.id })
+		.from(pooledBalances)
+		.where(
+			and(
+				eq(pooledBalances.internal_customer_id, identity.internalCustomerId),
+				eq(pooledBalances.internal_feature_id, identity.internalFeatureId),
+				eq(pooledBalances.unlimited, identity.unlimited),
+				eq(pooledBalances.interval, identity.interval),
+				eq(pooledBalances.interval_count, identity.intervalCount),
+				identity.resetCycleAnchor === null
+					? isNull(pooledBalances.reset_cycle_anchor)
+					: eq(pooledBalances.reset_cycle_anchor, identity.resetCycleAnchor),
+				eq(pooledBalances.reset_mode, identity.resetMode),
+				isNull(pooledBalances.stripe_subscription_id),
+				eq(
+					pooledBalances.customer_license_link_id,
+					identity.customerLicenseLinkId,
+				),
+				eq(pooledBalances.rollover_signature, identity.rolloverSignature),
+				isNull(pooledBalances.expires_at),
+			),
+		)
+		.limit(1);
+
+	return existing?.id;
+};
+
+/** One synthetic cusEnt + custom entitlement + pool row for this identity. */
+export const insertPooledBalanceGraph = async ({
+	db,
+	pooledAdd,
+	customerId,
+	orgId,
+	env,
+	now,
+}: {
+	db: DrizzleCli;
+	pooledAdd: PooledAddSpec;
+	customerId: string | null;
+	orgId: string;
+	env: string;
+	now: number;
+}): Promise<string> => {
+	const existingId = await findLivePooledBalanceId({
+		db,
+		identity: pooledAdd.identity,
+	});
+	if (existingId) return existingId;
+
+	const { identity, nextResetAt, featureId, rollover } = pooledAdd;
+	const entitlementId = generateId("ent");
+	const customerEntitlementId = generateId("cus_ent");
+	const pooledBalanceId = generateId("pool");
+
+	try {
+		await db.insert(entitlements).values({
+			id: entitlementId,
+			created_at: now,
+			internal_feature_id: identity.internalFeatureId,
+			internal_product_id: null,
+			internal_reward_id: null,
+			is_custom: true,
+			allowance_type: AllowanceType.Fixed,
+			allowance: 0,
+			interval: identity.interval,
+			interval_count: identity.intervalCount,
+			carry_from_previous: false,
+			pooled: true,
+			org_id: orgId,
+			feature_id: featureId,
+			rollover,
+		});
+		await db.insert(customerEntitlements).values({
+			id: customerEntitlementId,
+			customer_product_id: null,
+			entitlement_id: entitlementId,
+			internal_customer_id: identity.internalCustomerId,
+			internal_entity_id: null,
+			internal_feature_id: identity.internalFeatureId,
+			unlimited: identity.unlimited,
+			balance: 0,
+			created_at: now,
+			reset_cycle_anchor: identity.resetCycleAnchor,
+			next_reset_at: nextResetAt,
+			usage_allowed: false,
+			separate_interval: false,
+			adjustment: 0,
+			additional_balance: 0,
+			entities: null,
+			expires_at: null,
+			cache_version: 0,
+			customer_id: customerId,
+			feature_id: featureId,
+			external_id: null,
+			is_pooled_balance: true,
+			pooled_balance_id: pooledBalanceId,
+			reset_by_invoice: false,
+		});
+		await db.insert(pooledBalances).values({
+			id: pooledBalanceId,
+			org_id: orgId,
+			env,
+			internal_customer_id: identity.internalCustomerId,
+			internal_feature_id: identity.internalFeatureId,
+			unlimited: identity.unlimited,
+			granted: 0,
+			interval: identity.interval,
+			interval_count: identity.intervalCount,
+			reset_cycle_anchor: identity.resetCycleAnchor,
+			reset_mode: identity.resetMode,
+			stripe_subscription_id: null,
+			customer_license_link_id: identity.customerLicenseLinkId,
+			rollover_signature: identity.rolloverSignature,
+			customer_entitlement_id: customerEntitlementId,
+			last_applied_reset_at: null,
+			expires_at: null,
+			created_at: now,
+			updated_at: now,
+		});
+		return pooledBalanceId;
+	} catch (error) {
+		if (!isUniqueConstraintError(error)) throw error;
+		const racedId = await findLivePooledBalanceId({ db, identity });
+		if (!racedId) throw error;
+		return racedId;
+	}
+};

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/pooledRemoveBatchCtes.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/pooledRemoveBatchCtes.ts
@@ -1,0 +1,64 @@
+import { type SQL, sql } from "drizzle-orm";
+
+const leftoverContributionsExistSql = sql`
+			EXISTS (
+				SELECT 1
+				FROM pooled_balance_contributions AS contribution
+				WHERE contribution.pooled_balance_id = pool.id
+					AND NOT EXISTS (
+						SELECT 1
+						FROM locked_contributions AS locked
+						WHERE locked.id = contribution.id
+					)
+			)`;
+
+export const pooledRemoveBatchCtes = ({ now }: { now: number }): SQL => sql`,
+		locked_contributions AS MATERIALIZED (
+			SELECT
+				contribution.id,
+				contribution.pooled_balance_id,
+				contribution.current_contribution
+			FROM pooled_balance_contributions AS contribution
+			INNER JOIN customer_entitlements AS customer_entitlement
+				ON customer_entitlement.id = contribution.source_customer_entitlement_id
+			INNER JOIN target_rows
+				ON customer_entitlement.id = target_rows.target_id
+		),
+		deleted_contributions AS (
+			DELETE FROM pooled_balance_contributions AS contribution
+			USING locked_contributions
+			WHERE contribution.id = locked_contributions.id
+			RETURNING contribution.pooled_balance_id, contribution.current_contribution
+		),
+		pool_deltas AS (
+			SELECT
+				pooled_balance_id,
+				COUNT(*)::int AS contribution_count,
+				SUM(current_contribution) AS granted_delta
+			FROM deleted_contributions
+			GROUP BY pooled_balance_id
+		),
+		updated_pools AS (
+			UPDATE pooled_balances AS pool
+			SET
+				granted = pool.granted - pool_deltas.granted_delta,
+				expires_at = CASE
+					WHEN ${leftoverContributionsExistSql} THEN pool.expires_at
+					ELSE ${now}
+				END,
+				updated_at = ${now}
+			FROM pool_deltas
+			WHERE pool.id = pool_deltas.pooled_balance_id
+			RETURNING pool.id, pool.expires_at
+		),
+		updated_synthetic AS (
+			UPDATE customer_entitlements AS synthetic
+			SET
+				balance = COALESCE(synthetic.balance, 0) - pool_deltas.granted_delta,
+				expires_at = updated_pools.expires_at,
+				cache_version = COALESCE(synthetic.cache_version, 0) + 1
+			FROM pool_deltas, updated_pools
+			WHERE synthetic.pooled_balance_id = pool_deltas.pooled_balance_id
+				AND synthetic.customer_product_id IS NULL
+			RETURNING 1
+		)`;

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch.ts
@@ -15,6 +15,58 @@ const balanceAssignment = (
 	return sql`, balance = ${patch.amount}`;
 };
 
+const assignedSeatFilter = (
+	operation: ReplaceEntitlementPriceOperation,
+): SQL =>
+	operation.pooledContributionPatch
+		? sql``
+		: sql`AND seat.internal_entity_id IS NOT NULL`;
+
+const pooledAggregateCtes = (
+	operation: ReplaceEntitlementPriceOperation,
+): SQL => {
+	const amount = operation.pooledContributionPatch?.amount;
+	if (!amount) return sql``;
+	const now = Date.now();
+	return sql`,
+		updated_contributions AS (
+			UPDATE pooled_balance_contributions AS contribution
+			SET
+				current_contribution = contribution.current_contribution + ${amount},
+				next_cycle_contribution = contribution.next_cycle_contribution + ${amount},
+				updated_at = ${now}
+			FROM updated
+			WHERE contribution.source_customer_entitlement_id = updated.id
+			RETURNING contribution.pooled_balance_id
+		),
+		pool_deltas AS (
+			SELECT
+				pooled_balance_id,
+				COUNT(*)::int AS contribution_count
+			FROM updated_contributions
+			GROUP BY pooled_balance_id
+		),
+		updated_pools AS (
+			UPDATE pooled_balances AS pool
+			SET
+				granted = pool.granted + (${amount} * pool_deltas.contribution_count),
+				updated_at = ${now}
+			FROM pool_deltas
+			WHERE pool.id = pool_deltas.pooled_balance_id
+			RETURNING 1
+		),
+		updated_synthetic AS (
+			UPDATE customer_entitlements AS synthetic
+			SET
+				balance = COALESCE(synthetic.balance, 0) + (${amount} * pool_deltas.contribution_count),
+				cache_version = COALESCE(synthetic.cache_version, 0) + 1
+			FROM pool_deltas
+			WHERE synthetic.pooled_balance_id = pool_deltas.pooled_balance_id
+				AND synthetic.customer_product_id IS NULL
+			RETURNING 1
+		)`;
+};
+
 export const replaceCustomerEntitlementsBatch = async ({
 	db,
 	customerLicenseLinkId,
@@ -38,7 +90,7 @@ export const replaceCustomerEntitlementsBatch = async ({
 			INNER JOIN customer_entitlements AS customer_entitlement
 				ON customer_entitlement.customer_product_id = seat.id
 			WHERE seat.customer_license_link_id = ${customerLicenseLinkId}
-				AND seat.internal_entity_id IS NOT NULL
+				${assignedSeatFilter(operation)}
 				AND seat.status IN (${activeStatusesSql})
 				AND customer_entitlement.entitlement_id IN (${sqlList({ values: operation.fromEntitlementIds })})
 			ORDER BY seat.created_at, seat.id, customer_entitlement.id
@@ -61,8 +113,9 @@ export const replaceCustomerEntitlementsBatch = async ({
 				${unlimitedAssignment}
 			FROM target_rows
 			WHERE customer_entitlement.ctid = target_rows.target_ctid
-			RETURNING 1
+			RETURNING customer_entitlement.id
 		)
+		${pooledAggregateCtes(operation)}
 		SELECT
 			(SELECT COUNT(*)::int FROM updated) AS affected,
 			(SELECT COUNT(*) > ${batchSize} FROM candidate_rows) AS "hasMore"

--- a/server/src/internal/billing/v2/actions/batchTransition/types/entitlementPriceOperationTypes.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/types/entitlementPriceOperationTypes.ts
@@ -1,4 +1,9 @@
-import type { EntitlementPrice } from "@autumn/shared";
+import type {
+	EntInterval,
+	EntitlementPrice,
+	PooledBalanceResetMode,
+	RolloverConfig,
+} from "@autumn/shared";
 import type { InitCustomerEntitlementFields } from "@/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlementFields";
 
 export type CustomerEntitlementBalancePatch =
@@ -10,6 +15,11 @@ export type CustomerEntitlementPatch = {
 	unlimited?: boolean | null;
 };
 
+export type PooledContributionPatch = {
+	type: "increment";
+	amount: number;
+};
+
 export type ReplaceEntitlementPriceOperation = {
 	type: "replace";
 	fromEntitlementIds: string[];
@@ -17,6 +27,29 @@ export type ReplaceEntitlementPriceOperation = {
 	fromEntitlementPrice: EntitlementPrice;
 	toEntitlementPrice: EntitlementPrice;
 	customerEntitlementPatch: CustomerEntitlementPatch;
+	/** Present when both sides are pooled: source balance stays 0; Δ goes to contributions + pool. */
+	pooledContributionPatch?: PooledContributionPatch;
+};
+
+export type PooledAddIdentity = {
+	internalCustomerId: string;
+	internalFeatureId: string;
+	unlimited: boolean;
+	interval: EntInterval;
+	intervalCount: number;
+	resetCycleAnchor: number | null;
+	resetMode: PooledBalanceResetMode;
+	stripeSubscriptionId: null;
+	customerLicenseLinkId: string;
+	rolloverSignature: string;
+};
+
+export type PooledAddSpec = {
+	contributionAmount: number;
+	identity: PooledAddIdentity;
+	nextResetAt: number | null;
+	featureId: string;
+	rollover: RolloverConfig | null;
 };
 
 export type AddEntitlementPriceOperation = {
@@ -24,6 +57,8 @@ export type AddEntitlementPriceOperation = {
 	entitlementPrice: EntitlementPrice;
 	existingEntitlementIds: string[];
 	customerEntitlement: InitCustomerEntitlementFields;
+	/** Present when the added entitlement is pooled: sources stay at 0. */
+	pooledAdd?: PooledAddSpec;
 };
 
 export type RemoveEntitlementPriceOperation = {

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/computePooledBalanceLifecycle.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/computePooledBalanceLifecycle.ts
@@ -89,17 +89,17 @@ const getPooledBalanceLifecycleIds = ({
 	PooledBalanceLifecycle,
 	"stripeSubscriptionId" | "customerLicenseLinkId"
 > => {
-	if (resetMode === PooledBalanceResetMode.Lifetime) {
-		return {
-			stripeSubscriptionId: null,
-			customerLicenseLinkId: null,
-		};
-	}
-
 	if (customerProduct.customer_license_link_id) {
 		return {
 			stripeSubscriptionId: null,
 			customerLicenseLinkId: customerProduct.customer_license_link_id,
+		};
+	}
+
+	if (resetMode === PooledBalanceResetMode.Lifetime) {
+		return {
+			stripeSubscriptionId: null,
+			customerLicenseLinkId: null,
 		};
 	}
 

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initCustomerEntitlementPooledIdentity.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initCustomerEntitlementPooledIdentity.ts
@@ -1,10 +1,7 @@
 import {
-	EntInterval,
+	entToPooledBalanceIdentity,
 	type FullCustomerEntitlement,
-	isBooleanEntitlement,
-	isUnlimitedEntitlement,
 	type PooledBalanceIdentity,
-	rolloverConfigToSignature,
 } from "@autumn/shared";
 import type { PooledBalanceLifecycle } from "../types/pooledBalanceComputeTypes";
 
@@ -22,28 +19,12 @@ export const initCustomerEntitlementPooledIdentity = ({
 }: {
 	customerEntitlement: FullCustomerEntitlement;
 	lifecycle: PooledBalanceIdentityLifecycle;
-}): PooledBalanceIdentity => {
-	const unlimited = isUnlimitedEntitlement({
+}): PooledBalanceIdentity => ({
+	...entToPooledBalanceIdentity({
 		entitlement: customerEntitlement.entitlement,
-	});
-	const tracksBalance =
-		!unlimited &&
-		!isBooleanEntitlement({
-			entitlement: customerEntitlement.entitlement,
-		});
-	const rollover = tracksBalance
-		? customerEntitlement.entitlement.rollover
-		: null;
-
-	return {
-		internalFeatureId: customerEntitlement.internal_feature_id,
-		unlimited,
-		interval: customerEntitlement.entitlement.interval ?? EntInterval.Lifetime,
-		intervalCount: customerEntitlement.entitlement.interval_count ?? 1,
-		resetCycleAnchor: lifecycle.resetCycleAnchor,
-		resetMode: lifecycle.resetMode,
-		stripeSubscriptionId: lifecycle.stripeSubscriptionId,
-		customerLicenseLinkId: lifecycle.customerLicenseLinkId,
-		rolloverSignature: rolloverConfigToSignature({ rollover }),
-	};
-};
+	}),
+	resetCycleAnchor: lifecycle.resetCycleAnchor,
+	resetMode: lifecycle.resetMode,
+	stripeSubscriptionId: lifecycle.stripeSubscriptionId,
+	customerLicenseLinkId: lifecycle.customerLicenseLinkId,
+});

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -26,6 +26,7 @@ import {
 	getCustomerListFilterSql,
 	POOLED_CUSTOMER_ENTITLEMENT_LIMIT,
 } from "./getFullCusQuery.js";
+import { licensePooledBalanceIsLiveSql } from "./licensePooledBalanceIsLiveSql.js";
 import { looseEntitlementIsLiveSql } from "./looseEntitlementSql.js";
 
 export type CursorPaginatedFullCusQueryArgs = {
@@ -338,6 +339,8 @@ export const getCursorPaginatedFullCusQuery = ({
 			JOIN LATERAL (
 				SELECT ce.*
 				FROM customer_entitlements ce
+				JOIN pooled_balances live_pb ON live_pb.id = ce.pooled_balance_id
+					AND ${licensePooledBalanceIsLiveSql({ pooledBalanceAlias: "live_pb" })}
 				WHERE ce.internal_customer_id = cr.internal_id
 					AND ce.customer_product_id IS NULL
 					AND ce.pooled_balance_id IS NOT NULL

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -42,6 +42,7 @@ import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { RepoContext } from "@/db/repoContext";
 import { withStatementTimeout } from "@/db/withStatementTimeout.js";
 import { markCustomersUpdatedAtByInternalIds } from "@/internal/customers/customerLsns/markCustomerUpdatedAt.js";
+import { licensePooledBalanceIsLiveSql } from "@/internal/customers/licensePooledBalanceIsLiveSql.js";
 import RecaseError from "@/utils/errorUtils.js";
 
 export class CusEntService {
@@ -427,6 +428,9 @@ export class CusEntService {
 					isNull(customerEntitlements.customer_product_id),
 					isCronResettableLooseCustomerEntitlement(),
 					commonResetPredicates(),
+					licensePooledBalanceIsLiveSql({
+						pooledBalanceAlias: "pooled_balances",
+					}),
 					afterCursor(),
 				),
 			);

--- a/server/src/internal/customers/cusProducts/cusEnts/repos/getResetContextByIds.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/repos/getResetContextByIds.ts
@@ -3,6 +3,7 @@ import { RELEVANT_STATUSES } from "@autumn/shared";
 import { sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { resetCronQueryTag } from "@/internal/balances/batchReset/resetCronQueryTag.js";
+import { licensePooledBalanceIsLiveSql } from "@/internal/customers/licensePooledBalanceIsLiveSql.js";
 
 /**
  * A customer entitlement hydrated with everything batch reset needs:
@@ -91,6 +92,7 @@ export const buildResetContextByIdsQuery = ({
 		WHERE e.rollover IS NOT NULL AND r.cus_ent_id = ce.id
 	) rollovers_agg ON true
 	WHERE ce.id = ANY(${sql.param(customerEntitlementIds)}::text[])
+		AND ${licensePooledBalanceIsLiveSql()}
 	${resetCronQueryTag("hydrateContext")}
 `;
 

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -9,6 +9,7 @@ import {
 import { type SQL, sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
 import { resolvedProductIdsSql } from "@/internal/invoices/repos/utils/resolvedProductIdsSql.js";
+import { licensePooledBalanceIsLiveSql } from "./licensePooledBalanceIsLiveSql.js";
 import { looseEntitlementIsLiveSql } from "./looseEntitlementSql.js";
 
 const RECURRING_BILLING_INTERVALS = [
@@ -435,8 +436,10 @@ const buildPooledCustomerEntitlementsCTE = () => sql`
 			'[]'::json
 		) AS pooled_customer_entitlements
 		FROM (
-			SELECT *
+			SELECT ce.*
 			FROM customer_entitlements ce
+			JOIN pooled_balances live_pb ON live_pb.id = ce.pooled_balance_id
+				AND ${licensePooledBalanceIsLiveSql({ pooledBalanceAlias: "live_pb" })}
 			WHERE ce.internal_customer_id = (SELECT internal_id FROM customer_record)
 				AND ce.customer_product_id IS NULL
 				AND ce.pooled_balance_id IS NOT NULL
@@ -795,8 +798,10 @@ export const getPaginatedFullCusQuery = ({
 			) AS pooled_customer_entitlements
 		FROM customer_records cr
 		LEFT JOIN LATERAL (
-			SELECT *
+			SELECT ce.*
 			FROM customer_entitlements ce
+			JOIN pooled_balances live_pb ON live_pb.id = ce.pooled_balance_id
+				AND ${licensePooledBalanceIsLiveSql({ pooledBalanceAlias: "live_pb" })}
 			WHERE ce.internal_customer_id = cr.internal_id
 				AND ce.customer_product_id IS NULL
 				AND ce.pooled_balance_id IS NOT NULL

--- a/server/src/internal/customers/licensePooledBalanceIsLiveSql.ts
+++ b/server/src/internal/customers/licensePooledBalanceIsLiveSql.ts
@@ -1,0 +1,27 @@
+import { RELEVANT_STATUSES } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+
+/** License-keyed pools inherit parent liveness the same way seats do:
+ * no write-path expire — a dead parent hides the pool at read time. */
+export const licensePooledBalanceIsLiveSql = ({
+	pooledBalanceAlias = "pb",
+}: {
+	pooledBalanceAlias?: string;
+} = {}) => {
+	const pb = sql.raw(pooledBalanceAlias);
+	return sql`(
+		${pb}.customer_license_link_id IS NULL
+		OR EXISTS (
+			SELECT 1
+			FROM customer_licenses pool
+			JOIN customer_products pool_parent
+				ON pool_parent.id = pool.parent_customer_product_id
+			WHERE pool.link_id = ${pb}.customer_license_link_id
+				AND pool.internal_customer_id = ${pb}.internal_customer_id
+				AND pool_parent.status IN (${sql.join(
+					RELEVANT_STATUSES.map((status) => sql`${status}`),
+					sql`, `,
+				)})
+		)
+	)`;
+};

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
@@ -7,6 +7,7 @@ import { type SQL, sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
 import { resolvedProductIdsSql } from "@/internal/invoices/repos/utils/resolvedProductIdsSql.js";
 import { notLicenseAssignmentSql } from "@/internal/licenses/repos/licenseAssignmentRepo.js";
+import { licensePooledBalanceIsLiveSql } from "../../licensePooledBalanceIsLiveSql.js";
 import { looseEntitlementIsLiveSql } from "../../looseEntitlementSql.js";
 import { composeCustomerLicensesCtes } from "./composeCustomerLicensesCtes.js";
 import { getEntityAggregateFragments } from "./getEntityAggregateFragments.js";
@@ -324,6 +325,7 @@ export const getFullSubjectRowsQuery = ({
 				FROM customer_entitlements ce
 				JOIN pooled_balances pb
 					ON pb.id = ce.pooled_balance_id
+					AND ${licensePooledBalanceIsLiveSql()}
 				WHERE ce.internal_customer_id = sr.internal_customer_id
 					AND ce.customer_product_id IS NULL
 					AND ce.pooled_balance_id IS NOT NULL

--- a/server/src/internal/licenses/actions/links/validateLicenseLink.ts
+++ b/server/src/internal/licenses/actions/links/validateLicenseLink.ts
@@ -20,15 +20,6 @@ export const validateLicenseLink = ({
 	if (prepaidOnly !== undefined) {
 		validateLicenseBillingMode({ prepaidOnly });
 	}
-	for (const entitlement of licenseProduct.entitlements) {
-		if (!entitlement.pooled) continue;
-
-		throw new RecaseError({
-			message: `Pooled items are not supported for plan licenses (${licensePlanId ?? licenseProduct.id}).`,
-			code: ErrCode.InvalidRequest,
-			statusCode: 400,
-		});
-	}
 	if (licensePlanId && licenseProduct.archived) {
 		throw new RecaseError({
 			message: `License plan ${licensePlanId} is archived and cannot be linked.`,

--- a/server/src/internal/licenses/actions/reconcile/expireUnusedAssignments.ts
+++ b/server/src/internal/licenses/actions/reconcile/expireUnusedAssignments.ts
@@ -1,5 +1,7 @@
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { applyPooledBalanceCustomerProductTransitions } from "@/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCustomerProductTransitions.js";
 import { licenseAssignmentRepo } from "../../repos/licenseAssignmentRepo.js";
+import { listFullCustomerProductsByIds } from "../../repos/listFullCustomerProductsByIds.js";
 import type { ReconcileContext } from "./types.js";
 
 /** Over-allocated pools (remaining < 0) can never rebind their released
@@ -16,9 +18,25 @@ export const expireUnusedAssignments = async ({
 		.map((customerLicense) => customerLicense.link_id);
 	if (overAllocatedLinkIds.length === 0) return;
 
-	await licenseAssignmentRepo.expireUnusedAssignmentsByLinkIds({
+	const endedAt = Date.now();
+	const expiredSeats =
+		await licenseAssignmentRepo.expireUnusedAssignmentsByLinkIds({
+			db: ctx.db,
+			customerLicenseLinkIds: overAllocatedLinkIds,
+			endedAt,
+		});
+	if (expiredSeats.length === 0) return;
+
+	// Unassigned seats that are expired (eg, over-allocated pools) are outgoing
+	const outgoingCustomerProducts = await listFullCustomerProductsByIds({
 		db: ctx.db,
-		customerLicenseLinkIds: overAllocatedLinkIds,
-		endedAt: Date.now(),
+		customerProductIds: expiredSeats.map((seat) => seat.id),
+	});
+	await applyPooledBalanceCustomerProductTransitions({
+		ctx,
+		fullCustomer: context.fullCustomer,
+		outgoingCustomerProducts,
+		incomingCustomerProducts: [],
+		now: endedAt,
 	});
 };

--- a/server/src/internal/licenses/repos/licenseAssignmentRepo.ts
+++ b/server/src/internal/licenses/repos/licenseAssignmentRepo.ts
@@ -217,8 +217,8 @@ const expireUnusedAssignmentsByLinkIds = async ({
 	customerLicenseLinkIds: string[];
 	endedAt: number;
 }) => {
-	if (customerLicenseLinkIds.length === 0) return;
-	await db
+	if (customerLicenseLinkIds.length === 0) return [];
+	return db
 		.update(customerProducts)
 		.set({ status: CusProductStatus.Expired, ended_at: endedAt })
 		.where(
@@ -230,7 +230,8 @@ const expireUnusedAssignmentsByLinkIds = async ({
 				isNull(customerProducts.internal_entity_id),
 				inArray(customerProducts.status, ACTIVE_STATUSES),
 			),
-		);
+		)
+		.returning();
 };
 
 /** Seats are grouped through their customer license — the seat's own parent

--- a/server/src/internal/licenses/repos/listFullCustomerProductsByIds.ts
+++ b/server/src/internal/licenses/repos/listFullCustomerProductsByIds.ts
@@ -1,0 +1,34 @@
+import { customerProducts, type FullCusProduct } from "@autumn/shared";
+import { inArray } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+/** Hydrate specific customer_products by id — no status filter, so an
+ * expire's RETURNING set can be loaded after the write. */
+export const listFullCustomerProductsByIds = async ({
+	db,
+	customerProductIds,
+}: {
+	db: DrizzleCli;
+	customerProductIds: string[];
+}): Promise<FullCusProduct[]> => {
+	if (customerProductIds.length === 0) return [];
+
+	const seats = await db.query.customerProducts.findMany({
+		where: inArray(customerProducts.id, customerProductIds),
+		with: {
+			product: true,
+			customer_entitlements: {
+				with: {
+					entitlement: { with: { feature: true } },
+					replaceables: true,
+					rollovers: true,
+					pooled_balance_contribution: true,
+				},
+			},
+			customer_prices: { with: { price: true } },
+			free_trial: true,
+		},
+	});
+
+	return seats as FullCusProduct[];
+};

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/licenses/batch-license-pooled-transitions.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/licenses/batch-license-pooled-transitions.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Every pooled transition shape declines the batch lane and completes on the
+ * per-customer lane: pooled→pooled Δ, private→pooled, pooled→private.
+ *
+ * The batch lane's set-based writes never reach a pool's anchor row
+ * (customer_product_id NULL), so `pooled_add_item` rejects any customize
+ * whose remove/add sides touch a pooled entitlement.
+ */
+import { expect, test } from "bun:test";
+import { BillingInterval } from "@autumn/shared";
+import { runChunkedMigration } from "@tests/integration/billing/migrations-v2/utils/runChunkedMigration";
+import { setupLicenseUpdateScenario } from "@tests/integration/licenses/billing/update/setupLicenseUpdateScenario";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import chalk from "chalk";
+
+const INCLUDED_SEATS = 1;
+const ATTACHED_SEATS = 3;
+const ASSIGNED_SEATS = 2;
+const SEAT_MESSAGES = 100;
+const NEW_SEAT_MESSAGES = 200;
+
+const removeMonthlyMessages = {
+	feature_id: TestFeature.Messages,
+	interval: BillingInterval.Month,
+	interval_count: 1,
+};
+
+const laneCases = [
+	{
+		id: "pooled-delta",
+		label: "pooled→pooled allowance change",
+		seatItem: () => ({
+			...items.monthlyMessages({ includedUsage: SEAT_MESSAGES }),
+			pooled: true,
+		}),
+		customize: {
+			add_items: [
+				{
+					...itemsV2.monthlyMessages({ included: NEW_SEAT_MESSAGES }),
+					pooled: true,
+				},
+			],
+			remove_items: [removeMonthlyMessages],
+		},
+	},
+	{
+		id: "to-pooled",
+		label: "private→pooled flip",
+		seatItem: () => items.monthlyMessages({ includedUsage: SEAT_MESSAGES }),
+		customize: {
+			add_items: [
+				{
+					...itemsV2.monthlyMessages({ included: SEAT_MESSAGES }),
+					pooled: true,
+				},
+			],
+			remove_items: [removeMonthlyMessages],
+		},
+	},
+	{
+		id: "to-private",
+		label: "pooled→private flip",
+		seatItem: () => ({
+			...items.monthlyMessages({ includedUsage: SEAT_MESSAGES }),
+			pooled: true,
+		}),
+		customize: {
+			add_items: [itemsV2.monthlyMessages({ included: SEAT_MESSAGES })],
+			remove_items: [removeMonthlyMessages],
+		},
+	},
+];
+
+for (const laneCase of laneCases) {
+	test(`${chalk.yellowBright(`batch-license-pooled: ${laneCase.label} stays off the batch lane`)}`, async () => {
+		const customerId = `batch-pooled-lane-${laneCase.id}`;
+		const idPrefix = `batch-pooled-lane-${laneCase.id}`;
+
+		const scenario = await setupLicenseUpdateScenario({
+			customerId,
+			idPrefix,
+			seatItems: [laneCase.seatItem()],
+			includedSeats: INCLUDED_SEATS,
+			attachedSeats: ATTACHED_SEATS,
+		});
+		await scenario.assignSeats({ count: ASSIGNED_SEATS });
+
+		const { ctx, autumnV2_2, parent, devSeat } = scenario;
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_2,
+			migrationId: `${idPrefix}-mig`,
+			filter: { customer: { plan: { plan_id: parent.id, custom: false } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: parent.id, custom: false },
+						customize: {
+							upsert_licenses: [
+								{
+									license_plan_id: devSeat.id,
+									customize: laneCase.customize,
+								},
+							],
+						},
+					},
+				],
+			},
+			noBillingChanges: true,
+		});
+
+		expect(result?.lane).toBe("per_customer");
+	});
+}

--- a/server/tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.ts
+++ b/server/tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.ts
@@ -16,7 +16,13 @@ type PoolExpectation = {
 	resetCycleAnchor: "present" | null;
 	resetMode: PooledBalanceResetMode;
 	stripeSubscriptionId: "stripe_subscription" | null;
+	customerLicenseLinkId?: string | null;
 	rollovers?: Array<{ balance: number; usage?: number }>;
+};
+
+type PoolFilter = {
+	customerLicenseLinkId?: string | null;
+	internalFeatureId?: string;
 };
 
 type ContributionExpectation = {
@@ -38,12 +44,14 @@ export const expectPooledBalanceCorrect = async ({
 	pool,
 	contributions,
 	sources,
+	filter,
 }: {
 	db: DrizzleCli;
 	customerId: string;
 	pool: PoolExpectation;
 	contributions: ContributionExpectation;
 	sources: SourceExpectation;
+	filter?: PoolFilter;
 }) => {
 	const fullState = await getPooledBalanceDbState({ db, customerId });
 	const poolCount = pool.count ?? 1;
@@ -53,8 +61,23 @@ export const expectPooledBalanceCorrect = async ({
 	// always means the live one — use getPooledBalanceDbState for the history.
 	const isLive = (expiresAt: number | null) =>
 		expiresAt === null || expiresAt > Date.now();
-	const pools = fullState.pools.filter((candidate) =>
-		isLive(candidate.expires_at),
+	const matchesFilter = (candidate: (typeof fullState.pools)[number]) => {
+		if (
+			filter?.customerLicenseLinkId !== undefined &&
+			candidate.customer_license_link_id !== filter.customerLicenseLinkId
+		) {
+			return false;
+		}
+		if (
+			filter?.internalFeatureId !== undefined &&
+			candidate.internal_feature_id !== filter.internalFeatureId
+		) {
+			return false;
+		}
+		return true;
+	};
+	const pools = fullState.pools.filter(
+		(candidate) => isLive(candidate.expires_at) && matchesFilter(candidate),
 	);
 	const livePoolIds = new Set(pools.map((candidate) => candidate.id));
 	const poolCustomerEntitlements = fullState.poolCustomerEntitlements.filter(
@@ -62,7 +85,20 @@ export const expectPooledBalanceCorrect = async ({
 			candidate.pooled_balance_id !== null &&
 			livePoolIds.has(candidate.pooled_balance_id),
 	);
-	const state = { ...fullState, pools, poolCustomerEntitlements };
+	const filteredContributions = fullState.contributions.filter((contribution) =>
+		livePoolIds.has(contribution.pooled_balance_id),
+	);
+	const filteredSourceCustomerEntitlementIds = new Set(
+		filteredContributions.map(
+			(contribution) => contribution.source_customer_entitlement_id,
+		),
+	);
+	const state = {
+		...fullState,
+		pools,
+		poolCustomerEntitlements,
+		contributions: filteredContributions,
+	};
 
 	expect(state.pools).toHaveLength(poolCount);
 	expect(state.poolCustomerEntitlements).toHaveLength(poolCount);
@@ -107,7 +143,10 @@ export const expectPooledBalanceCorrect = async ({
 			unlimited: pool.unlimited ?? false,
 			interval: pool.interval,
 			reset_mode: pool.resetMode,
-			customer_license_link_id: null,
+			customer_license_link_id:
+				pool.customerLicenseLinkId === undefined
+					? (filter?.customerLicenseLinkId ?? null)
+					: pool.customerLicenseLinkId,
 		});
 		if (pool.resetCycleAnchor === "present") {
 			expect(pooledBalance.reset_cycle_anchor).not.toBeNull();
@@ -170,9 +209,13 @@ export const expectPooledBalanceCorrect = async ({
 
 	const pooledSourceCustomerEntitlements = state.sourceCustomerProducts.flatMap(
 		(customerProduct) =>
-			customerProduct.customer_entitlements.filter(
-				(customerEntitlement) => customerEntitlement.entitlement.pooled,
-			),
+			customerProduct.customer_entitlements.filter((customerEntitlement) => {
+				if (!customerEntitlement.entitlement.pooled) return false;
+				if (!filter) return true;
+				return filteredSourceCustomerEntitlementIds.has(
+					customerEntitlement.id,
+				);
+			}),
 	);
 	expect(pooledSourceCustomerEntitlements).toHaveLength(sources.count);
 	for (const sourceCustomerEntitlement of pooledSourceCustomerEntitlements) {

--- a/server/tests/integration/catalog-v2/plans/licenses/declared/declared-license-pooled.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/declared/declared-license-pooled.test.ts
@@ -1,18 +1,18 @@
 /**
- * catalogV2.update — declared licenses[] reject pooled items.
+ * catalogV2.update — declared licenses[] accept pooled items.
  *
  * Contract:
- *   pooled item on the child → 400
- *   pooled item in customize add_items → 400
+ *   pooled item on the child → link persists
+ *   pooled item in customize add_items → customized link persists
  */
 
 import { test } from "bun:test";
-import { ErrCode, ResetInterval } from "@autumn/shared";
+import { ResetInterval } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
-import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import { expectLicenseLinkCorrect } from "../utils/expectLicenseLinkCorrect.js";
 import { messagesItem, withCatalogPlans } from "../utils/seedLicensePlans.js";
 
 const pooledMessages = {
@@ -30,7 +30,7 @@ const pooledWords = {
 };
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: pooled item on child → 400")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: pooled item on child links")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const parentId = uniqueTestId("cv2_lic_pool_p");
@@ -50,18 +50,22 @@ test.concurrent(
 					],
 				});
 
-				await expectAutumnError({
-					errCode: ErrCode.InvalidRequest,
-					errMessage: "Pooled items are not supported",
-					func: () =>
-						autumnV2_3.catalogV2.update({
-							plans: [
-								{
-									plan_id: parentId,
-									licenses: [{ license_plan_id: childId, included: 1 }],
-								},
-							],
-						}),
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: parentId,
+							licenses: [{ license_plan_id: childId, included: 1 }],
+						},
+					],
+				});
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					included: 1,
+					customized: false,
+					messagesAllowance: 10,
 				});
 			},
 		});
@@ -69,7 +73,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: pooled item in customize add_items → 400")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: pooled item in customize add_items links")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const parentId = uniqueTestId("cv2_lic_poolc_p");
@@ -89,24 +93,29 @@ test.concurrent(
 					],
 				});
 
-				await expectAutumnError({
-					errCode: ErrCode.InvalidRequest,
-					errMessage: "Pooled items are not supported",
-					func: () =>
-						autumnV2_3.catalogV2.update({
-							plans: [
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: parentId,
+							licenses: [
 								{
-									plan_id: parentId,
-									licenses: [
-										{
-											license_plan_id: childId,
-											included: 1,
-											customize: { add_items: [pooledWords] },
-										},
-									],
+									license_plan_id: childId,
+									included: 1,
+									customize: { add_items: [pooledWords] },
 								},
 							],
-						}),
+						},
+					],
+				});
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					included: 1,
+					customized: true,
+					messagesAllowance: 10,
+					entitlements: [{ feature_id: TestFeature.Words, allowance: 10 }],
 				});
 			},
 		});

--- a/server/tests/integration/licenses/catalog-update/license-link-validation.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-link-validation.test.ts
@@ -1,5 +1,5 @@
-// Contract: license links reject pooled entitlements from base or customized license items.
-// The pooled catalog plan remains valid, and rejection persists no parent-to-license link.
+// Contract: license links accept pooled entitlements on the child and in
+// customize add_items. Self-link and archived-license still reject.
 
 import { expect, test } from "bun:test";
 import { type ApiPlanExpandedV1, ErrCode } from "@autumn/shared";
@@ -119,7 +119,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("licenses catalog: pooled catalog items cannot be linked as a license")}`,
+	`${chalk.yellowBright("licenses catalog: pooled catalog items can be linked as a license")}`,
 	async () => {
 		const parent = products.base({
 			id: "pooled-license-link-parent",
@@ -135,7 +135,7 @@ test.concurrent(
 			],
 		});
 		const { autumnV2_2 } = await initScenario({
-			customerId: "license-link-rejects-pooled-catalog-item",
+			customerId: "license-link-accepts-pooled-catalog-item",
 			setup: [
 				s.customer({ testClock: false }),
 				s.products({ list: [parent, pooledLicense] }),
@@ -143,25 +143,24 @@ test.concurrent(
 			actions: [],
 		});
 
-		await expectAutumnError({
-			errCode: ErrCode.InvalidRequest,
-			errMessage: "Pooled items are not supported for plan licenses",
-			func: () =>
-				autumnV2_2.post("/plans.update", {
-					plan_id: parent.id,
-					licenses: [{ license_plan_id: pooledLicense.id, included: 1 }],
-				}),
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [{ license_plan_id: pooledLicense.id, included: 1 }],
 		});
 
 		const persistedParent = (await autumnV2_2.post("/plans.get", {
 			plan_id: parent.id,
 		})) as ApiPlanExpandedV1;
-		expect(persistedParent.licenses ?? []).toHaveLength(0);
+		expect(persistedParent.licenses ?? []).toHaveLength(1);
+		expect(persistedParent.licenses?.[0]).toMatchObject({
+			license_plan_id: pooledLicense.id,
+			included: 1,
+		});
 	},
 );
 
 test.concurrent(
-	`${chalk.yellowBright("licenses catalog: pooled customized items cannot be added to a license")}`,
+	`${chalk.yellowBright("licenses catalog: pooled customized items can be added to a license")}`,
 	async () => {
 		const parent = products.base({
 			id: "pooled-license-custom-parent",
@@ -172,7 +171,7 @@ test.concurrent(
 			items: [items.monthlyMessages({ includedUsage: 25 })],
 		});
 		const { autumnV2_2 } = await initScenario({
-			customerId: "license-link-rejects-pooled-custom-item",
+			customerId: "license-link-accepts-pooled-custom-item",
 			setup: [
 				s.customer({ testClock: false }),
 				s.products({ list: [parent, license] }),
@@ -180,32 +179,31 @@ test.concurrent(
 			actions: [],
 		});
 
-		await expectAutumnError({
-			errCode: ErrCode.InvalidRequest,
-			errMessage: "Pooled items are not supported for plan licenses",
-			func: () =>
-				autumnV2_2.post("/plans.update", {
-					plan_id: parent.id,
-					licenses: [
-						{
-							license_plan_id: license.id,
-							included: 1,
-							customize: {
-								add_items: [
-									{
-										...itemsV2.monthlyCredits({ included: 100 }),
-										pooled: true,
-									},
-								],
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 1,
+					customize: {
+						add_items: [
+							{
+								...itemsV2.monthlyCredits({ included: 100 }),
+								pooled: true,
 							},
-						},
-					],
-				}),
+						],
+					},
+				},
+			],
 		});
 
 		const persistedParent = (await autumnV2_2.post("/plans.get", {
 			plan_id: parent.id,
 		})) as ApiPlanExpandedV1;
-		expect(persistedParent.licenses ?? []).toHaveLength(0);
+		expect(persistedParent.licenses ?? []).toHaveLength(1);
+		expect(persistedParent.licenses?.[0]).toMatchObject({
+			license_plan_id: license.id,
+			included: 1,
+		});
 	},
 );

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-add-remove.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-add-remove.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Contract: parent switch that adds or removes a pooled seat item mints or
+ * expires that feature's license pool in batch SQL. Existing pools on the
+ * link stay put. Source balances stay 0. link_id is stable.
+ *
+ *   immediate add → new words pool, granted = N × 100
+ *   spare seats are in scope (release does not drop the new contribution)
+ *   scheduled remove → words pool unchanged until activation, then expires
+ */
+
+import { test } from "bun:test";
+import type { ApiCustomerV5, AttachParamsV1Input } from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { advanceToNextInvoice } from "@tests/utils/testAttachUtils/testAttachUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	LICENSE_POOLED_ADDED_GRANT,
+	LICENSE_POOLED_LOW_GRANT,
+	expectLicensePooledBalanceExpired,
+	expectLicensePooledGrant,
+	pooledMonthlyMessages,
+	pooledMonthlyWords,
+	pooledSeatPlan,
+	seatLinkId,
+} from "./utils/licensePooledBalanceTestUtils.js";
+
+const SEAT_COUNT = 3;
+
+const addRemovePlans = ({ prefix }: { prefix: string }) => {
+	const seatGroup = `${prefix}-seats`;
+	return {
+		pro: products.pro({
+			id: `${prefix}-pro`,
+			items: [items.dashboard()],
+		}),
+		premium: products.premium({
+			id: `${prefix}-premium`,
+			items: [items.dashboard()],
+		}),
+		seatMessages: pooledSeatPlan({
+			id: `${prefix}-seat-messages`,
+			item: pooledMonthlyMessages({
+				includedUsage: LICENSE_POOLED_LOW_GRANT,
+			}),
+			group: seatGroup,
+		}),
+		seatMessagesAndWords: pooledSeatPlan({
+			id: `${prefix}-seat-messages-words`,
+			items: [
+				pooledMonthlyMessages({
+					includedUsage: LICENSE_POOLED_LOW_GRANT,
+				}),
+				pooledMonthlyWords({
+					includedUsage: LICENSE_POOLED_ADDED_GRANT,
+				}),
+			],
+			group: seatGroup,
+		}),
+	};
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: immediate parent upgrade mints a pool for the added item")}`,
+	async () => {
+		const { pro, premium, seatMessages, seatMessagesAndWords } =
+			addRemovePlans({ prefix: "lic-pool-add" });
+		const customerId = "lic-pool-add-item";
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
+				s.products({
+					list: [pro, premium, seatMessages, seatMessagesAndWords],
+				}),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: pro.id,
+					licenseProductId: seatMessages.id,
+					included: SEAT_COUNT,
+				}),
+				s.licenses.link({
+					parentProductId: premium.id,
+					licenseProductId: seatMessagesAndWords.id,
+					included: SEAT_COUNT,
+				}),
+				s.billing.attach({ productId: pro.id }),
+				s.licenses.assign({
+					licenseProductId: seatMessages.id,
+					entityIndexes: [0, 1, 2],
+				}),
+			],
+		});
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatMessages.id,
+		});
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_LOW_GRANT,
+			seatCount: SEAT_COUNT,
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+			redirect_mode: "if_required",
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		await expectCustomerProducts({ customer, active: [premium.id] });
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_LOW_GRANT,
+			seatCount: SEAT_COUNT,
+		});
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_ADDED_GRANT,
+			seatCount: SEAT_COUNT,
+			featureId: TestFeature.Words,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: spare seats take the added pooled item")}`,
+	async () => {
+		const { pro, premium, seatMessages, seatMessagesAndWords } =
+			addRemovePlans({ prefix: "lic-pool-add-spare" });
+		const customerId = "lic-pool-add-spare";
+		const { entities, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
+				s.products({
+					list: [pro, premium, seatMessages, seatMessagesAndWords],
+				}),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: pro.id,
+					licenseProductId: seatMessages.id,
+					included: SEAT_COUNT,
+				}),
+				s.licenses.link({
+					parentProductId: premium.id,
+					licenseProductId: seatMessagesAndWords.id,
+					included: SEAT_COUNT,
+				}),
+				s.billing.attach({ productId: pro.id }),
+				s.licenses.assign({
+					licenseProductId: seatMessages.id,
+					entityIndexes: [0, 1, 2],
+				}),
+			],
+		});
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatMessages.id,
+		});
+		await autumnV2_3.licenses.release({
+			customer_id: customerId,
+			license_plan_id: seatMessages.id,
+			entity_ids: [entities[0].id],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+			redirect_mode: "if_required",
+		});
+
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_ADDED_GRANT,
+			seatCount: SEAT_COUNT,
+			featureId: TestFeature.Words,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: scheduled parent downgrade expires the removed item's pool at activation")}`,
+	async () => {
+		const { pro, premium, seatMessages, seatMessagesAndWords } =
+			addRemovePlans({ prefix: "lic-pool-rm-sched" });
+		const customerId = "lic-pool-remove-scheduled";
+		const { autumnV2_3, ctx, testClockId, advancedTo } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: true }),
+				s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
+				s.products({
+					list: [pro, premium, seatMessages, seatMessagesAndWords],
+				}),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: pro.id,
+					licenseProductId: seatMessages.id,
+					included: SEAT_COUNT,
+				}),
+				s.licenses.link({
+					parentProductId: premium.id,
+					licenseProductId: seatMessagesAndWords.id,
+					included: SEAT_COUNT,
+				}),
+				s.billing.attach({ productId: premium.id }),
+				s.licenses.assign({
+					licenseProductId: seatMessagesAndWords.id,
+					entityIndexes: [0, 1, 2],
+				}),
+			],
+		});
+		if (!testClockId) throw new Error("Test clock not enabled");
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatMessagesAndWords.id,
+		});
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_ADDED_GRANT,
+			seatCount: SEAT_COUNT,
+			featureId: TestFeature.Words,
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			redirect_mode: "if_required",
+		});
+
+		const scheduled = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		await expectCustomerProducts({
+			customer: scheduled,
+			canceling: [premium.id],
+			scheduled: [pro.id],
+		});
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_ADDED_GRANT,
+			seatCount: SEAT_COUNT,
+			featureId: TestFeature.Words,
+		});
+
+		await advanceToNextInvoice({
+			stripeCli: ctx.stripeCli,
+			testClockId,
+			currentEpochMs: advancedTo,
+		});
+
+		const activated = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		await expectCustomerProducts({
+			customer: activated,
+			active: [pro.id],
+			notPresent: [premium.id],
+		});
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_LOW_GRANT,
+			seatCount: SEAT_COUNT,
+		});
+		await expectLicensePooledBalanceExpired({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			featureId: TestFeature.Words,
+		});
+	},
+);

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-amount-change.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-amount-change.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Contract: parent switch where the paired seat plan's pooled allowance
+ * changes (200 → 400 or 400 → 200) patches contributions by Δ and updates
+ * the pool aggregate. Source balances stay 0. link_id is stable.
+ *
+ *   immediate upgrade → granted = N × 400, usage preserved
+ *   spare seats are in scope (release does not drop a contribution)
+ *   scheduled downgrade → pool unchanged until activation
+ */
+
+import { test } from "bun:test";
+import type { ApiCustomerV5, AttachParamsV1Input } from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { advanceToNextInvoice } from "@tests/utils/testAttachUtils/testAttachUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	LICENSE_POOLED_HIGH_GRANT,
+	LICENSE_POOLED_LOW_GRANT,
+	expectLicensePooledGrant,
+	pooledMonthlyMessages,
+	pooledSeatPlan,
+	seatLinkId,
+} from "./utils/licensePooledBalanceTestUtils.js";
+
+const SEAT_COUNT = 3;
+const USAGE = 50;
+
+const amountChangePlans = ({ prefix }: { prefix: string }) => {
+	const seatGroup = `${prefix}-seats`;
+	return {
+		pro: products.pro({
+			id: `${prefix}-pro`,
+			items: [items.dashboard()],
+		}),
+		premium: products.premium({
+			id: `${prefix}-premium`,
+			items: [items.dashboard()],
+		}),
+		seatLow: pooledSeatPlan({
+			id: `${prefix}-seat-200`,
+			item: pooledMonthlyMessages({
+				includedUsage: LICENSE_POOLED_LOW_GRANT,
+			}),
+			group: seatGroup,
+		}),
+		seatHigh: pooledSeatPlan({
+			id: `${prefix}-seat-400`,
+			item: pooledMonthlyMessages({
+				includedUsage: LICENSE_POOLED_HIGH_GRANT,
+			}),
+			group: seatGroup,
+		}),
+	};
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: immediate parent upgrade applies the 200→400 delta")}`,
+	async () => {
+		const { pro, premium, seatLow, seatHigh } = amountChangePlans({
+			prefix: "lic-pool-amt-up",
+		});
+		const customerId = "lic-pool-amt-upgrade";
+		const { entities, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
+				s.products({ list: [pro, premium, seatLow, seatHigh] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: pro.id,
+					licenseProductId: seatLow.id,
+					included: SEAT_COUNT,
+				}),
+				s.licenses.link({
+					parentProductId: premium.id,
+					licenseProductId: seatHigh.id,
+					included: SEAT_COUNT,
+				}),
+				s.billing.attach({ productId: pro.id }),
+				s.licenses.assign({
+					licenseProductId: seatLow.id,
+					entityIndexes: [0, 1, 2],
+				}),
+			],
+		});
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatLow.id,
+		});
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_LOW_GRANT,
+			seatCount: SEAT_COUNT,
+		});
+
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				value: USAGE,
+			},
+			{ timeout: 2000 },
+		);
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+			redirect_mode: "if_required",
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		await expectCustomerProducts({ customer, active: [premium.id] });
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_HIGH_GRANT,
+			seatCount: SEAT_COUNT,
+			usage: USAGE,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: spare seats take the parent-upgrade delta")}`,
+	async () => {
+		const { pro, premium, seatLow, seatHigh } = amountChangePlans({
+			prefix: "lic-pool-amt-spare",
+		});
+		const customerId = "lic-pool-amt-spare";
+		const { entities, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
+				s.products({ list: [pro, premium, seatLow, seatHigh] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: pro.id,
+					licenseProductId: seatLow.id,
+					included: SEAT_COUNT,
+				}),
+				s.licenses.link({
+					parentProductId: premium.id,
+					licenseProductId: seatHigh.id,
+					included: SEAT_COUNT,
+				}),
+				s.billing.attach({ productId: pro.id }),
+				s.licenses.assign({
+					licenseProductId: seatLow.id,
+					entityIndexes: [0, 1, 2],
+				}),
+			],
+		});
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatLow.id,
+		});
+		await autumnV2_3.licenses.release({
+			customer_id: customerId,
+			license_plan_id: seatLow.id,
+			entity_ids: [entities[0].id],
+		});
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_LOW_GRANT,
+			seatCount: SEAT_COUNT,
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+			redirect_mode: "if_required",
+		});
+
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_HIGH_GRANT,
+			seatCount: SEAT_COUNT,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: scheduled parent downgrade applies the 400→200 delta at activation")}`,
+	async () => {
+		const { pro, premium, seatLow, seatHigh } = amountChangePlans({
+			prefix: "lic-pool-amt-sched",
+		});
+		const customerId = "lic-pool-amt-scheduled";
+		const { autumnV2_3, ctx, testClockId, advancedTo } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: true }),
+				s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
+				s.products({ list: [pro, premium, seatLow, seatHigh] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: pro.id,
+					licenseProductId: seatLow.id,
+					included: SEAT_COUNT,
+				}),
+				s.licenses.link({
+					parentProductId: premium.id,
+					licenseProductId: seatHigh.id,
+					included: SEAT_COUNT,
+				}),
+				s.billing.attach({ productId: premium.id }),
+				s.licenses.assign({
+					licenseProductId: seatHigh.id,
+					entityIndexes: [0, 1, 2],
+				}),
+			],
+		});
+		if (!testClockId) throw new Error("Test clock not enabled");
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatHigh.id,
+		});
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_HIGH_GRANT,
+			seatCount: SEAT_COUNT,
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			redirect_mode: "if_required",
+		});
+
+		const scheduled = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		await expectCustomerProducts({
+			customer: scheduled,
+			canceling: [premium.id],
+			scheduled: [pro.id],
+		});
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_HIGH_GRANT,
+			seatCount: SEAT_COUNT,
+		});
+
+		await advanceToNextInvoice({
+			stripeCli: ctx.stripeCli,
+			testClockId,
+			currentEpochMs: advancedTo,
+		});
+
+		const activated = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		await expectCustomerProducts({
+			customer: activated,
+			active: [pro.id],
+			notPresent: [premium.id],
+		});
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_LOW_GRANT,
+			seatCount: SEAT_COUNT,
+		});
+	},
+);

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-check-track.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-check-track.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Contract: license pools are what check/track read. Assigned, unassigned,
+ * and customer-level checks all see seats × grant. Track deducts the pool
+ * (source balances stay 0). Overage is denied.
+ */
+
+import { test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	LICENSE_POOLED_LOW_GRANT,
+	expectLicensePooledCheck,
+	expectLicensePooledGrant,
+	parentPlan,
+	pooledMonthlyMessages,
+	pooledSeatPlan,
+	seatLinkId,
+} from "./utils/licensePooledBalanceTestUtils.js";
+
+const SEAT_COUNT = 3;
+const USAGE = 50;
+
+const checkTrackScenario = async ({
+	customerId,
+	prefix,
+}: {
+	customerId: string;
+	prefix: string;
+}) => {
+	const parent = parentPlan({ id: `${prefix}-parent` });
+	const seat = pooledSeatPlan({
+		id: `${prefix}-seat`,
+		item: pooledMonthlyMessages({ includedUsage: LICENSE_POOLED_LOW_GRANT }),
+	});
+	const scenario = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: SEAT_COUNT + 1, featureId: TestFeature.Users }),
+			s.products({ list: [parent, seat] }),
+		],
+		actions: [
+			s.licenses.link({
+				parentProductId: parent.id,
+				licenseProductId: seat.id,
+				included: SEAT_COUNT,
+			}),
+			s.billing.attach({ productId: parent.id }),
+			s.licenses.assign({
+				licenseProductId: seat.id,
+				entityIndexes: [0, 1, 2],
+			}),
+		],
+	});
+	const customerLicenseLinkId = await seatLinkId({
+		db: scenario.ctx.db,
+		customerId,
+		licenseProductId: seat.id,
+	});
+	return { ...scenario, customerLicenseLinkId };
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled check: assigned, unassigned, and customer see the same pool")}`,
+	async () => {
+		const customerId = "lic-pool-check-subjects";
+		const { autumnV2_3, entities } = await checkTrackScenario({
+			customerId,
+			prefix: "lic-pool-check-subjects",
+		});
+		const remaining = LICENSE_POOLED_LOW_GRANT * SEAT_COUNT;
+
+		await expectLicensePooledCheck({
+			autumn: autumnV2_3,
+			customerId,
+			allowed: true,
+			remaining,
+		});
+		await expectLicensePooledCheck({
+			autumn: autumnV2_3,
+			customerId,
+			entityId: entities[0].id,
+			allowed: true,
+			remaining,
+		});
+		await expectLicensePooledCheck({
+			autumn: autumnV2_3,
+			customerId,
+			entityId: entities[3].id,
+			allowed: true,
+			remaining,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled track: deducts the pool, source balances stay 0")}`,
+	async () => {
+		const customerId = "lic-pool-track-pool";
+		const { autumnV2_3, ctx, entities, customerLicenseLinkId } =
+			await checkTrackScenario({
+				customerId,
+				prefix: "lic-pool-track-pool",
+			});
+
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				value: USAGE,
+			},
+			{ timeout: 2000 },
+		);
+
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_LOW_GRANT,
+			seatCount: SEAT_COUNT,
+			usage: USAGE,
+		});
+		await expectLicensePooledCheck({
+			autumn: autumnV2_3,
+			customerId,
+			entityId: entities[3].id,
+			allowed: true,
+			remaining: LICENSE_POOLED_LOW_GRANT * SEAT_COUNT - USAGE,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled check: overage against the pool is denied")}`,
+	async () => {
+		const customerId = "lic-pool-check-overage";
+		const { autumnV2_3, entities } = await checkTrackScenario({
+			customerId,
+			prefix: "lic-pool-check-overage",
+		});
+		const granted = LICENSE_POOLED_LOW_GRANT * SEAT_COUNT;
+
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				value: granted,
+			},
+			{ timeout: 2000 },
+		);
+
+		await expectLicensePooledCheck({
+			autumn: autumnV2_3,
+			customerId,
+			allowed: false,
+			remaining: 0,
+		});
+	},
+);

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-flip.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-flip.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Contract: same-feature pooledness or pool-identity changes are remove+add
+ * (fresh grants, usage dropped). link_id is stable. Sources stay 0 when pooled.
+ *
+ *   immediate private→pooled → new pool, usage forgiven
+ *   scheduled pooled→private → pool lives until activation, then fresh seats
+ *   immediate monthly→lifetime → new lifetime pool, usage forgiven
+ */
+
+import { test } from "bun:test";
+import type { ApiCustomerV5, AttachParamsV1Input } from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { advanceToNextInvoice } from "@tests/utils/testAttachUtils/testAttachUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	LICENSE_POOLED_LOW_GRANT,
+	expectLicensePooledBalanceExpired,
+	expectLicensePooledGrant,
+	expectLicensePrivateSeatGrant,
+	lifetimeLicensePoolLifecycle,
+	pooledLifetimeMessages,
+	pooledMonthlyMessages,
+	pooledSeatPlan,
+	seatLinkId,
+} from "./utils/licensePooledBalanceTestUtils.js";
+
+const SEAT_COUNT = 3;
+const USAGE = 50;
+
+const flipPlans = ({ prefix }: { prefix: string }) => {
+	const seatGroup = `${prefix}-seats`;
+	return {
+		pro: products.pro({
+			id: `${prefix}-pro`,
+			items: [items.dashboard()],
+		}),
+		premium: products.premium({
+			id: `${prefix}-premium`,
+			items: [items.dashboard()],
+		}),
+		seatPrivate: products.base({
+			id: `${prefix}-seat-private`,
+			items: [
+				items.monthlyMessages({
+					includedUsage: LICENSE_POOLED_LOW_GRANT,
+				}),
+			],
+			group: seatGroup,
+		}),
+		seatPooled: pooledSeatPlan({
+			id: `${prefix}-seat-pooled`,
+			item: pooledMonthlyMessages({
+				includedUsage: LICENSE_POOLED_LOW_GRANT,
+			}),
+			group: seatGroup,
+		}),
+		seatPooledLifetime: pooledSeatPlan({
+			id: `${prefix}-seat-lifetime`,
+			item: pooledLifetimeMessages({
+				includedUsage: LICENSE_POOLED_LOW_GRANT,
+			}),
+			group: seatGroup,
+		}),
+	};
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: immediate private→pooled mints a fresh pool")}`,
+	async () => {
+		const { pro, premium, seatPrivate, seatPooled } = flipPlans({
+			prefix: "lic-pool-flip-in",
+		});
+		const customerId = "lic-pool-flip-to-pooled";
+		const { entities, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
+				s.products({ list: [pro, premium, seatPrivate, seatPooled] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: pro.id,
+					licenseProductId: seatPrivate.id,
+					included: SEAT_COUNT,
+				}),
+				s.licenses.link({
+					parentProductId: premium.id,
+					licenseProductId: seatPooled.id,
+					included: SEAT_COUNT,
+				}),
+				s.billing.attach({ productId: pro.id }),
+				s.licenses.assign({
+					licenseProductId: seatPrivate.id,
+					entityIndexes: [0, 1, 2],
+				}),
+			],
+		});
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatPrivate.id,
+		});
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				value: USAGE,
+			},
+			{ timeout: 2000 },
+		);
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+			redirect_mode: "if_required",
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		await expectCustomerProducts({ customer, active: [premium.id] });
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_LOW_GRANT,
+			seatCount: SEAT_COUNT,
+			usage: 0,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: scheduled pooled→private expires the pool at activation")}`,
+	async () => {
+		const { pro, premium, seatPrivate, seatPooled } = flipPlans({
+			prefix: "lic-pool-flip-out",
+		});
+		const customerId = "lic-pool-flip-to-private";
+		const { entities, autumnV2_3, ctx, testClockId, advancedTo } =
+			await initScenario({
+				customerId,
+				setup: [
+					s.customer({ paymentMethod: "success", testClock: true }),
+					s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
+					s.products({ list: [pro, premium, seatPrivate, seatPooled] }),
+				],
+				actions: [
+					s.licenses.link({
+						parentProductId: pro.id,
+						licenseProductId: seatPrivate.id,
+						included: SEAT_COUNT,
+					}),
+					s.licenses.link({
+						parentProductId: premium.id,
+						licenseProductId: seatPooled.id,
+						included: SEAT_COUNT,
+					}),
+					s.billing.attach({ productId: premium.id }),
+					s.licenses.assign({
+						licenseProductId: seatPooled.id,
+						entityIndexes: [0, 1, 2],
+					}),
+				],
+			});
+		if (!testClockId) throw new Error("Test clock not enabled");
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatPooled.id,
+		});
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				value: USAGE,
+			},
+			{ timeout: 2000 },
+		);
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_LOW_GRANT,
+			seatCount: SEAT_COUNT,
+			usage: USAGE,
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			redirect_mode: "if_required",
+		});
+
+		const scheduled = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		await expectCustomerProducts({
+			customer: scheduled,
+			canceling: [premium.id],
+			scheduled: [pro.id],
+		});
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_LOW_GRANT,
+			seatCount: SEAT_COUNT,
+			usage: USAGE,
+		});
+
+		await advanceToNextInvoice({
+			stripeCli: ctx.stripeCli,
+			testClockId,
+			currentEpochMs: advancedTo,
+		});
+
+		const activated = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		await expectCustomerProducts({
+			customer: activated,
+			active: [pro.id],
+			notPresent: [premium.id],
+		});
+		await expectLicensePooledBalanceExpired({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+		});
+		await expectLicensePrivateSeatGrant({
+			autumn: autumnV2_3,
+			customerId,
+			entityIds: entities.map((entity) => entity.id),
+			grant: LICENSE_POOLED_LOW_GRANT,
+			usage: 0,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: immediate monthly→lifetime mints a fresh identity")}`,
+	async () => {
+		const { pro, premium, seatPooled, seatPooledLifetime } = flipPlans({
+			prefix: "lic-pool-flip-id",
+		});
+		const customerId = "lic-pool-flip-identity";
+		const { entities, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
+				s.products({
+					list: [pro, premium, seatPooled, seatPooledLifetime],
+				}),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: pro.id,
+					licenseProductId: seatPooled.id,
+					included: SEAT_COUNT,
+				}),
+				s.licenses.link({
+					parentProductId: premium.id,
+					licenseProductId: seatPooledLifetime.id,
+					included: SEAT_COUNT,
+				}),
+				s.billing.attach({ productId: pro.id }),
+				s.licenses.assign({
+					licenseProductId: seatPooled.id,
+					entityIndexes: [0, 1, 2],
+				}),
+			],
+		});
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatPooled.id,
+		});
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				value: USAGE,
+			},
+			{ timeout: 2000 },
+		);
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+			redirect_mode: "if_required",
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		await expectCustomerProducts({ customer, active: [premium.id] });
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_LOW_GRANT,
+			seatCount: SEAT_COUNT,
+			usage: 0,
+			lifecycle: lifetimeLicensePoolLifecycle,
+		});
+	},
+);

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-identity-basic.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-identity-basic.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Contract: assigning a pooled license seat mints one lazy pool keyed by
+ * customer_licenses.link_id. N seats under that link are N contributions.
+ *
+ * Cases: 1, 8, 9, 17
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5, CheckResponseV3 } from "@autumn/shared";
+import { expectPooledBalanceCorrect } from "@tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.js";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { getPooledBalanceDbState } from "@tests/integration/billing/pooled-balances/utils/getPooledBalanceDbState.js";
+import {
+	LICENSE_POOLED_GRANT,
+	lazyLicensePoolLifecycle,
+	parentPlan,
+	pooledMonthlyMessages,
+	pooledSeatPlan,
+	seatLinkId,
+} from "./utils/licensePooledBalanceTestUtils.js";
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: assign 3 seats mints one lazy pool keyed by link_id")}`,
+	async () => {
+		const parent = parentPlan({ id: "lic-pool-basic-parent" });
+		const seat = pooledSeatPlan({
+			id: "lic-pool-basic-seat",
+			item: pooledMonthlyMessages(),
+		});
+		const customerId = "lic-pool-basic-assign";
+		const { entities, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 4, featureId: TestFeature.Users }),
+				s.products({ list: [parent, seat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: seat.id,
+					included: 3,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: seat.id,
+					entityIndexes: [0, 1, 2],
+				}),
+			],
+		});
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seat.id,
+		});
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId },
+			pool: {
+				balance: LICENSE_POOLED_GRANT * 3,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT * 3,
+				customerLicenseLinkId,
+				...lazyLicensePoolLifecycle,
+			},
+			contributions: {
+				count: 3,
+				currentContribution: LICENSE_POOLED_GRANT,
+				nextCycleContribution: LICENSE_POOLED_GRANT,
+			},
+			sources: { count: 3, balance: 0, adjustment: 0 },
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			granted: LICENSE_POOLED_GRANT * 3,
+			remaining: LICENSE_POOLED_GRANT * 3,
+			usage: 0,
+		});
+
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				value: 80,
+			},
+			{ timeout: 2000 },
+		);
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				entity_id: entities[3].id,
+				feature_id: TestFeature.Messages,
+				value: 20,
+			},
+			{ timeout: 2000 },
+		);
+
+		const afterTrack = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		expectBalanceCorrect({
+			customer: afterTrack,
+			featureId: TestFeature.Messages,
+			granted: LICENSE_POOLED_GRANT * 3,
+			remaining: LICENSE_POOLED_GRANT * 3 - 100,
+			usage: 100,
+		});
+
+		const unassignedCheck = await autumnV2_3.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[3].id,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(unassignedCheck.allowed).toBe(true);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: parent attach alone mints no pool; first assign does")}`,
+	async () => {
+		const parent = parentPlan({ id: "lic-pool-first-parent" });
+		const seat = pooledSeatPlan({
+			id: "lic-pool-first-seat",
+			item: pooledMonthlyMessages(),
+		});
+		const customerId = "lic-pool-first-assign";
+		const { entities, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, seat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: seat.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
+		});
+
+		const before = await getPooledBalanceDbState({ db: ctx.db, customerId });
+		expect(before.pools).toHaveLength(0);
+		expect(before.contributions).toHaveLength(0);
+
+		await autumnV2_3.licenses.attach({
+			customer_id: customerId,
+			plan_id: seat.id,
+			entities: [{ entity_id: entities[0].id }],
+		});
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seat.id,
+		});
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId },
+			pool: {
+				balance: LICENSE_POOLED_GRANT,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT,
+				customerLicenseLinkId,
+				...lazyLicensePoolLifecycle,
+			},
+			contributions: {
+				count: 1,
+				currentContribution: LICENSE_POOLED_GRANT,
+			},
+			sources: { count: 1, balance: 0 },
+		});
+	},
+);

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-identity-lifetime.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-identity-lifetime.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Contract: lifetime license pools stay keyed by link_id. Two lifetime
+ * licenses granting the same feature must not merge.
+ *
+ * Cases: 6, 7
+ */
+
+import { test } from "bun:test";
+import { expectPooledBalanceCorrect } from "@tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	LICENSE_POOLED_GRANT,
+	lifetimeLicensePoolLifecycle,
+	parentPlan,
+	pooledLifetimeMessages,
+	pooledSeatPlan,
+	seatLinkId,
+} from "./utils/licensePooledBalanceTestUtils.js";
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: lifetime seat pool is keyed by link_id")}`,
+	async () => {
+		const parent = parentPlan({ id: "lic-pool-life-parent" });
+		const seat = pooledSeatPlan({
+			id: "lic-pool-life-seat",
+			item: pooledLifetimeMessages(),
+		});
+		const customerId = "lic-pool-lifetime";
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, seat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: seat.id,
+					included: 2,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: seat.id,
+					entityIndexes: [0, 1],
+				}),
+			],
+		});
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seat.id,
+		});
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId },
+			pool: {
+				balance: LICENSE_POOLED_GRANT * 2,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT * 2,
+				customerLicenseLinkId,
+				...lifetimeLicensePoolLifecycle,
+			},
+			contributions: {
+				count: 2,
+				currentContribution: LICENSE_POOLED_GRANT,
+			},
+			sources: { count: 2, balance: 0 },
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: two lifetime licenses of the same feature do not merge")}`,
+	async () => {
+		const parentA = parentPlan({
+			id: "lic-pool-life-parent-a",
+			group: "lic-pool-life-parent-a",
+		});
+		const parentB = parentPlan({
+			id: "lic-pool-life-parent-b",
+			group: "lic-pool-life-parent-b",
+		});
+		const seatA = pooledSeatPlan({
+			id: "lic-pool-life-seat-a",
+			item: pooledLifetimeMessages(),
+		});
+		const seatB = pooledSeatPlan({
+			id: "lic-pool-life-seat-b",
+			item: pooledLifetimeMessages(),
+		});
+		const customerId = "lic-pool-lifetime-two";
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parentA, parentB, seatA, seatB] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parentA.id,
+					licenseProductId: seatA.id,
+					included: 1,
+				}),
+				s.licenses.link({
+					parentProductId: parentB.id,
+					licenseProductId: seatB.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parentA.id }),
+				s.billing.attach({ productId: parentB.id }),
+				s.licenses.assign({ licenseProductId: seatA.id, entityIndex: 0 }),
+				s.licenses.assign({ licenseProductId: seatB.id, entityIndex: 1 }),
+			],
+		});
+
+		const linkA = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatA.id,
+		});
+		const linkB = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatB.id,
+		});
+
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId: linkA },
+			pool: {
+				balance: LICENSE_POOLED_GRANT,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT,
+				customerLicenseLinkId: linkA,
+				...lifetimeLicensePoolLifecycle,
+			},
+			contributions: { count: 1 },
+			sources: { count: 1, balance: 0 },
+		});
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId: linkB },
+			pool: {
+				balance: LICENSE_POOLED_GRANT,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT,
+				customerLicenseLinkId: linkB,
+				...lifetimeLicensePoolLifecycle,
+			},
+			contributions: { count: 1 },
+			sources: { count: 1, balance: 0 },
+		});
+	},
+);

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-identity-multi.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-identity-multi.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Contract: license pools do not coalesce across link_ids. Two links granting
+ * the same feature are two pools. A customer-level pooled item (null link)
+ * stays a third identity.
+ *
+ * Cases: 2, 3, 4, 5
+ */
+
+import { test } from "bun:test";
+import { expectPooledBalanceCorrect } from "@tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	LICENSE_POOLED_GRANT,
+	lazyLicensePoolLifecycle,
+	parentPlan,
+	pooledMonthlyMessages,
+	pooledSeatPlan,
+	seatLinkId,
+} from "./utils/licensePooledBalanceTestUtils.js";
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: two licenses on one parent keep distinct link identities")}`,
+	async () => {
+		const parent = parentPlan({ id: "lic-pool-two-lic-parent" });
+		const seatA = pooledSeatPlan({
+			id: "lic-pool-two-lic-a",
+			item: pooledMonthlyMessages(),
+		});
+		const seatB = pooledSeatPlan({
+			id: "lic-pool-two-lic-b",
+			item: pooledMonthlyMessages(),
+		});
+		const customerId = "lic-pool-two-licenses";
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, seatA, seatB] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: seatA.id,
+					included: 1,
+				}),
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: seatB.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: seatA.id,
+					entityIndex: 0,
+				}),
+				s.licenses.assign({
+					licenseProductId: seatB.id,
+					entityIndex: 1,
+				}),
+			],
+		});
+
+		const linkA = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatA.id,
+		});
+		const linkB = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatB.id,
+		});
+
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId: linkA },
+			pool: {
+				balance: LICENSE_POOLED_GRANT,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT,
+				customerLicenseLinkId: linkA,
+				...lazyLicensePoolLifecycle,
+			},
+			contributions: { count: 1, currentContribution: LICENSE_POOLED_GRANT },
+			sources: { count: 1, balance: 0 },
+		});
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId: linkB },
+			pool: {
+				balance: LICENSE_POOLED_GRANT,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT,
+				customerLicenseLinkId: linkB,
+				...lazyLicensePoolLifecycle,
+			},
+			contributions: { count: 1, currentContribution: LICENSE_POOLED_GRANT },
+			sources: { count: 1, balance: 0 },
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: two parents granting the same feature keep distinct link identities")}`,
+	async () => {
+		const parentA = parentPlan({
+			id: "lic-pool-two-parent-a",
+			group: "lic-pool-two-parent-a",
+		});
+		const parentB = parentPlan({
+			id: "lic-pool-two-parent-b",
+			group: "lic-pool-two-parent-b",
+		});
+		const seatA = pooledSeatPlan({
+			id: "lic-pool-two-parent-seat-a",
+			item: pooledMonthlyMessages(),
+		});
+		const seatB = pooledSeatPlan({
+			id: "lic-pool-two-parent-seat-b",
+			item: pooledMonthlyMessages(),
+		});
+		const customerId = "lic-pool-two-parents";
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parentA, parentB, seatA, seatB] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parentA.id,
+					licenseProductId: seatA.id,
+					included: 1,
+				}),
+				s.licenses.link({
+					parentProductId: parentB.id,
+					licenseProductId: seatB.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parentA.id }),
+				s.billing.attach({ productId: parentB.id }),
+				s.licenses.assign({ licenseProductId: seatA.id, entityIndex: 0 }),
+				s.licenses.assign({ licenseProductId: seatB.id, entityIndex: 1 }),
+			],
+		});
+
+		const linkA = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatA.id,
+		});
+		const linkB = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatB.id,
+		});
+
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId: linkA },
+			pool: {
+				balance: LICENSE_POOLED_GRANT,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT,
+				customerLicenseLinkId: linkA,
+				...lazyLicensePoolLifecycle,
+			},
+			contributions: { count: 1 },
+			sources: { count: 1, balance: 0 },
+		});
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId: linkB },
+			pool: {
+				balance: LICENSE_POOLED_GRANT,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT,
+				customerLicenseLinkId: linkB,
+				...lazyLicensePoolLifecycle,
+			},
+			contributions: { count: 1 },
+			sources: { count: 1, balance: 0 },
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: customer-level pool and license pool do not coalesce")}`,
+	async () => {
+		const customerGrant = 200;
+		const parent = products.base({
+			id: "lic-pool-cus-level-parent",
+			items: [
+				items.dashboard(),
+				{
+					...items.monthlyMessages({ includedUsage: customerGrant }),
+					pooled: true,
+				},
+			],
+		});
+		const seat = pooledSeatPlan({
+			id: "lic-pool-cus-level-seat",
+			item: pooledMonthlyMessages(),
+		});
+		const customerId = "lic-pool-customer-level";
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, seat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: seat.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({ licenseProductId: seat.id, entityIndex: 0 }),
+			],
+		});
+
+		const licenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seat.id,
+		});
+
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId: null },
+			pool: {
+				balance: customerGrant,
+				adjustment: 0,
+				granted: customerGrant,
+				customerLicenseLinkId: null,
+				...lazyLicensePoolLifecycle,
+			},
+			contributions: { count: 1, currentContribution: customerGrant },
+			sources: { count: 1, balance: 0 },
+		});
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId: licenseLinkId },
+			pool: {
+				balance: LICENSE_POOLED_GRANT,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT,
+				customerLicenseLinkId: licenseLinkId,
+				...lazyLicensePoolLifecycle,
+			},
+			contributions: { count: 1, currentContribution: LICENSE_POOLED_GRANT },
+			sources: { count: 1, balance: 0 },
+		});
+	},
+);

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-parent-expire.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-parent-expire.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Contract: canceling the license parent expires the license-keyed pool at
+ * read time — same inherit-parent-liveness rule as seats.
+ *
+ *   cancel_immediately → Messages gone on get/check; getFull does not
+ *     hydrate the pooled cusEnt for that link_id
+ *   cancel one of two parents → only that link is unhydrated; remaining
+ *     pool still grants
+ *   re-attach → fresh link_id; expired pool stays hidden
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV5,
+	AttachParamsV1Input,
+	UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	LICENSE_POOLED_GRANT,
+	expectLicensePooledBalanceExpired,
+	expectLicensePooledEntitlementHydrated,
+	expectLicensePooledEntitlementNotHydrated,
+	parentPlan,
+	pooledMonthlyMessages,
+	pooledSeatPlan,
+	seatLinkId,
+} from "./utils/licensePooledBalanceTestUtils.js";
+
+const cancelParentImmediately = async ({
+	autumn,
+	customerId,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	customerId: string;
+	planId: string;
+}) => {
+	await autumn.billing.update<UpdateSubscriptionV1ParamsInput>({
+		customer_id: customerId,
+		plan_id: planId,
+		cancel_action: "cancel_immediately",
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: parent cancel expires the pool at read time")}`,
+	async () => {
+		const parent = parentPlan({ id: "lic-pool-exp-parent" });
+		const seat = pooledSeatPlan({
+			id: "lic-pool-exp-seat",
+			item: pooledMonthlyMessages(),
+		});
+		const customerId = "lic-pool-parent-expire";
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, seat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: seat.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({ licenseProductId: seat.id, entityIndex: 0 }),
+			],
+		});
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seat.id,
+		});
+		await expectLicensePooledEntitlementHydrated({
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+		});
+
+		await cancelParentImmediately({
+			autumn: autumnV2_3,
+			customerId,
+			planId: parent.id,
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		await expectCustomerProducts({
+			customer,
+			notPresent: [parent.id],
+		});
+		await expectLicensePooledBalanceExpired({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: canceling one of two parents expires only that pool")}`,
+	async () => {
+		const parentA = parentPlan({
+			id: "lic-pool-exp-one-a",
+			group: "lic-pool-exp-one-a",
+		});
+		const parentB = parentPlan({
+			id: "lic-pool-exp-one-b",
+			group: "lic-pool-exp-one-b",
+		});
+		const seatA = pooledSeatPlan({
+			id: "lic-pool-exp-one-seat-a",
+			item: pooledMonthlyMessages(),
+		});
+		const seatB = pooledSeatPlan({
+			id: "lic-pool-exp-one-seat-b",
+			item: pooledMonthlyMessages(),
+		});
+		const customerId = "lic-pool-parent-expire-one-of-two";
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parentA, parentB, seatA, seatB] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parentA.id,
+					licenseProductId: seatA.id,
+					included: 1,
+				}),
+				s.licenses.link({
+					parentProductId: parentB.id,
+					licenseProductId: seatB.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parentA.id }),
+				s.billing.attach({ productId: parentB.id }),
+				s.licenses.assign({ licenseProductId: seatA.id, entityIndex: 0 }),
+				s.licenses.assign({ licenseProductId: seatB.id, entityIndex: 1 }),
+			],
+		});
+
+		const linkA = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatA.id,
+		});
+		const linkB = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seatB.id,
+		});
+		await expectLicensePooledEntitlementHydrated({
+			ctx,
+			customerId,
+			customerLicenseLinkId: linkA,
+		});
+		await expectLicensePooledEntitlementHydrated({
+			ctx,
+			customerId,
+			customerLicenseLinkId: linkB,
+		});
+
+		await cancelParentImmediately({
+			autumn: autumnV2_3,
+			customerId,
+			planId: parentA.id,
+		});
+
+		await expectLicensePooledEntitlementNotHydrated({
+			ctx,
+			customerId,
+			customerLicenseLinkId: linkA,
+		});
+		await expectLicensePooledEntitlementHydrated({
+			ctx,
+			customerId,
+			customerLicenseLinkId: linkB,
+		});
+		await expectBalanceCorrect({
+			customerId,
+			autumn: autumnV2_3,
+			skipCache: true,
+			featureId: TestFeature.Messages,
+			granted: LICENSE_POOLED_GRANT,
+			remaining: LICENSE_POOLED_GRANT,
+			usage: 0,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: re-attach after cancel mints a fresh pool")}`,
+	async () => {
+		const parent = parentPlan({ id: "lic-pool-reattach-parent" });
+		const seat = pooledSeatPlan({
+			id: "lic-pool-reattach-seat",
+			item: pooledMonthlyMessages(),
+		});
+		const customerId = "lic-pool-parent-reattach";
+		const { entities, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, seat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: seat.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({ licenseProductId: seat.id, entityIndex: 0 }),
+			],
+		});
+
+		const expiredLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seat.id,
+		});
+		await expectLicensePooledEntitlementHydrated({
+			ctx,
+			customerId,
+			customerLicenseLinkId: expiredLinkId,
+		});
+
+		await cancelParentImmediately({
+			autumn: autumnV2_3,
+			customerId,
+			planId: parent.id,
+		});
+		await expectLicensePooledBalanceExpired({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId: expiredLinkId,
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: parent.id,
+			redirect_mode: "if_required",
+		});
+		await autumnV2_3.licenses.attach({
+			customer_id: customerId,
+			plan_id: seat.id,
+			entities: [{ entity_id: entities[0].id }],
+		});
+
+		const liveLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seat.id,
+		});
+		expect(liveLinkId).not.toBe(expiredLinkId);
+		await expectLicensePooledEntitlementNotHydrated({
+			ctx,
+			customerId,
+			customerLicenseLinkId: expiredLinkId,
+		});
+		await expectLicensePooledEntitlementHydrated({
+			ctx,
+			customerId,
+			customerLicenseLinkId: liveLinkId,
+		});
+		await expectBalanceCorrect({
+			customerId,
+			autumn: autumnV2_3,
+			skipCache: true,
+			featureId: TestFeature.Messages,
+			granted: LICENSE_POOLED_GRANT,
+			remaining: LICENSE_POOLED_GRANT,
+			usage: 0,
+		});
+	},
+);

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-release-rebind.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-release-rebind.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Contract: release and re-bind do not touch the pool. Spares keep
+ * contributing; entity delete rides the release path.
+ *
+ * Cases: 10, 11, 12
+ */
+
+import { expect, test } from "bun:test";
+import { expectPooledBalanceCorrect } from "@tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.js";
+import { getPooledBalanceDbState } from "@tests/integration/billing/pooled-balances/utils/getPooledBalanceDbState.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import {
+	LICENSE_POOLED_GRANT,
+	lazyLicensePoolLifecycle,
+	parentPlan,
+	pooledMonthlyMessages,
+	pooledSeatPlan,
+	seatLinkId,
+} from "./utils/licensePooledBalanceTestUtils.js";
+
+const livePoolId = async ({
+	db,
+	customerId,
+	customerLicenseLinkId,
+}: {
+	db: DrizzleCli;
+	customerId: string;
+	customerLicenseLinkId: string;
+}) => {
+	const state = await getPooledBalanceDbState({ db, customerId });
+	const pool = state.pools.find(
+		(candidate) =>
+			candidate.customer_license_link_id === customerLicenseLinkId &&
+			(candidate.expires_at === null || candidate.expires_at > Date.now()),
+	);
+	if (!pool) {
+		throw new Error(`No live pool for link ${customerLicenseLinkId}`);
+	}
+	return pool.id;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: release keeps granted; rebind keeps the same pool")}`,
+	async () => {
+		const parent = parentPlan({ id: "lic-pool-release-parent" });
+		const seat = pooledSeatPlan({
+			id: "lic-pool-release-seat",
+			item: pooledMonthlyMessages(),
+		});
+		const customerId = "lic-pool-release-rebind";
+		const { entities, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 4, featureId: TestFeature.Users }),
+				s.products({ list: [parent, seat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: seat.id,
+					included: 3,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: seat.id,
+					entityIndexes: [0, 1, 2],
+				}),
+			],
+		});
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seat.id,
+		});
+		const poolIdBefore = await livePoolId({
+			db: ctx.db,
+			customerId,
+			customerLicenseLinkId,
+		});
+
+		await autumnV2_3.licenses.release({
+			customer_id: customerId,
+			license_plan_id: seat.id,
+			entity_ids: [entities[0].id],
+		});
+
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId },
+			pool: {
+				balance: LICENSE_POOLED_GRANT * 3,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT * 3,
+				customerLicenseLinkId,
+				...lazyLicensePoolLifecycle,
+			},
+			contributions: {
+				count: 3,
+				currentContribution: LICENSE_POOLED_GRANT,
+			},
+			sources: { count: 3, balance: 0 },
+		});
+		expect(
+			await livePoolId({
+				db: ctx.db,
+				customerId,
+				customerLicenseLinkId,
+			}),
+		).toBe(poolIdBefore);
+
+		await autumnV2_3.licenses.attach({
+			customer_id: customerId,
+			plan_id: seat.id,
+			entities: [{ entity_id: entities[3].id }],
+		});
+
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId },
+			pool: {
+				balance: LICENSE_POOLED_GRANT * 3,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT * 3,
+				customerLicenseLinkId,
+				...lazyLicensePoolLifecycle,
+			},
+			contributions: {
+				count: 3,
+				currentContribution: LICENSE_POOLED_GRANT,
+			},
+			sources: { count: 3, balance: 0 },
+		});
+		expect(
+			await livePoolId({
+				db: ctx.db,
+				customerId,
+				customerLicenseLinkId,
+			}),
+		).toBe(poolIdBefore);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: entity delete is a release — pool stays")}`,
+	async () => {
+		const parent = parentPlan({ id: "lic-pool-entdel-parent" });
+		const seat = pooledSeatPlan({
+			id: "lic-pool-entdel-seat",
+			item: pooledMonthlyMessages(),
+		});
+		const customerId = "lic-pool-entity-delete";
+		const { entities, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, seat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: seat.id,
+					included: 2,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: seat.id,
+					entityIndexes: [0, 1],
+				}),
+			],
+		});
+
+		const customerLicenseLinkId = await seatLinkId({
+			db: ctx.db,
+			customerId,
+			licenseProductId: seat.id,
+		});
+		const poolIdBefore = await livePoolId({
+			db: ctx.db,
+			customerId,
+			customerLicenseLinkId,
+		});
+
+		await autumnV2_3.entities.delete(customerId, entities[0].id);
+
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			filter: { customerLicenseLinkId },
+			pool: {
+				balance: LICENSE_POOLED_GRANT * 2,
+				adjustment: 0,
+				granted: LICENSE_POOLED_GRANT * 2,
+				customerLicenseLinkId,
+				...lazyLicensePoolLifecycle,
+			},
+			contributions: {
+				count: 2,
+				currentContribution: LICENSE_POOLED_GRANT,
+			},
+			sources: { count: 2, balance: 0 },
+		});
+		expect(
+			await livePoolId({
+				db: ctx.db,
+				customerId,
+				customerLicenseLinkId,
+			}),
+		).toBe(poolIdBefore);
+	},
+);

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-reset.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-reset.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Contract: license pools run the same runtime reset machinery as regular
+ * pools. Overdue lazy license pools reset to seatCount × grant through reads;
+ * rollover caps size off the pool grant; the reset cron selects the synthetic
+ * row (never the seat sources). A dead parent hides the pool from reset.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	customerEntitlements,
+	PooledBalanceResetMode,
+	RolloverExpiryDurationType,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expirePooledBalanceForReset } from "@tests/integration/billing/pooled-balances/utils/expirePooledBalanceForReset.js";
+import { getPooledBalanceDbState } from "@tests/integration/billing/pooled-balances/utils/getPooledBalanceDbState.js";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq, inArray } from "drizzle-orm";
+import { resetCustomerEntitlement } from "@/cron/resetCron/resetCustomerEntitlement.js";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+import { getResetContextByIds } from "@/internal/customers/cusProducts/cusEnts/repos/getResetContextByIds.js";
+import {
+	LICENSE_POOLED_LOW_GRANT,
+	expectLicensePooledGrant,
+	parentPlan,
+	pooledMonthlyMessages,
+	pooledSeatPlan,
+	seatLinkId,
+} from "./utils/licensePooledBalanceTestUtils.js";
+
+const SEAT_COUNT = 3;
+const USAGE = 50;
+
+const seatResetScenario = async ({
+	customerId,
+	prefix,
+	rolloverConfig,
+}: {
+	customerId: string;
+	prefix: string;
+	rolloverConfig?: {
+		max_percentage: number;
+		length: number;
+		duration: RolloverExpiryDurationType;
+	};
+}) => {
+	const parent = parentPlan({ id: `${prefix}-parent` });
+	const seatItem = rolloverConfig
+		? {
+				...items.monthlyMessagesWithRollover({
+					includedUsage: LICENSE_POOLED_LOW_GRANT,
+					rolloverConfig,
+				}),
+				pooled: true,
+			}
+		: pooledMonthlyMessages({ includedUsage: LICENSE_POOLED_LOW_GRANT });
+	const seat = pooledSeatPlan({ id: `${prefix}-seat`, item: seatItem });
+
+	const scenario = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
+			s.products({ list: [parent, seat] }),
+		],
+		actions: [
+			s.licenses.link({
+				parentProductId: parent.id,
+				licenseProductId: seat.id,
+				included: SEAT_COUNT,
+			}),
+			s.billing.attach({ productId: parent.id }),
+			s.licenses.assign({
+				licenseProductId: seat.id,
+				entityIndexes: [0, 1, 2],
+			}),
+		],
+	});
+	const customerLicenseLinkId = await seatLinkId({
+		db: scenario.ctx.db,
+		customerId,
+		licenseProductId: seat.id,
+	});
+	return { ...scenario, customerLicenseLinkId, parent };
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled reset: overdue lazy license pool resets to seats × grant")}`,
+	async () => {
+		const customerId = "lic-pool-reset-lazy";
+		const { autumnV2_3, ctx, entities, customerLicenseLinkId } =
+			await seatResetScenario({
+				customerId,
+				prefix: "lic-pool-reset-lazy",
+			});
+
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				value: USAGE,
+			},
+			{ timeout: 2000 },
+		);
+		await expirePooledBalanceForReset({
+			ctx,
+			customerId,
+			resetMode: PooledBalanceResetMode.Lazy,
+		});
+
+		await expectLicensePooledGrant({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			customerLicenseLinkId,
+			grantPerSeat: LICENSE_POOLED_LOW_GRANT,
+			seatCount: SEAT_COUNT,
+			usage: 0,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled reset: rollover max_percentage sizes off the pool grant")}`,
+	async () => {
+		const customerId = "lic-pool-reset-rollover";
+		const { autumnV2_3, ctx, entities } = await seatResetScenario({
+			customerId,
+			prefix: "lic-pool-reset-roll",
+			rolloverConfig: {
+				max_percentage: 50,
+				length: 1,
+				duration: RolloverExpiryDurationType.Month,
+			},
+		});
+
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				value: USAGE,
+			},
+			{ timeout: 2000 },
+		);
+		await expirePooledBalanceForReset({
+			ctx,
+			customerId,
+			resetMode: PooledBalanceResetMode.Lazy,
+		});
+
+		// Pool grant = 600, cap = 300; unused 550 trims to 300. A per-seat cap
+		// would wrongly stop at 100.
+		const granted = LICENSE_POOLED_LOW_GRANT * SEAT_COUNT;
+		const rolledOver = granted / 2;
+		await expectBalanceCorrect({
+			customerId,
+			autumn: autumnV2_3,
+			skipCache: true,
+			featureId: TestFeature.Messages,
+			granted: granted + rolledOver,
+			remaining: granted + rolledOver,
+			usage: 0,
+			rollovers: [{ balance: rolledOver }],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled reset: cron selects the synthetic pool row, never seat sources")}`,
+	async () => {
+		const customerId = "lic-pool-reset-cron";
+		const { ctx } = await seatResetScenario({
+			customerId,
+			prefix: "lic-pool-reset-cron",
+		});
+
+		const { pool, pooledCustomerEntitlement } =
+			await expirePooledBalanceForReset({
+				ctx,
+				customerId,
+				resetMode: PooledBalanceResetMode.Lazy,
+			});
+		const state = await getPooledBalanceDbState({ db: ctx.db, customerId });
+		const sourceCustomerEntitlementIds = state.sourceCustomerProducts.flatMap(
+			(customerProduct) =>
+				customerProduct.customer_entitlements
+					.filter(
+						(customerEntitlement) => customerEntitlement.entitlement.pooled,
+					)
+					.map((customerEntitlement) => customerEntitlement.id),
+		);
+		await ctx.db
+			.update(customerEntitlements)
+			.set({ next_reset_at: Date.now() - 1_000 })
+			.where(inArray(customerEntitlements.id, sourceCustomerEntitlementIds));
+
+		const resettable = await CusEntService.getActiveResetPassed({
+			db: ctx.db,
+			customDateUnix: Date.now(),
+		});
+		const resettableIds = resettable.map((candidate) => candidate.id);
+		expect(resettableIds).toContain(pooledCustomerEntitlement.id);
+		for (const sourceCustomerEntitlementId of sourceCustomerEntitlementIds) {
+			expect(resettableIds).not.toContain(sourceCustomerEntitlementId);
+		}
+
+		const cronCustomerEntitlement = resettable.find(
+			(candidate) => candidate.id === pooledCustomerEntitlement.id,
+		);
+		if (!cronCustomerEntitlement) {
+			throw new Error("Expected cron to return the license pooled balance");
+		}
+		expect(cronCustomerEntitlement.pooled_balance?.id).toBe(pool.id);
+		await resetCustomerEntitlement({
+			ctx,
+			cusEnt: cronCustomerEntitlement,
+			updatedCusEnts: [],
+		});
+
+		const afterReset = await ctx.db.query.customerEntitlements.findFirst({
+			where: eq(customerEntitlements.id, pooledCustomerEntitlement.id),
+		});
+		expect(afterReset?.balance).toBe(LICENSE_POOLED_LOW_GRANT * SEAT_COUNT);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled reset: dead-parent license pool is not reset")}`,
+	async () => {
+		const customerId = "lic-pool-reset-dead-parent";
+		const { autumnV2_3, ctx, parent } = await seatResetScenario({
+			customerId,
+			prefix: "lic-pool-reset-dead-parent",
+		});
+		const { pooledCustomerEntitlement } = await expirePooledBalanceForReset({
+			ctx,
+			customerId,
+			resetMode: PooledBalanceResetMode.Lazy,
+		});
+
+		await autumnV2_3.billing.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: parent.id,
+			cancel_action: "cancel_immediately",
+		});
+
+		const hydrated = await getResetContextByIds({
+			db: ctx.db,
+			customerEntitlementIds: [pooledCustomerEntitlement.id],
+		});
+		expect(hydrated.missingIds).toContain(pooledCustomerEntitlement.id);
+		expect(hydrated.customerEntitlements).toHaveLength(0);
+
+		const resettable = await CusEntService.getActiveResetPassed({
+			db: ctx.db,
+			customDateUnix: Date.now(),
+		});
+		expect(resettable.map((candidate) => candidate.id)).not.toContain(
+			pooledCustomerEntitlement.id,
+		);
+	},
+);

--- a/server/tests/integration/licenses/pooled-balances/utils/licensePooledBalanceTestUtils.ts
+++ b/server/tests/integration/licenses/pooled-balances/utils/licensePooledBalanceTestUtils.ts
@@ -282,6 +282,33 @@ export const expectLicensePooledGrant = async ({
 	});
 };
 
+export const expectLicensePooledCheck = async ({
+	autumn,
+	customerId,
+	entityId,
+	featureId = TestFeature.Messages,
+	allowed,
+	remaining,
+}: {
+	autumn: AutumnInt;
+	customerId: string;
+	entityId?: string;
+	featureId?: string;
+	allowed: boolean;
+	remaining?: number;
+}) => {
+	const check = await autumn.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entityId,
+		feature_id: featureId,
+		skip_cache: true,
+	});
+	expect(check.allowed).toBe(allowed);
+	if (remaining !== undefined) {
+		expect(check.balance?.remaining).toBe(remaining);
+	}
+};
+
 export const expectLicensePrivateSeatGrant = async ({
 	autumn,
 	customerId,

--- a/server/tests/integration/licenses/pooled-balances/utils/licensePooledBalanceTestUtils.ts
+++ b/server/tests/integration/licenses/pooled-balances/utils/licensePooledBalanceTestUtils.ts
@@ -6,7 +6,9 @@ import {
 	EntInterval,
 	PooledBalanceResetMode,
 } from "@autumn/shared";
+import { expectPooledBalanceCorrect } from "@tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.js";
 import { getLicenseDbState } from "@tests/integration/licenses/licenseTestUtils.js";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
@@ -16,6 +18,9 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { CusService } from "@/internal/customers/CusService.js";
 
 export const LICENSE_POOLED_GRANT = 500;
+export const LICENSE_POOLED_LOW_GRANT = 200;
+export const LICENSE_POOLED_HIGH_GRANT = 400;
+export const LICENSE_POOLED_ADDED_GRANT = 100;
 
 export const lazyLicensePoolLifecycle = {
 	interval: EntInterval.Month,
@@ -73,16 +78,26 @@ export const parentPlan = ({
 		group,
 	});
 
+type PooledSeatItem =
+	| ReturnType<typeof pooledMonthlyMessages>
+	| ReturnType<typeof pooledMonthlyWords>
+	| ReturnType<typeof pooledLifetimeMessages>;
+
 export const pooledSeatPlan = ({
 	id,
 	item,
+	items,
+	group,
 }: {
 	id: string;
-	item: ReturnType<typeof pooledMonthlyMessages>;
+	item?: PooledSeatItem;
+	items?: PooledSeatItem[];
+	group?: string;
 }) =>
 	products.base({
 		id,
-		items: [item],
+		items: items ?? (item ? [item] : []),
+		group,
 	});
 
 export const seatLinkId = async ({
@@ -114,10 +129,12 @@ const hydratedLicensePooledEntitlements = async ({
 	ctx,
 	customerId,
 	customerLicenseLinkId,
+	featureId,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	customerLicenseLinkId: string;
+	featureId?: string;
 }) => {
 	const fullCustomer = await CusService.getFull({
 		ctx,
@@ -125,9 +142,16 @@ const hydratedLicensePooledEntitlements = async ({
 		skipReset: true,
 	});
 	return (fullCustomer.pooled_customer_entitlements ?? []).filter(
-		(customerEntitlement) =>
-			customerEntitlement.pooled_balance?.customer_license_link_id ===
-			customerLicenseLinkId,
+		(customerEntitlement) => {
+			if (
+				customerEntitlement.pooled_balance?.customer_license_link_id !==
+				customerLicenseLinkId
+			) {
+				return false;
+			}
+			if (featureId === undefined) return true;
+			return customerEntitlement.feature_id === featureId;
+		},
 	);
 };
 
@@ -189,9 +213,100 @@ export const expectLicensePooledBalanceExpired = async ({
 		skip_cache: true,
 	});
 	expect(check.allowed).toBe(false);
-	await expectLicensePooledEntitlementNotHydrated({
+	const hydrated = await hydratedLicensePooledEntitlements({
 		ctx,
 		customerId,
 		customerLicenseLinkId,
+		featureId,
 	});
+	expect(hydrated).toHaveLength(0);
+};
+
+export const expectLicensePooledGrant = async ({
+	autumn,
+	ctx,
+	customerId,
+	customerLicenseLinkId,
+	grantPerSeat,
+	seatCount,
+	usage = 0,
+	featureId = TestFeature.Messages,
+	lifecycle = lazyLicensePoolLifecycle,
+}: {
+	autumn: AutumnInt;
+	ctx: AutumnContext;
+	customerId: string;
+	customerLicenseLinkId: string;
+	grantPerSeat: number;
+	seatCount: number;
+	usage?: number;
+	featureId?: string;
+	lifecycle?:
+		| typeof lazyLicensePoolLifecycle
+		| typeof lifetimeLicensePoolLifecycle;
+}) => {
+	const granted = grantPerSeat * seatCount;
+	const feature = ctx.features.find((candidate) => candidate.id === featureId);
+	if (!feature) {
+		throw new Error(`Missing feature ${featureId}`);
+	}
+	await expectBalanceCorrect({
+		customerId,
+		autumn,
+		skipCache: true,
+		featureId,
+		granted,
+		remaining: granted - usage,
+		usage,
+	});
+	await expectPooledBalanceCorrect({
+		db: ctx.db,
+		customerId,
+		filter: {
+			customerLicenseLinkId,
+			internalFeatureId: feature.internal_id,
+		},
+		pool: {
+			balance: granted - usage,
+			adjustment: 0,
+			granted,
+			customerLicenseLinkId,
+			...lifecycle,
+		},
+		contributions: {
+			count: seatCount,
+			currentContribution: grantPerSeat,
+			nextCycleContribution: grantPerSeat,
+		},
+		sources: { count: seatCount, balance: 0, adjustment: 0 },
+	});
+};
+
+export const expectLicensePrivateSeatGrant = async ({
+	autumn,
+	customerId,
+	entityIds,
+	grant,
+	usage = 0,
+	featureId = TestFeature.Messages,
+}: {
+	autumn: AutumnInt;
+	customerId: string;
+	entityIds: string[];
+	grant: number;
+	usage?: number;
+	featureId?: string;
+}) => {
+	for (const entityId of entityIds) {
+		await expectBalanceCorrect({
+			customerId,
+			entityId,
+			autumn,
+			skipCache: true,
+			featureId,
+			granted: grant,
+			remaining: grant - usage,
+			usage,
+		});
+	}
 };

--- a/server/tests/integration/licenses/pooled-balances/utils/licensePooledBalanceTestUtils.ts
+++ b/server/tests/integration/licenses/pooled-balances/utils/licensePooledBalanceTestUtils.ts
@@ -1,0 +1,197 @@
+import { expect } from "bun:test";
+import {
+	type ApiCustomerV5,
+	type CheckResponseV3,
+	CusProductStatus,
+	EntInterval,
+	PooledBalanceResetMode,
+} from "@autumn/shared";
+import { getLicenseDbState } from "@tests/integration/licenses/licenseTestUtils.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { CusService } from "@/internal/customers/CusService.js";
+
+export const LICENSE_POOLED_GRANT = 500;
+
+export const lazyLicensePoolLifecycle = {
+	interval: EntInterval.Month,
+	nextResetAt: "present" as const,
+	resetCycleAnchor: "present" as const,
+	resetMode: PooledBalanceResetMode.Lazy,
+	stripeSubscriptionId: null,
+};
+
+export const lifetimeLicensePoolLifecycle = {
+	interval: EntInterval.Lifetime,
+	nextResetAt: null,
+	resetCycleAnchor: null,
+	resetMode: PooledBalanceResetMode.Lifetime,
+	stripeSubscriptionId: null,
+};
+
+export const pooledMonthlyMessages = ({
+	includedUsage = LICENSE_POOLED_GRANT,
+}: {
+	includedUsage?: number;
+} = {}) => ({
+	...items.monthlyMessages({ includedUsage }),
+	pooled: true,
+});
+
+export const pooledLifetimeMessages = ({
+	includedUsage = LICENSE_POOLED_GRANT,
+}: {
+	includedUsage?: number;
+} = {}) => ({
+	...items.lifetimeMessages({ includedUsage }),
+	pooled: true,
+});
+
+export const pooledMonthlyWords = ({
+	includedUsage = LICENSE_POOLED_GRANT,
+}: {
+	includedUsage?: number;
+} = {}) => ({
+	...items.monthlyWords({ includedUsage }),
+	pooled: true,
+});
+
+export const parentPlan = ({
+	id,
+	group,
+}: {
+	id: string;
+	group?: string;
+}) =>
+	products.base({
+		id,
+		items: [items.dashboard()],
+		group,
+	});
+
+export const pooledSeatPlan = ({
+	id,
+	item,
+}: {
+	id: string;
+	item: ReturnType<typeof pooledMonthlyMessages>;
+}) =>
+	products.base({
+		id,
+		items: [item],
+	});
+
+export const seatLinkId = async ({
+	db,
+	customerId,
+	licenseProductId,
+}: {
+	db: DrizzleCli;
+	customerId: string;
+	licenseProductId: string;
+}) => {
+	const { assignments } = await getLicenseDbState({ db, customerId });
+	const matching = assignments.filter(
+		(candidate) => candidate.product_id === licenseProductId,
+	);
+	const assignment =
+		matching.find(
+			(candidate) => candidate.status !== CusProductStatus.Expired,
+		) ?? matching[0];
+	if (!assignment?.customer_license_link_id) {
+		throw new Error(
+			`No seat assignment for license ${licenseProductId} on ${customerId}`,
+		);
+	}
+	return assignment.customer_license_link_id;
+};
+
+const hydratedLicensePooledEntitlements = async ({
+	ctx,
+	customerId,
+	customerLicenseLinkId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	customerLicenseLinkId: string;
+}) => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		skipReset: true,
+	});
+	return (fullCustomer.pooled_customer_entitlements ?? []).filter(
+		(customerEntitlement) =>
+			customerEntitlement.pooled_balance?.customer_license_link_id ===
+			customerLicenseLinkId,
+	);
+};
+
+export const expectLicensePooledEntitlementHydrated = async ({
+	ctx,
+	customerId,
+	customerLicenseLinkId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	customerLicenseLinkId: string;
+}) => {
+	const hydrated = await hydratedLicensePooledEntitlements({
+		ctx,
+		customerId,
+		customerLicenseLinkId,
+	});
+	expect(hydrated).toHaveLength(1);
+};
+
+export const expectLicensePooledEntitlementNotHydrated = async ({
+	ctx,
+	customerId,
+	customerLicenseLinkId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	customerLicenseLinkId: string;
+}) => {
+	const hydrated = await hydratedLicensePooledEntitlements({
+		ctx,
+		customerId,
+		customerLicenseLinkId,
+	});
+	expect(hydrated).toHaveLength(0);
+};
+
+/** Parent liveness hides the license pool at read time — same as seats. */
+export const expectLicensePooledBalanceExpired = async ({
+	autumn,
+	ctx,
+	customerId,
+	customerLicenseLinkId,
+	featureId = TestFeature.Messages,
+}: {
+	autumn: AutumnInt;
+	ctx: AutumnContext;
+	customerId: string;
+	customerLicenseLinkId: string;
+	featureId?: string;
+}) => {
+	const customer = await autumn.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+	expect(customer.balances[featureId]).toBeUndefined();
+	const check = await autumn.check<CheckResponseV3>({
+		customer_id: customerId,
+		feature_id: featureId,
+		skip_cache: true,
+	});
+	expect(check.allowed).toBe(false);
+	await expectLicensePooledEntitlementNotHydrated({
+		ctx,
+		customerId,
+		customerLicenseLinkId,
+	});
+};

--- a/server/tests/perf/benchPooledLicenseAddRemove.ts
+++ b/server/tests/perf/benchPooledLicenseAddRemove.ts
@@ -1,0 +1,422 @@
+/**
+ * Times pooled add (insert sources + contributions + granted Δ) and
+ * pooled remove (delete contributions, subtract granted, expire) on an
+ * isolated DEV schema. One customer, one pre-minted empty pool, N seats.
+ *
+ *   NODE_ENV=development infisical run --env=dev --recursive -- \
+ *     bun tests/perf/benchPooledLicenseAddRemove.ts
+ *
+ *   BENCHMARK_CONTRIBUTIONS=10000  (default 10_000)
+ *
+ * Does not use staging or prod. Drops the schema on exit.
+ */
+
+import { EntInterval } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import { assertNotProductionDb } from "@/db/dbUtils.js";
+import { addCustomerEntitlementsBatch } from "@/internal/billing/v2/actions/batchTransition/execute/sql/addCustomerEntitlementsBatch.js";
+import { deleteCustomerEntitlementsBatch } from "@/internal/billing/v2/actions/batchTransition/execute/sql/deleteCustomerEntitlementsBatch.js";
+import type {
+	AddEntitlementPriceOperation,
+	RemoveEntitlementPriceOperation,
+} from "@/internal/billing/v2/actions/batchTransition/types/entitlementPriceOperationTypes.js";
+import { BATCH_TRANSITION_ROW_BATCH_SIZE } from "@/internal/billing/v2/actions/batchTransition/utils/batchTransitionConstants.js";
+import { generateId } from "@/utils/genUtils.js";
+import { assertBenchDatabaseSafe } from "./batch-migrations/utils/benchContext.js";
+
+if (process.env.NODE_ENV !== "development") {
+	throw new Error("Run this benchmark with NODE_ENV=development");
+}
+if (
+	process.env.INFISICAL_ENVIRONMENT &&
+	process.env.INFISICAL_ENVIRONMENT !== "dev"
+) {
+	throw new Error("Run this benchmark with the Infisical dev environment");
+}
+if (process.env.ENV_FILE && process.env.ENV_FILE !== ".env") {
+	throw new Error("Run this benchmark with the dev ENV_FILE");
+}
+if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is required");
+assertNotProductionDb(process.env.DATABASE_URL);
+assertBenchDatabaseSafe();
+
+const SEAT_COUNT = Number(process.env.BENCHMARK_CONTRIBUTIONS ?? "10000");
+if (!Number.isInteger(SEAT_COUNT) || SEAT_COUNT < 1 || SEAT_COUNT > 2_000_000) {
+	throw new Error("BENCHMARK_CONTRIBUTIONS must be 1..2000000");
+}
+
+const GRANT = 100;
+const NOW = Date.now();
+const ASSIGNMENT_CUTOFF_MS = NOW + 60_000;
+
+const LINK_ID = "ppar_link";
+const INTERNAL_CUSTOMER_ID = "ppar_cus";
+const ADD_ENTITLEMENT_ID = "ppar_ent_words";
+const FEATURE_INTERNAL_ID = "ppar_feat_words";
+const FEATURE_ID = "words";
+const POOL_ID = "ppar_pool";
+const SYNTHETIC_ID = "ppar_pool_ce";
+
+const benchmarkDatabaseUrl = new URL(process.env.DATABASE_URL);
+benchmarkDatabaseUrl.hostname = benchmarkDatabaseUrl.hostname.replace(
+	"-pooler.",
+	".",
+);
+
+const BENCHMARK_SCHEMA = `pooled_add_remove_bench_${process.pid}_${Date.now()}`;
+if (!/^pooled_add_remove_bench_\d+_\d+$/.test(BENCHMARK_SCHEMA)) {
+	throw new Error("Invalid benchmark schema name");
+}
+
+const { initDrizzle } = await import("@/db/initDrizzle.js");
+const { db: bootstrapDb, client: bootstrapClient } = initDrizzle({
+	databaseUrl: benchmarkDatabaseUrl.toString(),
+	maxConnections: 1,
+	poolConfig: {
+		application_name: "pooled-add-remove-bench-bootstrap",
+		query_timeout: 0,
+	},
+});
+await bootstrapDb.execute(
+	sql`CREATE SCHEMA ${sql.identifier(BENCHMARK_SCHEMA)}`,
+);
+
+const { db, client } = initDrizzle({
+	databaseUrl: benchmarkDatabaseUrl.toString(),
+	maxConnections: 1,
+	poolConfig: {
+		application_name: "pooled-add-remove-bench",
+		options: `-c search_path=${BENCHMARK_SCHEMA},public -c statement_timeout=0`,
+		query_timeout: 0,
+	},
+});
+
+const timed = async <T>({
+	label,
+	fn,
+}: {
+	label: string;
+	fn: () => Promise<T>;
+}) => {
+	const startedAt = performance.now();
+	const result = await fn();
+	const milliseconds = performance.now() - startedAt;
+	console.log(`${label}: ${(milliseconds / 1000).toFixed(2)}s`);
+	return { result, milliseconds };
+};
+
+const addOperation = {
+	type: "add",
+	entitlementPrice: {
+		entitlement: { id: ADD_ENTITLEMENT_ID, pooled: true },
+	},
+	existingEntitlementIds: [ADD_ENTITLEMENT_ID],
+	customerEntitlement: {
+		entitlement_id: ADD_ENTITLEMENT_ID,
+		internal_customer_id: INTERNAL_CUSTOMER_ID,
+		internal_feature_id: FEATURE_INTERNAL_ID,
+		internal_entity_id: null,
+		feature_id: FEATURE_ID,
+		customer_id: "ppar_cus_ext",
+		unlimited: false,
+		balance: 0,
+		created_at: NOW,
+		reset_cycle_anchor: NOW,
+		next_reset_at: NOW,
+		usage_allowed: false,
+		separate_interval: false,
+		adjustment: 0,
+		additional_balance: 0,
+		entities: null,
+		expires_at: null,
+		cache_version: 0,
+		external_id: null,
+	},
+	pooledAdd: { contributionAmount: GRANT },
+} as AddEntitlementPriceOperation;
+
+const removeOperation = {
+	type: "remove",
+	entitlementPrice: { entitlement: { pooled: true } },
+	fromEntitlementIds: [ADD_ENTITLEMENT_ID],
+} as RemoveEntitlementPriceOperation;
+
+const runAddBatch = () =>
+	addCustomerEntitlementsBatch({
+		db,
+		customerLicenseLinkId: LINK_ID,
+		assignmentCutoffMs: ASSIGNMENT_CUTOFF_MS,
+		customerEntitlementIds: Array.from(
+			{ length: BATCH_TRANSITION_ROW_BATCH_SIZE },
+			() => generateId("cus_ent"),
+		),
+		operation: addOperation,
+		batchSize: BATCH_TRANSITION_ROW_BATCH_SIZE,
+		pooledBalanceId: POOL_ID,
+		contributionIds: Array.from(
+			{ length: BATCH_TRANSITION_ROW_BATCH_SIZE },
+			() => generateId("pool_contribution"),
+		),
+	});
+
+const runRemoveBatch = () =>
+	deleteCustomerEntitlementsBatch({
+		db,
+		customerLicenseLinkId: LINK_ID,
+		operation: removeOperation,
+		batchSize: BATCH_TRANSITION_ROW_BATCH_SIZE,
+	});
+
+const runRemaining = async ({
+	executeBatch,
+}: {
+	executeBatch: () => Promise<{ affected: number; hasMore: boolean }>;
+}) => {
+	let affected = 0;
+	let batches = 0;
+	let hasMore = true;
+	while (hasMore) {
+		const result = await executeBatch();
+		affected += result.affected;
+		batches += 1;
+		hasMore = result.hasMore;
+		if (result.affected === 0 && hasMore) {
+			throw new Error("batch made no progress");
+		}
+	}
+	return { affected, batches };
+};
+
+const createTables = async () => {
+	for (const table of [
+		"customer_products",
+		"customer_entitlements",
+		"pooled_balances",
+		"pooled_balance_contributions",
+	]) {
+		await db.execute(
+			sql`CREATE TABLE ${sql.identifier(table)} (LIKE public.${sql.identifier(table)} INCLUDING ALL)`,
+		);
+	}
+};
+
+const seed = async () => {
+	await db.execute(sql`
+		INSERT INTO customer_products (
+			id, internal_customer_id, internal_product_id, internal_entity_id,
+			created_at, status, customer_license_link_id
+		)
+		SELECT
+			'ppar_seat_' || i,
+			${INTERNAL_CUSTOMER_ID},
+			'ppar_prod',
+			'ppar_entity_' || i,
+			${NOW},
+			'active',
+			${LINK_ID}
+		FROM generate_series(1, ${SEAT_COUNT}) AS i
+	`);
+
+	await db.execute(sql`
+		INSERT INTO customer_entitlements (
+			id, customer_product_id, entitlement_id, internal_customer_id,
+			internal_feature_id, feature_id, unlimited, balance, created_at,
+			usage_allowed, separate_interval, cache_version, is_pooled_balance,
+			pooled_balance_id
+		)
+		VALUES (
+			${SYNTHETIC_ID},
+			NULL,
+			${ADD_ENTITLEMENT_ID},
+			${INTERNAL_CUSTOMER_ID},
+			${FEATURE_INTERNAL_ID},
+			${FEATURE_ID},
+			false,
+			0,
+			${NOW},
+			false,
+			false,
+			0,
+			true,
+			${POOL_ID}
+		)
+	`);
+
+	await db.execute(sql`
+		INSERT INTO pooled_balances (
+			id, org_id, env, internal_customer_id, internal_feature_id,
+			unlimited, granted, interval, interval_count, reset_mode,
+			rollover_signature, customer_entitlement_id,
+			customer_license_link_id, created_at, updated_at
+		)
+		VALUES (
+			${POOL_ID},
+			'ppar_org',
+			'sandbox',
+			${INTERNAL_CUSTOMER_ID},
+			${FEATURE_INTERNAL_ID},
+			false,
+			0,
+			${EntInterval.Month},
+			1,
+			'lazy',
+			'none',
+			${SYNTHETIC_ID},
+			${LINK_ID},
+			${NOW},
+			${NOW}
+		)
+	`);
+
+	await db.execute(sql`
+		ANALYZE customer_products, customer_entitlements,
+			pooled_balances, pooled_balance_contributions
+	`);
+};
+
+const verifyAdd = async () => {
+	const [row] = await db.execute<{
+		sources: number;
+		contributions: number;
+		granted: number;
+		synthetic_balance: number;
+		source_balance: number;
+		linked_sources: number;
+	}>(sql`
+		SELECT
+			(SELECT count(*)::int FROM customer_entitlements
+				WHERE entitlement_id = ${ADD_ENTITLEMENT_ID}
+					AND customer_product_id IS NOT NULL) AS sources,
+			(SELECT count(*)::int FROM pooled_balance_contributions
+				WHERE pooled_balance_id = ${POOL_ID}) AS contributions,
+			(SELECT granted FROM pooled_balances WHERE id = ${POOL_ID}) AS granted,
+			(SELECT balance FROM customer_entitlements WHERE id = ${SYNTHETIC_ID}) AS synthetic_balance,
+			(SELECT COALESCE(MIN(balance), -1) FROM customer_entitlements
+				WHERE entitlement_id = ${ADD_ENTITLEMENT_ID}
+					AND customer_product_id IS NOT NULL) AS source_balance,
+			(SELECT count(*)::int FROM customer_entitlements
+				WHERE entitlement_id = ${ADD_ENTITLEMENT_ID}
+					AND customer_product_id IS NOT NULL
+					AND pooled_contribution_id IS NOT NULL) AS linked_sources
+	`);
+	const expectedGranted = GRANT * SEAT_COUNT;
+	if (
+		row.sources !== SEAT_COUNT ||
+		row.contributions !== SEAT_COUNT ||
+		Number(row.granted) !== expectedGranted ||
+		Number(row.synthetic_balance) !== expectedGranted ||
+		Number(row.source_balance) !== 0 ||
+		row.linked_sources !== SEAT_COUNT
+	) {
+		throw new Error(`add verify failed: ${JSON.stringify(row)}`);
+	}
+};
+
+const verifyRemove = async () => {
+	const [row] = await db.execute<{
+		sources: number;
+		contributions: number;
+		granted: number;
+		pool_expired: boolean;
+		synthetic_expired: boolean;
+	}>(sql`
+		SELECT
+			(SELECT count(*)::int FROM customer_entitlements
+				WHERE entitlement_id = ${ADD_ENTITLEMENT_ID}
+					AND customer_product_id IS NOT NULL) AS sources,
+			(SELECT count(*)::int FROM pooled_balance_contributions
+				WHERE pooled_balance_id = ${POOL_ID}) AS contributions,
+			(SELECT granted FROM pooled_balances WHERE id = ${POOL_ID}) AS granted,
+			(SELECT expires_at IS NOT NULL FROM pooled_balances WHERE id = ${POOL_ID}) AS pool_expired,
+			(SELECT expires_at IS NOT NULL FROM customer_entitlements WHERE id = ${SYNTHETIC_ID}) AS synthetic_expired
+	`);
+	if (
+		row.sources !== 0 ||
+		row.contributions !== 0 ||
+		Number(row.granted) !== 0 ||
+		row.pool_expired !== true ||
+		row.synthetic_expired !== true
+	) {
+		throw new Error(`remove verify failed: ${JSON.stringify(row)}`);
+	}
+};
+
+try {
+	console.log(
+		`DEV schema ${BENCHMARK_SCHEMA}; seats=${SEAT_COUNT.toLocaleString()}; grant=${GRANT}`,
+	);
+	await createTables();
+	const seeded = await timed({
+		label: `seed ${SEAT_COUNT.toLocaleString()} seats + empty pool`,
+		fn: seed,
+	});
+
+	const firstAdd = await timed({
+		label: `add first batch (${BATCH_TRANSITION_ROW_BATCH_SIZE.toLocaleString()} rows)`,
+		fn: runAddBatch,
+	});
+	console.log(
+		`  affected=${firstAdd.result.affected} hasMore=${firstAdd.result.hasMore}`,
+	);
+	const restAdd = await timed({
+		label: "add remaining batches",
+		fn: () => runRemaining({ executeBatch: runAddBatch }),
+	});
+	await verifyAdd();
+
+	const firstRemove = await timed({
+		label: `remove first batch (${BATCH_TRANSITION_ROW_BATCH_SIZE.toLocaleString()} rows)`,
+		fn: runRemoveBatch,
+	});
+	console.log(
+		`  affected=${firstRemove.result.affected} hasMore=${firstRemove.result.hasMore}`,
+	);
+	const restRemove = await timed({
+		label: "remove remaining batches",
+		fn: () => runRemaining({ executeBatch: runRemoveBatch }),
+	});
+	await verifyRemove();
+
+	const addMs = firstAdd.milliseconds + restAdd.milliseconds;
+	const removeMs = firstRemove.milliseconds + restRemove.milliseconds;
+	const addAffected = firstAdd.result.affected + restAdd.result.affected;
+	const removeAffected =
+		firstRemove.result.affected + restRemove.result.affected;
+
+	console.table([
+		{
+			op: "add",
+			seats: SEAT_COUNT,
+			seedMs: Number(seeded.milliseconds.toFixed(1)),
+			firstBatchMs: Number(firstAdd.milliseconds.toFixed(1)),
+			remainingBatches: restAdd.result.batches,
+			totalMs: Number(addMs.toFixed(1)),
+			rowsPerSecond: Math.round((addAffected * 1000) / addMs),
+			msPer5k: Number(
+				((addMs / addAffected) * BATCH_TRANSITION_ROW_BATCH_SIZE).toFixed(1),
+			),
+		},
+		{
+			op: "remove",
+			seats: SEAT_COUNT,
+			seedMs: Number(seeded.milliseconds.toFixed(1)),
+			firstBatchMs: Number(firstRemove.milliseconds.toFixed(1)),
+			remainingBatches: restRemove.result.batches,
+			totalMs: Number(removeMs.toFixed(1)),
+			rowsPerSecond: Math.round((removeAffected * 1000) / removeMs),
+			msPer5k: Number(
+				((removeMs / removeAffected) * BATCH_TRANSITION_ROW_BATCH_SIZE).toFixed(
+					1,
+				),
+			),
+		},
+	]);
+} finally {
+	await client.end();
+	await bootstrapDb.execute(
+		sql`DROP SCHEMA ${sql.identifier(BENCHMARK_SCHEMA)} CASCADE`,
+	);
+	await bootstrapClient.end();
+}
+
+process.exit(0);

--- a/server/tests/perf/benchPooledLicenseReplace.ts
+++ b/server/tests/perf/benchPooledLicenseReplace.ts
@@ -1,0 +1,369 @@
+/**
+ * Times pooled replace (entitlement swap + contribution/pool Δ) on an
+ * isolated DEV schema. One customer, one pool, N source contributions.
+ *
+ *   NODE_ENV=development infisical run --env=dev --recursive -- \
+ *     bun tests/perf/benchPooledLicenseReplace.ts
+ *
+ *   BENCHMARK_CONTRIBUTIONS=10000  (default 1_000_000)
+ *
+ * Does not use staging or prod. Drops the schema on exit.
+ */
+
+import { EntInterval } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import { assertNotProductionDb } from "@/db/dbUtils.js";
+import { replaceCustomerEntitlementsBatch } from "@/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch.js";
+import type { ReplaceEntitlementPriceOperation } from "@/internal/billing/v2/actions/batchTransition/types/entitlementPriceOperationTypes.js";
+import { BATCH_TRANSITION_ROW_BATCH_SIZE } from "@/internal/billing/v2/actions/batchTransition/utils/batchTransitionConstants.js";
+import { assertBenchDatabaseSafe } from "./batch-migrations/utils/benchContext.js";
+
+if (process.env.NODE_ENV !== "development") {
+	throw new Error("Run this benchmark with NODE_ENV=development");
+}
+if (
+	process.env.INFISICAL_ENVIRONMENT &&
+	process.env.INFISICAL_ENVIRONMENT !== "dev"
+) {
+	throw new Error("Run this benchmark with the Infisical dev environment");
+}
+if (process.env.ENV_FILE && process.env.ENV_FILE !== ".env") {
+	throw new Error("Run this benchmark with the dev ENV_FILE");
+}
+if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is required");
+assertNotProductionDb(process.env.DATABASE_URL);
+assertBenchDatabaseSafe();
+
+const CONTRIBUTION_COUNT = Number(
+	process.env.BENCHMARK_CONTRIBUTIONS ?? "1000000",
+);
+if (
+	!Number.isInteger(CONTRIBUTION_COUNT) ||
+	CONTRIBUTION_COUNT < 1 ||
+	CONTRIBUTION_COUNT > 2_000_000
+) {
+	throw new Error("BENCHMARK_CONTRIBUTIONS must be 1..2000000");
+}
+
+const GRANT_FROM = 200;
+const GRANT_TO = 400;
+const DELTA = GRANT_TO - GRANT_FROM;
+const NOW = Date.now();
+
+const LINK_ID = "ppr_link";
+const INTERNAL_CUSTOMER_ID = "ppr_cus";
+const FROM_ENTITLEMENT_ID = "ppr_ent_from";
+const TO_ENTITLEMENT_ID = "ppr_ent_to";
+const FEATURE_INTERNAL_ID = "ppr_feat_messages";
+const FEATURE_ID = "messages";
+const POOL_ID = "ppr_pool";
+const SYNTHETIC_ID = "ppr_pool_ce";
+
+const benchmarkDatabaseUrl = new URL(process.env.DATABASE_URL);
+benchmarkDatabaseUrl.hostname = benchmarkDatabaseUrl.hostname.replace(
+	"-pooler.",
+	".",
+);
+
+const BENCHMARK_SCHEMA = `pooled_replace_bench_${process.pid}_${Date.now()}`;
+if (!/^pooled_replace_bench_\d+_\d+$/.test(BENCHMARK_SCHEMA)) {
+	throw new Error("Invalid benchmark schema name");
+}
+
+const { initDrizzle } = await import("@/db/initDrizzle.js");
+const { db: bootstrapDb, client: bootstrapClient } = initDrizzle({
+	databaseUrl: benchmarkDatabaseUrl.toString(),
+	maxConnections: 1,
+	poolConfig: {
+		application_name: "pooled-replace-bench-bootstrap",
+		query_timeout: 0,
+	},
+});
+await bootstrapDb.execute(
+	sql`CREATE SCHEMA ${sql.identifier(BENCHMARK_SCHEMA)}`,
+);
+
+const { db, client } = initDrizzle({
+	databaseUrl: benchmarkDatabaseUrl.toString(),
+	maxConnections: 1,
+	poolConfig: {
+		application_name: "pooled-replace-bench",
+		options: `-c search_path=${BENCHMARK_SCHEMA},public -c statement_timeout=0`,
+		query_timeout: 0,
+	},
+});
+
+const timed = async <T>({
+	label,
+	fn,
+}: {
+	label: string;
+	fn: () => Promise<T>;
+}) => {
+	const startedAt = performance.now();
+	const result = await fn();
+	const milliseconds = performance.now() - startedAt;
+	console.log(`${label}: ${(milliseconds / 1000).toFixed(2)}s`);
+	return { result, milliseconds };
+};
+
+const operation = {
+	type: "replace",
+	fromEntitlementIds: [FROM_ENTITLEMENT_ID],
+	toEntitlementId: TO_ENTITLEMENT_ID,
+	fromEntitlementPrice: {
+		entitlement: { id: FROM_ENTITLEMENT_ID, pooled: true },
+	},
+	toEntitlementPrice: {
+		entitlement: {
+			id: TO_ENTITLEMENT_ID,
+			pooled: true,
+			internal_feature_id: FEATURE_INTERNAL_ID,
+			feature: { id: FEATURE_ID },
+		},
+	},
+	customerEntitlementPatch: {},
+	pooledContributionPatch: { type: "increment", amount: DELTA },
+} as ReplaceEntitlementPriceOperation;
+
+const createTables = async () => {
+	for (const table of [
+		"customer_products",
+		"customer_entitlements",
+		"pooled_balances",
+		"pooled_balance_contributions",
+	]) {
+		await db.execute(
+			sql`CREATE TABLE ${sql.identifier(table)} (LIKE public.${sql.identifier(table)} INCLUDING ALL)`,
+		);
+	}
+};
+
+const seed = async () => {
+	await db.execute(sql`
+		INSERT INTO customer_products (
+			id, internal_customer_id, internal_product_id, internal_entity_id,
+			created_at, status, customer_license_link_id
+		)
+		SELECT
+			'ppr_seat_' || i,
+			${INTERNAL_CUSTOMER_ID},
+			'ppr_prod_from',
+			'ppr_entity_' || i,
+			${NOW},
+			'active',
+			${LINK_ID}
+		FROM generate_series(1, ${CONTRIBUTION_COUNT}) AS i
+	`);
+
+	await db.execute(sql`
+		INSERT INTO customer_entitlements (
+			id, customer_product_id, entitlement_id, internal_customer_id,
+			internal_feature_id, feature_id, unlimited, balance, created_at,
+			usage_allowed, separate_interval, cache_version, is_pooled_balance
+		)
+		SELECT
+			'ppr_ce_' || i,
+			'ppr_seat_' || i,
+			${FROM_ENTITLEMENT_ID},
+			${INTERNAL_CUSTOMER_ID},
+			${FEATURE_INTERNAL_ID},
+			${FEATURE_ID},
+			false,
+			0,
+			${NOW},
+			false,
+			false,
+			0,
+			false
+		FROM generate_series(1, ${CONTRIBUTION_COUNT}) AS i
+	`);
+
+	await db.execute(sql`
+		INSERT INTO customer_entitlements (
+			id, customer_product_id, entitlement_id, internal_customer_id,
+			internal_feature_id, feature_id, unlimited, balance, created_at,
+			usage_allowed, separate_interval, cache_version, is_pooled_balance,
+			pooled_balance_id
+		)
+		VALUES (
+			${SYNTHETIC_ID},
+			NULL,
+			${FROM_ENTITLEMENT_ID},
+			${INTERNAL_CUSTOMER_ID},
+			${FEATURE_INTERNAL_ID},
+			${FEATURE_ID},
+			false,
+			${GRANT_FROM * CONTRIBUTION_COUNT},
+			${NOW},
+			false,
+			false,
+			0,
+			true,
+			${POOL_ID}
+		)
+	`);
+
+	await db.execute(sql`
+		INSERT INTO pooled_balances (
+			id, org_id, env, internal_customer_id, internal_feature_id,
+			unlimited, granted, interval, interval_count, reset_mode,
+			rollover_signature, customer_entitlement_id,
+			customer_license_link_id, created_at, updated_at
+		)
+		VALUES (
+			${POOL_ID},
+			'ppr_org',
+			'sandbox',
+			${INTERNAL_CUSTOMER_ID},
+			${FEATURE_INTERNAL_ID},
+			false,
+			${GRANT_FROM * CONTRIBUTION_COUNT},
+			${EntInterval.Month},
+			1,
+			'lazy',
+			'none',
+			${SYNTHETIC_ID},
+			${LINK_ID},
+			${NOW},
+			${NOW}
+		)
+	`);
+
+	await db.execute(sql`
+		INSERT INTO pooled_balance_contributions (
+			id, pooled_balance_id, source_customer_product_id,
+			source_customer_entitlement_id, current_contribution,
+			next_cycle_contribution, created_at, updated_at
+		)
+		SELECT
+			'ppr_contrib_' || i,
+			${POOL_ID},
+			'ppr_seat_' || i,
+			'ppr_ce_' || i,
+			${GRANT_FROM},
+			${GRANT_FROM},
+			${NOW},
+			${NOW}
+		FROM generate_series(1, ${CONTRIBUTION_COUNT}) AS i
+	`);
+
+	await db.execute(sql`
+		ANALYZE customer_products, customer_entitlements,
+			pooled_balances, pooled_balance_contributions
+	`);
+};
+
+const runAllBatches = async () => {
+	let affected = 0;
+	let batches = 0;
+	let hasMore = true;
+	while (hasMore) {
+		const result = await replaceCustomerEntitlementsBatch({
+			db,
+			customerLicenseLinkId: LINK_ID,
+			operation,
+			batchSize: BATCH_TRANSITION_ROW_BATCH_SIZE,
+		});
+		affected += result.affected;
+		batches += 1;
+		hasMore = result.hasMore;
+		if (result.affected === 0 && hasMore) {
+			throw new Error("pooled replace made no progress");
+		}
+	}
+	return { affected, batches };
+};
+
+const verify = async () => {
+	const [row] = await db.execute<{
+		swapped: number;
+		leftover: number;
+		granted: number;
+		synthetic_balance: number;
+		contribution: number;
+	}>(sql`
+		SELECT
+			(SELECT count(*)::int FROM customer_entitlements
+				WHERE entitlement_id = ${TO_ENTITLEMENT_ID}
+					AND customer_product_id IS NOT NULL) AS swapped,
+			(SELECT count(*)::int FROM customer_entitlements
+				WHERE entitlement_id = ${FROM_ENTITLEMENT_ID}
+					AND customer_product_id IS NOT NULL) AS leftover,
+			(SELECT granted FROM pooled_balances WHERE id = ${POOL_ID}) AS granted,
+			(SELECT balance FROM customer_entitlements WHERE id = ${SYNTHETIC_ID}) AS synthetic_balance,
+			(SELECT current_contribution FROM pooled_balance_contributions
+				WHERE source_customer_entitlement_id = 'ppr_ce_1') AS contribution
+	`);
+	const expectedGranted = GRANT_TO * CONTRIBUTION_COUNT;
+	if (
+		row.swapped !== CONTRIBUTION_COUNT ||
+		row.leftover !== 0 ||
+		Number(row.granted) !== expectedGranted ||
+		Number(row.synthetic_balance) !== expectedGranted ||
+		Number(row.contribution) !== GRANT_TO
+	) {
+		throw new Error(`verify failed: ${JSON.stringify(row)}`);
+	}
+};
+
+try {
+	console.log(
+		`DEV schema ${BENCHMARK_SCHEMA}; contributions=${CONTRIBUTION_COUNT.toLocaleString()}; Δ=${DELTA}`,
+	);
+	console.log(
+		`prod batchTransition caps at 100k rows / 20 batches — this loop is the SQL only`,
+	);
+	await createTables();
+	const seeded = await timed({
+		label: `seed ${CONTRIBUTION_COUNT.toLocaleString()} seats + contributions + pool`,
+		fn: seed,
+	});
+
+	const first = await timed({
+		label: `first batch (${BATCH_TRANSITION_ROW_BATCH_SIZE.toLocaleString()} rows)`,
+		fn: () =>
+			replaceCustomerEntitlementsBatch({
+				db,
+				customerLicenseLinkId: LINK_ID,
+				operation,
+				batchSize: BATCH_TRANSITION_ROW_BATCH_SIZE,
+			}),
+	});
+	console.log(
+		`  affected=${first.result.affected} hasMore=${first.result.hasMore}`,
+	);
+
+	const rest = await timed({
+		label: "remaining batches",
+		fn: runAllBatches,
+	});
+	const totalMs = first.milliseconds + rest.milliseconds;
+	const totalAffected = first.result.affected + rest.result.affected;
+	await verify();
+
+	console.table([
+		{
+			contributions: CONTRIBUTION_COUNT,
+			seedMs: Number(seeded.milliseconds.toFixed(1)),
+			firstBatchMs: Number(first.milliseconds.toFixed(1)),
+			remainingBatches: rest.result.batches,
+			remainingMs: Number(rest.milliseconds.toFixed(1)),
+			totalReplaceMs: Number(totalMs.toFixed(1)),
+			rowsPerSecond: Math.round((totalAffected * 1000) / totalMs),
+			msPer5k: Number(
+				((totalMs / totalAffected) * BATCH_TRANSITION_ROW_BATCH_SIZE).toFixed(
+					1,
+				),
+			),
+		},
+	]);
+} finally {
+	await client.end();
+	await bootstrapDb.execute(
+		sql`DROP SCHEMA ${sql.identifier(BENCHMARK_SCHEMA)} CASCADE`,
+	);
+	await bootstrapClient.end();
+}
+
+process.exit(0);

--- a/shared/drizzle/0072_swift_morlun.sql
+++ b/shared/drizzle/0072_swift_morlun.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pooled_balances" DROP CONSTRAINT "pooled_balances_lifecycle_ids_valid";

--- a/shared/drizzle/meta/0072_snapshot.json
+++ b/shared/drizzle/meta/0072_snapshot.json
@@ -1,0 +1,11307 @@
+{
+  "id": "f2d1befa-3872-47d3-8ca8-b6f666d5effa",
+  "prevId": "2f43ad4e-6e52-4710-a9e7-4aa7a995c58e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_actions_on_internal_entity_id": {
+          "name": "idx_actions_on_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_org_id_fkey": {
+          "name": "actions_org_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "actions_customer_id_fkey": {
+          "name": "actions_customer_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "actions_entity_id_fkey": {
+          "name": "actions_entity_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.agent_rules": {
+      "name": "agent_rules",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_rules": {
+          "name": "entity_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_rules": {
+          "name": "credit_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_rules_org_id_fkey": {
+          "name": "agent_rules_org_id_fkey",
+          "tableFrom": "agent_rules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_org_id_fkey": {
+          "name": "api_keys_org_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_key": {
+          "name": "api_keys_hashed_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_topup_limit_states": {
+      "name": "auto_topup_limit_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_window_ends_at": {
+          "name": "purchase_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempt_window_ends_at": {
+          "name": "attempt_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_attempt_window_ends_at": {
+          "name": "failed_attempt_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_attempt_count": {
+          "name": "failed_attempt_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failed_attempt_at": {
+          "name": "last_failed_attempt_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failure_count": {
+          "name": "consecutive_failure_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_payment_method_fingerprint": {
+          "name": "suspended_payment_method_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "auto_topup_limits_org_env_internal_customer_feature_unique": {
+          "name": "auto_topup_limits_org_env_internal_customer_feature_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_topup_limits_org_id_fkey": {
+          "name": "auto_topup_limits_org_id_fkey",
+          "tableFrom": "auto_topup_limit_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_topup_limits_internal_customer_id_fkey": {
+          "name": "auto_topup_limits_internal_customer_id_fkey",
+          "tableFrom": "auto_topup_limit_states",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_approval_writes": {
+      "name": "chat_approval_writes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deny_option_id": {
+          "name": "deny_option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_args": {
+          "name": "tool_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview": {
+          "name": "preview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_approval_writes_approval_id_fkey": {
+          "name": "chat_approval_writes_approval_id_fkey",
+          "tableFrom": "chat_approval_writes",
+          "tableTo": "chat_approvals",
+          "columnsFrom": [
+            "approval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_approval_writes_approval_position_key": {
+          "name": "chat_approval_writes_approval_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "approval_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_approvals": {
+      "name": "chat_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_args": {
+          "name": "tool_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview": {
+          "name": "preview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_session_ids": {
+          "name": "child_session_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approve_option_id": {
+          "name": "approve_option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deny_option_id": {
+          "name": "deny_option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_provider_user_id": {
+          "name": "decided_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_approvals_org_id_fkey": {
+          "name": "chat_approvals_org_id_fkey",
+          "tableFrom": "chat_approvals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_installations": {
+      "name": "chat_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_env": {
+          "name": "default_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_api_key_id": {
+          "name": "sandbox_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_api_key": {
+          "name": "sandbox_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_api_key_id": {
+          "name": "live_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_api_key": {
+          "name": "live_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_provider_user_id": {
+          "name": "installed_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_installations_org_id_fkey": {
+          "name": "chat_installations_org_id_fkey",
+          "tableFrom": "chat_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_installations_org_provider_key": {
+          "name": "chat_installations_org_provider_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "provider"
+          ]
+        },
+        "chat_installations_provider_workspace_key": {
+          "name": "chat_installations_provider_workspace_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_oauth_credentials": {
+      "name": "chat_oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_oauth_credentials_installation_id_fkey": {
+          "name": "chat_oauth_credentials_installation_id_fkey",
+          "tableFrom": "chat_oauth_credentials",
+          "tableTo": "chat_installations",
+          "columnsFrom": [
+            "chat_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_oauth_credentials_org_id_fkey": {
+          "name": "chat_oauth_credentials_org_id_fkey",
+          "tableFrom": "chat_oauth_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_oauth_credentials_installation_org_env_user_key": {
+          "name": "chat_oauth_credentials_installation_org_env_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chat_installation_id",
+            "org_id",
+            "env",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_results": {
+      "name": "chat_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "leaf.chat_thread_contexts": {
+      "name": "chat_thread_contexts",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_identifier": {
+          "name": "target_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_provider_user_id": {
+          "name": "created_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_thread_contexts_thread_key": {
+          "name": "chat_thread_contexts_thread_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "channel_id",
+            "thread_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkouts": {
+      "name": "checkouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_version": {
+          "name": "params_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_checkouts_stripe_invoice_id": {
+          "name": "idx_checkouts_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_memory": {
+      "name": "cma_memory",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_store_id": {
+          "name": "memory_store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cma_memory_org_id_env_pk": {
+          "name": "cma_memory_org_id_env_pk",
+          "columns": [
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_sessions": {
+      "name": "cma_sessions",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "braintrust_parent": {
+          "name": "braintrust_parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cma_sessions_org_id_env_thread_key_pk": {
+          "name": "cma_sessions_org_id_env_thread_key_pk",
+          "columns": [
+            "org_id",
+            "env",
+            "thread_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_vaults": {
+      "name": "cma_vaults",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_id": {
+          "name": "vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cma_vaults_installation_org_env_user_key": {
+          "name": "cma_vaults_installation_org_env_user_key",
+          "nullsNotDistinct": true,
+          "columns": [
+            "chat_installation_id",
+            "org_id",
+            "env",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_entitlements": {
+      "name": "customer_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_product_id": {
+          "name": "customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unlimited": {
+          "name": "unlimited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usage_attribution": {
+          "name": "usage_attribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_cycle_anchor": {
+          "name": "reset_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reset_at": {
+          "name": "next_reset_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_allowed": {
+          "name": "usage_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "separate_interval": {
+          "name": "separate_interval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pooled_balance": {
+          "name": "is_pooled_balance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pooled_balance_id": {
+          "name": "pooled_balance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pooled_contribution_id": {
+          "name": "pooled_contribution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjustment": {
+          "name": "adjustment",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_balance": {
+          "name": "additional_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_version": {
+          "name": "cache_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired": {
+          "name": "expired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_by_invoice": {
+          "name": "reset_by_invoice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_entitlements_product_id": {
+          "name": "idx_customer_entitlements_product_id",
+          "columns": [
+            {
+              "expression": "customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_customer_id_btree": {
+          "name": "idx_customer_entitlements_internal_customer_id_btree",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_entitlement_id": {
+          "name": "idx_customer_entitlements_entitlement_id",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_feature_id_c": {
+          "name": "idx_customer_entitlements_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_internal_feature_id": {
+          "name": "idx_ce_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_customer_product_id_c": {
+          "name": "idx_ce_customer_product_id_c",
+          "columns": [
+            {
+              "expression": "\"customer_product_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_entity_id": {
+          "name": "idx_customer_entitlements_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        },
+        "idx_customer_entitlements_on_next_reset_at": {
+          "name": "idx_customer_entitlements_on_next_reset_at",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_loose_customer_expires": {
+          "name": "idx_customer_entitlements_loose_customer_expires",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_next_reset_not_expired": {
+          "name": "idx_customer_entitlements_next_reset_not_expired",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_pooled_contribution": {
+          "name": "idx_customer_entitlements_pooled_contribution",
+          "columns": [
+            {
+              "expression": "pooled_contribution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"pooled_contribution_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_reset_scan": {
+          "name": "idx_customer_entitlements_reset_scan",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"reset_by_invoice\" IS NOT TRUE AND \"customer_entitlements\".\"pooled_contribution_id\" IS NULL AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_internal_feature_id_fkey": {
+          "name": "entitlements_internal_feature_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_entitlements_internal_entity_id_fkey": {
+          "name": "customer_entitlements_internal_entity_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_entitlements_customer_product_id_fkey": {
+          "name": "customer_entitlements_customer_product_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_entitlements_entitlement_id_fkey": {
+          "name": "customer_entitlements_entitlement_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_exports": {
+      "name": "customer_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_count": {
+          "name": "byte_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_exports_org_env_created_at": {
+          "name": "idx_customer_exports_org_env_created_at",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_exports_active_per_org_env_unique": {
+          "name": "customer_exports_active_per_org_env_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customer_exports\".\"status\" IN ('queued', 'running')",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_exports_org_id_fkey": {
+          "name": "customer_exports_org_id_fkey",
+          "tableFrom": "customer_exports",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_jwt_families": {
+      "name": "customer_jwt_families",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "refresh_kid": {
+          "name": "refresh_kid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "indefinite": {
+          "name": "indefinite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "customer_jwt_families_internal_customer_id_fkey": {
+          "name": "customer_jwt_families_internal_customer_id_fkey",
+          "tableFrom": "customer_jwt_families",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "customer_jwt_families_internal_customer_id_key": {
+          "name": "customer_jwt_families_internal_customer_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "internal_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_licenses": {
+      "name": "customer_licenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_customer_product_id": {
+          "name": "parent_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_internal_product_id": {
+          "name": "license_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted": {
+          "name": "granted",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "paid_quantity": {
+          "name": "paid_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_customer_licenses_plan_license": {
+          "name": "idx_customer_licenses_plan_license",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_customer_license": {
+          "name": "unique_customer_license",
+          "columns": [
+            {
+              "expression": "parent_customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_licenses_customer": {
+          "name": "idx_customer_licenses_customer",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_licenses_link": {
+          "name": "idx_customer_licenses_link",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_licenses_customer_fkey": {
+          "name": "customer_licenses_customer_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_parent_customer_product_fkey": {
+          "name": "customer_licenses_parent_customer_product_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "parent_customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_license_product_fkey": {
+          "name": "customer_licenses_license_product_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "products",
+          "columnsFrom": [
+            "license_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_plan_license_fkey": {
+          "name": "customer_licenses_plan_license_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_lsns": {
+      "name": "customer_lsns",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "customer_lsns_pkey": {
+          "name": "customer_lsns_pkey",
+          "columns": [
+            "org_id",
+            "env",
+            "customer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.customer_prices": {
+      "name": "customer_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_product_id": {
+          "name": "customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_prices_product_id": {
+          "name": "idx_customer_prices_product_id",
+          "columns": [
+            {
+              "expression": "customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_prices_price_id": {
+          "name": "idx_customer_prices_price_id",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_prices_internal_customer_id": {
+          "name": "idx_customer_prices_internal_customer_id",
+          "columns": [
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_prices\".\"internal_customer_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cpr_customer_product_id_c": {
+          "name": "idx_cpr_customer_product_id_c",
+          "columns": [
+            {
+              "expression": "\"customer_product_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_prices_customer_product_id_fkey": {
+          "name": "customer_prices_customer_product_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_prices_internal_customer_id_fkey": {
+          "name": "customer_prices_internal_customer_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_prices_price_id_fkey": {
+          "name": "customer_prices_price_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "prices",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_products": {
+      "name": "customer_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled": {
+          "name": "canceled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_starts_at": {
+          "name": "access_starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_trial_id": {
+          "name": "free_trial_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor": {
+          "name": "billing_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor_resets_at": {
+          "name": "billing_cycle_anchor_resets_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_method": {
+          "name": "collection_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'charge_automatically'"
+        },
+        "subscription_ids": {
+          "name": "subscription_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_ids": {
+          "name": "scheduled_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customer_license_link_id": {
+          "name": "customer_license_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_version": {
+          "name": "billing_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_version": {
+          "name": "api_version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_semver": {
+          "name": "api_semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_customer_product_id": {
+          "name": "previous_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_trial_end": {
+          "name": "on_trial_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_products_customer_status": {
+          "name": "idx_customer_products_customer_status",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_customer_status_created_at": {
+          "name": "idx_customer_products_customer_status_created_at",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_status": {
+          "name": "idx_customer_products_product_status",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_on_internal_entity_id": {
+          "name": "idx_customer_products_on_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_customer_c": {
+          "name": "idx_customer_products_product_customer_c",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_on_internal_product_id": {
+          "name": "idx_customer_products_on_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_subscription_ids": {
+          "name": "idx_customer_products_subscription_ids",
+          "columns": [
+            {
+              "expression": "subscription_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customer_products_scheduled_ids": {
+          "name": "idx_customer_products_scheduled_ids",
+          "columns": [
+            {
+              "expression": "scheduled_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customer_products_stripe_checkout_session_id": {
+          "name": "idx_customer_products_stripe_checkout_session_id",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_customer_license": {
+          "name": "idx_customer_products_customer_license",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_license_seat_order": {
+          "name": "idx_customer_products_license_seat_order",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_seat_sync": {
+          "name": "idx_customer_products_seat_sync",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_unused_seats": {
+          "name": "idx_customer_products_unused_seats",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_active_pool_assignment": {
+          "name": "unique_active_pool_assignment",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NOT NULL AND \"customer_products\".\"status\" IN ('active', 'past_due')",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_free_trial_id": {
+          "name": "idx_customer_products_free_trial_id",
+          "columns": [
+            {
+              "expression": "free_trial_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"free_trial_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_revenuecat_processor": {
+          "name": "idx_customer_products_revenuecat_processor",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"customer_products\".\"processor\" ->> 'type') = 'revenuecat'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_ended_at": {
+          "name": "idx_customer_products_ended_at",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"ended_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_trial_ends_at": {
+          "name": "idx_customer_products_trial_ends_at",
+          "columns": [
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"trial_ends_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_id": {
+          "name": "idx_customer_products_product_id",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_products_free_trial_id_fkey": {
+          "name": "customer_products_free_trial_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "free_trials",
+          "columnsFrom": [
+            "free_trial_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_products_internal_customer_id_fkey": {
+          "name": "customer_products_internal_customer_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_products_internal_product_id_fkey": {
+          "name": "customer_products_internal_product_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_products_internal_entity_id_fkey": {
+          "name": "customer_products_internal_entity_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processors": {
+          "name": "processors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "send_email_receipts": {
+          "name": "send_email_receipts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topups": {
+          "name": "auto_topups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "customers_email_null_id_unique": {
+          "name": "customers_email_null_id_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customers\".\"id\" IS NULL AND \"customers\".\"email\" IS NOT NULL AND \"customers\".\"email\" != ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_org_env_fingerprint": {
+          "name": "idx_customers_org_env_fingerprint",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"fingerprint\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processor_id": {
+          "name": "idx_customers_processor_id",
+          "columns": [
+            {
+              "expression": "(\"processor\" ->> 'id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_composite": {
+          "name": "idx_customers_composite",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_org_env_internal_id": {
+          "name": "idx_customers_org_env_internal_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_email_trgm": {
+          "name": "idx_customers_email_trgm",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_name_trgm": {
+          "name": "idx_customers_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_id_trgm": {
+          "name": "idx_customers_id_trgm",
+          "columns": [
+            {
+              "expression": "\"id\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_org_id_env_created_at": {
+          "name": "idx_customers_org_id_env_created_at",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_cursor": {
+          "name": "idx_customers_cursor",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat": {
+          "name": "idx_customers_processors_revenuecat",
+          "columns": [
+            {
+              "expression": "(\"processors\" ->> 'revenuecat')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat_id": {
+          "name": "idx_customers_processors_revenuecat_id",
+          "columns": [
+            {
+              "expression": "(\"processors\" -> 'revenuecat' ->> 'id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat_aliases": {
+          "name": "idx_customers_processors_revenuecat_aliases",
+          "columns": [
+            {
+              "expression": "(\"processors\" -> 'revenuecat' -> 'aliases')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_processors_vercel": {
+          "name": "idx_customers_processors_vercel",
+          "columns": [
+            {
+              "expression": "(\"processors\" ->> 'vercel')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_org_id_fkey": {
+          "name": "customers_org_id_fkey",
+          "tableFrom": "customers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cus_id_constraint": {
+          "name": "cus_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entities_internal_customer_id": {
+          "name": "idx_entities_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_internal_feature_id_c": {
+          "name": "idx_entities_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_internal_feature_id": {
+          "name": "idx_entities_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_customer_internal_desc": {
+          "name": "idx_entities_customer_internal_desc",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_org_env_id": {
+          "name": "idx_entities_org_env_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_cursor": {
+          "name": "idx_entities_cursor",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_customer_created_at": {
+          "name": "idx_entities_customer_created_at",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_internal_customer_id_fkey": {
+          "name": "entities_internal_customer_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entities_internal_feature_id_fkey": {
+          "name": "entities_internal_feature_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entities_org_id_fkey": {
+          "name": "entities_org_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_id_constraint": {
+          "name": "entity_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "internal_customer_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entitlements": {
+      "name": "entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_id": {
+          "name": "internal_reward_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "allowance_type": {
+          "name": "allowance_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowance": {
+          "name": "allowance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_count": {
+          "name": "interval_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "carry_from_previous": {
+          "name": "carry_from_previous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entity_feature_id": {
+          "name": "entity_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "pooled": {
+          "name": "pooled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limit": {
+          "name": "usage_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_duration": {
+          "name": "expiry_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_length": {
+          "name": "expiry_length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollover": {
+          "name": "rollover",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entitlements_internal_product_id": {
+          "name": "idx_entitlements_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_reward_id": {
+          "name": "idx_entitlements_internal_reward_id",
+          "columns": [
+            {
+              "expression": "internal_reward_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_reward_feature": {
+          "name": "idx_entitlements_reward_feature",
+          "columns": [
+            {
+              "expression": "internal_reward_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_feature_id_c": {
+          "name": "idx_entitlements_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_feature_id": {
+          "name": "idx_entitlements_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_reward_id_c_partial": {
+          "name": "idx_entitlements_internal_reward_id_c_partial",
+          "columns": [
+            {
+              "expression": "\"internal_reward_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entitlements\".\"internal_reward_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_entity_feature_id": {
+          "name": "idx_entitlements_entity_feature_id",
+          "columns": [
+            {
+              "expression": "entity_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entitlements\".\"entity_feature_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_internal_feature_id_fkey": {
+          "name": "entitlements_internal_feature_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entitlements_internal_product_id_fkey": {
+          "name": "entitlements_internal_product_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "entitlements_internal_reward_id_fkey": {
+          "name": "entitlements_internal_reward_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "rewards",
+          "columnsFrom": [
+            "internal_reward_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entitlements_id_key": {
+          "name": "entitlements_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_usage": {
+          "name": "set_usage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductions": {
+          "name": "deductions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_events_internal_customer_id": {
+          "name": "idx_events_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_internal_entity_id": {
+          "name": "idx_events_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_customer_non_usage_ts": {
+          "name": "idx_events_customer_non_usage_ts",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"timestamp\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"set_usage\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_timestamp": {
+          "name": "idx_events_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_internal_customer_id_fkey": {
+          "name": "events_internal_customer_id_fkey",
+          "tableFrom": "events",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_constraint": {
+          "name": "unique_event_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "customer_id",
+            "event_name",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.features": {
+      "name": "features",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_names": {
+          "name": "event_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "model_markups": {
+          "name": "model_markups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "stripe_meter": {
+          "name": "stripe_meter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_features_composite": {
+          "name": "idx_features_composite",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "features_org_id_fkey": {
+          "name": "features_org_id_fkey",
+          "tableFrom": "features",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_id_constraint": {
+          "name": "feature_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_trials": {
+      "name": "free_trials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'day'"
+        },
+        "length": {
+          "name": "length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unique_fingerprint": {
+          "name": "unique_fingerprint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "card_required": {
+          "name": "card_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "on_end": {
+          "name": "on_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_free_trials_internal_product_id": {
+          "name": "idx_free_trials_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "free_trials_internal_product_id_fkey": {
+          "name": "free_trials_internal_product_id_fkey",
+          "tableFrom": "free_trials",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.harness_sessions": {
+      "name": "harness_sessions",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resume_state": {
+          "name": "resume_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "braintrust_parent": {
+          "name": "braintrust_parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_harness_sessions_session_id": {
+          "name": "idx_harness_sessions_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "harness_sessions_org_id_env_thread_key_pk": {
+          "name": "harness_sessions_org_id_env_thread_key_pk",
+          "columns": [
+            "org_id",
+            "env",
+            "thread_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organizations_id_fk": {
+          "name": "invitation_organization_id_organizations_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invoice_line_items": {
+      "name": "invoice_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_item_id": {
+          "name": "stripe_invoice_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_discountable": {
+          "name": "stripe_discountable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_after_discounts": {
+          "name": "amount_after_discounts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_quantity": {
+          "name": "stripe_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_quantity": {
+          "name": "total_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_quantity": {
+          "name": "paid_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_source": {
+          "name": "description_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_timing": {
+          "name": "billing_timing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prorated": {
+          "name": "prorated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_product_ids": {
+          "name": "customer_product_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_price_ids": {
+          "name": "customer_price_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_entitlement_ids": {
+          "name": "customer_entitlement_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_period_start": {
+          "name": "effective_period_start",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_period_end": {
+          "name": "effective_period_end",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discounts": {
+          "name": "discounts",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "idx_invoice_line_items_customer_product_ids": {
+          "name": "idx_invoice_line_items_customer_product_ids",
+          "columns": [
+            {
+              "expression": "customer_product_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_invoice_line_items_stripe_invoice_id": {
+          "name": "idx_invoice_line_items_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoice_line_items_invoice_id": {
+          "name": "idx_invoice_line_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"invoice_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoice_line_items_stripe_invoice_item_id": {
+          "name": "idx_invoice_line_items_stripe_invoice_item_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"stripe_invoice_item_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_line_items_invoice_id_fkey": {
+          "name": "invoice_line_items_invoice_id_fkey",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_line_items_stripe_id_unique": {
+          "name": "invoice_line_items_stripe_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_templates": {
+      "name": "invoice_templates",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "net_terms_days": {
+          "name": "net_terms_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_invoice_templates_org_id": {
+          "name": "idx_invoice_templates_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_templates_org_id_fkey": {
+          "name": "invoice_templates_org_id_fkey",
+          "tableFrom": "invoice_templates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_templates_id_unique": {
+          "name": "invoice_templates_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "product_ids": {
+          "name": "product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "internal_product_ids": {
+          "name": "internal_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor_type": {
+          "name": "processor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "hosted_invoice_url": {
+          "name": "hosted_invoice_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_amount": {
+          "name": "refunded_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "discounts": {
+          "name": "discounts",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "items": {
+          "name": "items",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "idx_invoices_customer_created": {
+          "name": "idx_invoices_customer_created",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_internal_entity_id": {
+          "name": "idx_invoices_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoices\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_internal_customer_id_fkey": {
+          "name": "invoices_internal_customer_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_internal_entity_id_fkey": {
+          "name": "invoices_internal_entity_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_stripe_id_key": {
+          "name": "invoices_stripe_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.license_entitlements": {
+      "name": "license_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_license_entitlement": {
+          "name": "unique_license_entitlement",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_license_entitlements_entitlement": {
+          "name": "idx_license_entitlements_entitlement",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_entitlements_plan_license_fkey": {
+          "name": "license_entitlements_plan_license_fkey",
+          "tableFrom": "license_entitlements",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "license_entitlements_entitlement_fkey": {
+          "name": "license_entitlements_entitlement_fkey",
+          "tableFrom": "license_entitlements",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_prices": {
+      "name": "license_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_license_price": {
+          "name": "unique_license_price",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_license_prices_price": {
+          "name": "idx_license_prices_price",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_prices_plan_license_fkey": {
+          "name": "license_prices_plan_license_fkey",
+          "tableFrom": "license_prices",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "license_prices_price_fkey": {
+          "name": "license_prices_price_fkey",
+          "tableFrom": "license_prices",
+          "tableTo": "prices",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organizations_id_fk": {
+          "name": "member_organization_id_organizations_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.metadata": {
+      "name": "metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_metadata_on_type_expires_at": {
+          "name": "idx_metadata_on_type_expires_at",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "metadata_expires_at_idx": {
+          "name": "metadata_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metadata\".\"expires_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_errors": {
+      "name": "migration_errors",
+      "schema": "",
+      "columns": {
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_job_id": {
+          "name": "migration_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "migration_customers_internal_customer_id_fkey": {
+          "name": "migration_customers_internal_customer_id_fkey",
+          "tableFrom": "migration_errors",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_customers_migration_job_id_fkey": {
+          "name": "migration_customers_migration_job_id_fkey",
+          "tableFrom": "migration_errors",
+          "tableTo": "migration_jobs",
+          "columnsFrom": [
+            "migration_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "migration_errors_pkey": {
+          "name": "migration_errors_pkey",
+          "columns": [
+            "internal_customer_id",
+            "migration_job_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_item_runs": {
+      "name": "migration_item_runs",
+      "schema": "",
+      "columns": {
+        "migration_item_run_id": {
+          "name": "migration_item_run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "migration_internal_id": {
+          "name": "migration_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_run_id": {
+          "name": "migration_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_item_runs_live_unique": {
+          "name": "migration_item_runs_live_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_live_c_idx": {
+          "name": "migration_item_runs_live_c_idx",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"item_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_live_item_exclusive": {
+          "name": "migration_item_runs_live_item_exclusive",
+          "columns": [
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"item_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"status\" = 'running' AND \"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_dry_run_unique": {
+          "name": "migration_item_runs_dry_run_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "migration_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"dry_run\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_customer_recent_idx": {
+          "name": "migration_item_runs_customer_recent_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_item_runs\".\"item_kind\" = 'customer'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_jobs": {
+      "name": "migration_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_internal_product_id": {
+          "name": "from_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_internal_product_id": {
+          "name": "to_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_details": {
+          "name": "step_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "migration_jobs_from_internal_product_id_fkey": {
+          "name": "migration_jobs_from_internal_product_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "from_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_jobs_org_id_fkey": {
+          "name": "migration_jobs_org_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_jobs_to_internal_product_id_fkey": {
+          "name": "migration_jobs_to_internal_product_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "to_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "migration_internal_id": {
+          "name": "migration_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lazy_run": {
+          "name": "lazy_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_ids": {
+          "name": "only_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_limit": {
+          "name": "target_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_per_migration_unique": {
+          "name": "migration_runs_active_per_migration_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" IN ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_migration_internal_id_fkey": {
+          "name": "migration_runs_migration_internal_id_fkey",
+          "tableFrom": "migration_runs",
+          "tableTo": "migrations",
+          "columnsFrom": [
+            "migration_internal_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_runs_org_id_fkey": {
+          "name": "migration_runs_org_id_fkey",
+          "tableFrom": "migration_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migrations": {
+      "name": "migrations",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operations": {
+          "name": "operations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prepared_state": {
+          "name": "prepared_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_billing_changes": {
+          "name": "no_billing_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_failed": {
+          "name": "retry_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migrations_org_env_id_unique": {
+          "name": "migrations_org_env_id_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migrations_org_id_fkey": {
+          "name": "migrations_org_id_fkey",
+          "tableFrom": "migrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_oauth_consent_id_oauth_consent_id_fk": {
+          "name": "oauth_access_token_oauth_consent_id_oauth_consent_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_consent",
+          "columnsFrom": [
+            "oauth_consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_api_key_id": {
+          "name": "oauth_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk": {
+          "name": "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_consent",
+          "columnsFrom": [
+            "oauth_consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_currency": {
+          "name": "default_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'usd'"
+        },
+        "stripe_connected": {
+          "name": "stripe_connected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "stripe_config": {
+          "name": "stripe_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_stripe_connect": {
+          "name": "test_stripe_connect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "live_stripe_connect": {
+          "name": "live_stripe_connect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "processor_configs": {
+          "name": "processor_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_pkey": {
+          "name": "test_pkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_pkey": {
+          "name": "live_pkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "svix_config": {
+          "name": "svix_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "idempotency_config": {
+          "name": "idempotency_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_buttons": {
+          "name": "custom_buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded": {
+          "name": "onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deployed": {
+          "name": "deployed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_sandbox": {
+          "name": "is_sandbox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sandbox_color": {
+          "name": "sandbox_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_icon": {
+          "name": "sandbox_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redis_config": {
+          "name": "redis_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_organizations_name_trgm": {
+          "name": "idx_organizations_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organizations\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_organizations_slug_trgm": {
+          "name": "idx_organizations_slug_trgm",
+          "columns": [
+            {
+              "expression": "\"slug\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organizations\".\"slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_organizations_created_at_id": {
+          "name": "idx_organizations_created_at_id",
+          "columns": [
+            {
+              "expression": "\"createdAt\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orgs_test_connect_default_account": {
+          "name": "idx_orgs_test_connect_default_account",
+          "columns": [
+            {
+              "expression": "(\"test_stripe_connect\"->>'default_account_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orgs_test_connect_account": {
+          "name": "idx_orgs_test_connect_account",
+          "columns": [
+            {
+              "expression": "(\"test_stripe_connect\"->>'account_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orgs_live_connect_account": {
+          "name": "idx_orgs_live_connect_account",
+          "columns": [
+            {
+              "expression": "(\"live_stripe_connect\"->>'account_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organizations_test_pkey_key": {
+          "name": "organizations_test_pkey_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_pkey"
+          ]
+        },
+        "organizations_live_pkey_key": {
+          "name": "organizations_live_pkey_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "live_pkey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialId_idx": {
+          "name": "passkey_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkey_credential_id_unique": {
+          "name": "passkey_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.plan_license": {
+      "name": "plan_license",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_internal_product_id": {
+          "name": "parent_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_internal_product_id": {
+          "name": "license_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "included": {
+          "name": "included",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prepaid_only": {
+          "name": "prepaid_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "customized": {
+          "name": "customized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_plan_license": {
+          "name": "unique_plan_license",
+          "columns": [
+            {
+              "expression": "parent_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"plan_license\".\"is_custom\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_plan_license_parent_product": {
+          "name": "idx_plan_license_parent_product",
+          "columns": [
+            {
+              "expression": "parent_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_plan_license_license": {
+          "name": "idx_plan_license_license",
+          "columns": [
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plan_license_parent_product_fkey": {
+          "name": "plan_license_parent_product_fkey",
+          "tableFrom": "plan_license",
+          "tableTo": "products",
+          "columnsFrom": [
+            "parent_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_license_license_product_fkey": {
+          "name": "plan_license_license_product_fkey",
+          "tableFrom": "plan_license",
+          "tableTo": "products",
+          "columnsFrom": [
+            "license_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pooled_balance_contributions": {
+      "name": "pooled_balance_contributions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pooled_balance_id": {
+          "name": "pooled_balance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_customer_product_id": {
+          "name": "source_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_customer_entitlement_id": {
+          "name": "source_customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_contribution": {
+          "name": "current_contribution",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_cycle_contribution": {
+          "name": "next_cycle_contribution",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_pooled_balance_contributions_pool": {
+          "name": "idx_pooled_balance_contributions_pool",
+          "columns": [
+            {
+              "expression": "pooled_balance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balance_contributions_source_customer_entitlement": {
+          "name": "idx_pooled_balance_contributions_source_customer_entitlement",
+          "columns": [
+            {
+              "expression": "source_customer_entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pooled_balance_contributions_pool_fkey": {
+          "name": "pooled_balance_contributions_pool_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "pooled_balances",
+          "columnsFrom": [
+            "pooled_balance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balance_contributions_customer_product_fkey": {
+          "name": "pooled_balance_contributions_customer_product_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "source_customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balance_contributions_customer_entitlement_fkey": {
+          "name": "pooled_balance_contributions_customer_entitlement_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "source_customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pooled_balance_contribution": {
+          "name": "unique_pooled_balance_contribution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_customer_entitlement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pooled_balance_contributions_current_non_negative": {
+          "name": "pooled_balance_contributions_current_non_negative",
+          "value": "\"pooled_balance_contributions\".\"current_contribution\" >= 0"
+        },
+        "pooled_balance_contributions_next_non_negative": {
+          "name": "pooled_balance_contributions_next_non_negative",
+          "value": "\"pooled_balance_contributions\".\"next_cycle_contribution\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pooled_balances": {
+      "name": "pooled_balances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unlimited": {
+          "name": "unlimited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "granted": {
+          "name": "granted",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval_count": {
+          "name": "interval_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reset_cycle_anchor": {
+          "name": "reset_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_mode": {
+          "name": "reset_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_license_link_id": {
+          "name": "customer_license_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollover_signature": {
+          "name": "rollover_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "customer_entitlement_id": {
+          "name": "customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_applied_reset_at": {
+          "name": "last_applied_reset_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_pooled_balances_org": {
+          "name": "idx_pooled_balances_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_reset_mode": {
+          "name": "idx_pooled_balances_reset_mode",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reset_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_feature": {
+          "name": "idx_pooled_balances_feature",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_stripe_subscription": {
+          "name": "idx_pooled_balances_stripe_subscription",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_customer_license": {
+          "name": "idx_pooled_balances_customer_license",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pooled_balances\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pooled_balances_customer_fkey": {
+          "name": "pooled_balances_customer_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balances_feature_fkey": {
+          "name": "pooled_balances_feature_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "pooled_balances_customer_entitlement_fkey": {
+          "name": "pooled_balances_customer_entitlement_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pooled_balance": {
+          "name": "unique_pooled_balance",
+          "nullsNotDistinct": true,
+          "columns": [
+            "internal_customer_id",
+            "internal_feature_id",
+            "unlimited",
+            "interval",
+            "interval_count",
+            "reset_cycle_anchor",
+            "reset_mode",
+            "stripe_subscription_id",
+            "customer_license_link_id",
+            "rollover_signature",
+            "expires_at"
+          ]
+        },
+        "unique_pooled_balance_customer_entitlement": {
+          "name": "unique_pooled_balance_customer_entitlement",
+          "nullsNotDistinct": false,
+          "columns": [
+            "customer_entitlement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pooled_balances_interval_count_positive": {
+          "name": "pooled_balances_interval_count_positive",
+          "value": "\"pooled_balances\".\"interval_count\" > 0"
+        },
+        "pooled_balances_granted_non_negative": {
+          "name": "pooled_balances_granted_non_negative",
+          "value": "\"pooled_balances\".\"granted\" >= 0"
+        },
+        "pooled_balances_reset_mode_valid": {
+          "name": "pooled_balances_reset_mode_valid",
+          "value": "\"pooled_balances\".\"reset_mode\" IN ('lazy', 'subscription', 'lifetime')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier_behavior": {
+          "name": "tier_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "proration_config": {
+          "name": "proration_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {
+        "idx_prices_internal_product_id": {
+          "name": "idx_prices_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_entitlement_id": {
+          "name": "idx_prices_entitlement_id",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_config_internal_feature_id": {
+          "name": "idx_prices_config_internal_feature_id",
+          "columns": [
+            {
+              "expression": "(\"config\" ->> 'internal_feature_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"prices\".\"config\" ->> 'internal_feature_id') IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prices_entitlement_id_fkey": {
+          "name": "prices_entitlement_id_fkey",
+          "tableFrom": "prices",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prices_internal_product_id_fkey": {
+          "name": "prices_internal_product_id_fkey",
+          "tableFrom": "prices",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "prices_id_key": {
+          "name": "prices_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_aliases": {
+      "name": "product_aliases",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_plan_id": {
+          "name": "canonical_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_aliases_org_id_fkey": {
+          "name": "product_aliases_org_id_fkey",
+          "tableFrom": "product_aliases",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_aliases_pkey": {
+          "name": "product_aliases_pkey",
+          "columns": [
+            "org_id",
+            "env",
+            "alias_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "product_aliases_canonical_unique": {
+          "name": "product_aliases_canonical_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "canonical_plan_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_add_on": {
+          "name": "is_add_on",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "version_slug": {
+          "name": "version_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_version_slug": {
+          "name": "previous_version_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "base_variant_id": {
+          "name": "base_variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_internal_product_id": {
+          "name": "base_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "auto_topups": {
+          "name": "auto_topups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_products_org_env_id_version": {
+          "name": "idx_products_org_env_id_version",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_org_env_base_internal_product_id": {
+          "name": "idx_products_org_env_base_internal_product_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"products\".\"base_internal_product_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_product_version_slug": {
+          "name": "unique_product_version_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"products\".\"version_slug\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_active_product": {
+          "name": "unique_active_product",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"products\".\"active\" = true",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_org_id_fkey": {
+          "name": "products_org_id_fkey",
+          "tableFrom": "products",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_product": {
+          "name": "unique_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referral_codes": {
+      "name": "referral_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_program_id": {
+          "name": "internal_reward_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_referral_codes_internal_customer_id": {
+          "name": "idx_referral_codes_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "referral_codes_internal_customer_id_fkey": {
+          "name": "referral_codes_internal_customer_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "referral_codes_internal_reward_program_id_fkey": {
+          "name": "referral_codes_internal_reward_program_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "reward_programs",
+          "columnsFrom": [
+            "internal_reward_program_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "referral_codes_org_id_fkey": {
+          "name": "referral_codes_org_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "referral_codes_pkey": {
+          "name": "referral_codes_pkey",
+          "columns": [
+            "code",
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "referral_codes_id_key": {
+          "name": "referral_codes_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.replaceables": {
+      "name": "replaceables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cus_ent_id": {
+          "name": "cus_ent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_next_cycle": {
+          "name": "delete_next_cycle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_replaceables_cus_ent_id": {
+          "name": "idx_replaceables_cus_ent_id",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "replaceables_cus_ent_id_fkey": {
+          "name": "replaceables_cus_ent_id_fkey",
+          "tableFrom": "replaceables",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "cus_ent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.revenuecat_mappings": {
+      "name": "revenuecat_mappings",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "autumn_product_id": {
+          "name": "autumn_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenuecat_product_ids": {
+          "name": "revenuecat_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "feature_quantities": {
+          "name": "feature_quantities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "revenuecat_mappings_org_id_fkey": {
+          "name": "revenuecat_mappings_org_id_fkey",
+          "tableFrom": "revenuecat_mappings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "revenuecat_mappings_pkey": {
+          "name": "revenuecat_mappings_pkey",
+          "columns": [
+            "org_id",
+            "env",
+            "autumn_product_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_programs": {
+      "name": "reward_programs",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_id": {
+          "name": "internal_reward_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_redemptions": {
+          "name": "max_redemptions",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unlimited_redemptions": {
+          "name": "unlimited_redemptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when": {
+          "name": "when",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'immediately'"
+        },
+        "product_ids": {
+          "name": "product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"\"}'"
+        },
+        "exclude_trial": {
+          "name": "exclude_trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reward_triggers_internal_reward_id_fkey": {
+          "name": "reward_triggers_internal_reward_id_fkey",
+          "tableFrom": "reward_programs",
+          "tableTo": "rewards",
+          "columnsFrom": [
+            "internal_reward_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_triggers_org_id_fkey": {
+          "name": "reward_triggers_org_id_fkey",
+          "tableFrom": "reward_programs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_redemptions": {
+      "name": "reward_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered": {
+          "name": "triggered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_program_id": {
+          "name": "internal_reward_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "redeemer_applied": {
+          "name": "redeemer_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "referral_code_id": {
+          "name": "referral_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_internal_id": {
+          "name": "reward_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_code": {
+          "name": "promo_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_reward_redemptions_referral_code_id": {
+          "name": "idx_reward_redemptions_referral_code_id",
+          "columns": [
+            {
+              "expression": "referral_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reward_redemptions_reward_internal_id": {
+          "name": "idx_reward_redemptions_reward_internal_id",
+          "columns": [
+            {
+              "expression": "reward_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reward_redemptions_customer_reward": {
+          "name": "idx_reward_redemptions_customer_reward",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reward_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reward_redemptions_internal_customer_id_fkey": {
+          "name": "reward_redemptions_internal_customer_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_redemptions_internal_reward_program_id_fkey": {
+          "name": "reward_redemptions_internal_reward_program_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "reward_programs",
+          "columnsFrom": [
+            "internal_reward_program_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_redemptions_referral_code_id_fkey": {
+          "name": "reward_redemptions_referral_code_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "referral_codes",
+          "columnsFrom": [
+            "referral_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_config": {
+          "name": "discount_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_product_config": {
+          "name": "free_product_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_product_id": {
+          "name": "free_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_codes": {
+          "name": "promo_codes",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_rewards_org_id_env": {
+          "name": "idx_rewards_org_id_env",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coupons_org_id_fkey": {
+          "name": "coupons_org_id_fkey",
+          "tableFrom": "rewards",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollovers": {
+      "name": "rollovers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cus_ent_id": {
+          "name": "cus_ent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_rollovers_cus_ent_id": {
+          "name": "idx_rollovers_cus_ent_id",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rollovers_cus_ent_expires": {
+          "name": "idx_rollovers_cus_ent_expires",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rollover_cus_ent_id_fkey": {
+          "name": "rollover_cus_ent_id_fkey",
+          "tableFrom": "rollovers",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "cus_ent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.phases": {
+      "name": "phases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_product_ids": {
+          "name": "customer_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "phases_schedule_id_fkey": {
+          "name": "phases_schedule_id_fkey",
+          "tableFrom": "phases",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phases_schedule_id_starts_at_key": {
+          "name": "phases_schedule_id_starts_at_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "schedule_id",
+            "starts_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "schedules_customer_scope_unique": {
+          "name": "schedules_customer_scope_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"internal_entity_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_entity_scope_unique": {
+          "name": "schedules_entity_scope_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_internal_customer_id": {
+          "name": "idx_schedules_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_internal_entity_id": {
+          "name": "idx_schedules_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_org_id_fkey": {
+          "name": "schedules_org_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedules_internal_customer_id_fkey": {
+          "name": "schedules_internal_customer_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedules_internal_entity_id_fkey": {
+          "name": "schedules_internal_entity_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "leaf.slack_admin_threads": {
+      "name": "slack_admin_threads",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_identifier": {
+          "name": "target_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_provider_user_id": {
+          "name": "created_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_admin_threads_thread_key": {
+          "name": "slack_admin_threads_thread_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "channel_id",
+            "thread_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_connection": {
+      "name": "sso_connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_domain_verification'"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sso_connection_organization_id_idx": {
+          "name": "sso_connection_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_connection_provider_id_sso_provider_provider_id_fk": {
+          "name": "sso_connection_provider_id_sso_provider_provider_id_fk",
+          "tableFrom": "sso_connection",
+          "tableTo": "sso_provider",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "provider_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_connection_organization_id_organizations_id_fk": {
+          "name": "sso_connection_organization_id_organizations_id_fk",
+          "tableFrom": "sso_connection",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_connection_provider_id_unique": {
+          "name": "sso_connection_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        },
+        "sso_connection_organization_id_unique": {
+          "name": "sso_connection_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_domain_idx": {
+          "name": "sso_provider_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organizations_id_fk": {
+          "name": "sso_provider_organization_id_organizations_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_domain_unique": {
+          "name": "sso_provider_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        },
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "usage_features": {
+          "name": "usage_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor_seconds": {
+          "name": "billing_cycle_anchor_seconds",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_org_id_fkey": {
+          "name": "subscriptions_org_id_fkey",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_id_key": {
+          "name": "subscriptions_stripe_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transition_rules": {
+      "name": "transition_rules",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carry_over_usages": {
+          "name": "carry_over_usages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transition_rules_org_id_fkey": {
+          "name": "transition_rules_org_id_fkey",
+          "tableFrom": "transition_rules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transition_rules_pkey": {
+          "name": "transition_rules_pkey",
+          "columns": [
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_windows": {
+      "name": "usage_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_key": {
+          "name": "filter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor_customer_entitlement_id": {
+          "name": "anchor_customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage": {
+          "name": "usage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_windows_internal_customer_id": {
+          "name": "idx_usage_windows_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_windows_internal_customer_id_c": {
+          "name": "idx_usage_windows_internal_customer_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uw_internal_feature_id": {
+          "name": "idx_uw_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_windows_customer_feature_scope": {
+          "name": "idx_usage_windows_customer_feature_scope",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"internal_entity_id\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"filter_key\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_windows_internal_customer_id_fkey": {
+          "name": "usage_windows_internal_customer_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_internal_entity_id_fkey": {
+          "name": "usage_windows_internal_entity_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_internal_feature_id_fkey": {
+          "name": "usage_windows_internal_feature_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_anchor_customer_entitlement_id_fkey": {
+          "name": "usage_windows_anchor_customer_entitlement_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "anchor_customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_name_trgm": {
+          "name": "idx_user_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_email_trgm": {
+          "name": "idx_user_email_trgm",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_created_at_id": {
+          "name": "idx_user_created_at_id",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_created_by_fkey": {
+          "name": "user_created_by_fkey",
+          "tableFrom": "user",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_resources": {
+      "name": "vercel_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "vercel_resources_installation_name_unique_idx": {
+          "name": "vercel_resources_installation_name_unique_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status <> 'uninstalled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_resources_org_id_fkey": {
+          "name": "vercel_resources_org_id_fkey",
+          "tableFrom": "vercel_resources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "leaf": "leaf"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/drizzle/meta/_journal.json
+++ b/shared/drizzle/meta/_journal.json
@@ -505,6 +505,13 @@
       "when": 1787771170135,
       "tag": "0071_calm_may_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1787940885724,
+      "tag": "0072_swift_morlun",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/models/pooledBalanceModels/pooledBalanceTable.ts
+++ b/shared/models/pooledBalanceModels/pooledBalanceTable.ts
@@ -93,21 +93,6 @@ export const pooledBalances = pgTable(
 			"pooled_balances_reset_mode_valid",
 			sql`${table.reset_mode} IN ('lazy', 'subscription', 'lifetime')`,
 		),
-		check(
-			"pooled_balances_lifecycle_ids_valid",
-			sql`(
-				${table.reset_mode} = 'subscription'
-				AND ${table.stripe_subscription_id} IS NOT NULL
-				AND ${table.customer_license_link_id} IS NULL
-			) OR (
-				${table.reset_mode} = 'lazy'
-				AND ${table.stripe_subscription_id} IS NULL
-			) OR (
-				${table.reset_mode} = 'lifetime'
-				AND ${table.stripe_subscription_id} IS NULL
-				AND ${table.customer_license_link_id} IS NULL
-			)`,
-		),
 		unique("unique_pooled_balance_customer_entitlement").on(
 			table.customer_entitlement_id,
 		),

--- a/shared/utils/pooledBalanceUtils/convertPooledBalance/entToPooledBalanceIdentity.ts
+++ b/shared/utils/pooledBalanceUtils/convertPooledBalance/entToPooledBalanceIdentity.ts
@@ -1,0 +1,41 @@
+import type { EntitlementWithFeature } from "../../../models/productModels/entModels/entModels.js";
+import type { PooledBalanceIdentity } from "../../../models/pooledBalanceModels/pooledBalanceIdentity.js";
+import {
+	isBooleanEntitlement,
+	isUnlimitedEntitlement,
+} from "../../productUtils/entUtils/classifyEntUtils.js";
+import {
+	normalizedEntitlementInterval,
+	normalizedEntitlementIntervalCount,
+} from "../../productUtils/entUtils/compareEnt/entsAreSame.js";
+import { rolloverConfigToSignature } from "./rolloverConfigToSignature.js";
+
+/** The entitlement-derived facets; lifecycle facets (anchor, reset mode,
+ * subscription, link) complete a full PooledBalanceIdentity. */
+export type EntPooledBalanceIdentity = Pick<
+	PooledBalanceIdentity,
+	| "internalFeatureId"
+	| "unlimited"
+	| "interval"
+	| "intervalCount"
+	| "rolloverSignature"
+>;
+
+export const entToPooledBalanceIdentity = ({
+	entitlement,
+}: {
+	entitlement: EntitlementWithFeature;
+}): EntPooledBalanceIdentity => {
+	const unlimited = isUnlimitedEntitlement({ entitlement });
+	const tracksBalance = !unlimited && !isBooleanEntitlement({ entitlement });
+
+	return {
+		internalFeatureId: entitlement.internal_feature_id,
+		unlimited,
+		interval: normalizedEntitlementInterval(entitlement),
+		intervalCount: normalizedEntitlementIntervalCount(entitlement),
+		rolloverSignature: rolloverConfigToSignature({
+			rollover: tracksBalance ? entitlement.rollover : null,
+		}),
+	};
+};

--- a/shared/utils/pooledBalanceUtils/index.ts
+++ b/shared/utils/pooledBalanceUtils/index.ts
@@ -1,3 +1,4 @@
+export * from "./convertPooledBalance/entToPooledBalanceIdentity.js";
 export * from "./convertPooledBalance/pooledBalanceIdentityToKey.js";
 export * from "./convertPooledBalance/pooledBalanceToPooledBalanceIdentity.js";
 export * from "./convertPooledBalance/rolloverConfigToSignature.js";

--- a/shared/utils/productUtils/entUtils/compareEnt/entsHaveSamePooledIdentity.ts
+++ b/shared/utils/productUtils/entUtils/compareEnt/entsHaveSamePooledIdentity.ts
@@ -1,0 +1,12 @@
+import type { EntitlementWithFeature } from "../../../../models/productModels/entModels/entModels.js";
+import { entToPooledBalanceIdentity } from "../../../pooledBalanceUtils/convertPooledBalance/entToPooledBalanceIdentity.js";
+
+const identityKey = (entitlement: EntitlementWithFeature) =>
+	JSON.stringify(entToPooledBalanceIdentity({ entitlement }));
+
+/** True when both entitlements derive the same pool identity — a transition
+ * between them is an in-place pool change, not a re-mint. */
+export const entsHaveSamePooledIdentity = (
+	ent1: EntitlementWithFeature,
+	ent2: EntitlementWithFeature,
+) => identityKey(ent1) === identityKey(ent2);

--- a/shared/utils/productUtils/entUtils/index.ts
+++ b/shared/utils/productUtils/entUtils/index.ts
@@ -1,5 +1,6 @@
 export * from "./classifyEntUtils.js";
 export * from "./compareEnt/entsAreSame.js";
+export * from "./compareEnt/entsHaveSamePooledIdentity.js";
 export * from "./enrichEntitlement.js";
 export * from "./findEntitlement/findEntitlementSuccessor.js";
 export * from "./formatEntUtils.js";

--- a/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
@@ -38,6 +38,7 @@ import { formatUnixToDateTime } from "@/utils/formatUtils/formatDateUtils";
 import { getBackendErr, notNullish } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { useCustomerContext } from "../../customer/CustomerContext";
+import { getCustomerBalancePlanName } from "../table/customer-balance/customerBalanceUtils";
 import { BalanceEditPreviews } from "./BalanceEditPreviews";
 import { GrantedBalancePopover } from "./GrantedBalancePopover";
 import { PooledBalanceContributions } from "./PooledBalanceContributions";
@@ -328,6 +329,16 @@ function EntitlementInfoRows({
 	unlimitedUsage?: number;
 	billingCycleEnd: number | null;
 }) {
+	const { customer } = useCusQuery();
+	const planName =
+		getCustomerBalancePlanName({
+			balance: {
+				...selectedCusEnt,
+				customer_product: cusProduct ?? null,
+			},
+			fullCustomer: customer,
+		}) ?? "N/A";
+
 	return (
 		<div className="flex flex-col gap-2 rounded-lg">
 			{selectedCusEnt.external_id && (
@@ -344,7 +355,7 @@ function EntitlementInfoRows({
 				/>
 			)}
 			{entity && <InfoRow label="Entity" value={entity.name || entity.id} />}
-			<InfoRow label="Plan" value={cusProduct?.product.name || "N/A"} />
+			<InfoRow label="Plan" value={planName} />
 			<InfoRow
 				label="Interval"
 				value={

--- a/vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx
@@ -92,7 +92,11 @@ export function BalanceRecalculateDialog({
 						{changedRows.map((row) => {
 							const ent = entById.get(row.customer_entitlement_id);
 							const parts = ent
-								? getCustomerBalanceSourceParts({ balance: ent, entities })
+								? getCustomerBalanceSourceParts({
+										balance: ent,
+										entities,
+										fullCustomer: customer,
+									})
 								: null;
 							const label = parts
 								? [parts.productName, parts.intervalLabel]

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceBillingIcon.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceBillingIcon.tsx
@@ -1,0 +1,58 @@
+import {
+	type FullCusEntWithFullCusProduct,
+	isFreeCustomerEntitlement,
+	isPrepaidCustomerEntitlement,
+} from "@autumn/shared";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@autumn/ui";
+import {
+	BoxArrowDownIcon,
+	MoneyWavyIcon,
+	WalletIcon,
+} from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+
+function getBalanceBillingIcon({
+	balance,
+}: {
+	balance: FullCusEntWithFullCusProduct;
+}) {
+	const size = 14;
+	const weight = "duotone" as const;
+
+	if (isFreeCustomerEntitlement(balance))
+		return {
+			icon: <BoxArrowDownIcon size={size} weight={weight} />,
+			color: "text-green-500",
+			label: "Included",
+		};
+
+	if (isPrepaidCustomerEntitlement(balance))
+		return {
+			icon: <WalletIcon size={size} weight={weight} />,
+			color: "text-orange-500",
+			label: "Prepaid price",
+		};
+
+	return {
+		icon: <MoneyWavyIcon size={size} weight={weight} />,
+		color: "text-yellow-500",
+		label: "Usage-based price",
+	};
+}
+
+export function CustomerBalanceBillingIcon({
+	balance,
+}: {
+	balance: FullCusEntWithFullCusProduct;
+}) {
+	const { icon, color, label } = getBalanceBillingIcon({ balance });
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<div className={cn("shrink-0", color)}>{icon}</div>
+			</TooltipTrigger>
+			<TooltipContent>{label}</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceFeatureCell.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceFeatureCell.tsx
@@ -1,0 +1,96 @@
+import {
+	type Entity,
+	type FullCusEntWithFullCusProduct,
+	type FullCustomer,
+	isSyntheticPooledBalanceCustomerEntitlement,
+} from "@autumn/shared";
+import { CaretRightIcon } from "@phosphor-icons/react";
+import type { Row } from "@tanstack/react-table";
+import { AdminHover } from "@/components/general/AdminHover";
+import { cn } from "@/lib/utils";
+import { getCusEntHoverTexts } from "@/views/admin/adminUtils";
+import { CustomerBalanceSourceCell } from "./CustomerBalanceSourceCell";
+import type { CustomerBalanceRowData } from "./CustomerBalanceTable";
+import { getCustomerBalancePlanName } from "./customerBalanceUtils";
+
+export function CustomerBalanceFeatureCell({
+	row,
+	entities,
+	fullCustomer,
+}: {
+	row: Row<CustomerBalanceRowData>;
+	entities: Entity[];
+	fullCustomer?: FullCustomer | null;
+}) {
+	const balance = row.original;
+
+	if (row.depth > 0) {
+		return (
+			<CustomerBalanceSourceCell
+				balance={balance}
+				entities={entities}
+				fullCustomer={fullCustomer}
+			/>
+		);
+	}
+
+	const canExpand = row.getCanExpand();
+	const planName = getParentRowPlanName({
+		balance,
+		canExpand,
+		fullCustomer,
+	});
+
+	return (
+		<div className="flex items-center gap-2 min-w-0">
+			{canExpand && (
+				<span
+					className={cn(
+						"inline-flex text-tertiary-foreground transition-transform duration-200",
+						row.getIsExpanded() && "rotate-90",
+					)}
+				>
+					<CaretRightIcon size={14} weight="bold" />
+				</span>
+			)}
+			<AdminHover
+				texts={getCusEntHoverTexts({
+					cusEnt: balance,
+					entities,
+				})}
+			>
+				<div className="flex min-w-0 flex-col gap-0.5">
+					<span className="font-medium text-foreground truncate">
+						{balance.entitlement.feature.name}
+					</span>
+					{planName && (
+						<span className="text-tertiary-foreground text-xs truncate">
+							{planName}
+						</span>
+					)}
+				</div>
+			</AdminHover>
+		</div>
+	);
+}
+
+const getParentRowPlanName = ({
+	balance,
+	canExpand,
+	fullCustomer,
+}: {
+	balance: FullCusEntWithFullCusProduct;
+	canExpand: boolean;
+	fullCustomer?: FullCustomer | null;
+}) => {
+	if (canExpand) return undefined;
+	if (
+		!isSyntheticPooledBalanceCustomerEntitlement({
+			customerEntitlement: balance,
+		})
+	) {
+		return undefined;
+	}
+
+	return getCustomerBalancePlanName({ balance, fullCustomer });
+};

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceSourceCell.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceSourceCell.tsx
@@ -1,0 +1,63 @@
+import type {
+	Entity,
+	FullCusEntWithFullCusProduct,
+	FullCustomer,
+} from "@autumn/shared";
+import { AdminHover } from "@/components/general/AdminHover";
+import { getCusEntHoverTexts } from "@/views/admin/adminUtils";
+import { CustomerBalanceBillingIcon } from "./CustomerBalanceBillingIcon";
+import { getCustomerBalanceSourceParts } from "./customerBalanceUtils";
+
+export function CustomerBalanceSourceCell({
+	balance,
+	entities,
+	fullCustomer,
+}: {
+	balance: FullCusEntWithFullCusProduct;
+	entities: Entity[];
+	fullCustomer?: FullCustomer | null;
+}) {
+	const { productName, intervalLabel, entityName } =
+		getCustomerBalanceSourceParts({ balance, entities, fullCustomer });
+	const hasPlan = productName !== "No plan";
+	const metaParts = [intervalLabel, entityName].filter(Boolean).join(" · ");
+
+	if (!hasPlan) {
+		return (
+			<div className="flex items-center gap-2 min-w-0">
+				<CustomerBalanceBillingIcon balance={balance} />
+				<AdminHover
+					texts={getCusEntHoverTexts({
+						cusEnt: balance,
+						entities,
+					})}
+				>
+					<span className="text-tertiary-foreground truncate text-xs">
+						{metaParts}
+					</span>
+				</AdminHover>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-0.5 min-w-0">
+			<div className="flex items-center gap-2">
+				<CustomerBalanceBillingIcon balance={balance} />
+				<AdminHover
+					texts={getCusEntHoverTexts({
+						cusEnt: balance,
+						entities,
+					})}
+				>
+					<span className="text-foreground text-xs font-medium truncate">
+						{productName}
+					</span>
+				</AdminHover>
+			</div>
+			<span className="text-tertiary-foreground text-xs truncate pl-5.5">
+				{metaParts}
+			</span>
+		</div>
+	);
+}

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -9,9 +9,6 @@ import {
 	cusEntsToPrepaidQuantity,
 	cusEntsToUnlimitedUsage,
 	getRolloverFields,
-	isFreeCustomerEntitlement,
-	isPrepaidCustomerEntitlement,
-	isSyntheticPooledBalanceCustomerEntitlement,
 	nullish,
 } from "@autumn/shared";
 import {
@@ -26,76 +23,24 @@ import {
 } from "@autumn/ui";
 import {
 	ArrowsClockwiseIcon,
-	BoxArrowDownIcon,
 	BracketsSquareIcon,
-	CaretRightIcon,
 	ClockCountdownIcon,
-	MoneyWavyIcon,
 	PulseIcon,
-	WalletIcon,
 } from "@phosphor-icons/react";
 import type { Row } from "@tanstack/react-table";
 import { Trash } from "lucide-react";
-import { AdminHover } from "@/components/general/AdminHover";
 import { cn } from "@/lib/utils";
 import { formatUnixToDateTime } from "@/utils/formatUtils/formatDateUtils";
-import { getCusEntHoverTexts } from "@/views/admin/adminUtils";
 import { useFeatureUsageBalance } from "@/views/customers2/hooks/useFeatureUsageBalance";
 import { CustomerFeatureUsageBar } from "../customer-feature-usage/CustomerFeatureUsageBar";
 import { FeatureBalanceDisplay } from "../customer-feature-usage/FeatureBalanceDisplay";
 import { AdminSyncAnchorMenuItem } from "./AdminSyncAnchorMenuItem";
+import { CustomerBalanceFeatureCell } from "./CustomerBalanceFeatureCell";
 import type { CustomerBalanceRowData } from "./CustomerBalanceTable";
 import {
 	canDeleteCustomerBalance,
 	canRecalculateCustomerBalances,
-	getCustomerBalanceSourceParts,
 } from "./customerBalanceUtils";
-
-function getBalanceBillingIcon({
-	balance,
-}: {
-	balance: FullCusEntWithFullCusProduct;
-}) {
-	const size = 14;
-	const weight = "duotone" as const;
-
-	if (isFreeCustomerEntitlement(balance))
-		return {
-			icon: <BoxArrowDownIcon size={size} weight={weight} />,
-			color: "text-green-500",
-			label: "Included",
-		};
-
-	if (isPrepaidCustomerEntitlement(balance))
-		return {
-			icon: <WalletIcon size={size} weight={weight} />,
-			color: "text-orange-500",
-			label: "Prepaid price",
-		};
-
-	return {
-		icon: <MoneyWavyIcon size={size} weight={weight} />,
-		color: "text-yellow-500",
-		label: "Usage-based price",
-	};
-}
-
-function BalanceBillingIcon({
-	balance,
-}: {
-	balance: FullCusEntWithFullCusProduct;
-}) {
-	const { icon, color, label } = getBalanceBillingIcon({ balance });
-
-	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<div className={cn("shrink-0", color)}>{icon}</div>
-			</TooltipTrigger>
-			<TooltipContent>{label}</TooltipContent>
-		</Tooltip>
-	);
-}
 
 /** Computes balance values from a single entitlement (for sub-rows) */
 function getIndividualEntValues({
@@ -606,90 +551,13 @@ export const CustomerBalanceTableColumns = ({
 		accessorKey: "feature",
 		enableResizing: true,
 		minSize: 100,
-		cell: ({ row }: { row: Row<CustomerBalanceRowData> }) => {
-			const ent = row.original;
-			const isSubRow = row.depth > 0;
-
-			if (isSubRow) {
-				const isPooledBalance = isSyntheticPooledBalanceCustomerEntitlement({
-					customerEntitlement: ent,
-				});
-				const { productName, intervalLabel, entityName } =
-					getCustomerBalanceSourceParts({ balance: ent, entities });
-				const sourceName = isPooledBalance ? "Pooled" : productName;
-				const hasPlan = !!ent.customer_product;
-				const metaParts = [intervalLabel, entityName]
-					.filter(Boolean)
-					.join(" · ");
-
-				if (!hasPlan && !isPooledBalance) {
-					return (
-						<div className="flex items-center gap-2 min-w-0">
-							<BalanceBillingIcon balance={ent} />
-							<AdminHover
-								texts={getCusEntHoverTexts({
-									cusEnt: ent,
-									entities,
-								})}
-							>
-								<span className="text-tertiary-foreground truncate text-xs">
-									{metaParts}
-								</span>
-							</AdminHover>
-						</div>
-					);
-				}
-
-				return (
-					<div className="flex flex-col gap-0.5 min-w-0">
-						<div className="flex items-center gap-2">
-							<BalanceBillingIcon balance={ent} />
-							<AdminHover
-								texts={getCusEntHoverTexts({
-									cusEnt: ent,
-									entities,
-								})}
-							>
-								<span className="text-foreground text-xs font-medium truncate">
-									{sourceName}
-								</span>
-							</AdminHover>
-						</div>
-						<span className="text-tertiary-foreground text-xs truncate pl-5.5">
-							{metaParts}
-						</span>
-					</div>
-				);
-			}
-
-			const canExpand = row.getCanExpand();
-			const isExpanded = row.getIsExpanded();
-
-			return (
-				<div className="flex items-center gap-2">
-					{canExpand && (
-						<span
-							className={cn(
-								"inline-flex text-tertiary-foreground transition-transform duration-200",
-								isExpanded && "rotate-90",
-							)}
-						>
-							<CaretRightIcon size={14} weight="bold" />
-						</span>
-					)}
-					<AdminHover
-						texts={getCusEntHoverTexts({
-							cusEnt: ent,
-							entities,
-						})}
-					>
-						<span className="font-medium text-foreground truncate">
-							{ent.entitlement.feature.name}
-						</span>
-					</AdminHover>
-				</div>
-			);
-		},
+		cell: ({ row }: { row: Row<CustomerBalanceRowData> }) => (
+			<CustomerBalanceFeatureCell
+				row={row}
+				entities={entities}
+				fullCustomer={fullCustomer}
+			/>
+		),
 	},
 	{
 		header: "Usage",

--- a/vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts
+++ b/vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts
@@ -5,7 +5,12 @@ import {
 	type Entity,
 	type FullCusEntWithFullCusProduct,
 	type FullCustomer,
+	type FullCustomerEntitlement,
+	filterCustomerEntitlementsByPooledBalanceSource,
+	findCustomerLicenseByLinkId,
+	findCustomerProductById,
 	fullCustomerToCustomerEntitlements,
+	fullCustomerToCustomerLicenses,
 	hasRecalculableScope,
 	isPaidCustomerEntitlement,
 	isPooledBalanceSourceCustomerEntitlement,
@@ -33,14 +38,102 @@ export const canDeleteCustomerBalance = ({
 		isPooledBalanceSourceCustomerEntitlement({ customerEntitlement: balance })
 	);
 
+type BalanceWithOptionalProduct = FullCustomerEntitlement & {
+	customer_product?: { product: { name: string } } | null;
+};
+
+const getLicensePooledBalancePlanName = ({
+	balance,
+	fullCustomer,
+}: {
+	balance: BalanceWithOptionalProduct;
+	fullCustomer: FullCustomer;
+}) => {
+	const customerLicense = findCustomerLicenseByLinkId({
+		customerLicenses: fullCustomerToCustomerLicenses({ fullCustomer }),
+		customerLicenseLinkId: balance.pooled_balance?.customer_license_link_id,
+	});
+	if (!customerLicense) return undefined;
+
+	return (
+		findCustomerProductById({
+			fullCustomer,
+			customerProductId: customerLicense.parent_customer_product_id,
+		})?.product.name ?? customerLicense.planLicense?.product.name
+	);
+};
+
+const getRegularPooledBalancePlanName = ({
+	balance,
+	fullCustomer,
+}: {
+	balance: BalanceWithOptionalProduct;
+	fullCustomer: FullCustomer;
+}) => {
+	const pooledBalanceId =
+		balance.pooled_balance_id ?? balance.pooled_balance?.id;
+	if (!pooledBalanceId) return undefined;
+
+	const planNames = new Set<string>();
+	for (const customerProduct of fullCustomer.customer_products) {
+		const contributes = filterCustomerEntitlementsByPooledBalanceSource({
+			customerEntitlements: customerProduct.customer_entitlements,
+		}).some(
+			(customerEntitlement) =>
+				customerEntitlement.pooled_balance_id === pooledBalanceId,
+		);
+		if (contributes && customerProduct.product.name) {
+			planNames.add(customerProduct.product.name);
+		}
+	}
+
+	if (planNames.size !== 1) return undefined;
+	return [...planNames][0];
+};
+
+/** Plan that granted this balance. Pooled ents have no customer_product. */
+export const getCustomerBalancePlanName = ({
+	balance,
+	fullCustomer,
+}: {
+	balance: BalanceWithOptionalProduct;
+	fullCustomer?: FullCustomer | null;
+}): string | undefined => {
+	if (balance.customer_product?.product.name) {
+		return balance.customer_product.product.name;
+	}
+
+	if (
+		!fullCustomer ||
+		!isSyntheticPooledBalanceCustomerEntitlement({
+			customerEntitlement: balance,
+		})
+	) {
+		return undefined;
+	}
+
+	if (balance.pooled_balance?.customer_license_link_id) {
+		return getLicensePooledBalancePlanName({ balance, fullCustomer });
+	}
+
+	return getRegularPooledBalancePlanName({ balance, fullCustomer });
+};
+
 export function getCustomerBalanceSourceParts({
 	balance,
 	entities,
+	fullCustomer,
 }: {
 	balance: FullCusEntWithFullCusProduct;
 	entities: Entity[];
+	fullCustomer?: FullCustomer | null;
 }) {
-	const productName = balance.customer_product?.product.name || "No plan";
+	const isPooledBalance = isSyntheticPooledBalanceCustomerEntitlement({
+		customerEntitlement: balance,
+	});
+	const productName =
+		getCustomerBalancePlanName({ balance, fullCustomer }) ??
+		(isPooledBalance ? "Pooled" : "No plan");
 
 	const { interval, interval_count } = balance.entitlement;
 	let intervalLabel: string;
@@ -70,12 +163,14 @@ export function getCustomerBalanceSourceParts({
 export function getCustomerBalanceSourceLabel({
 	balance,
 	entities,
+	fullCustomer,
 }: {
 	balance: FullCusEntWithFullCusProduct;
 	entities: Entity[];
+	fullCustomer?: FullCustomer | null;
 }) {
 	const { productName, intervalLabel, entityName } =
-		getCustomerBalanceSourceParts({ balance, entities });
+		getCustomerBalanceSourceParts({ balance, entities, fullCustomer });
 	const parts = [productName, intervalLabel];
 	if (entityName) parts.push(entityName);
 	return parts.join(" · ");


### PR DESCRIPTION
## Summary
- License seats contribute to pooled balances keyed by `customer_license_link_id`; batchTransition handles amount-change, add/remove, and pooledness/identity flips in set-based SQL.
- Runtime treats those pools like any other: check/track read the pool, lazy reset and rollover size off the pool grant, and cron selects the synthetic row (never seat sources).
- A dead parent hides the pool from reset hydration and the V1 cron scan. Pooled migration customizes stay on the `per_customer` lane.

## Test plan
- [ ] `license-pooled-*` under `tests/integration/licenses/pooled-balances` (identity, add/remove, amount-change, flips, reset, check/track, parent-expire)
- [ ] `batch-license-pooled-transitions.test.ts` — all three shapes decline to `per_customer`
- [ ] `bun tw` sweep of licenses + pooled-balances + related reset paths


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pooled balance support to license plans. Previously pooled items on license links were rejected; now each license link mints a pool keyed by `customer_license_link_id`, and all seats under that link contribute to one shared balance.

**New Features**
- Batch transitions handle seat add/remove, amount changes, and pooledness/identity flips in set-based SQL; flips (private↔pooled, interval change) drop usage and re-mint fresh.
- Check, track, lazy reset, rollover, and the reset cron all read the license pool like any other pool, never the seat sources.
- A dead license parent hides its pools from reads and reset hydration.
- Removed the link-time rejection of pooled items on license plans.
- Customer balance table now shows the parent plan name for license pooled balances.

**Migration**
- Drops the `pooled_balances_lifecycle_ids_valid` check constraint so license pools can carry a `customer_license_link_id`.

<sup>Written for commit 6642263132a15d4d5cfafafcaa3f1985345574cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds pooled usage balances for license seats and carries them through lifecycle transitions, runtime reads, resets, migrations, and dashboard presentation.
- **[Improvements, API changes]** License seats now contribute to a shared balance keyed by their customer license link.
- **[Improvements]** Batch transitions add, remove, resize, and re-create pooled contributions when entitlement identity changes.
- **[Bug fixes, Improvements]** Runtime and reset queries use the synthetic pool row and hide license pools whose parent is no longer live.
- **[Improvements]** Customer balance screens resolve and display the plan behind pooled balances.
- **[API changes]** The schema constraint that previously prohibited license-linked pool lifecycle identities is removed.
</details>


<h3>Confidence Score: 3/5</h3>

This PR should not merge until expiring a pooled license seat and removing its shared contribution are made atomic or reliably recoverable.

A failure after the seat status update can leave the seat expired while its stored contribution remains available to runtime usage checks.

**Files Needing Attention:** server/src/internal/licenses/actions/reconcile/expireUnusedAssignments.ts

<details open><summary><h3>Security Review</h3></summary>

A partial-failure path can leave an expired license seat contributing capacity to a shared usage pool because seat expiration and contribution removal are separate transactions.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/licenses/actions/reconcile/expireUnusedAssignments.ts | Adds pooled-contribution removal for expired spare seats, but the seat and pool updates are not atomic. |
| server/src/internal/billing/v2/actions/batchTransition/compute/operations/entitlementPriceOperations/computeEntitlementPriceOperations.ts | Splits pooled identity flips into remove/add operations and computes in-place contribution deltas for amount changes. |
| server/src/internal/billing/v2/actions/batchTransition/execute/sql/addCustomerEntitlementsBatch.ts | Inserts seat entitlements and contributions while updating the shared grant and synthetic balance in one SQL statement. |
| server/src/internal/billing/v2/actions/batchTransition/execute/sql/pooledRemoveBatchCtes.ts | Removes pooled contributions in batches and expires the pool when its final contribution disappears. |
| server/src/internal/billing/v2/actions/batchTransition/execute/sql/insertPooledBalanceGraph.ts | Creates synthetic pool graph records and attempts identity-race recovery; no independently publishable production failure was established. |
| server/src/internal/customers/licensePooledBalanceIsLiveSql.ts | Centralizes parent-product liveness filtering for license-linked pooled balances. |
| shared/models/pooledBalanceModels/pooledBalanceTable.ts | Permits a customer license link on lifetime pools by removing the previous lifecycle-ID constraint. |
| vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts | Resolves pooled-balance source plan names from customer license and contribution relationships. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[License seat created or updated] --> B[Seat pooled contribution]
  B --> C[Synthetic license pool balance]
  C --> D[Check and track usage]
  C --> E[Lazy or scheduled reset]
  F[License reconciliation] --> G[Expire unused seat]
  G --> H[Remove pooled contribution]
  H --> C
  G -. failure before removal .-> I[Expired seat still grants capacity]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/licenses/actions/reconcile/expireUnusedAssignments.ts:22-35
**Seat expiration leaves stale capacity**

When hydration or pooled-balance processing fails after the seat update succeeds, the seat remains expired while its contribution remains in the shared balance, so check and track requests can continue using capacity that the expired seat no longer grants. For example, failing after expiring a 10-unit seat leaves those 10 units available. **How this was verified:** The seat update commits before the separate pooled transition, while runtime reads the stored synthetic pool balance rather than recalculating it from live seats.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Show the parent plan name for license po..."](https://github.com/useautumn/autumn/commit/6642263132a15d4d5cfafafcaa3f1985345574cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58392238)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Event metering, balances, and insights](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/event-metering-and-insights.md)
- Knowledge Base — [Database schema, relations, and migrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/database-schema-and-migrations.md)
- Knowledge Base — [Customer, subject, and entitlement operations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/customer-management.md)
- Knowledge Base — [Scheduled operations and trigger automation](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/scheduled-operations-and-triggers.md)
</details>


<!-- /greptile_comment -->