### PR TITLE
feat(catalog-v2): version-anchored license links

### DIFF
--- a/server/src/internal/catalogV2/actions/buildPlanChange/buildPlanLicenseChanges/buildPlanLicensePreviousAttributes.ts
+++ b/server/src/internal/catalogV2/actions/buildPlanChange/buildPlanLicenseChanges/buildPlanLicensePreviousAttributes.ts
@@ -18,5 +18,8 @@ export const buildPlanLicensePreviousAttributes = ({
 	if (from.product.version !== to.product.version) {
 		previous.version = from.product.version;
 	}
+	if (from.product.version_slug !== to.product.version_slug) {
+		previous.version_slug = from.product.version_slug ?? undefined;
+	}
 	return Object.keys(previous).length > 0 ? previous : null;
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/propagateLicenseDraftUpserts.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/propagateLicenseDraftUpserts.ts
@@ -9,7 +9,11 @@ import {
 	licenseUpsertFromPlanLicense,
 	sortLicenseDraftUpserts,
 } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/licenseUpsertFromPlanLicense";
-import { shouldPropagate } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
+import {
+	parentLicenseLinkForChild,
+	propagateReachesLink,
+	shouldPropagate,
+} from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 
@@ -44,6 +48,10 @@ export const propagateLicenseDraftUpserts = ({
 		) {
 			continue;
 		}
+
+		const currentPlanLicense = parentLicenseLinkForChild({ parent, child });
+		if (!currentPlanLicense) continue;
+		if (!propagateReachesLink({ currentPlanLicense, child })) continue;
 
 		const planLicense = parent.planLicenses?.find(
 			(link) => link.licensePlanId === child.row.planId,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/assembleNextFullProduct.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/assembleNextFullProduct.ts
@@ -32,5 +32,6 @@ export const assembleNextFullProduct = ({
 		entitlements,
 		free_trial: freeTrial,
 		licenses: currentFullProduct?.licenses,
+		parent_plan_licenses: currentFullProduct?.parent_plan_licenses,
 	} as FullProduct;
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/declared/resolveDeclaredPlanLicenses.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/declared/resolveDeclaredPlanLicenses.ts
@@ -7,6 +7,8 @@ import type {
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { PlanLicensePlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
+import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
+import { fullProductForSlug } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/fullProductForSlug";
 
 const declaredLinkChanged = ({
 	currentPlanLicense,
@@ -38,6 +40,39 @@ const declaredLinkChanged = ({
 	return false;
 };
 
+/** Stated slug = that row. Omitted keeps the existing child id; new links use active. */
+const anchorFullProductForDeclared = ({
+	params,
+	currentPlanLicense,
+	productStatesContext,
+}: {
+	params: PlanLicenseParams;
+	currentPlanLicense: FullPlanLicense | null;
+	productStatesContext: ProductStatesContext;
+}): FullProduct | null => {
+	if (params.version_slug !== undefined) {
+		return fullProductForSlug({
+			planId: params.license_plan_id,
+			versionSlug: params.version_slug,
+			productStatesContext,
+		});
+	}
+
+	if (currentPlanLicense) {
+		return (
+			findFullProductByInternalId({
+				internalId: currentPlanLicense.license_internal_product_id,
+				productStatesContext,
+			}) ?? currentPlanLicense.product
+		);
+	}
+
+	return activeFullProductForPlan({
+		planId: params.license_plan_id,
+		productStatesContext,
+	});
+};
+
 /** Declared licenses[] vs current links → per-link write ops. */
 export const resolveDeclaredPlanLicenses = ({
 	declared,
@@ -58,12 +93,13 @@ export const resolveDeclaredPlanLicenses = ({
 	const declaredIds = new Set(declared.map((entry) => entry.license_plan_id));
 
 	const planned: PlanLicensePlan[] = declared.map((params) => {
-		const licenseProduct = activeFullProductForPlan({
-			planId: params.license_plan_id,
-			productStatesContext,
-		});
 		const currentPlanLicense =
 			currentPlanLicenseByPlanId.get(params.license_plan_id) ?? null;
+		const licenseProduct = anchorFullProductForDeclared({
+			params,
+			currentPlanLicense,
+			productStatesContext,
+		});
 
 		const op = !currentPlanLicense
 			? "create"
@@ -87,6 +123,7 @@ export const resolveDeclaredPlanLicenses = ({
 			prepaidOnly: params.prepaid_only ?? true,
 			metadata: params.metadata,
 			customize: params.customize,
+			declaredVersionSlug: params.version_slug,
 		};
 	});
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils.ts
@@ -1,6 +1,7 @@
 import {
 	type CatalogPropagateTargetParams,
 	type FullPlanLicense,
+	type FullProduct,
 	type LicenseCustomize,
 	productKeyToString,
 	productToProductKey,
@@ -9,6 +10,7 @@ import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCa
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { activeVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeVersionForPlan";
 import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
+import { versionForSlug } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/versionForSlug";
 
 /** Current plan_license links on this row. Minted versions fall back to the clone source. */
 export const upsertProductPlanToLicenses = ({
@@ -35,26 +37,13 @@ const childSourceInternalIds = ({
 	),
 ];
 
-/** Incoming links on the upserted child plus the demoted pointer (promote). */
-export const reverseLinksForChild = ({
-	upsert,
-	productStatesContext,
+const uniqueReverseLinks = ({
+	products,
 }: {
-	upsert: UpsertProductPlan;
-	productStatesContext: ProductStatesContext;
+	products: Array<FullProduct | null | undefined>;
 }) => {
-	const previousActive = upsert.previousActiveInternalId
-		? findFullProductByInternalId({
-				internalId: upsert.previousActiveInternalId,
-				productStatesContext,
-			})
-		: null;
 	const seen = new Set<string>();
-	return [
-		upsert.row.currentFullProduct,
-		upsert.row.baseFullProduct,
-		previousActive,
-	].flatMap((product) => {
+	return products.flatMap((product) => {
 		if (!product) return [];
 		return (product.parent_plan_licenses ?? []).filter((link) => {
 			const key = productKeyToString({
@@ -67,6 +56,65 @@ export const reverseLinksForChild = ({
 	});
 };
 
+/** Incoming links on every live version row of this child plan. */
+export const reverseLinksOnChildPlan = ({
+	planId,
+	productStatesContext,
+}: {
+	planId: string;
+	productStatesContext: ProductStatesContext;
+}) =>
+	uniqueReverseLinks({
+		products: productStatesContext.versionsByPlanId[planId] ?? [],
+	});
+
+/** Incoming links on one child version row. */
+export const reverseLinksOnChildProduct = ({
+	planId,
+	childInternalId,
+	productStatesContext,
+}: {
+	planId: string;
+	childInternalId: string;
+	productStatesContext: ProductStatesContext;
+}) => {
+	const childRow = (productStatesContext.versionsByPlanId[planId] ?? []).find(
+		(row) => row.internal_id === childInternalId,
+	);
+	return uniqueReverseLinks({ products: [childRow] });
+};
+
+/** Incoming links on the planned child row, plus the demoted pointer (promote). */
+export const reverseLinksForChild = ({
+	upsert,
+	productStatesContext,
+}: {
+	upsert: UpsertProductPlan;
+	productStatesContext: ProductStatesContext;
+}) => {
+	const plannedInternalId =
+		upsert.row.currentFullProduct?.internal_id ??
+		upsert.row.baseFullProduct?.internal_id ??
+		upsert.row.nextFullProduct.internal_id;
+	const hydrated = (
+		productStatesContext.versionsByPlanId[upsert.row.planId] ?? []
+	).find((row) => row.internal_id === plannedInternalId);
+	const previousActive = upsert.previousActiveInternalId
+		? findFullProductByInternalId({
+				internalId: upsert.previousActiveInternalId,
+				productStatesContext,
+			})
+		: null;
+	return uniqueReverseLinks({
+		products: [
+			hydrated,
+			upsert.row.currentFullProduct,
+			upsert.row.baseFullProduct,
+			previousActive,
+		],
+	});
+};
+
 export const parentLicenseLinkForChild = ({
 	parent,
 	child,
@@ -74,8 +122,14 @@ export const parentLicenseLinkForChild = ({
 	parent: UpsertProductPlan;
 	child: UpsertProductPlan;
 }): FullPlanLicense | undefined => {
+	const licenses = upsertProductPlanToLicenses({ upsert: parent });
+	// Adopt mint clones the old row's link; pair by child plan so follow can
+	// re-anchor onto the child's active row in this batch.
+	if (parent.row.source === "license_adopt") {
+		return licenses.find((link) => link.product.id === child.row.planId);
+	}
 	const sourceInternalIds = childSourceInternalIds({ child });
-	return upsertProductPlanToLicenses({ upsert: parent }).find(
+	return licenses.find(
 		(link) =>
 			link.product.id === child.row.planId &&
 			(sourceInternalIds.length === 0 ||
@@ -110,17 +164,25 @@ const propagateTargetMatchesParent = ({
 	target,
 	parent,
 	activeVersion,
+	productStatesContext,
 }: {
 	target: CatalogPropagateTargetParams;
 	parent: UpsertProductPlan;
 	activeVersion: number | undefined;
+	productStatesContext: ProductStatesContext;
 }): boolean => {
 	if (target.plan_id !== parent.row.planId) return false;
 	if (target.version !== undefined) return target.version === parent.row.version;
+	if (target.version_slug !== undefined) {
+		const version = versionForSlug({
+			planId: target.plan_id,
+			versionSlug: target.version_slug,
+			productStatesContext,
+		});
+		return version !== undefined && version === parent.row.version;
+	}
 	if (target.versioning === "all_versions") return true;
-	return (
-		activeVersion !== undefined && parent.row.version === activeVersion
-	);
+	return activeVersion !== undefined && parent.row.version === activeVersion;
 };
 
 export const childPropagatesToParent = ({
@@ -137,7 +199,12 @@ export const childPropagatesToParent = ({
 		productStatesContext,
 	});
 	return (child.propagate?.license_parents ?? []).some((target) =>
-		propagateTargetMatchesParent({ target, parent, activeVersion }),
+		propagateTargetMatchesParent({
+			target,
+			parent,
+			activeVersion,
+			productStatesContext,
+		}),
 	);
 };
 
@@ -153,17 +220,35 @@ export const movesActivePointer = ({
 	return nextIsActive && (mintedNewRow || promotedExisting);
 };
 
-/** In-place item writes, or the child taking the pointer. Draft-mint clones do not. */
-export const childTriggersLicenseRewrite = ({
+/** Pin-lane trigger: in-place item writes only. Mints/promotes leave anchored links alone. */
+export const childEditsItemsInPlace = ({
 	child,
 }: {
 	child: UpsertProductPlan;
 }): boolean => {
 	const mintedNewRow = child.row.versioning === "new_version";
 	const childHasItemWrites = child.entitlementPricesPlan != null;
-	const inPlaceItemWrites = childHasItemWrites && !mintedNewRow;
-	return inPlaceItemWrites || movesActivePointer({ upsert: child });
+	return childHasItemWrites && !mintedNewRow;
 };
+
+/** Propagate-lane trigger: in-place item writes, or the child taking the pointer. */
+export const childTriggersLicenseRewrite = ({
+	child,
+}: {
+	child: UpsertProductPlan;
+}): boolean =>
+	childEditsItemsInPlace({ child }) || movesActivePointer({ upsert: child });
+
+/** In-place follow only reaches the row this link already points at. Mint/promote still move it. */
+export const propagateReachesLink = ({
+	currentPlanLicense,
+	child,
+}: {
+	currentPlanLicense: FullPlanLicense;
+	child: UpsertProductPlan;
+}): boolean =>
+	movesActivePointer({ upsert: child }) ||
+	!needsRepoint({ currentPlanLicense, child });
 
 export const shouldPropagate = ({
 	parent,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/pinned/computePinnedPlanLicenses.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/pinned/computePinnedPlanLicenses.ts
@@ -1,27 +1,19 @@
-import type { FullPlanLicense, FullProduct } from "@autumn/shared";
+import type { FullPlanLicense } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type {
 	PlanLicensePlan,
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
-import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
-import { isExistingRowPromote } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/isExistingRowPromote";
 import { getEntsWithFeature } from "@/internal/products/entitlements/entitlementUtils.js";
 import {
-	childTriggersLicenseRewrite,
+	childEditsItemsInPlace,
 	needsRepoint,
 	parentLicenseLinkForChild,
 	shouldPropagate,
 	upsertProductPlansToChildPlans,
 } from "../licensePlanUtils";
 import { cloneFrozenChildAsLicenseOverlay } from "./cloneFrozenChildAsLicenseOverlay";
-
-const childIsPromote = ({ child }: { child: UpsertProductPlan }): boolean =>
-	isExistingRowPromote({
-		current: child.row.currentFullProduct,
-		next: child.row.nextFullProduct,
-	});
 
 const shouldPin = ({
 	parent,
@@ -35,84 +27,52 @@ const shouldPin = ({
 	productStatesContext: ProductStatesContext;
 }): boolean => {
 	const hasDeclaredLicenses = parent.declaredLicenses !== undefined;
-	const rewritesLicenses = childTriggersLicenseRewrite({ child });
-	const promote = childIsPromote({ child });
+	const editsInPlace = childEditsItemsInPlace({ child });
+	const anchorsEditedRow = !needsRepoint({ currentPlanLicense, child });
 	const followsViaPropagate = shouldPropagate({
 		parent,
 		child,
 		productStatesContext,
 	});
 	const alreadyCustomized = currentPlanLicense.customized;
-	const alreadyPinnedToNext = !needsRepoint({ currentPlanLicense, child });
 
 	if (hasDeclaredLicenses) return false;
 	if (followsViaPropagate) return false;
-	if (!rewritesLicenses) return false;
-	if (promote && alreadyCustomized) return false;
-	if (alreadyCustomized && alreadyPinnedToNext) return false;
+	if (!editsInPlace) return false;
+	if (!anchorsEditedRow) return false;
+	if (alreadyCustomized) return false;
 	return true;
-};
-
-const pinTargetProduct = ({
-	child,
-	productStatesContext,
-}: {
-	child: UpsertProductPlan;
-	productStatesContext: ProductStatesContext;
-}): FullProduct => {
-	const promote = childIsPromote({ child });
-	const demotedInternalId = child.previousActiveInternalId;
-	if (promote && demotedInternalId) {
-		return (
-			findFullProductByInternalId({
-				internalId: demotedInternalId,
-				productStatesContext,
-			}) ?? child.row.nextFullProduct
-		);
-	}
-	return child.row.nextFullProduct;
 };
 
 const pinnedPlanLicense = ({
 	ctx,
 	currentPlanLicense,
 	child,
-	productStatesContext,
 }: {
 	ctx: AutumnContext;
 	currentPlanLicense: FullPlanLicense;
 	child: UpsertProductPlan;
-	productStatesContext: ProductStatesContext;
 }): PlanLicensePlan | undefined => {
-	const childProduct = pinTargetProduct({ child, productStatesContext });
-	const entitlementPricesPlan = currentPlanLicense.customized
-		? undefined
-		: cloneFrozenChildAsLicenseOverlay({
-				ctx,
-				frozenChildProduct: currentPlanLicense.product,
-				childProduct,
-			});
-	const writesLink =
-		currentPlanLicense.license_internal_product_id !==
-		childProduct.internal_id;
-	if (!writesLink && !entitlementPricesPlan) return undefined;
+	const childProduct = child.row.nextFullProduct;
+	const entitlementPricesPlan = cloneFrozenChildAsLicenseOverlay({
+		ctx,
+		frozenChildProduct: currentPlanLicense.product,
+		childProduct,
+	});
+	if (!entitlementPricesPlan) return undefined;
 
 	return {
 		op: "update",
 		licensePlanId: child.row.planId,
 		licenseProduct: childProduct,
-		effectiveLicenseProduct: entitlementPricesPlan
-			? {
-					...childProduct,
-					prices: entitlementPricesPlan.projected.prices,
-					entitlements: getEntsWithFeature({
-						ents: entitlementPricesPlan.projected.entitlements,
-						features: ctx.features,
-					}),
-				}
-			: currentPlanLicense.customized
-				? currentPlanLicense.product
-				: childProduct,
+		effectiveLicenseProduct: {
+			...childProduct,
+			prices: entitlementPricesPlan.projected.prices,
+			entitlements: getEntsWithFeature({
+				ents: entitlementPricesPlan.projected.entitlements,
+				features: ctx.features,
+			}),
+		},
 		currentPlanLicense,
 		included: currentPlanLicense.included,
 		prepaidOnly: currentPlanLicense.prepaid_only,
@@ -121,8 +81,8 @@ const pinnedPlanLicense = ({
 };
 
 /**
- * Child-driven pin: clone the frozen child's items onto this parent if it
- * does not follow. Customized links and declared licenses[] are skipped.
+ * Child-driven pin: an in-place child edit freezes non-following links anchored
+ * to the edited row via an overlay. Mints/promotes never reach this lane.
  */
 export const computePinnedPlanLicenses = ({
 	ctx,
@@ -149,7 +109,6 @@ export const computePinnedPlanLicenses = ({
 			ctx,
 			currentPlanLicense,
 			child,
-			productStatesContext,
 		});
 		if (planLicense) pinned.push(planLicense);
 	}

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/propagated/computePropagatedPlanLicenses.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/propagated/computePropagatedPlanLicenses.ts
@@ -10,6 +10,7 @@ import {
 	needsNewParentLink,
 	needsRepoint,
 	parentLicenseLinkForChild,
+	propagateReachesLink,
 	shouldPropagate,
 	upsertProductPlansToChildPlans,
 } from "../licensePlanUtils";
@@ -94,8 +95,8 @@ const propagatedPlanLicense = ({
 		: propagatedStockPlanLicense({ currentPlanLicense, child, parent });
 
 /**
- * Child-driven adopt: parents listed in propagate.license_parents follow the
- * child's new items. In-place uncustomized share stock (`op: "none"`) for preview.
+ * Child-driven adopt: listed parents follow this child's next items.
+ * In-place uncustomized share stock; mint/promote may re-point.
  */
 export const computePropagatedPlanLicenses = ({
 	ctx,
@@ -113,7 +114,14 @@ export const computePropagatedPlanLicenses = ({
 	for (const child of upsertProductPlansToChildPlans({ upsertProducts })) {
 		const currentPlanLicense = parentLicenseLinkForChild({ parent, child });
 		if (!currentPlanLicense) continue;
+		if (
+			parent.row.source === "license_adopt" &&
+			!child.row.nextFullProduct.active
+		) {
+			continue;
+		}
 		if (!shouldPropagate({ parent, child, productStatesContext })) continue;
+		if (!propagateReachesLink({ currentPlanLicense, child })) continue;
 
 		const planLicense = propagatedPlanLicense({
 			ctx,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan.ts
@@ -1,13 +1,12 @@
-import {
-	productToProductKey,
-} from "@autumn/shared";
+import { productToProductKey } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { assembleNextFullProduct } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/assembleNextFullProduct";
-import { declaredVariantsForSource } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/declaredVariantsForSource";
 import { computeCatalogEntitlementPricesPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeCatalogEntitlementPricesPlan/computeCatalogEntitlementPricesPlan";
 import { computeFreeTrialPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeFreeTrialPlan/computeFreeTrialPlan";
 import { computeProductDetailsPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/computeProductDetailsPlan";
+import { declaredVariantsForSource } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/declaredVariantsForSource";
 import { resolveUpsertVariantPointer } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/resolveUpsertVariantPointer";
+import { planParamsFromEditDiff } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/planParamsFromEditDiff";
 import { resolveUpsertOp } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/resolveUpsertOp";
 import { resolveUpsertVersioning } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/resolveUpsertVersioning";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
@@ -15,7 +14,6 @@ import type {
 	ProductUpsertIntent,
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
-import { planParamsFromEditDiff } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/planParamsFromEditDiff";
 import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
 import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
 import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
@@ -172,8 +170,7 @@ export const intentToUpsertProductPlan = ({
 			versioning,
 			currentFullProduct,
 			// Mint-only clone source for preview; null on in-place writes.
-			baseFullProduct:
-				versioning === "new_version" ? baseFullProduct : null,
+			baseFullProduct: versioning === "new_version" ? baseFullProduct : null,
 			nextFullProduct,
 		},
 		...(details.changed ? { details } : {}),
@@ -194,7 +191,8 @@ export const intentToUpsertProductPlan = ({
 			: {}),
 		...(declaredVariants !== undefined ? { declaredVariants } : {}),
 		...(unlink ? { unlink: true } : {}),
-		...(source === "direct" && planParams.propagate !== undefined
+		...((source === "direct" || source === "all_versions") &&
+		planParams.propagate !== undefined
 			? { propagate: planParams.propagate }
 			: {}),
 		...(planParams.create_in_stripe !== undefined
@@ -215,8 +213,8 @@ export const intentToUpsertProductPlan = ({
 						})
 					: customerUsage.hasVersionableCustomerProducts,
 			planHadLiveVersions:
-				(productStatesContext.versionsByPlanId[productKey.planId] ?? []).length >
-				0,
+				(productStatesContext.versionsByPlanId[productKey.planId] ?? [])
+					.length > 0,
 		},
 	};
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentIntents.ts
@@ -1,7 +1,10 @@
 import { productKeyToString, productToProductKey } from "@autumn/shared";
 import {
+	childEditsItemsInPlace,
 	childTriggersLicenseRewrite,
+	movesActivePointer,
 	reverseLinksForChild,
+	reverseLinksOnChildPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
 import { deriveLicenseParentMintIntents } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentMintIntents";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
@@ -10,7 +13,12 @@ import type {
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 
-/** Links-only pin for parent versions not already in the batch. Skip all_versions plans — siblings cover them. */
+/**
+ * Pull absent parent versions into the batch. In-place edits pull every
+ * reverse-linked parent (pin candidates); mints/promotes pull only parents
+ * listed in propagate — anchored links stay untouched. Skip all_versions
+ * plans — siblings cover them.
+ */
 export const deriveLicenseParentIntents = ({
 	intent,
 	upsert,
@@ -25,10 +33,19 @@ export const deriveLicenseParentIntents = ({
 	const rewritesLicenses = childTriggersLicenseRewrite({ child: upsert });
 	if (!rewritesLicenses) return [];
 
-	const reverseLinks = reverseLinksForChild({
-		upsert,
-		productStatesContext: projectedProductStatesContext,
-	});
+	const editsInPlace = childEditsItemsInPlace({ child: upsert });
+	const propagatePlanIds = new Set(
+		(upsert.propagate?.license_parents ?? []).map((target) => target.plan_id),
+	);
+	const reverseLinks = movesActivePointer({ upsert })
+		? reverseLinksOnChildPlan({
+				planId: upsert.row.planId,
+				productStatesContext: projectedProductStatesContext,
+			})
+		: reverseLinksForChild({
+				upsert,
+				productStatesContext: projectedProductStatesContext,
+			});
 
 	return [
 		...deriveLicenseParentMintIntents({
@@ -39,6 +56,8 @@ export const deriveLicenseParentIntents = ({
 		...reverseLinks.flatMap((link) => {
 			const productKey = productToProductKey({ product: link.product });
 			if (allVersionsPlanIds.has(productKey.planId)) return [];
+			if (!editsInPlace && !propagatePlanIds.has(productKey.planId))
+				return [];
 			const parentIsLoaded =
 				projectedProductStatesContext.statesByPlanVersion[
 					productKeyToString({ productKey })

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentMintIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentMintIntents.ts
@@ -4,6 +4,7 @@ import type {
 	ProductUpsertIntent,
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { movesActivePointer } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
 import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
 import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
@@ -55,6 +56,9 @@ export const deriveLicenseParentMintIntents = ({
 }): ProductUpsertIntent[] => {
 	const mintedPlanIds = new Set<string>();
 	const intents: ProductUpsertIntent[] = [];
+	const childTakesActive =
+		upsert.row.nextFullProduct.active || movesActivePointer({ upsert });
+	if (!childTakesActive) return [];
 
 	for (const target of upsert.propagate?.license_parents ?? []) {
 		if (target.versioning !== "new_version") continue;

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleLicenseAnchorLifecycleErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleLicenseAnchorLifecycleErrors.ts
@@ -1,0 +1,71 @@
+import { ErrCode, RecaseError } from "@autumn/shared";
+import { StatusCodes } from "http-status-codes";
+import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
+
+const parentsAnchoredTo = ({
+	childInternalId,
+	updateCatalogPlan,
+}: {
+	childInternalId: string;
+	updateCatalogPlan: UpdateCatalogPlan;
+}): string[] => [
+	...new Set(
+		updateCatalogPlan.projected.products.flatMap((parent) =>
+			(parent.licenses ?? [])
+				.filter(
+					(link) =>
+						!link.is_custom &&
+						link.license_internal_product_id === childInternalId,
+				)
+				.map((link) => parent.id),
+		),
+	),
+];
+
+/**
+ * Block archive/remove of a child version that catalog links still point at.
+ * Named parents come from the projected catalog (same-call unlinks are gone).
+ */
+export const handleLicenseAnchorLifecycleErrors = ({
+	updateCatalogPlan,
+}: {
+	updateCatalogPlan: UpdateCatalogPlan;
+}): void => {
+	const retiring = [
+		...updateCatalogPlan.removePlans.flatMap((removePlan) =>
+			removePlan.current
+				? [
+						{
+							planId: removePlan.planId,
+							version: removePlan.version,
+							internalId: removePlan.current.internal_id,
+						},
+					]
+				: [],
+		),
+		...updateCatalogPlan.upsertProducts.flatMap((upsert) => {
+			const { currentFullProduct, nextFullProduct } = upsert.row;
+			if (!nextFullProduct.archived || currentFullProduct?.archived) return [];
+			return [
+				{
+					planId: upsert.row.planId,
+					version: upsert.row.version,
+					internalId: nextFullProduct.internal_id,
+				},
+			];
+		}),
+	];
+
+	for (const row of retiring) {
+		const parentIds = parentsAnchoredTo({
+			childInternalId: row.internalId,
+			updateCatalogPlan,
+		});
+		if (parentIds.length === 0) continue;
+		throw new RecaseError({
+			message: `Cannot archive or remove ${row.planId} version ${row.version} while ${parentIds.join(", ")} still ${parentIds.length === 1 ? "links" : "link"} to it`,
+			code: ErrCode.InvalidRequest,
+			statusCode: StatusCodes.BAD_REQUEST,
+		});
+	}
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
@@ -6,6 +6,7 @@ import {
 	type UpdateCatalogParams,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { handleLicenseAnchorLifecycleErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleLicenseAnchorLifecycleErrors";
 import { handleRemoveFeatureErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleRemoveFeatureErrors/handleRemoveFeatureErrors";
 import { handleRemovePlanErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleRemovePlanErrors/handleRemovePlanErrors";
 import { handleUpdateFeatureErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpdateFeatureErrors/handleUpdateFeatureErrors";
@@ -169,4 +170,5 @@ export const handleUpdateCatalogErrors = async ({
 		updateCatalogPlan,
 		productStatesContext: catalogContext.productStatesContext,
 	});
+	handleLicenseAnchorLifecycleErrors({ updateCatalogPlan });
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleLicenseParentPropagationErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleLicenseParentPropagationErrors.ts
@@ -1,10 +1,13 @@
 import { ErrCode, RecaseError } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
+import { reverseLinksOnChildPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
-import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
 
-/** propagate.license_parents must name plans that already offer this child. */
+/**
+ * propagate.license_parents must name plans that offer this child — links are
+ * version-anchored, so a link on ANY child version row qualifies the parent.
+ */
 export const handleLicenseParentPropagationErrors = ({
 	upsert,
 	productStatesContext,
@@ -15,20 +18,11 @@ export const handleLicenseParentPropagationErrors = ({
 	const targets = upsert.propagate?.license_parents ?? [];
 	if (targets.length === 0) return;
 
-	const previousActive = upsert.previousActiveInternalId
-		? findFullProductByInternalId({
-				internalId: upsert.previousActiveInternalId,
-				productStatesContext,
-			})
-		: null;
 	const parentIds = new Set(
-		[
-			upsert.row.currentFullProduct,
-			upsert.row.baseFullProduct,
-			previousActive,
-		].flatMap((product) =>
-			(product?.parent_plan_licenses ?? []).map((link) => link.product.id),
-		),
+		reverseLinksOnChildPlan({
+			planId: upsert.row.planId,
+			productStatesContext,
+		}).map((link) => link.product.id),
 	);
 
 	for (const target of targets) {

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handlePlanLicenseErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handlePlanLicenseErrors.ts
@@ -62,6 +62,24 @@ export const handlePlanLicenseErrors = ({
 	}
 
 	for (const planLicense of declared) {
+		// Declared anchor must resolve to a live row; drafts are allowed.
+		if (planLicense.declaredVersionSlug !== undefined) {
+			if (!planLicense.licenseProduct) {
+				throw new RecaseError({
+					message: `License ${planLicense.licensePlanId} has no version with slug ${planLicense.declaredVersionSlug}`,
+					code: ErrCode.InvalidRequest,
+					statusCode: StatusCodes.BAD_REQUEST,
+				});
+			}
+			if (planLicense.licenseProduct.archived) {
+				throw new RecaseError({
+					message: `Cannot anchor license ${planLicense.licensePlanId} to archived version ${planLicense.declaredVersionSlug}`,
+					code: ErrCode.InvalidRequest,
+					statusCode: StatusCodes.BAD_REQUEST,
+				});
+			}
+		}
+
 		if (!planLicense.effectiveLicenseProduct) {
 			throw new ProductNotFoundError({
 				productId: planLicense.licensePlanId,

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts
@@ -128,7 +128,22 @@ export const handleUpsertProductVersioningErrors = ({
 				planId: target.plan_id,
 				versioning: target.versioning,
 				version: target.version,
+				versionSlug: target.version_slug,
 			});
+			if (target.version_slug !== undefined && target.version === undefined) {
+				const version = versionForSlug({
+					planId: target.plan_id,
+					versionSlug: target.version_slug,
+					productStatesContext,
+				});
+				if (version === undefined) {
+					throw new RecaseError({
+						message: `Unknown version_slug "${target.version_slug}" for plan_id=${target.plan_id}`,
+						code: ErrCode.InvalidRequest,
+						statusCode: 400,
+					});
+				}
+			}
 			rejectNewVersionOnMissingPlan({
 				planId: target.plan_id,
 				versioning: target.versioning,

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicenseParentsPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicenseParentsPreview.ts
@@ -10,8 +10,11 @@ import { productToProductKey } from "@autumn/shared";
 import { buildPlanChangeFromFullProducts } from "@/internal/catalogV2/actions/buildPlanChange";
 import { catalogRowIdentity } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity";
 import {
+	childEditsItemsInPlace,
 	childPropagatesToParent,
-	reverseLinksForChild,
+	movesActivePointer,
+	reverseLinksOnChildPlan,
+	reverseLinksOnChildProduct,
 } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
 import { withCatalogConflicts } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/conflicts/withCatalogConflicts";
 import { customerUsageForPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/planUsage/buildPlanUsage";
@@ -38,6 +41,11 @@ const byVersionAscending = (
 
 /** A parent version plus the plan name, which only the top-level entry keeps. */
 type NamedParentVersion = CatalogLicenseParentVersionPreview & { name: string };
+
+type ReverseChildLink = {
+	license_internal_product_id: string;
+	product: FullProduct;
+};
 
 const parentVersioningOptions = ({
 	planId,
@@ -172,11 +180,26 @@ const parentPlanChange = ({
 			})
 		: undefined;
 
+/** This child edit will rewrite the catalog link (in-place on this row, or mint/promote). */
+const childEditRewritesLink = ({
+	link,
+	child,
+}: {
+	link: ReverseChildLink | undefined;
+	child: UpsertProductPlan;
+}): boolean => {
+	if (movesActivePointer({ upsert: child })) return true;
+	if (!childEditsItemsInPlace({ child })) return false;
+	if (!link) return false;
+	return link.license_internal_product_id === child.row.nextFullProduct.internal_id;
+};
+
 const buildParentVersionPreview = ({
 	parentUpsert,
 	stateProduct,
 	previewVersion,
 	child,
+	link,
 	upsertProducts,
 	productStatesContext,
 	previewContext,
@@ -185,6 +208,7 @@ const buildParentVersionPreview = ({
 	stateProduct: FullProduct;
 	previewVersion: number;
 	child: UpsertProductPlan;
+	link?: ReverseChildLink;
 	upsertProducts: UpsertProductPlan[];
 	productStatesContext: ProductStatesContext;
 	previewContext: PreviewCatalogContext | undefined;
@@ -199,11 +223,13 @@ const buildParentVersionPreview = ({
 		parentUpsert?.row.baseFullProduct ??
 		parentState.currentFullProduct ??
 		stateProduct;
-	const licenseAction = resolveLicenseAction({
-		parent: parentUpsert,
-		child,
-		productStatesContext,
-	});
+	const licenseAction = childEditRewritesLink({ link, child })
+		? resolveLicenseAction({
+				parent: parentUpsert,
+				child,
+				productStatesContext,
+			})
+		: ("unchanged" as const);
 	const planChange = parentPlanChange({ parentUpsert });
 	const preview = {
 		...catalogRowIdentity({
@@ -228,7 +254,12 @@ const buildParentVersionPreview = ({
 		license_action: licenseAction,
 		...(planChange ? { plan_change: planChange } : {}),
 	};
-	if (licenseAction === "explicit") return preview;
+	if (
+		licenseAction === "explicit" ||
+		!childEditRewritesLink({ link, child })
+	) {
+		return preview;
+	}
 	return withCatalogConflicts({
 		preview,
 		current: child.row.currentFullProduct,
@@ -274,9 +305,15 @@ const foldParentVersions = ({
 			.filter((version) => version.version !== active.version)
 			.map(({ name: _name, ...sibling }) => sibling)
 			.sort(byVersionAscending);
+		const minted = planVersions.find(
+			(version) => version.version > (activeVersion ?? active.version),
+		);
 
 		return {
 			...active,
+			...(minted?.plan_change && !active.plan_change
+				? { plan_change: minted.plan_change }
+				: {}),
 			versioning: parentVersioning({
 				planId: active.plan_id,
 				linkedVersions: planVersions,
@@ -289,23 +326,29 @@ const foldParentVersions = ({
 	});
 };
 
-/** Parents currently offering this child. Empty → omit the lane. */
+/** Parents whose planLicense points at this child version row. Empty → omit. */
 export const buildLicenseParentsPreview = ({
 	directUpsert,
+	childInternalId,
+	includeMintedParents = true,
 	upsertProducts,
 	productStatesContext,
 	previewContext,
 }: {
 	directUpsert: UpsertProductPlan;
+	childInternalId?: string;
+	includeMintedParents?: boolean;
 	upsertProducts: UpsertProductPlan[];
 	productStatesContext: ProductStatesContext;
 	previewContext: PreviewCatalogContext | undefined;
 }): CatalogLicenseParentPreview[] => {
-	const reverseLinks = reverseLinksForChild({
-		upsert: directUpsert,
+	const scopedInternalId =
+		childInternalId ?? directUpsert.row.nextFullProduct.internal_id;
+	const reverseLinks = reverseLinksOnChildProduct({
+		planId: directUpsert.row.planId,
+		childInternalId: scopedInternalId,
 		productStatesContext,
 	});
-	if (reverseLinks.length === 0) return [];
 
 	const existingVersions = reverseLinks
 		.filter((link) => !link.product.archived)
@@ -321,16 +364,78 @@ export const buildLicenseParentsPreview = ({
 				stateProduct: link.product,
 				previewVersion: parentKey.version,
 				child: directUpsert,
+				link,
 				upsertProducts,
 				productStatesContext,
 				previewContext,
 			});
 		});
+	if (!includeMintedParents) {
+		return foldParentVersions({
+			versions: existingVersions,
+			directUpsert,
+			upsertProducts,
+			productStatesContext,
+		}).sort(byPlanId);
+	}
+
+	const sourceInternalId =
+		directUpsert.row.currentFullProduct?.internal_id ??
+		directUpsert.row.baseFullProduct?.internal_id;
+	const followingFromSource =
+		sourceInternalId &&
+		sourceInternalId !== scopedInternalId &&
+		movesActivePointer({ upsert: directUpsert })
+			? reverseLinksOnChildProduct({
+					planId: directUpsert.row.planId,
+					childInternalId: sourceInternalId,
+					productStatesContext,
+				})
+					.filter((link) => !link.product.archived)
+					.flatMap((link): NamedParentVersion[] => {
+						const parentKey = productToProductKey({ product: link.product });
+						const parentUpsert = findParentUpsert({
+							upsertProducts,
+							planId: parentKey.planId,
+							version: parentKey.version,
+						});
+						const listedForPropagate = (
+							directUpsert.propagate?.license_parents ?? []
+						).some((target) => target.plan_id === parentKey.planId);
+						if (
+							!listedForPropagate &&
+							resolveLicenseAction({
+								parent: parentUpsert,
+								child: directUpsert,
+								productStatesContext,
+							}) === "unchanged"
+						) {
+							return [];
+						}
+						return [
+							buildParentVersionPreview({
+								parentUpsert,
+								stateProduct: link.product,
+								previewVersion: parentKey.version,
+								child: directUpsert,
+								link,
+								upsertProducts,
+								productStatesContext,
+								previewContext,
+							}),
+						];
+					})
+			: [];
+
 	const linkedParentPlanIds = new Set(
-		existingVersions.map((version) => version.plan_id),
+		reverseLinksOnChildPlan({
+			planId: directUpsert.row.planId,
+			productStatesContext,
+		}).map((link) => productToProductKey({ product: link.product }).planId),
 	);
 	const mintedVersions = upsertProducts.flatMap((parentUpsert) => {
 		if (!linkedParentPlanIds.has(parentUpsert.row.planId)) return [];
+		if (parentUpsert.row.source !== "license_adopt") return [];
 		const maxVersion = maxVersionForPlan({
 			planId: parentUpsert.row.planId,
 			productStatesContext,
@@ -361,7 +466,7 @@ export const buildLicenseParentsPreview = ({
 	});
 
 	return foldParentVersions({
-		versions: [...existingVersions, ...mintedVersions],
+		versions: [...existingVersions, ...followingFromSource, ...mintedVersions],
 		directUpsert,
 		upsertProducts,
 		productStatesContext,

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicensesPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicensesPreview.ts
@@ -18,6 +18,9 @@ const plannedLicensesPreview = ({
 			{
 				license_plan_id: planLicense.licensePlanId,
 				version: planLicense.licenseProduct.version,
+				...(planLicense.licenseProduct.version_slug
+					? { version_slug: planLicense.licenseProduct.version_slug }
+					: {}),
 				included: planLicense.included,
 				prepaid_only: planLicense.prepaidOnly,
 			},

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildSiblingVersionsPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildSiblingVersionsPreview.ts
@@ -1,5 +1,9 @@
-import type { CatalogSiblingVersionPreview, FullProduct } from "@autumn/shared";
+import type {
+	CatalogPlanSiblingVersionPreview,
+	FullProduct,
+} from "@autumn/shared";
 import { productToProductKey } from "@autumn/shared";
+import { buildLicenseParentsPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicenseParentsPreview";
 import { buildPlanChangeFromFullProducts } from "@/internal/catalogV2/actions/buildPlanChange";
 import { catalogRowIdentity } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity";
 import { withCatalogConflicts } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/conflicts/withCatalogConflicts";
@@ -12,8 +16,8 @@ import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatal
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
 
 const byVersionAscending = (
-	left: CatalogSiblingVersionPreview,
-	right: CatalogSiblingVersionPreview,
+	left: CatalogPlanSiblingVersionPreview,
+	right: CatalogPlanSiblingVersionPreview,
 ) => left.version - right.version;
 
 const selectedSiblingFromUpsert = ({
@@ -26,7 +30,7 @@ const selectedSiblingFromUpsert = ({
 	editedCurrent: FullProduct | null;
 	editedNext: FullProduct;
 	previewContext: PreviewCatalogContext | undefined;
-}): CatalogSiblingVersionPreview => {
+}): CatalogPlanSiblingVersionPreview => {
 	const planChange = buildPlanChangeFromFullProducts({
 		from: sibling.row.currentFullProduct ?? undefined,
 		to: sibling.row.nextFullProduct,
@@ -69,7 +73,7 @@ const unselectedSiblingFromVersion = ({
 	editedCurrent: FullProduct | null;
 	editedNext: FullProduct;
 	previewContext: PreviewCatalogContext | undefined;
-}): CatalogSiblingVersionPreview =>
+}): CatalogPlanSiblingVersionPreview =>
 	withCatalogConflicts({
 		preview: {
 			...catalogRowIdentity({
@@ -112,6 +116,35 @@ const isAllVersionsSiblingForPlan = ({
 	planId: string;
 }) => upsert.row.source === "all_versions" && upsert.row.planId === planId;
 
+const withSiblingLicenseParents = ({
+	sibling,
+	childInternalId,
+	childUpsert,
+	upsertProducts,
+	productStatesContext,
+	previewContext,
+}: {
+	sibling: CatalogPlanSiblingVersionPreview;
+	childInternalId: string;
+	childUpsert: UpsertProductPlan;
+	upsertProducts: UpsertProductPlan[];
+	productStatesContext: ProductStatesContext;
+	previewContext: PreviewCatalogContext | undefined;
+}): CatalogPlanSiblingVersionPreview => {
+	const licenseParents = buildLicenseParentsPreview({
+		directUpsert: childUpsert,
+		childInternalId,
+		includeMintedParents: false,
+		upsertProducts,
+		productStatesContext,
+		previewContext,
+	});
+	return {
+		...sibling,
+		...(licenseParents.length > 0 ? { license_parents: licenseParents } : {}),
+	};
+};
+
 /** Other existing versions of this direct entry's plan. Empty → omit the lane. */
 export const buildSiblingVersionsPreview = ({
 	directUpsert,
@@ -123,7 +156,7 @@ export const buildSiblingVersionsPreview = ({
 	upsertProducts: UpsertProductPlan[];
 	productStatesContext: ProductStatesContext;
 	previewContext: PreviewCatalogContext | undefined;
-}): CatalogSiblingVersionPreview[] => {
+}): CatalogPlanSiblingVersionPreview[] => {
 	const { planId, versioning, version } = directUpsert.row;
 	const hasExactlyOneDirectEntry =
 		upsertProducts.filter((upsert) => isDirectForPlan({ upsert, planId }))
@@ -132,16 +165,37 @@ export const buildSiblingVersionsPreview = ({
 
 	const editedCurrent = directUpsert.row.currentFullProduct;
 	const editedNext = directUpsert.row.nextFullProduct;
+	const attachParents = ({
+		sibling,
+		childInternalId,
+		childUpsert,
+	}: {
+		sibling: CatalogPlanSiblingVersionPreview;
+		childInternalId: string;
+		childUpsert: UpsertProductPlan;
+	}) =>
+		withSiblingLicenseParents({
+			sibling,
+			childInternalId,
+			childUpsert,
+			upsertProducts,
+			productStatesContext,
+			previewContext,
+		});
 
 	if (versioning === "all_versions") {
 		return upsertProducts
 			.filter((upsert) => isAllVersionsSiblingForPlan({ upsert, planId }))
 			.map((sibling) =>
-				selectedSiblingFromUpsert({
-					sibling,
-					editedCurrent,
-					editedNext,
-					previewContext,
+				attachParents({
+					sibling: selectedSiblingFromUpsert({
+						sibling,
+						editedCurrent,
+						editedNext,
+						previewContext,
+					}),
+					childInternalId: sibling.row.nextFullProduct.internal_id,
+					childUpsert: sibling,
 				}),
 			)
 			.sort(byVersionAscending);
@@ -155,7 +209,7 @@ export const buildSiblingVersionsPreview = ({
 					upsert.row.planId === product.id &&
 					upsert.row.version === product.version,
 			);
-			return sibling
+			const preview = sibling
 				? selectedSiblingFromUpsert({
 						sibling,
 						editedCurrent,
@@ -169,6 +223,13 @@ export const buildSiblingVersionsPreview = ({
 						editedNext,
 						previewContext,
 					});
+			return attachParents({
+				sibling: preview,
+				childInternalId: sibling
+					? sibling.row.nextFullProduct.internal_id
+					: product.internal_id,
+				childUpsert: sibling ?? directUpsert,
+			});
 		})
 		.sort(byVersionAscending);
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/planLicensePlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/planLicensePlan.ts
@@ -55,6 +55,8 @@ export type PlanLicensePlan = {
 	metadata?: Record<string, unknown>;
 	/** Declared customize: object = replace, null = clear, undefined = preserve. */
 	customize?: LicenseCustomize | null;
+	/** Declared anchor slug, kept for guard messages. */
+	declaredVersionSlug?: string;
 	/** Overlay vs the child's rows: `same` keeps stock ids, `new` is the is_custom inserts. */
 	entitlementPricesPlan?: EntitlementPricesPlan;
 	/** Absent = nothing to persist for this link. */

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/collectProductStateRows.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/collectProductStateRows.ts
@@ -1,6 +1,7 @@
 import type { FullProduct } from "@autumn/shared";
 
-/** Flatten listFull rows plus nested license parents and payload-base variants. */
+/** Flatten listFull rows plus nested license parents and payload-base variants.
+ * Prefer a row that already carries reverse `parent_plan_licenses`. */
 export const collectProductStateRows = ({
 	products,
 	payloadPlanIds,
@@ -12,8 +13,17 @@ export const collectProductStateRows = ({
 	const payloadIds = payloadPlanIds ? new Set(payloadPlanIds) : null;
 
 	const add = (product: FullProduct | null | undefined) => {
-		if (!product || byInternalId.has(product.internal_id)) return;
-		byInternalId.set(product.internal_id, product);
+		if (!product) return;
+		const existing = byInternalId.get(product.internal_id);
+		if (!existing) {
+			byInternalId.set(product.internal_id, product);
+			return;
+		}
+		const existingHasReverse = (existing.parent_plan_licenses ?? []).length > 0;
+		const incomingHasReverse = (product.parent_plan_licenses ?? []).length > 0;
+		if (!existingHasReverse && incomingHasReverse) {
+			byInternalId.set(product.internal_id, product);
+		}
 	};
 
 	for (const product of products) {

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/fullProductForSlug.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/fullProductForSlug.ts
@@ -1,0 +1,16 @@
+import type { FullProduct } from "@autumn/shared";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+
+/** The row that owns this plan_id + version_slug, or null. */
+export const fullProductForSlug = ({
+	planId,
+	versionSlug,
+	productStatesContext,
+}: {
+	planId: string;
+	versionSlug: string;
+	productStatesContext: ProductStatesContext;
+}): FullProduct | null =>
+	(productStatesContext.versionsByPlanId[planId] ?? []).find(
+		(product) => product.version_slug === versionSlug,
+	) ?? null;

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/versionForSlug.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/versionForSlug.ts
@@ -1,4 +1,5 @@
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import { fullProductForSlug } from "./fullProductForSlug";
 
 /** Version number for this plan_id + version_slug, or undefined if no row owns it. */
 export const versionForSlug = ({
@@ -10,6 +11,4 @@ export const versionForSlug = ({
 	versionSlug: string;
 	productStatesContext: ProductStatesContext;
 }): number | undefined =>
-	(productStatesContext.versionsByPlanId[planId] ?? []).find(
-		(product) => product.version_slug === versionSlug,
-	)?.version;
+	fullProductForSlug({ planId, versionSlug, productStatesContext })?.version;

--- a/server/src/internal/licenses/licenseUtils.ts
+++ b/server/src/internal/licenses/licenseUtils.ts
@@ -13,6 +13,9 @@ export const toApiPlanLicenses = (
 	licenses.map((license) => ({
 		license_plan_id: license.product.id,
 		version: license.product.version,
+		...(license.product.version_slug
+			? { version_slug: license.product.version_slug }
+			: {}),
 		included: license.included,
 		prepaid_only: license.prepaid_only,
 	}));

--- a/server/tests/integration/catalog-v2/plans/CASES.md
+++ b/server/tests/integration/catalog-v2/plans/CASES.md
@@ -834,7 +834,7 @@ Direct parent `licenses[]` only. Omit = leave links unchanged; present = full-se
 | Two licenses; drop one, keep the other | ✓ `set-replace.test.ts` |
 | `customize: null` clears overlay | ✓ `set-fields.test.ts` |
 | included / prepaid_only / metadata-only (no customize) | ✓ `set-fields.test.ts` |
-| Child already has v2; `licenses:[child]` links latest | ✓ `set-replace.test.ts` |
+| Child already has v2; new `licenses:[child]` create-defaults to the ACTIVE row | ✓ `set-replace.test.ts` |
 | Duplicate `license_plan_id` in `licenses[]` → 400 | ✓ `declared-license-errors.test.ts` |
 | Self-link → 400 | ✓ `declared-license-guards.test.ts` |
 | Archived child → 400 | ✓ `declared-license-guards.test.ts` |
@@ -844,6 +844,21 @@ Direct parent `licenses[]` only. Omit = leave links unchanged; present = full-se
 | Customize changing a child's prepaid amount → 400 | ✓ `declared-license-paid-feature.test.ts` |
 | Create feature + parent customize `add_items` that feature | ✓ `set-fields.test.ts` |
 
+### Version anchor (`version_slug` on `licenses[]`) — `declared-version-anchor.test.ts`
+
+Stated slug = that child row. Omitted on an **existing** link = keep the current
+child product id (no move). Omitted on a **new** link = child's active row
+(create-default). Repoint only via an explicit slug or `propagate.license_parents`.
+
+| Case | Status |
+|---|---|
+| New link, `version_slug: v1` while child active is v2 → link on v1 | ✓ `declared-version-anchor.test.ts` |
+| New link, omitted slug, child already v2 → create-default to active v2 | ✓ `declared-version-anchor.test.ts` |
+| Existing link on v1, child minted v2, omitted slug → stay on v1 | ✓ `declared-version-anchor.test.ts` |
+| Existing link on v1, `version_slug: v2` → move to v2; later omit stays on v2 | ✓ `declared-version-anchor.test.ts` |
+| Unknown slug → 400 | ✓ `declared-version-anchor.test.ts` |
+| Anchoring to an archived child version → 400 | ✓ `declared-version-anchor.test.ts` |
+
 ## 18. Plan licenses — pin / follow / compose — `licenses/`
 
 Follow is `child.propagate.license_parents[].versioning` (`existing` | `new_version` |
@@ -852,15 +867,19 @@ propagate = pin (freeze).
 
 ### pinned/ — parent not listed in child's propagate
 
+Pin (freeze overlay) fires ONLY on in-place child edits. Child `new_version` /
+promote leaves non-propagated links untouched — no repoint, no manufactured
+overlay; the link stays version-anchored to the row it points at.
+
 | Case | Status |
 |---|---|
 | In-batch parent without propagate freezes uncustomized child item change | ✓ `pin-in-place-item-change.test.ts` |
 | Absent parent (not in `plans[]`) is derived and pinned | ✓ `pin-in-place-item-change.test.ts` |
-| Child `new_version` re-points absent parent to v2 (pin freeze) | ✓ `pin-on-child-new-version.test.ts` |
+| Child `new_version` leaves absent parent anchored to v1 — no repoint, no overlay, same row id | ✓ `pin-on-child-new-version.test.ts` |
 | Child 10→200 **and** add Words; parent not in propagate → overlay msgs=10, **no Words** | ✓ `pin-freeze-items.test.ts` |
 | Pin leak: overlay messages ent id ≠ child's stock e1 | ✓ `pin-freeze-items.test.ts` |
 | Overlay already 500; child 10→200 + Words; no propagate → skip; still 500; no Words | ✓ `pin-freeze-items.test.ts` |
-| Overlay 500; child `new_version` 200+Words; no propagate → re-point to v2, keep 500, no Words | ✓ `pin-freeze-items.test.ts` |
+| Overlay 500; child `new_version` 200+Words; no propagate → link untouched on v1, keep 500, no Words, same row id | ✓ `pin-freeze-items.test.ts` |
 | After a pin, child 200→10 → stay `customized:true` (no collapse) | ✓ `pin-freeze-items.test.ts` |
 | Child name-only → no pin; link stays uncustomized sharing stock | ✓ `pin-freeze-items.test.ts` |
 | Parent v1+v2, child bump, **no** propagate → **both** versions pin | ✓ `pin-freeze-items.test.ts` |
@@ -874,8 +893,9 @@ propagate = pin (freeze).
 | Omit / `existing` → latest follows, historical frozen | ✓ `follow-latest-or-explicit-version.test.ts` |
 | `{ version: 1 }` → that version follows, latest frozen | ✓ `follow-latest-or-explicit-version.test.ts` |
 | `all_versions` → every existing parent version follows | ✓ `follow-all-parent-versions.test.ts` |
-| `new_version` + customers on latest → mint, follow mint, freeze old | ✓ `follow-new-parent-version.test.ts` |
-| `new_version` + no customers → fall back to existing (no mint) | ✓ `follow-new-parent-version.test.ts` |
+| `new_version` + customers on latest → mint follows child v2; old parent versions untouched (anchored v1, uncustomized) | ✓ `follow-new-parent-version.test.ts` |
+| `new_version` + no customers → no mint; live link MOVES to child v2; older versions stay v1 uncustomized | ✓ `follow-new-parent-version.test.ts` |
+| omit / `existing` + customers on latest → NO mint; live link still MOVES to child v2 | ✓ `follow-new-parent-version.test.ts` |
 | v1 customized 500, v2 stock; child propagate `all_versions` + Words → v1 rebase 500+Words; v2 stock 200+Words | ✓ `follow-version-overlays.test.ts` |
 | Latest customized 500; propagate `new_version` + customers → mint follows rebased 500+Words; old latest pins (500, no Words) | ✓ `follow-version-overlays.test.ts` |
 | Customers on parent **v1** only; latest empty; propagate `new_version` → no mint; latest follows in place; v1 pins | ✓ `follow-version-overlays.test.ts` |
@@ -891,7 +911,7 @@ Seed via DB `customer_licenses.plan_license_id`. `seedVersionableCustomer` is th
 | Same customer; child propagate → no plan_license write; customer **sees 200** (shares stock) | ✓ `assigned-seat-follow.test.ts` |
 | Same customer; parent `licenses[]` customize 300 → retire+mint successor at 300; customer stays on retired row | ✓ `assigned-seat-declared.test.ts` |
 | Same customer; `licenses: []` → retire, **not** hard-delete | ✓ `assigned-seat-declared.test.ts` |
-| Customer on plan_license; child `new_version` + pin → catalog link on a new plan_license; customer remains on retired v1-era row | ✓ `assigned-seat-pin.test.ts` |
+| Customer on plan_license; child `new_version` + pin → NO write: catalog + customer share the same live row, still anchored to v1 | ✓ `assigned-seat-pin.test.ts` |
 
 ### mix/ — declared × follow, guards
 
@@ -909,7 +929,9 @@ Seed via DB `customer_licenses.plan_license_id`. `seedVersionableCustomer` is th
 | Child 10→200 + propagate + parent `licenses: []` → link gone; propagate does **not** resurrect | ✓ `declared-exclusive-vs-propagate.test.ts` |
 | Parent offers Seat+Pack; declare only Seat; Pack child in propagate → Pack **removed**, not followed | ✓ `declared-exclusive-vs-propagate.test.ts` |
 | Parent `licenses:[child]` no customize; child 10→200 + propagate → uncustomized 200 via declared re-link | ✓ `declared-exclusive-vs-propagate.test.ts` |
-| Child `new_version` + parent `licenses[]` customize 300 → declared links **latest** (v2) at 300 | ✓ `declared-exclusive-vs-propagate.test.ts` |
+| Child `new_version` + parent `licenses[]` customize 300 (no slug) → declared stays on current (v1) at 300 | unrun `declared-exclusive-vs-propagate.test.ts` |
+| Same-batch omit slug + child `new_version` + propagate → stay on child v1 | unrun `mix/declared-slug-vs-propagate.test.ts` |
+| Same-batch `version_slug: v1` + child `new_version` + propagate → stay on child v1 | unrun `mix/declared-slug-vs-propagate.test.ts` |
 | M-excl / pin+Words, parent-then-child vs child-then-parent → identical | ✓ `declared-exclusive-vs-propagate.test.ts` |
 | Team offers Seat+Pack; Seat not in propagate, Pack is; both 10→200 → Seat overlay 10; Pack stock 200 | ✓ `concat-pin-and-follow.test.ts` |
 | One Seat; Team not in propagate, Org is → Team 10; Org 200 | ✓ `concat-pin-and-follow.test.ts` |
@@ -930,8 +952,44 @@ Seed via DB `customer_licenses.plan_license_id`. `seedVersionableCustomer` is th
 | A(v1,v2) `all_versions`, B(v1,v2) omitted → both A follow 200; **both** B freeze at 10 | ✓ `two-parents-versions-split.test.ts` |
 | Same + A v1 customized 500, child adds Words → A v1 rebases 500+Words, A v2 200+Words; both B stay 10 with **no** Words | ✓ `two-parents-versions-split.test.ts` |
 | A `{ version: 1 }`, B omitted → A v1 follows; A **v2** freezes; both B freeze | ✓ `two-parents-versions-split.test.ts` |
-| Child `new_version` over two parents at v1+v2 → all four rows re-point to the new child row and pin 10 | ✓ `child-versions-two-parents.test.ts` |
-| Then child 200+Words, A `all_versions`, B omitted → A inherits Words on both versions but holds its pinned 10; B inherits nothing | ✓ `child-versions-two-parents.test.ts` |
+| Child `new_version` over two parents at v1+v2 → all four rows untouched: anchored to child v1, uncustomized, stock 10 | ✓ `child-versions-two-parents.test.ts` |
+| Then child edits active v2 in place (200+Words), A `all_versions`, B omitted → NO row reached: an in-place edit only reaches links pointing at the edited row | ✓ `child-versions-two-parents.test.ts` |
+
+#### Distributed anchors under child `all_versions` — `mix/all-versions-distributed-anchors.test.ts`
+
+Child `versioning: all_versions` edits every child row in place; each sibling's
+edit reaches exactly the links anchored to THAT row, pin/follow decided per
+(sibling row × parent link) pair.
+
+| Case | Status |
+|---|---|
+| A anchored child v1, B anchored child v2; child `all_versions` edit, both in propagate → A shares v1's edited stock, B shares v2's; anchors unchanged | ✓ |
+| Same anchors, no propagate → A pins v1's pre-edit content (10), B pins v2's (50) — per-row frozen values | ✓ |
+
+#### Same parent, versions split across child siblings — `mix/all-versions-parent-version-anchors.test.ts`
+
+Team/EU v1 → child v1, Team/EU v2 → child v2. Child `all_versions` can
+follow each parent version from the child sibling it actually points at.
+`propagate.license_parents[].version_slug` pins that parent row.
+
+| Case | Status |
+|---|---|
+| Preview: v2 parents on `license_parents`, v1 parents on `sibling_versions[v1].license_parents`, both `propagated` when parent `all_versions` | ✓ |
+| `{ version_slug: "v1" }` follows only that parent row; the parent's v2 and the other parent pin | ✓ |
+| Parent `all_versions` follows every linked version from its anchored child sibling; anchors stay put | ✓ |
+| Diverged child items: v1 is 100 Messages, v2 is 50 + Words; add Dashboard on v2 `all_versions` → parent v1 is 100 + Dashboard (no Words), parent v2 is 50 + Words + Dashboard | ✓ |
+
+### lifecycle/ — archive or remove an anchored child version — `lifecycle/anchored-version-remove.test.ts`
+
+Remove/archive of a child version is blocked while any catalog link still
+points at that row. Same-call unlink (`licenses: []`) then remove is allowed
+because the projection no longer has the link.
+
+| Case | Status |
+|---|---|
+| Remove child v1 while a parent still links to it → 400 naming the parent | ✓ |
+| Archive child v1 while a parent still links to it → 400 naming the parent | ✓ |
+| Same-call `licenses: []` then remove v1 → allowed | ✓ |
 
 ## 19. Plan licenses preview — `licenses/preview/`
 
@@ -952,7 +1010,7 @@ Seed via DB `customer_licenses.plan_license_id`. `seedVersionableCustomer` is th
 | After `new_version` + license customize add Dashboard, later `preview_update` parses and echoes the overlay | ✓ `license-changes-customize.test.ts` |
 | In-batch pin → updated freeze, no nested `plan_change` | ✓ `license-changes-follow.test.ts` |
 | In-batch propagate → updated + nested item `plan_change` | ✓ `license-changes-follow.test.ts` |
-| Child `new_version` + pin → `previous_attributes.version` | ✓ `license-changes-follow.test.ts` |
+| Child `new_version` + pin → link untouched, NO `license_changes` row on the parent | ✓ `license-changes-follow.test.ts` |
 | Child `versioning.options` unions reverse-link parents (no propagate yet) | ✓ `child-versioning-options-union.test.ts` |
 | Same options when propagate is later filled (must not shrink) | ✓ `child-versioning-options-union.test.ts` |
 | Child `license_parents`: declared item override → `explicit` + final customize (declared wins; child-only items still flow) | ✓ `license-parents-lane.test.ts` |
@@ -975,7 +1033,7 @@ under `sibling_versions` with their own `license_action` and `conflicts`:
 | A `all_versions`, B omitted → A latest+sibling `propagated`; B latest+sibling `unchanged`; no conflicts | ✓ `conflicts/two-parents-versions-split.test.ts` |
 | A v1 and B v1 each customized 500 → `value_divergence` on **both** siblings, on neither latest | ✓ `conflicts/two-parents-versions-split.test.ts` |
 | A `{ version: 1 }` → A latest `unchanged` while its sibling v1 is the `propagated` one | ✓ `conflicts/two-parents-versions-split.test.ts` |
-| Child minted a version, then 200+Words: every row diverges but `license_action` still splits A `propagated` / B `unchanged` | ✓ `mix/child-versions-two-parents.test.ts` |
+| Child minted a version, then 200+Words: v2 `license_parents` omitted; both parents sit on `sibling_versions[v1].license_parents` as `unchanged` | ✓ `mix/child-versions-two-parents.test.ts` |
 
 Deferred (need absent-parent fan-out or are invalid):
 
@@ -1330,10 +1388,10 @@ Draft mint (`new_version` without `active`) does not take the pointer.
 | Base promote re-points follow variant; no variant mint | ✓ `variants/pointer/pointer-on-base-promote.test.ts` |
 | Base promote leaves historical variant v1 on the old row | ✓ `variants/pointer/pointer-on-base-promote.test.ts` |
 | Promote leaves a pin at a historical non-active base | ✓ `variants/pointer/pointer-on-base-promote.test.ts` |
-| Child promote freezes uncustomized parent; propagate follows v2 | ✓ `licenses/pinned/uncustomized-freeze-on-child-promote.test.ts` |
+| Child promote leaves uncustomized parent anchored to v1 (no repoint, no overlay); propagate follows v2 | ✓ `licenses/pinned/uncustomized-freeze-on-child-promote.test.ts` |
 | Customized parent is left on child promote | ✓ `licenses/pinned/uncustomized-freeze-on-child-promote.test.ts` |
 | Parent promote (licenses omitted): child identity unchanged; v2 stays empty | ✓ `licenses/pinned/uncustomized-freeze-on-child-promote.test.ts` |
-| Declared `licenses[]` on child promote re-links to newly active child | ✓ `licenses/pinned/uncustomized-freeze-on-child-promote.test.ts` |
+| Declared `licenses[]` on child promote omit keeps the existing v1 anchor; customize still applies | ✓ `licenses/pinned/uncustomized-freeze-on-child-promote.test.ts` |
 | Preview `promotion_details` present when a row takes the pointer | ✓ `versions/promote-preview.test.ts` + `promote-preview-details.test.ts` |
 | Preview `promotion_details` omitted on no-op / draft mint / first create | ✓ `versions/promote-preview-details.test.ts` |
 | Preview rename + promote returns both rename fields and `promotion_details` | ✓ `versions/promote-preview-details.test.ts` |

--- a/server/tests/integration/catalog-v2/plans/CASES.md
+++ b/server/tests/integration/catalog-v2/plans/CASES.md
@@ -979,6 +979,28 @@ follow each parent version from the child sibling it actually points at.
 | Parent `all_versions` follows every linked version from its anchored child sibling; anchors stay put | ✓ |
 | Diverged child items: v1 is 100 Messages, v2 is 50 + Words; add Dashboard on v2 `all_versions` → parent v1 is 100 + Dashboard (no Words), parent v2 is 50 + Words + Dashboard | ✓ |
 
+#### Atmn PUT — four pinned directs — `mix/atmn-put-direct-versions.test.ts`
+
+Same diverged fixture. Each version is a direct `{ version_slug }` row;
+parents restate `licenses[]` (optional child `version_slug`). No
+`all_versions` / `propagate`.
+
+| Case | Status |
+|---|---|
+| Preview of child v1+v2 + parent v1+v2 → each row omits `sibling_versions` | ✓ |
+| PUT add Dashboard on both children, restate parent licenses → all four get Dashboard; Words stay v2-only; anchors stay | ✓ |
+| Restate `licenses[]` without `version_slug` → stay on the current child row | ✓ |
+| Identical re-PUT → preview `none`; `plan_license` row ids unchanged | ✓ |
+| Customers on all four + `draft: true` → one draft, collapsed `{ plan_id }` filters, child add Dashboard + parent `upsert_licenses` add Dashboard | ✓ |
+
+#### Atmn PUT lanes — `mix/atmn-put-direct-version-lanes.test.ts`
+
+| Case | Status |
+|---|---|
+| Dashboard only on child v2 → parent v1 unchanged; parent v2 gets it | ✓ |
+| Preview: both parents `license_action: explicit`; `license_changes` add Dashboard; no unlink | ✓ |
+| Restated overlays (v1=80, v2=40) stay; Dashboard still flows | ✓ |
+
 ### lifecycle/ — archive or remove an anchored child version — `lifecycle/anchored-version-remove.test.ts`
 
 Remove/archive of a child version is blocked while any catalog link still

--- a/server/tests/integration/catalog-v2/plans/licenses/declared/declared-version-anchor.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/declared/declared-version-anchor.test.ts
@@ -1,0 +1,303 @@
+/**
+ * catalogV2.update — declared licenses[] version anchor (`version_slug`).
+ *
+ * Contract:
+ *   Stated slug → that child row.
+ *   Omitted on an existing link → keep license_internal_product_id (no move).
+ *   Omitted on a new link → child's active row (create-default, not a repoint).
+ *   Unknown slug → 400.
+ */
+import { expect, test } from "bun:test";
+import { ErrCode } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import { expectLicenseLinkCorrect } from "../utils/expectLicenseLinkCorrect.js";
+import {
+	bumpChild,
+	type CatalogV2Client,
+	getFullPlan,
+	messagesItem,
+	seedLinkedChildParent,
+	withCatalogPlans,
+} from "../utils/seedLicensePlans.js";
+
+/** Child v1 (10) + active v2 (50), no parents yet. */
+const seedChildWithTwoVersions = async ({
+	autumn,
+	childId,
+}: {
+	autumn: CatalogV2Client;
+	childId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: childId, name: "Seat", items: [messagesItem(10)] }],
+	});
+	await bumpChild({
+		autumn,
+		childId,
+		items: [messagesItem(50)],
+		versioning: "new_version",
+	});
+};
+
+const declareParentLink = async ({
+	autumn,
+	parentId,
+	childId,
+	versionSlug,
+}: {
+	autumn: CatalogV2Client;
+	parentId: string;
+	childId: string;
+	versionSlug?: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: parentId,
+				name: "Parent",
+				licenses: [
+					{
+						license_plan_id: childId,
+						included: 2,
+						...(versionSlug ? { version_slug: versionSlug } : {}),
+					},
+				],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: declared version_slug on a new link anchors that row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_anchdec_p");
+		const childId = uniqueTestId("cv2_lic_anchdec_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedChildWithTwoVersions({ autumn: autumnV2_3, childId });
+				const childV1 = await getFullPlan({ ctx, planId: childId, version: 1 });
+
+				await declareParentLink({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+					versionSlug: "v1",
+				});
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					licenseVersion: 1,
+					included: 2,
+					customized: false,
+					messagesAllowance: 10,
+					licenseInternalProductId: childV1.internal_id,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: new declared omit create-defaults to the active row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_anchnew_p");
+		const childId = uniqueTestId("cv2_lic_anchnew_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedChildWithTwoVersions({ autumn: autumnV2_3, childId });
+				const childV2 = await getFullPlan({ ctx, planId: childId });
+				expect(childV2.version).toBe(2);
+
+				await declareParentLink({ autumn: autumnV2_3, parentId, childId });
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					included: 2,
+					customized: false,
+					messagesAllowance: 50,
+					licenseInternalProductId: childV2.internal_id,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: declared omit keeps the existing child version")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_anchkeep_p");
+		const childId = uniqueTestId("cv2_lic_anchkeep_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					versioning: "new_version",
+				});
+
+				await declareParentLink({ autumn: autumnV2_3, parentId, childId });
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					licenseVersion: 1,
+					included: 2,
+					customized: false,
+					messagesAllowance: 10,
+					licenseInternalProductId: childV1.internal_id,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: declared version_slug moves; later omit stays")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_anchmov_p");
+		const childId = uniqueTestId("cv2_lic_anchmov_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+				});
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					items: [messagesItem(50)],
+					versioning: "new_version",
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId, version: 1 });
+				const childV2 = await getFullPlan({ ctx, planId: childId });
+				expect(childV2.version).toBe(2);
+
+				await declareParentLink({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+					versionSlug: "v2",
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					licenseVersion: 2,
+					messagesAllowance: 50,
+					licenseInternalProductId: childV2.internal_id,
+				});
+
+				await declareParentLink({ autumn: autumnV2_3, parentId, childId });
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					licenseVersion: 2,
+					messagesAllowance: 50,
+					licenseInternalProductId: childV2.internal_id,
+				});
+
+				await declareParentLink({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+					versionSlug: "v1",
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					licenseVersion: 1,
+					messagesAllowance: 10,
+					licenseInternalProductId: childV1.internal_id,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: archived child version slug is rejected")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_ancharch_p");
+		const childId = uniqueTestId("cv2_lic_ancharch_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedChildWithTwoVersions({ autumn: autumnV2_3, childId });
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: childId, version: 1, archived: true }],
+				});
+
+				await expectAutumnError({
+					errCode: ErrCode.InvalidRequest,
+					errMessage: "archived version",
+					func: () =>
+						declareParentLink({
+							autumn: autumnV2_3,
+							parentId,
+							childId,
+							versionSlug: "v1",
+						}),
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: unknown anchor slug is rejected")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_anchmiss_p");
+		const childId = uniqueTestId("cv2_lic_anchmiss_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedChildWithTwoVersions({ autumn: autumnV2_3, childId });
+
+				await expectAutumnError({
+					errCode: ErrCode.InvalidRequest,
+					errMessage: "no version with slug",
+					func: () =>
+						declareParentLink({
+							autumn: autumnV2_3,
+							parentId,
+							childId,
+							versionSlug: "v9",
+						}),
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/licenses/declared/set-replace.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/declared/set-replace.test.ts
@@ -4,7 +4,7 @@
  * Contract:
  *   replace child A with child B in one declared set
  *   two licenses; drop one, keep the other
- *   child already has v2; licenses:[child] links latest
+ *   child already has v2; new licenses:[child] create-defaults to active
  */
 
 import { test } from "bun:test";
@@ -124,7 +124,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: licenses:[child] links the latest child version")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: new licenses:[child] create-defaults to the latest child version")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const parentId = uniqueTestId("cv2_lic_lat_p");

--- a/server/tests/integration/catalog-v2/plans/licenses/lifecycle/anchored-version-remove.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/lifecycle/anchored-version-remove.test.ts
@@ -1,0 +1,126 @@
+/**
+ * catalogV2.update — cannot archive or remove a child version that catalog
+ * links still point at. The error names the parent plans.
+ *
+ * Same-call unlink (licenses: []) then remove is allowed.
+ */
+
+import { expect, test } from "bun:test";
+import { ErrCode } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import { expectLicenseLinkMissing } from "../utils/expectLicenseLinkCorrect.js";
+import {
+	bumpChild,
+	getFullPlan,
+	messagesItem,
+	seedLinkedChildParent,
+	withCatalogPlans,
+} from "../utils/seedLicensePlans.js";
+import { expectDbPlansCorrect } from "../../utils/expectCatalogPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 lifecycle: remove child version still linked by a parent is 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_life_rm_p");
+		const childId = uniqueTestId("cv2_lic_life_rm_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedLinkedChildParent({ autumn: autumnV2_3, parentId, childId });
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					items: [messagesItem(50)],
+					versioning: "new_version",
+				});
+
+				await expectAutumnError({
+					errCode: ErrCode.InvalidRequest,
+					errMessage: parentId,
+					func: () =>
+						autumnV2_3.catalogV2.update({
+							remove_plans: [{ plan_id: childId, version: 1 }],
+						}),
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 lifecycle: archive child version still linked by a parent is 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_life_arch_p");
+		const childId = uniqueTestId("cv2_lic_life_arch_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedLinkedChildParent({ autumn: autumnV2_3, parentId, childId });
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					items: [messagesItem(50)],
+					versioning: "new_version",
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId, version: 1 });
+				expect(childV1.archived).toBe(false);
+
+				await expectAutumnError({
+					errCode: ErrCode.InvalidRequest,
+					errMessage: parentId,
+					func: () =>
+						autumnV2_3.catalogV2.update({
+							plans: [{ plan_id: childId, version: 1, archived: true }],
+						}),
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 lifecycle: unlink then remove the child version in one call is allowed")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_life_unl_p");
+		const childId = uniqueTestId("cv2_lic_life_unl_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedLinkedChildParent({ autumn: autumnV2_3, parentId, childId });
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					items: [messagesItem(50)],
+					versioning: "new_version",
+				});
+
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: parentId, licenses: [] }],
+					remove_plans: [{ plan_id: childId, version: 1 }],
+				});
+
+				await expectLicenseLinkMissing({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+				});
+				await expectDbPlansCorrect({
+					ctx,
+					expected: [
+						{ id: parentId },
+						{ id: childId },
+					],
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/licenses/mix/all-versions-distributed-anchors.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/mix/all-versions-distributed-anchors.test.ts
@@ -1,0 +1,176 @@
+/**
+ * catalogV2.update — child `all_versions` with parents anchored to different
+ * child rows. Each sibling edit reaches only the links on THAT row.
+ *
+ * Contract:
+ *   A → child v1, B → child v2. Child all_versions + both in propagate
+ *   → A follows v1's edited stock, B follows v2's; anchors stay put.
+ *   Same anchors, no propagate → A pins v1's pre-edit 10, B pins v2's 50.
+ */
+
+import { test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import { expectLicenseLinkCorrect } from "../utils/expectLicenseLinkCorrect.js";
+import {
+	bumpChild,
+	type CatalogV2Client,
+	getFullPlan,
+	messagesItem,
+	withCatalogPlans,
+	wordsItem,
+} from "../utils/seedLicensePlans.js";
+
+const seedDistributedAnchors = async ({
+	autumn,
+	childId,
+	parentAId,
+	parentBId,
+}: {
+	autumn: CatalogV2Client;
+	childId: string;
+	parentAId: string;
+	parentBId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: childId, name: "Seat", items: [messagesItem(10)] }],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: parentAId,
+				name: "Parent A",
+				licenses: [{ license_plan_id: childId, included: 2, version_slug: "v1" }],
+			},
+		],
+	});
+	await bumpChild({
+		autumn,
+		childId,
+		items: [messagesItem(50)],
+		versioning: "new_version",
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: parentBId,
+				name: "Parent B",
+				licenses: [{ license_plan_id: childId, included: 2, version_slug: "v2" }],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: all_versions follow reaches only the anchored sibling")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_lic_avdist_c");
+		const parentAId = uniqueTestId("cv2_lic_avdist_a");
+		const parentBId = uniqueTestId("cv2_lic_avdist_b");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentAId, parentBId],
+			run: async () => {
+				await seedDistributedAnchors({
+					autumn: autumnV2_3,
+					childId,
+					parentAId,
+					parentBId,
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId, version: 1 });
+				const childV2 = await getFullPlan({ ctx, planId: childId, version: 2 });
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							versioning: "all_versions",
+							items: [messagesItem(200), wordsItem(50)],
+							propagate: {
+								license_parents: [
+									{ plan_id: parentAId },
+									{ plan_id: parentBId },
+								],
+							},
+						},
+					],
+				});
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentAId,
+					licensePlanId: childId,
+					customized: false,
+					licenseInternalProductId: childV1.internal_id,
+					licenseVersion: 1,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentBId,
+					licensePlanId: childId,
+					customized: false,
+					licenseInternalProductId: childV2.internal_id,
+					licenseVersion: 2,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: all_versions pin freezes each sibling's pre-edit stock")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_lic_avpin_c");
+		const parentAId = uniqueTestId("cv2_lic_avpin_a");
+		const parentBId = uniqueTestId("cv2_lic_avpin_b");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentAId, parentBId],
+			run: async () => {
+				await seedDistributedAnchors({
+					autumn: autumnV2_3,
+					childId,
+					parentAId,
+					parentBId,
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId, version: 1 });
+				const childV2 = await getFullPlan({ ctx, planId: childId, version: 2 });
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							versioning: "all_versions",
+							items: [messagesItem(200), wordsItem(50)],
+						},
+					],
+				});
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentAId,
+					licensePlanId: childId,
+					customized: true,
+					messagesAllowance: 10,
+					omitFeatureIds: [TestFeature.Words],
+					licenseInternalProductId: childV1.internal_id,
+					licenseVersion: 1,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentBId,
+					licensePlanId: childId,
+					customized: true,
+					messagesAllowance: 50,
+					omitFeatureIds: [TestFeature.Words],
+					licenseInternalProductId: childV2.internal_id,
+					licenseVersion: 2,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/licenses/mix/all-versions-parent-version-anchors.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/mix/all-versions-parent-version-anchors.test.ts
@@ -1,0 +1,380 @@
+/**
+ * catalogV2 — child `all_versions` when the same parent plan has versions
+ * anchored to different child rows (Team/EU v1 → Seat v1, v2 → Seat v2).
+ *
+ * Contract:
+ *   Preview nests each parent version under the child sibling it points at
+ *   (v2 on license_parents, v1 on sibling_versions[v1].license_parents).
+ *   Propagate `{ version_slug: "v1" }` follows only that parent row.
+ *   Parent `all_versions` follows every linked parent version from its
+ *   anchored child sibling; anchors stay put.
+ *
+ * Red (current): sibling parent actions resolved against the edited child
+ *   row (unchanged); version_slug on propagate was stripped.
+ * Green (after): sibling parents resolve against that sibling's upsert;
+ *   version_slug pins the named parent version.
+ */
+
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../../preview/utils/expectPlanPreview.js";
+import { expectLicenseLinkCorrect } from "../utils/expectLicenseLinkCorrect.js";
+import {
+	type CatalogV2Client,
+	dashboardItem,
+	getFullPlan,
+	messagesItem,
+	seedDistributedParentVersionAnchors,
+	withCatalogPlans,
+	wordsItem,
+} from "../utils/seedLicensePlans.js";
+
+const editedItems = [messagesItem(200), wordsItem(50)];
+
+/** Child v1 keeps 100 Messages; v2 is 50 Messages + Words. Team v1→v1, v2→v2. */
+const seedDivergedChildAnchors = async ({
+	autumn,
+	childId,
+	parentId,
+}: {
+	autumn: CatalogV2Client;
+	childId: string;
+	parentId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: childId, name: "Seat", items: [messagesItem(100)] }],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: parentId,
+				name: "Team",
+				licenses: [{ license_plan_id: childId, included: 2 }],
+			},
+		],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: childId,
+				versioning: "new_version",
+				active: true,
+				items: [messagesItem(50), wordsItem(10)],
+			},
+		],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: parentId,
+				versioning: "new_version",
+				active: true,
+				licenses: [
+					{ license_plan_id: childId, included: 2, version_slug: "v2" },
+				],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: all_versions preview nests parent versions on the child sibling they point at")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_lic_avpva_pc");
+		const teamId = uniqueTestId("cv2_lic_avpva_team");
+		const euId = uniqueTestId("cv2_lic_avpva_eu");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId, euId],
+			run: async () => {
+				await seedDistributedParentVersionAnchors({
+					autumn: autumnV2_3,
+					childId,
+					parentIds: [teamId, euId],
+				});
+
+				const preview = parsePlanPreview(
+					await autumnV2_3.catalogV2.previewUpdate({
+						plans: [
+							{
+								plan_id: childId,
+								versioning: "all_versions",
+								items: editedItems,
+								propagate: {
+									license_parents: [
+										{ plan_id: teamId, versioning: "all_versions" },
+										{ plan_id: euId, versioning: "all_versions" },
+									],
+								},
+							},
+						],
+					}),
+				);
+
+				expectPlanPreviewRowCorrect({
+					preview,
+					expected: {
+						planId: childId,
+						licenseParents: [
+							{
+								planId: teamId,
+								version: 2,
+								versionSlug: "v2",
+								licenseAction: "propagated",
+								siblingVersions: null,
+							},
+							{
+								planId: euId,
+								version: 2,
+								versionSlug: "v2",
+								licenseAction: "propagated",
+								siblingVersions: null,
+							},
+						],
+						siblingVersions: [
+							{
+								version: 1,
+								licenseParents: [
+									{
+										planId: teamId,
+										version: 1,
+										versionSlug: "v1",
+										licenseAction: "propagated",
+									},
+									{
+										planId: euId,
+										version: 1,
+										versionSlug: "v1",
+										licenseAction: "propagated",
+									},
+								],
+							},
+						],
+					},
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: parent version_slug v1 follows only the sibling-linked parent row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_lic_avpva_slug");
+		const teamId = uniqueTestId("cv2_lic_avpva_st");
+		const euId = uniqueTestId("cv2_lic_avpva_se");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId, euId],
+			run: async () => {
+				await seedDistributedParentVersionAnchors({
+					autumn: autumnV2_3,
+					childId,
+					parentIds: [teamId, euId],
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId, version: 1 });
+				const childV2 = await getFullPlan({ ctx, planId: childId, version: 2 });
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							versioning: "all_versions",
+							items: editedItems,
+							propagate: {
+								license_parents: [{ plan_id: teamId, version_slug: "v1" }],
+							},
+						},
+					],
+				});
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: teamId,
+					parentVersion: 1,
+					licensePlanId: childId,
+					customized: false,
+					messagesAllowance: 200,
+					licenseInternalProductId: childV1.internal_id,
+					licenseVersion: 1,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: teamId,
+					parentVersion: 2,
+					licensePlanId: childId,
+					customized: true,
+					messagesAllowance: 50,
+					omitFeatureIds: [TestFeature.Words],
+					licenseInternalProductId: childV2.internal_id,
+					licenseVersion: 2,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: euId,
+					parentVersion: 1,
+					licensePlanId: childId,
+					customized: true,
+					messagesAllowance: 10,
+					omitFeatureIds: [TestFeature.Words],
+					licenseInternalProductId: childV1.internal_id,
+					licenseVersion: 1,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: parent all_versions follows each version from its anchored child sibling")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_lic_avpva_all");
+		const teamId = uniqueTestId("cv2_lic_avpva_at");
+		const euId = uniqueTestId("cv2_lic_avpva_ae");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId, euId],
+			run: async () => {
+				await seedDistributedParentVersionAnchors({
+					autumn: autumnV2_3,
+					childId,
+					parentIds: [teamId, euId],
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId, version: 1 });
+				const childV2 = await getFullPlan({ ctx, planId: childId, version: 2 });
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							versioning: "all_versions",
+							items: editedItems,
+							propagate: {
+								license_parents: [
+									{ plan_id: teamId, versioning: "all_versions" },
+									{ plan_id: euId, versioning: "all_versions" },
+								],
+							},
+						},
+					],
+				});
+
+				for (const parentPlanId of [teamId, euId]) {
+					await expectLicenseLinkCorrect({
+						ctx,
+						parentPlanId,
+						parentVersion: 1,
+						licensePlanId: childId,
+						customized: false,
+						messagesAllowance: 200,
+						licenseInternalProductId: childV1.internal_id,
+						licenseVersion: 1,
+					});
+					await expectLicenseLinkCorrect({
+						ctx,
+						parentPlanId,
+						parentVersion: 2,
+						licensePlanId: childId,
+						customized: false,
+						messagesAllowance: 200,
+						licenseInternalProductId: childV2.internal_id,
+						licenseVersion: 2,
+					});
+				}
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: parent v1 follows the child-v1 diff, not a copy of child v2")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_lic_avpva_diff");
+		const teamId = uniqueTestId("cv2_lic_avpva_dt");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedDivergedChildAnchors({
+					autumn: autumnV2_3,
+					childId,
+					parentId: teamId,
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId, version: 1 });
+				const childV2 = await getFullPlan({ ctx, planId: childId, version: 2 });
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							versioning: "all_versions",
+							items: [messagesItem(50), wordsItem(10), dashboardItem()],
+							propagate: {
+								license_parents: [
+									{ plan_id: teamId, versioning: "all_versions" },
+								],
+							},
+						},
+					],
+				});
+
+				const nextChildV1 = await getFullPlan({
+					ctx,
+					planId: childId,
+					version: 1,
+				});
+				expect(nextChildV1.entitlements).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({
+							feature_id: TestFeature.Messages,
+							allowance: 100,
+						}),
+						expect.objectContaining({ feature_id: TestFeature.Dashboard }),
+					]),
+				);
+				expect(
+					nextChildV1.entitlements.some(
+						(entitlement) => entitlement.feature_id === TestFeature.Words,
+					),
+				).toBe(false);
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: teamId,
+					parentVersion: 1,
+					licensePlanId: childId,
+					customized: false,
+					messagesAllowance: 100,
+					entitlements: [{ feature_id: TestFeature.Dashboard }],
+					omitFeatureIds: [TestFeature.Words],
+					licenseInternalProductId: childV1.internal_id,
+					licenseVersion: 1,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: teamId,
+					parentVersion: 2,
+					licensePlanId: childId,
+					customized: false,
+					messagesAllowance: 50,
+					entitlements: [
+						{ feature_id: TestFeature.Words, allowance: 10 },
+						{ feature_id: TestFeature.Dashboard },
+					],
+					licenseInternalProductId: childV2.internal_id,
+					licenseVersion: 2,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/licenses/mix/atmn-put-direct-version-lanes.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/mix/atmn-put-direct-version-lanes.test.ts
@@ -1,0 +1,310 @@
+/**
+ * catalogV2 — atmn PUT lanes that the four-row Dashboard compose does not cover.
+ *
+ * Contract:
+ *   G  Dashboard only on child v2 → parent v1 unchanged; parent v2 gets it
+ *   H  preview: both parents license_action explicit; license_changes add
+ *      Dashboard; no unlink
+ *   I  restated overlays (v1=80, v2=40) stay; Dashboard still flows
+ */
+
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../../preview/utils/expectPlanPreview.js";
+import {
+	atmnDirectPut,
+	expectAnchoredParentLink,
+	expectChildVersionItems,
+	seedDivergedChildAnchors,
+} from "../utils/atmnPutDirectVersions.js";
+import {
+	getFullPlan,
+	messagesItem,
+	messagesOverride,
+	withCatalogPlans,
+} from "../utils/seedLicensePlans.js";
+
+const seedParentOverlays = async ({
+	autumn,
+	childId,
+	parentId,
+}: {
+	autumn: Parameters<typeof seedDivergedChildAnchors>[0]["autumn"];
+	childId: string;
+	parentId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: parentId,
+				version_slug: "v1",
+				licenses: [
+					{
+						license_plan_id: childId,
+						included: 2,
+						version_slug: "v1",
+						customize: messagesOverride(80),
+					},
+				],
+			},
+			{
+				plan_id: parentId,
+				version_slug: "v2",
+				licenses: [
+					{
+						license_plan_id: childId,
+						included: 2,
+						version_slug: "v2",
+						customize: messagesOverride(40),
+					},
+				],
+			},
+		],
+	});
+};
+
+const expectExplicitDashboardPreview = ({
+	preview,
+	childId,
+	parentId,
+}: {
+	preview: ReturnType<typeof parsePlanPreview>;
+	childId: string;
+	parentId: string;
+}) => {
+	for (const currentVersion of [1, 2] as const) {
+		expectPlanPreviewRowCorrect({
+			preview,
+			expected: {
+				planId: childId,
+				currentVersion,
+				licenseParents: [
+					{
+						planId: parentId,
+						version: currentVersion,
+						licenseAction: "explicit",
+						licenseChanges: [
+							{
+								action: "updated",
+								license_plan_id: childId,
+								plan_change: {},
+							},
+						],
+						nestedItemChanges: [
+							{
+								action: "created",
+								feature_id: TestFeature.Dashboard,
+							},
+						],
+					},
+				],
+			},
+		});
+		expectPlanPreviewRowCorrect({
+			preview,
+			expected: {
+				planId: parentId,
+				currentVersion,
+				licenseChanges: [
+					{
+						action: "updated",
+						license_plan_id: childId,
+						plan_change: {},
+					},
+				],
+			},
+		});
+		const parentRow = preview.plans.find(
+			(row) =>
+				row.plan_id === parentId && row.version === currentVersion,
+		);
+		expect(
+			parentRow?.plan_change?.license_changes?.some(
+				(change) => change.action === "removed",
+			),
+		).toBe(false);
+		expect(parentRow?.plan_change?.customize?.remove_licenses).toBeUndefined();
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: atmn PUT Dashboard on child v2 only does not leak to v1")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_lic_atmn_g_c");
+		const parentId = uniqueTestId("cv2_lic_atmn_g_p");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentId],
+			run: async () => {
+				await seedDivergedChildAnchors({
+					autumn: autumnV2_3,
+					childId,
+					parentId,
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId, version: 1 });
+				const childV2 = await getFullPlan({ ctx, planId: childId, version: 2 });
+
+				await autumnV2_3.catalogV2.update({
+					plans: atmnDirectPut({
+						childId,
+						parentId,
+						childV1Items: [messagesItem(100)],
+					}),
+				});
+
+				await expectChildVersionItems({
+					ctx,
+					childId,
+					version: 1,
+					messagesAllowance: 100,
+					hasDashboard: false,
+					hasWords: false,
+				});
+				await expectChildVersionItems({
+					ctx,
+					childId,
+					version: 2,
+					messagesAllowance: 50,
+					hasDashboard: true,
+					hasWords: true,
+				});
+				await expectAnchoredParentLink({
+					ctx,
+					childId,
+					parentId,
+					parentVersion: 1,
+					childInternalId: childV1.internal_id,
+					childVersion: 1,
+					expected: { messagesAllowance: 100 },
+				});
+				await expectAnchoredParentLink({
+					ctx,
+					childId,
+					parentId,
+					parentVersion: 2,
+					childInternalId: childV2.internal_id,
+					childVersion: 2,
+					expected: {
+						messagesAllowance: 50,
+						hasDashboard: true,
+						hasWords: true,
+					},
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: atmn PUT preview is explicit and does not unlink")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_lic_atmn_h_c");
+		const parentId = uniqueTestId("cv2_lic_atmn_h_p");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentId],
+			run: async () => {
+				await seedDivergedChildAnchors({
+					autumn: autumnV2_3,
+					childId,
+					parentId,
+				});
+
+				const preview = parsePlanPreview(
+					await autumnV2_3.catalogV2.previewUpdate({
+						plans: atmnDirectPut({ childId, parentId }),
+					}),
+				);
+				expectExplicitDashboardPreview({ preview, childId, parentId });
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: atmn PUT restates overlays and still flows Dashboard")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_lic_atmn_i_c");
+		const parentId = uniqueTestId("cv2_lic_atmn_i_p");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentId],
+			run: async () => {
+				await seedDivergedChildAnchors({
+					autumn: autumnV2_3,
+					childId,
+					parentId,
+				});
+				await seedParentOverlays({
+					autumn: autumnV2_3,
+					childId,
+					parentId,
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId, version: 1 });
+				const childV2 = await getFullPlan({ ctx, planId: childId, version: 2 });
+
+				await autumnV2_3.catalogV2.update({
+					plans: atmnDirectPut({
+						childId,
+						parentId,
+						parentV1Customize: messagesOverride(80),
+						parentV2Customize: messagesOverride(40),
+					}),
+				});
+
+				await expectChildVersionItems({
+					ctx,
+					childId,
+					version: 1,
+					messagesAllowance: 100,
+					hasDashboard: true,
+					hasWords: false,
+				});
+				await expectChildVersionItems({
+					ctx,
+					childId,
+					version: 2,
+					messagesAllowance: 50,
+					hasDashboard: true,
+					hasWords: true,
+				});
+				await expectAnchoredParentLink({
+					ctx,
+					childId,
+					parentId,
+					parentVersion: 1,
+					childInternalId: childV1.internal_id,
+					childVersion: 1,
+					expected: {
+						messagesAllowance: 80,
+						customized: true,
+						hasDashboard: true,
+					},
+				});
+				await expectAnchoredParentLink({
+					ctx,
+					childId,
+					parentId,
+					parentVersion: 2,
+					childInternalId: childV2.internal_id,
+					childVersion: 2,
+					expected: {
+						messagesAllowance: 40,
+						customized: true,
+						hasDashboard: true,
+						hasWords: true,
+					},
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/licenses/mix/atmn-put-direct-versions.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/mix/atmn-put-direct-versions.test.ts
@@ -1,0 +1,254 @@
+/**
+ * catalogV2 — atmn PUT of every version as a direct intent.
+ *
+ * Child v1 (100 Messages) ← Team v1, child v2 (50 + Words) ← Team v2.
+ * Adding Dashboard is four pinned rows, not all_versions / propagate.
+ *
+ * Contract:
+ *   B  four directs → each preview row omits sibling_versions
+ *   C  child v1+v2 add Dashboard, parents restate the same licenses[] →
+ *      all four rows get Dashboard; Words stay v2-only; anchors stay put
+ *   E  restating licenses[] without version_slug keeps the current child row
+ *   D  identical re-PUT → action none; plan_license row ids unchanged
+ *   drafts  customers on all four + draft:true → one draft, collapsed
+ *      filters, child add Dashboard + parent upsert_licenses add Dashboard
+ */
+
+import { expect, test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import { seedVersionableCustomer } from "../../migrations/utils/seedVersionableCustomer.js";
+import {
+	childItemOp,
+	collapsedPlanFilter,
+	dashboardAddCustomize,
+	expectLicenseDraftCase,
+	orPlanFilter,
+	parentLicenseOp,
+} from "../../migrations/licenses/utils/expectLicenseMigrationDrafts.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../../preview/utils/expectPlanPreview.js";
+import {
+	atmnDirectPut,
+	expectAnchoredDashboardCompose,
+	seedDivergedChildAnchors,
+} from "../utils/atmnPutDirectVersions.js";
+import { getFullPlan, withCatalogPlans } from "../utils/seedLicensePlans.js";
+
+const expectNoSiblingVersionsOnDirects = ({
+	preview,
+	childId,
+	parentId,
+}: {
+	preview: ReturnType<typeof parsePlanPreview>;
+	childId: string;
+	parentId: string;
+}) => {
+	for (const currentVersion of [1, 2]) {
+		expectPlanPreviewRowCorrect({
+			preview,
+			expected: {
+				planId: childId,
+				currentVersion,
+				siblingVersions: null,
+			},
+		});
+		expectPlanPreviewRowCorrect({
+			preview,
+			expected: {
+				planId: parentId,
+				currentVersion,
+				siblingVersions: null,
+			},
+		});
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: atmn PUT two versions each → preview omits sibling_versions")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_lic_atmn_sib_c");
+		const parentId = uniqueTestId("cv2_lic_atmn_sib_p");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentId],
+			run: async () => {
+				await seedDivergedChildAnchors({
+					autumn: autumnV2_3,
+					childId,
+					parentId,
+				});
+
+				const preview = parsePlanPreview(
+					await autumnV2_3.catalogV2.previewUpdate({
+						plans: atmnDirectPut({ childId, parentId }),
+					}),
+				);
+
+				expect(
+					preview.plans.filter((row) => row.plan_id === childId),
+				).toHaveLength(2);
+				expect(
+					preview.plans.filter((row) => row.plan_id === parentId),
+				).toHaveLength(2);
+				expectNoSiblingVersionsOnDirects({ preview, childId, parentId });
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: atmn PUT adds Dashboard on all four rows and keeps anchors")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_lic_atmn_put_c");
+		const parentId = uniqueTestId("cv2_lic_atmn_put_p");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentId],
+			run: async () => {
+				await seedDivergedChildAnchors({
+					autumn: autumnV2_3,
+					childId,
+					parentId,
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId, version: 1 });
+				const childV2 = await getFullPlan({ ctx, planId: childId, version: 2 });
+
+				await autumnV2_3.catalogV2.update({
+					plans: atmnDirectPut({ childId, parentId }),
+				});
+
+				const { teamV1LicenseId, teamV2LicenseId } =
+					await expectAnchoredDashboardCompose({
+						ctx,
+						childId,
+						parentId,
+						childV1InternalId: childV1.internal_id,
+						childV2InternalId: childV2.internal_id,
+					});
+
+				await autumnV2_3.catalogV2.update({
+					plans: atmnDirectPut({
+						childId,
+						parentId,
+						includeChildSlugs: false,
+					}),
+				});
+				await expectAnchoredDashboardCompose({
+					ctx,
+					childId,
+					parentId,
+					childV1InternalId: childV1.internal_id,
+					childV2InternalId: childV2.internal_id,
+					teamV1LicenseId,
+					teamV2LicenseId,
+				});
+
+				const resent = atmnDirectPut({ childId, parentId });
+				const preview = parsePlanPreview(
+					await autumnV2_3.catalogV2.previewUpdate({ plans: resent }),
+				);
+				for (const currentVersion of [1, 2]) {
+					expectPlanPreviewRowCorrect({
+						preview,
+						expected: {
+							planId: childId,
+							currentVersion,
+							action: "none",
+						},
+					});
+					expectPlanPreviewRowCorrect({
+						preview,
+						expected: {
+							planId: parentId,
+							currentVersion,
+							action: "none",
+						},
+					});
+				}
+
+				await autumnV2_3.catalogV2.update({ plans: resent });
+				await expectAnchoredDashboardCompose({
+					ctx,
+					childId,
+					parentId,
+					childV1InternalId: childV1.internal_id,
+					childV2InternalId: childV2.internal_id,
+					teamV1LicenseId,
+					teamV2LicenseId,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: atmn PUT of four directs collapses one Dashboard draft")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_lic_atmn_dr_c");
+		const parentId = uniqueTestId("cv2_lic_atmn_dr_p");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentId],
+			run: async () => {
+				await seedDivergedChildAnchors({
+					autumn: autumnV2_3,
+					childId,
+					parentId,
+				});
+				await seedVersionableCustomer({ ctx, planId: childId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: childId, version: 2 });
+				await seedVersionableCustomer({ ctx, planId: parentId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: parentId, version: 2 });
+
+				const childFilter = collapsedPlanFilter({ planId: childId });
+				const parentFilter = collapsedPlanFilter({ planId: parentId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: atmnDirectPut({ childId, parentId, draft: true }),
+					preview: true,
+					responsePlans: [
+						[
+							{ plan_id: childId, versions: [1, 2] },
+							{ plan_id: parentId, versions: [1, 2] },
+						],
+					],
+					expected: [
+						{
+							planIds: [childId, parentId],
+							noBillingChanges: true,
+							filter: {
+								customer: {
+									plan: orPlanFilter({
+										branches: [
+											{ plan_id: childId },
+											{ plan_id: parentId },
+										],
+									}),
+								},
+							},
+							operations: [
+								childItemOp({
+									planFilter: childFilter,
+									customize: dashboardAddCustomize,
+								}),
+								parentLicenseOp({
+									planFilter: parentFilter,
+									childId,
+									customize: dashboardAddCustomize,
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/licenses/mix/child-versions-two-parents.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/mix/child-versions-two-parents.test.ts
@@ -1,17 +1,17 @@
 /**
  * catalogV2 — a child that has minted its own version, offered by two parents
- * that each have v1 + v2. The child mint freezes every parent row at its old
- * value, so a later propagate can only add; it must never silently un-freeze a
- * diverged slot.
+ * that each have v1 + v2. Links are version-anchored: the child mint touches
+ * no parent row, and a later in-place edit of the new child row reaches only
+ * links pointing at THAT row — a link on another child version never follows.
  *
  * Contract:
- *   - child `new_version` → all four parent rows re-point to the new child row
- *     and pin their old allowance
- *   - later child edit (messages 200 + Words) with A `all_versions`, B omitted
- *     → A inherits Words on both versions but keeps its pinned 10;
- *       B inherits nothing
- *   - preview of that edit → value_divergence on all four rows, but
- *     license_action splits propagated (A) vs unchanged (B)
+ *   - child `new_version` → all four parent rows untouched: still anchored to
+ *     child v1, uncustomized, stock 10
+ *   - later in-place edit of child v2 (messages 200 + Words) with A
+ *     `all_versions`, B omitted → no link is anchored to v2, so nothing is
+ *     reached; all four rows stay anchored to v1 at 10 with no Words
+ *   - preview of that edit → child v2 has no license_parents; both parents
+ *     sit on sibling_versions[v1].license_parents as unchanged
  */
 
 import { test } from "bun:test";
@@ -34,12 +34,6 @@ import {
 	wordsItem,
 } from "../utils/seedLicensePlans.js";
 
-const messagesValueDivergence = {
-	reason: "value_divergence" as const,
-	feature_name: "Messages",
-	item_filter: { feature_id: TestFeature.Messages },
-};
-
 /** Two parents at v1+v2 offering the child, then the child mints its own v2. */
 const seedChildVersionOverTwoParents = async ({
 	autumn,
@@ -59,19 +53,16 @@ const seedChildVersionOverTwoParents = async ({
 	});
 };
 
-const expectEveryParentRow = async ({
+const expectEveryParentRowAnchoredToV1 = async ({
 	ctx,
 	parentIds,
 	childId,
-	expected,
+	childV1InternalId,
 }: {
 	ctx: Parameters<typeof expectLicenseLinkCorrect>[0]["ctx"];
 	parentIds: string[];
 	childId: string;
-	expected: Omit<
-		Parameters<typeof expectLicenseLinkCorrect>[0],
-		"ctx" | "parentPlanId" | "licensePlanId" | "parentVersion"
-	>;
+	childV1InternalId: string;
 }) => {
 	for (const parentPlanId of parentIds) {
 		for (const parentVersion of [1, 2]) {
@@ -80,14 +71,18 @@ const expectEveryParentRow = async ({
 				parentPlanId,
 				parentVersion,
 				licensePlanId: childId,
-				...expected,
+				licenseVersion: 1,
+				customized: false,
+				messagesAllowance: 10,
+				omitFeatureIds: [TestFeature.Words],
+				licenseInternalProductId: childV1InternalId,
 			});
 		}
 	}
 };
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: child new_version freezes every version of every parent")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: child new_version leaves every parent row anchored to v1")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const childId = uniqueTestId("cv2_lic_cv2p_c");
@@ -97,23 +92,24 @@ test.concurrent(
 			ctx,
 			planIds: [childId, teamId, orgId],
 			run: async () => {
-				await seedChildVersionOverTwoParents({
+				await seedTwoParentsWithTwoVersions({
 					autumn: autumnV2_3,
 					childId,
 					parentIds: [teamId, orgId],
 				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					items: [messagesItem(50)],
+					versioning: "new_version",
+				});
 
-				const childV2 = await getFullPlan({ ctx, planId: childId });
-				// Every link re-points at the new child row but keeps the old allowance.
-				await expectEveryParentRow({
+				await expectEveryParentRowAnchoredToV1({
 					ctx,
 					parentIds: [teamId, orgId],
 					childId,
-					expected: {
-						customized: true,
-						messagesAllowance: 10,
-						licenseInternalProductId: childV2.internal_id,
-					},
+					childV1InternalId: childV1.internal_id,
 				});
 			},
 		});
@@ -121,7 +117,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: all_versions adds a new item to a frozen parent without un-freezing it")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: in-place edit of child v2 never reaches links anchored to v1")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const childId = uniqueTestId("cv2_lic_cv2f_c");
@@ -131,10 +127,17 @@ test.concurrent(
 			ctx,
 			planIds: [childId, followId, pinId],
 			run: async () => {
-				await seedChildVersionOverTwoParents({
+				await seedTwoParentsWithTwoVersions({
 					autumn: autumnV2_3,
 					childId,
 					parentIds: [followId, pinId],
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					items: [messagesItem(50)],
+					versioning: "new_version",
 				});
 				await bumpChild({
 					autumn: autumnV2_3,
@@ -147,29 +150,12 @@ test.concurrent(
 					},
 				});
 
-				// Followed parent: Words flows in, the diverged messages slot holds.
-				for (const parentVersion of [1, 2]) {
-					await expectLicenseLinkCorrect({
-						ctx,
-						parentPlanId: followId,
-						parentVersion,
-						licensePlanId: childId,
-						customized: true,
-						entitlements: [
-							{ feature_id: TestFeature.Messages, allowance: 10 },
-							{ feature_id: TestFeature.Words, allowance: 50 },
-						],
-					});
-				}
-				await expectEveryParentRow({
+				// Even the propagated parent holds: its links anchor v1, not the edited v2.
+				await expectEveryParentRowAnchoredToV1({
 					ctx,
-					parentIds: [pinId],
+					parentIds: [followId, pinId],
 					childId,
-					expected: {
-						customized: true,
-						messagesAllowance: 10,
-						omitFeatureIds: [TestFeature.Words],
-					},
+					childV1InternalId: childV1.internal_id,
 				});
 			},
 		});
@@ -177,7 +163,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: preview splits license_action across parents while every row diverges")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: preview puts v1-anchored parents on sibling_versions")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const childId = uniqueTestId("cv2_lic_cv2p_pc");
@@ -213,30 +199,18 @@ test.concurrent(
 					preview,
 					expected: {
 						planId: childId,
-						licenseParents: [
+						licenseParents: null,
+						siblingVersions: [
 							{
-								planId: followId,
-								version: 2,
-								licenseAction: "propagated",
-								conflicts: [messagesValueDivergence],
-								siblingVersions: [
+								version: 1,
+								licenseParents: [
 									{
-										version: 1,
-										licenseAction: "propagated",
-										conflicts: [messagesValueDivergence],
-									},
-								],
-							},
-							{
-								planId: pinId,
-								version: 2,
-								licenseAction: "unchanged",
-								conflicts: [messagesValueDivergence],
-								siblingVersions: [
-									{
-										version: 1,
+										planId: followId,
 										licenseAction: "unchanged",
-										conflicts: [messagesValueDivergence],
+									},
+									{
+										planId: pinId,
+										licenseAction: "unchanged",
 									},
 								],
 							},

--- a/server/tests/integration/catalog-v2/plans/licenses/mix/declared-exclusive-vs-propagate.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/mix/declared-exclusive-vs-propagate.test.ts
@@ -203,7 +203,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: declared customize on child new_version links latest")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: declared customize on child new_version stays on current")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const parentId = uniqueTestId("cv2_lic_mdm_p");
@@ -217,6 +217,7 @@ test.concurrent(
 					parentId,
 					childId,
 				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
 				await autumnV2_3.catalogV2.update({
 					plans: [
 						{
@@ -231,14 +232,14 @@ test.concurrent(
 					],
 				});
 
-				const childV2 = await getFullPlan({ ctx, planId: childId });
 				await expectLicenseLinkCorrect({
 					ctx,
 					parentPlanId: parentId,
 					licensePlanId: childId,
+					licenseVersion: 1,
 					customized: true,
 					messagesAllowance: 300,
-					licenseInternalProductId: childV2.internal_id,
+					licenseInternalProductId: childV1.internal_id,
 				});
 			},
 		});

--- a/server/tests/integration/catalog-v2/plans/licenses/mix/declared-slug-vs-propagate.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/mix/declared-slug-vs-propagate.test.ts
@@ -1,0 +1,132 @@
+/**
+ * catalogV2.update — same-batch declared licenses[] vs child propagate.
+ *
+ * Declared is exclusive. version_slug stated → that row.
+ * version_slug omitted → keep the existing link. Propagate does not move it.
+ */
+import { test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import {
+	expectLatestPlanVersion,
+	expectLicenseLinkCorrect,
+} from "../utils/expectLicenseLinkCorrect.js";
+import {
+	bumpChild,
+	getFullPlan,
+	seedLinkedChildParent,
+	withCatalogPlans,
+} from "../utils/seedLicensePlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: same-batch omit + propagate stays on current child")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_momit_p");
+		const childId = uniqueTestId("cv2_lic_momit_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					versioning: "new_version",
+					propagate: {
+						license_parents: [
+							{ plan_id: parentId, versioning: "new_version" },
+						],
+					},
+					parentPlans: [
+						{
+							plan_id: parentId,
+							licenses: [{ license_plan_id: childId, included: 2 }],
+						},
+					],
+				});
+
+				await expectLatestPlanVersion({
+					ctx,
+					planId: parentId,
+					version: 1,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					licenseVersion: 1,
+					customized: false,
+					messagesAllowance: 10,
+					licenseInternalProductId: childV1.internal_id,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: same-batch version_slug v1 + propagate stays on v1")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_mslug_p");
+		const childId = uniqueTestId("cv2_lic_mslug_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					versioning: "new_version",
+					propagate: {
+						license_parents: [
+							{ plan_id: parentId, versioning: "new_version" },
+						],
+					},
+					parentPlans: [
+						{
+							plan_id: parentId,
+							licenses: [
+								{
+									license_plan_id: childId,
+									included: 2,
+									version_slug: "v1",
+								},
+							],
+						},
+					],
+				});
+
+				await expectLatestPlanVersion({
+					ctx,
+					planId: parentId,
+					version: 1,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					licenseVersion: 1,
+					customized: false,
+					messagesAllowance: 10,
+					licenseInternalProductId: childV1.internal_id,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/licenses/mix/versioning-collisions.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/mix/versioning-collisions.test.ts
@@ -446,3 +446,74 @@ test.concurrent(
 		});
 	},
 );
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: parent existing edit + child v2 propagate new_version — mint and rename both land")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_vclaim_p");
+		const childId = uniqueTestId("cv2_lic_vclaim_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedLinkedChildParent({ autumn: autumnV2_3, parentId, childId });
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					items: [messagesItem(50)],
+					versioning: "new_version",
+				});
+				await seedVersionableCustomer({ ctx, planId: parentId });
+				const childV2 = await getFullPlan({ ctx, planId: childId });
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{ plan_id: parentId, name: "Renamed", versioning: "existing" },
+						{
+							plan_id: childId,
+							version: 2,
+							items: [messagesItem(200)],
+							propagate: {
+								license_parents: [
+									{ plan_id: parentId, versioning: "new_version" },
+								],
+							},
+						},
+					],
+				});
+
+				const parentV1 = await getFullPlan({
+					ctx,
+					planId: parentId,
+					version: 1,
+				});
+				expect(parentV1.name).toBe("Renamed");
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					parentVersion: 1,
+					licensePlanId: childId,
+					licenseInternalProductId: childV1.internal_id,
+					messagesAllowance: 10,
+				});
+				const minted = await expectLatestPlanVersion({
+					ctx,
+					planId: parentId,
+					version: 2,
+				});
+				expect(minted.internal_id).not.toBe(parentV1.internal_id);
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					parentVersion: 2,
+					licensePlanId: childId,
+					licenseInternalProductId: childV2.internal_id,
+					customized: false,
+					messagesAllowance: 200,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/licenses/pinned/assigned-seat-pin.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/pinned/assigned-seat-pin.test.ts
@@ -65,7 +65,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: child new_version pin retires assigned seat")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: child new_version leaves assigned seat and catalog link untouched")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const parentId = uniqueTestId("cv2_lic_cmint_p");
@@ -79,6 +79,7 @@ test.concurrent(
 					parentId,
 					childId,
 				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
 				const assigned = await seedAssignedLicenseCustomer({
 					ctx,
 					parentId,
@@ -91,16 +92,18 @@ test.concurrent(
 					versioning: "new_version",
 				});
 
-				const childV2 = await getFullPlan({ ctx, planId: childId });
+				// No write: catalog and customer share the same live row, still on v1.
 				const catalog = await expectLicenseLinkCorrect({
 					ctx,
 					parentPlanId: parentId,
 					licensePlanId: childId,
-					customized: true,
+					licenseVersion: 1,
+					customized: false,
 					messagesAllowance: 10,
-					licenseInternalProductId: childV2.internal_id,
+					licenseInternalProductId: childV1.internal_id,
+					planLicenseId: assigned.planLicenseId,
 				});
-				expect(catalog.planLicense.id).not.toBe(assigned.planLicenseId);
+				expect(catalog.planLicense.is_custom).toBe(false);
 				await expectCustomerLicensePinnedTo({
 					ctx,
 					customerLicenseId: assigned.customerLicenseId,

--- a/server/tests/integration/catalog-v2/plans/licenses/pinned/pin-freeze-items.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/pinned/pin-freeze-items.test.ts
@@ -143,7 +143,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: customized pin + child new_version re-points, keeps overlay")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: customized link + child new_version stays anchored to v1")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const parentId = uniqueTestId("cv2_lic_pcm_p");
@@ -158,6 +158,13 @@ test.concurrent(
 					childId,
 					customize: messagesOverride(500),
 				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+				const before = await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					licenseInternalProductId: childV1.internal_id,
+				});
 				await bumpWithWords({
 					autumn: autumnV2_3,
 					childId,
@@ -170,10 +177,12 @@ test.concurrent(
 					ctx,
 					parentPlanId: parentId,
 					licensePlanId: childId,
+					licenseVersion: 1,
 					customized: true,
 					messagesAllowance: 500,
 					omitFeatureIds: [TestFeature.Words],
-					licenseInternalProductId: childV2.internal_id,
+					licenseInternalProductId: childV1.internal_id,
+					planLicenseId: before.planLicense.id,
 				});
 			},
 		});

--- a/server/tests/integration/catalog-v2/plans/licenses/pinned/pin-on-child-new-version.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/pinned/pin-on-child-new-version.test.ts
@@ -1,6 +1,10 @@
 /**
- * catalogV2.update — child versioning:new_version re-points the catalog
- * license at the minted child row. Overlay freeze is still the pin planner.
+ * catalogV2.update — child versioning:new_version leaves a non-propagated
+ * parent's license link untouched: still anchored to child v1, no manufactured
+ * freeze overlay, same plan_license row.
+ *
+ * Red (current):  the mint re-points the link to v2 and clones a frozen overlay
+ * Green (after):  the link is version-anchored — no repoint, no overlay
  */
 import { expect, test } from "bun:test";
 import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
@@ -15,11 +19,11 @@ import {
 } from "../utils/seedLicensePlans.js";
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: child new_version re-points absent parent to v2")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: child new_version leaves absent parent anchored to v1")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
-		const parentId = uniqueTestId("cv2_lic_repoint_p");
-		const childId = uniqueTestId("cv2_lic_repoint_c");
+		const parentId = uniqueTestId("cv2_lic_anchor_p");
+		const childId = uniqueTestId("cv2_lic_anchor_c");
 		await withCatalogPlans({
 			ctx,
 			planIds: [parentId, childId],
@@ -30,6 +34,12 @@ test.concurrent(
 					childId,
 				});
 				const childV1 = await getFullPlan({ ctx, planId: childId });
+				const before = await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					licenseInternalProductId: childV1.internal_id,
+				});
 
 				await bumpChild({
 					autumn: autumnV2_3,
@@ -44,10 +54,12 @@ test.concurrent(
 					ctx,
 					parentPlanId: parentId,
 					licensePlanId: childId,
+					licenseVersion: 1,
 					included: 2,
-					customized: true,
+					customized: false,
 					messagesAllowance: 10,
-					licenseInternalProductId: childV2.internal_id,
+					licenseInternalProductId: childV1.internal_id,
+					planLicenseId: before.planLicense.id,
 				});
 			},
 		});

--- a/server/tests/integration/catalog-v2/plans/licenses/pinned/uncustomized-freeze-on-child-promote.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/pinned/uncustomized-freeze-on-child-promote.test.ts
@@ -1,15 +1,15 @@
 /**
- * catalogV2.update — child promote freezes uncustomized license definitions.
+ * catalogV2.update — child promote leaves non-propagated links untouched.
  *
  * Contract:
- *   Uncustomized parent NOT in propagate → mint/pin a planLicense to child
- *   v1 (customize overlay). Do not retarget to the newly active child.
+ *   Parent NOT in propagate → link stays version-anchored to child v1:
+ *   no repoint, no manufactured overlay, same plan_license row.
  *   Parent IN propagate → follow the newly active child (new reference).
  *   Already-customized parent → leave (same row, same overlay, no retarget).
  *   Parent promote (licenses omitted) → child identity unchanged;
  *   v2 stays empty, v1 keeps the existing links.
- *   Declared licenses[] on child promote is exclusive — re-link to the
- *   newly active child, not an implicit freeze on the demoted row.
+ *   Declared licenses[] on child promote is exclusive — omit version_slug
+ *   keeps the existing v1 anchor; customize still applies on that row.
  */
 
 import { expect, test } from "bun:test";
@@ -43,7 +43,7 @@ const mintChildDraftV2 = async ({
 };
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: child promote freezes uncustomized; propagate follows v2")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: child promote leaves non-propagated link anchored; propagate follows v2")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const frozenId = uniqueTestId("cv2_lic_pr_frz_p");
@@ -59,6 +59,12 @@ test.concurrent(
 					parentIds: [frozenId, followId],
 				});
 				const childV1 = await getFullPlan({ ctx, planId: childId });
+				const anchoredBefore = await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: frozenId,
+					licensePlanId: childId,
+					licenseInternalProductId: childV1.internal_id,
+				});
 				await mintChildDraftV2({ autumn: autumnV2_3, childId });
 				const childV2 = await getFullPlan({
 					ctx,
@@ -88,9 +94,10 @@ test.concurrent(
 					licensePlanId: childId,
 					licenseVersion: 1,
 					included: 2,
-					customized: true,
+					customized: false,
 					messagesAllowance: 10,
 					licenseInternalProductId: childV1.internal_id,
+					planLicenseId: anchoredBefore.planLicense.id,
 				});
 				await expectLicenseLinkCorrect({
 					ctx,
@@ -212,7 +219,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: declared licenses[] on child promote re-links to v2")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: declared licenses[] on child promote omit keeps the v1 anchor")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const parentId = uniqueTestId("cv2_lic_pr_dec_p");
@@ -227,12 +234,8 @@ test.concurrent(
 					childId,
 					customize: messagesOverride(500),
 				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
 				await mintChildDraftV2({ autumn: autumnV2_3, childId });
-				const childV2 = await getFullPlan({
-					ctx,
-					planId: childId,
-					version: 2,
-				});
 
 				await autumnV2_3.catalogV2.update({
 					plans: [
@@ -259,9 +262,10 @@ test.concurrent(
 					ctx,
 					parentPlanId: parentId,
 					licensePlanId: childId,
+					licenseVersion: 1,
 					customized: true,
 					messagesAllowance: 300,
-					licenseInternalProductId: childV2.internal_id,
+					licenseInternalProductId: childV1.internal_id,
 				});
 			},
 		});

--- a/server/tests/integration/catalog-v2/plans/licenses/preview/declared-licenses-lane.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/preview/declared-licenses-lane.test.ts
@@ -66,6 +66,7 @@ test.concurrent(
 							{
 								license_plan_id: childA,
 								version: 1,
+								version_slug: "v1",
 								included: 1,
 								prepaid_only: true,
 							},
@@ -92,6 +93,7 @@ test.concurrent(
 							{
 								license_plan_id: childB,
 								version: 1,
+								version_slug: "v1",
 								included: 3,
 								prepaid_only: true,
 							},
@@ -163,6 +165,7 @@ test.concurrent(
 							{
 								license_plan_id: childId,
 								version: 1,
+								version_slug: "v1",
 								included: 2,
 								prepaid_only: true,
 							},

--- a/server/tests/integration/catalog-v2/plans/licenses/preview/license-changes-customize.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/preview/license-changes-customize.test.ts
@@ -276,6 +276,7 @@ test.concurrent(
 							{
 								license_plan_id: childId,
 								version: 1,
+								version_slug: "v1",
 								included: 2,
 								prepaid_only: true,
 							},

--- a/server/tests/integration/catalog-v2/plans/licenses/preview/license-changes-follow.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/preview/license-changes-follow.test.ts
@@ -7,7 +7,7 @@
  * Contract:
  *   - pin (no propagate) → updated freeze, no nested plan_change
  *   - propagate → updated + nested item plan_change
- *   - child new_version + pin → previous_attributes.version
+ *   - child new_version + pin → no license_changes (link stays on v1)
  */
 
 import { test } from "bun:test";
@@ -121,7 +121,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 license_changes: child new_version + pin reports previous version")}`,
+	`${chalk.yellowBright("catalogV2 license_changes: child new_version + pin leaves the parent link untouched")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const parentId = uniqueTestId("cv2_lc_ver_p");
@@ -152,13 +152,7 @@ test.concurrent(
 					preview,
 					expected: {
 						planId: parentId,
-						licenseChanges: [
-							{
-								action: "updated",
-								license_plan_id: childId,
-								previous_attributes: { version: 1 },
-							},
-						],
+						licenseChanges: null,
 					},
 				});
 			},

--- a/server/tests/integration/catalog-v2/plans/licenses/propagated/follow-new-parent-version.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/propagated/follow-new-parent-version.test.ts
@@ -1,9 +1,11 @@
 /**
- * catalogV2.update — propagate.license_parents versioning:new_version.
- * Parent absent from plans[].
+ * catalogV2.update — propagate.license_parents after the child mints.
+ * Parent absent from plans[]. Propagate still MOVES the live link.
  *
- * Active has customers → mint, follow the mint, freeze old.
- * No customers → fall back to existing (in-place latest, no mint).
+ * new_version + customers → mint; the mint anchors child v2.
+ * new_version + no customers → no mint; live link still moves to child v2.
+ * omit / existing + customers → no mint; live link still moves to child v2.
+ * Older parent versions stay on child v1, customized false.
  */
 import { expect, test } from "bun:test";
 import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
@@ -37,6 +39,7 @@ test.concurrent(
 					childId,
 				});
 				const parentV2 = await getFullPlan({ ctx, planId: parentId });
+				const childV1 = await getFullPlan({ ctx, planId: childId });
 				await seedVersionableCustomer({
 					ctx,
 					planId: parentId,
@@ -60,6 +63,7 @@ test.concurrent(
 					version: 3,
 				});
 				expect(parentV3.internal_id).not.toBe(parentV2.internal_id);
+				const childV2 = await getFullPlan({ ctx, planId: childId });
 				await expectLicenseLinkCorrect({
 					ctx,
 					parentPlanId: parentId,
@@ -67,23 +71,20 @@ test.concurrent(
 					licensePlanId: childId,
 					customized: false,
 					messagesAllowance: 200,
+					licenseInternalProductId: childV2.internal_id,
 				});
-				await expectLicenseLinkCorrect({
-					ctx,
-					parentPlanId: parentId,
-					parentVersion: 2,
-					licensePlanId: childId,
-					customized: true,
-					messagesAllowance: 10,
-				});
-				await expectLicenseLinkCorrect({
-					ctx,
-					parentPlanId: parentId,
-					parentVersion: 1,
-					licensePlanId: childId,
-					customized: true,
-					messagesAllowance: 10,
-				});
+				for (const parentVersion of [1, 2]) {
+					await expectLicenseLinkCorrect({
+						ctx,
+						parentPlanId: parentId,
+						parentVersion,
+						licensePlanId: childId,
+						licenseVersion: 1,
+						customized: false,
+						messagesAllowance: 10,
+						licenseInternalProductId: childV1.internal_id,
+					});
+				}
 				const stillOnV2 = await getFullPlan({
 					ctx,
 					planId: parentId,
@@ -96,7 +97,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-licenses: new_version falls back to existing when parent has no customers")}`,
+	`${chalk.yellowBright("catalogV2 plan-licenses: new_version without customers moves latest in place")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const parentId = uniqueTestId("cv2_lic_pnv0_p");
@@ -110,10 +111,13 @@ test.concurrent(
 					parentId,
 					childId,
 				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+				const parentV2 = await getFullPlan({ ctx, planId: parentId });
 
 				await bumpChild({
 					autumn: autumnV2_3,
 					childId,
+					versioning: "new_version",
 					propagate: {
 						license_parents: [
 							{ plan_id: parentId, versioning: "new_version" },
@@ -126,6 +130,9 @@ test.concurrent(
 					planId: parentId,
 					version: 2,
 				});
+				const stillV2 = await getFullPlan({ ctx, planId: parentId });
+				expect(stillV2.internal_id).toBe(parentV2.internal_id);
+				const childV2 = await getFullPlan({ ctx, planId: childId });
 				await expectLicenseLinkCorrect({
 					ctx,
 					parentPlanId: parentId,
@@ -133,14 +140,79 @@ test.concurrent(
 					licensePlanId: childId,
 					customized: false,
 					messagesAllowance: 200,
+					licenseInternalProductId: childV2.internal_id,
 				});
 				await expectLicenseLinkCorrect({
 					ctx,
 					parentPlanId: parentId,
 					parentVersion: 1,
 					licensePlanId: childId,
-					customized: true,
+					licenseVersion: 1,
+					customized: false,
 					messagesAllowance: 10,
+					licenseInternalProductId: childV1.internal_id,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: omit/existing propagate moves latest even with customers")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_pexcus_p");
+		const childId = uniqueTestId("cv2_lic_pexcus_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedTwoParentVersions({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+				});
+				const parentV2 = await getFullPlan({ ctx, planId: parentId });
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+				await seedVersionableCustomer({
+					ctx,
+					planId: parentId,
+					version: 2,
+				});
+
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					versioning: "new_version",
+					propagate: { license_parents: [{ plan_id: parentId }] },
+				});
+
+				await expectLatestPlanVersion({
+					ctx,
+					planId: parentId,
+					version: 2,
+				});
+				const stillV2 = await getFullPlan({ ctx, planId: parentId });
+				expect(stillV2.internal_id).toBe(parentV2.internal_id);
+				const childV2 = await getFullPlan({ ctx, planId: childId });
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					parentVersion: 2,
+					licensePlanId: childId,
+					customized: false,
+					messagesAllowance: 200,
+					licenseInternalProductId: childV2.internal_id,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					parentVersion: 1,
+					licensePlanId: childId,
+					licenseVersion: 1,
+					customized: false,
+					messagesAllowance: 10,
+					licenseInternalProductId: childV1.internal_id,
 				});
 			},
 		});

--- a/server/tests/integration/catalog-v2/plans/licenses/utils/atmnPutDirectVersions.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/utils/atmnPutDirectVersions.ts
@@ -1,0 +1,289 @@
+import { expect } from "bun:test";
+import type { LicenseCustomize, UpdateCatalogPlanParams } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { expectLicenseLinkCorrect } from "./expectLicenseLinkCorrect.js";
+import {
+	type CatalogTestItem,
+	type CatalogV2Client,
+	dashboardItem,
+	getFullPlan,
+	messagesItem,
+	wordsItem,
+} from "./seedLicensePlans.js";
+
+/** Child v1 keeps 100 Messages; v2 is 50 Messages + Words. Team v1→v1, v2→v2. */
+export const seedDivergedChildAnchors = async ({
+	autumn,
+	childId,
+	parentId,
+}: {
+	autumn: CatalogV2Client;
+	childId: string;
+	parentId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: childId, name: "Seat", items: [messagesItem(100)] }],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: parentId,
+				name: "Team",
+				licenses: [{ license_plan_id: childId, included: 2 }],
+			},
+		],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: childId,
+				versioning: "new_version",
+				active: true,
+				items: [messagesItem(50), wordsItem(10)],
+			},
+		],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: parentId,
+				versioning: "new_version",
+				active: true,
+				licenses: [
+					{ license_plan_id: childId, included: 2, version_slug: "v2" },
+				],
+			},
+		],
+	});
+};
+
+export const atmnDirectPut = ({
+	childId,
+	parentId,
+	childV1Items = [messagesItem(100), dashboardItem()],
+	childV2Items = [messagesItem(50), wordsItem(10), dashboardItem()],
+	includeChildSlugs = true,
+	draft = false,
+	parentV1Customize,
+	parentV2Customize,
+}: {
+	childId: string;
+	parentId: string;
+	childV1Items?: CatalogTestItem[];
+	childV2Items?: CatalogTestItem[];
+	includeChildSlugs?: boolean;
+	draft?: boolean;
+	parentV1Customize?: LicenseCustomize;
+	parentV2Customize?: LicenseCustomize;
+}): UpdateCatalogPlanParams[] => {
+	const migration = draft ? { draft: true as const } : undefined;
+	return [
+		{
+			plan_id: childId,
+			version_slug: "v1",
+			items: childV1Items,
+			...(migration ? { migration } : {}),
+		},
+		{
+			plan_id: childId,
+			version_slug: "v2",
+			items: childV2Items,
+			...(migration ? { migration } : {}),
+		},
+		{
+			plan_id: parentId,
+			version_slug: "v1",
+			licenses: [
+				{
+					license_plan_id: childId,
+					included: 2,
+					...(includeChildSlugs ? { version_slug: "v1" } : {}),
+					...(parentV1Customize ? { customize: parentV1Customize } : {}),
+				},
+			],
+			...(migration ? { migration } : {}),
+		},
+		{
+			plan_id: parentId,
+			version_slug: "v2",
+			licenses: [
+				{
+					license_plan_id: childId,
+					included: 2,
+					...(includeChildSlugs ? { version_slug: "v2" } : {}),
+					...(parentV2Customize ? { customize: parentV2Customize } : {}),
+				},
+			],
+			...(migration ? { migration } : {}),
+		},
+	];
+};
+
+type ExpectedAnchoredRow = {
+	messagesAllowance: number;
+	customized?: boolean;
+	hasDashboard?: boolean;
+	hasWords?: boolean;
+	planLicenseId?: string;
+};
+
+export const expectAnchoredParentLink = async ({
+	ctx,
+	childId,
+	parentId,
+	parentVersion,
+	childInternalId,
+	childVersion,
+	expected,
+}: {
+	ctx: AutumnContext;
+	childId: string;
+	parentId: string;
+	parentVersion: 1 | 2;
+	childInternalId: string;
+	childVersion: 1 | 2;
+	expected: ExpectedAnchoredRow;
+}) =>
+	expectLicenseLinkCorrect({
+		ctx,
+		parentPlanId: parentId,
+		parentVersion,
+		licensePlanId: childId,
+		included: 2,
+		customized: expected.customized ?? false,
+		messagesAllowance: expected.messagesAllowance,
+		entitlements: [
+			...(expected.hasDashboard
+				? [{ feature_id: TestFeature.Dashboard }]
+				: []),
+			...(expected.hasWords
+				? [{ feature_id: TestFeature.Words, allowance: 10 }]
+				: []),
+		],
+		omitFeatureIds: [
+			...(expected.hasDashboard ? [] : [TestFeature.Dashboard]),
+			...(expected.hasWords ? [] : [TestFeature.Words]),
+		],
+		licenseInternalProductId: childInternalId,
+		licenseVersion: childVersion,
+		planLicenseId: expected.planLicenseId,
+	});
+
+export const expectChildVersionItems = async ({
+	ctx,
+	childId,
+	version,
+	messagesAllowance,
+	hasDashboard,
+	hasWords,
+}: {
+	ctx: AutumnContext;
+	childId: string;
+	version: 1 | 2;
+	messagesAllowance: number;
+	hasDashboard: boolean;
+	hasWords: boolean;
+}) => {
+	const plan = await getFullPlan({ ctx, planId: childId, version });
+	expect(plan.entitlements).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				feature_id: TestFeature.Messages,
+				allowance: messagesAllowance,
+			}),
+			...(hasDashboard
+				? [expect.objectContaining({ feature_id: TestFeature.Dashboard })]
+				: []),
+			...(hasWords
+				? [
+						expect.objectContaining({
+							feature_id: TestFeature.Words,
+							allowance: 10,
+						}),
+					]
+				: []),
+		]),
+	);
+	if (!hasDashboard) {
+		expect(
+			plan.entitlements.some(
+				(entitlement) => entitlement.feature_id === TestFeature.Dashboard,
+			),
+		).toBe(false);
+	}
+	if (!hasWords) {
+		expect(
+			plan.entitlements.some(
+				(entitlement) => entitlement.feature_id === TestFeature.Words,
+			),
+		).toBe(false);
+	}
+};
+
+export const expectAnchoredDashboardCompose = async ({
+	ctx,
+	childId,
+	parentId,
+	childV1InternalId,
+	childV2InternalId,
+	teamV1LicenseId,
+	teamV2LicenseId,
+}: {
+	ctx: AutumnContext;
+	childId: string;
+	parentId: string;
+	childV1InternalId: string;
+	childV2InternalId: string;
+	teamV1LicenseId?: string;
+	teamV2LicenseId?: string;
+}) => {
+	await expectChildVersionItems({
+		ctx,
+		childId,
+		version: 1,
+		messagesAllowance: 100,
+		hasDashboard: true,
+		hasWords: false,
+	});
+	await expectChildVersionItems({
+		ctx,
+		childId,
+		version: 2,
+		messagesAllowance: 50,
+		hasDashboard: true,
+		hasWords: true,
+	});
+
+	const teamV1 = await expectAnchoredParentLink({
+		ctx,
+		childId,
+		parentId,
+		parentVersion: 1,
+		childInternalId: childV1InternalId,
+		childVersion: 1,
+		expected: {
+			messagesAllowance: 100,
+			hasDashboard: true,
+			planLicenseId: teamV1LicenseId,
+		},
+	});
+	const teamV2 = await expectAnchoredParentLink({
+		ctx,
+		childId,
+		parentId,
+		parentVersion: 2,
+		childInternalId: childV2InternalId,
+		childVersion: 2,
+		expected: {
+			messagesAllowance: 50,
+			hasDashboard: true,
+			hasWords: true,
+			planLicenseId: teamV2LicenseId,
+		},
+	});
+	return {
+		teamV1LicenseId: teamV1.planLicense.id,
+		teamV2LicenseId: teamV2.planLicense.id,
+	};
+};

--- a/server/tests/integration/catalog-v2/plans/licenses/utils/seedLicensePlans.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/utils/seedLicensePlans.ts
@@ -212,6 +212,45 @@ export const seedTwoParentsWithTwoVersions = async ({
 	}
 };
 
+/** Each parent v1 stays on child v1; each parent v2 is minted onto child v2. */
+export const seedDistributedParentVersionAnchors = async ({
+	autumn,
+	childId,
+	parentIds,
+	included = 2,
+}: {
+	autumn: CatalogV2Client;
+	childId: string;
+	parentIds: [string, string];
+	included?: number;
+}) => {
+	await seedTwoParents({ autumn, childId, parentIds, included });
+	await bumpChild({
+		autumn,
+		childId,
+		items: [messagesItem(50)],
+		versioning: "new_version",
+	});
+	for (const parentId of parentIds) {
+		await autumn.catalogV2.update({
+			plans: [
+				{
+					plan_id: parentId,
+					versioning: "new_version",
+					active: true,
+					licenses: [
+						{
+							license_plan_id: childId,
+							included,
+							version_slug: "v2",
+						},
+					],
+				},
+			],
+		});
+	}
+};
+
 export const bumpChild = async ({
 	autumn,
 	childId,

--- a/server/tests/integration/catalog-v2/plans/preview/utils/expectPlanPreview.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/utils/expectPlanPreview.ts
@@ -4,6 +4,8 @@ import type {
 	CatalogConflictPreview,
 	CatalogCorePreview,
 	CatalogLicenseAction,
+	CatalogLicenseParentPreview,
+	CatalogPlanSiblingVersionPreview,
 	CatalogPlanVersioningStrategy,
 	CatalogSiblingVersionPreview,
 	CatalogVariantAction,
@@ -41,6 +43,8 @@ type ExpectedSiblingVersion = {
 	variantAction?: CatalogVariantAction;
 	/** Parent lanes only — each parent version resolves the child edit itself. */
 	licenseAction?: CatalogLicenseAction;
+	/** Parents whose link points at this sibling version. */
+	licenseParents?: ExpectedLicenseParent[] | null;
 };
 
 type ExpectedLicenseParent = {
@@ -211,10 +215,102 @@ const expectLicenseChangesMatch = ({
 	}
 };
 
-type ActualSiblingVersion = CatalogSiblingVersionPreview & {
-	selected?: boolean;
-	license_action?: CatalogLicenseAction;
-	variant_action?: CatalogVariantAction;
+type ActualSiblingVersion = CatalogSiblingVersionPreview &
+	Pick<CatalogPlanSiblingVersionPreview, "license_parents"> & {
+		selected?: boolean;
+		license_action?: CatalogLicenseAction;
+		variant_action?: CatalogVariantAction;
+	};
+
+const expectLicenseParentsMatch = ({
+	actual,
+	expected,
+}: {
+	actual: CatalogLicenseParentPreview[] | undefined;
+	expected: ExpectedLicenseParent[] | null;
+}) => {
+	if (expected === null) {
+		expect(actual).toBeUndefined();
+		return;
+	}
+	expect(actual).toHaveLength(expected.length);
+	for (const expectedParent of expected) {
+		const parent = actual?.find(
+			(candidate) =>
+				candidate.plan_id === expectedParent.planId &&
+				(expectedParent.version === undefined ||
+					candidate.version === expectedParent.version),
+		);
+		expect(
+			parent,
+			`missing license_parents entry for ${expectedParent.planId}`,
+		).toBeDefined();
+		if (parent) {
+			expectVersionSlugMatch({
+				actual: parent,
+				versionSlug: expectedParent.versionSlug,
+				newVersionSlug: expectedParent.newVersionSlug,
+			});
+		}
+		if (expectedParent.licenseAction !== undefined) {
+			expect(parent?.license_action).toBe(expectedParent.licenseAction);
+		}
+		if (expectedParent.versioning !== undefined) {
+			expect(
+				(parent as { versioning?: PlanPreviewVersioning } | undefined)
+					?.versioning,
+			).toEqual(expectedParent.versioning);
+		}
+		if (expectedParent.name !== undefined) {
+			expect(parent?.name).toBe(expectedParent.name);
+		}
+		if (expectedParent.hasCustomers !== undefined) {
+			expect(parent?.state.has_customers).toBe(expectedParent.hasCustomers);
+		}
+		if (expectedParent.hasPlanChange === true) {
+			expectPresent(parent?.plan_change);
+		} else if (expectedParent.hasPlanChange === false) {
+			expectAbsent(parent?.plan_change);
+		}
+		if (expectedParent.customize !== undefined) {
+			if (expectedParent.customize === null) {
+				expectAbsent(parent?.plan_change?.customize);
+			} else {
+				expect(parent?.plan_change?.customize).toMatchObject(
+					expectedParent.customize,
+				);
+			}
+		}
+		if (expectedParent.licenseChanges !== undefined) {
+			expectLicenseChangesMatch({
+				actual: parent?.plan_change?.license_changes,
+				expected: expectedParent.licenseChanges,
+			});
+		}
+		if (expectedParent.nestedItemChanges !== undefined) {
+			const actualItems =
+				parent?.plan_change?.license_changes?.[0]?.plan_change
+					?.item_changes ?? [];
+			for (const expectedItem of expectedParent.nestedItemChanges) {
+				expect(actualItems).toContainEqual(
+					expect.objectContaining(expectedItem),
+				);
+			}
+		}
+		if (expectedParent.conflicts !== undefined) {
+			expectConflictsMatch({
+				actual: parent?.conflicts,
+				expected: expectedParent.conflicts,
+			});
+		}
+		if (expectedParent.siblingVersions !== undefined) {
+			expectSiblingVersionsMatch({
+				actual: parent?.sibling_versions,
+				expected: expectedParent.siblingVersions,
+				label: `${expectedParent.planId} sibling_versions`,
+			});
+		}
+	}
 };
 
 const expectSiblingVersionsMatch = ({
@@ -277,6 +373,12 @@ const expectSiblingVersionsMatch = ({
 			expectConflictsMatch({
 				actual: sibling?.conflicts,
 				expected: expectedSibling.conflicts,
+			});
+		}
+		if (expectedSibling.licenseParents !== undefined) {
+			expectLicenseParentsMatch({
+				actual: sibling?.license_parents,
+				expected: expectedSibling.licenseParents,
 			});
 		}
 	}
@@ -447,88 +549,10 @@ export const expectPlanPreviewRowCorrect = ({
 		}
 	}
 	if (expected.licenseParents !== undefined) {
-		if (expected.licenseParents === null) {
-			expect(row.license_parents).toBeUndefined();
-		} else {
-			expect(row.license_parents).toHaveLength(expected.licenseParents.length);
-			for (const expectedParent of expected.licenseParents) {
-				const parent = row.license_parents?.find(
-					(candidate) =>
-						candidate.plan_id === expectedParent.planId &&
-						(expectedParent.version === undefined ||
-							candidate.version === expectedParent.version),
-				);
-				expect(
-					parent,
-					`missing license_parents entry for ${expectedParent.planId}`,
-				).toBeDefined();
-				if (parent) {
-					expectVersionSlugMatch({
-						actual: parent,
-						versionSlug: expectedParent.versionSlug,
-						newVersionSlug: expectedParent.newVersionSlug,
-					});
-				}
-				if (expectedParent.licenseAction !== undefined) {
-					expect(parent?.license_action).toBe(expectedParent.licenseAction);
-				}
-				if (expectedParent.versioning !== undefined) {
-					expect(
-						(parent as { versioning?: PlanPreviewVersioning } | undefined)
-							?.versioning,
-					).toEqual(expectedParent.versioning);
-				}
-				if (expectedParent.name !== undefined) {
-					expect(parent?.name).toBe(expectedParent.name);
-				}
-				if (expectedParent.hasCustomers !== undefined) {
-					expect(parent?.state.has_customers).toBe(expectedParent.hasCustomers);
-				}
-				if (expectedParent.hasPlanChange === true) {
-					expectPresent(parent?.plan_change);
-				} else if (expectedParent.hasPlanChange === false) {
-					expectAbsent(parent?.plan_change);
-				}
-				if (expectedParent.customize !== undefined) {
-					if (expectedParent.customize === null) {
-						expectAbsent(parent?.plan_change?.customize);
-					} else {
-						expect(parent?.plan_change?.customize).toMatchObject(
-							expectedParent.customize,
-						);
-					}
-				}
-				if (expectedParent.licenseChanges !== undefined) {
-					expectLicenseChangesMatch({
-						actual: parent?.plan_change?.license_changes,
-						expected: expectedParent.licenseChanges,
-					});
-				}
-				if (expectedParent.nestedItemChanges !== undefined) {
-					const actualItems =
-						parent?.plan_change?.license_changes?.[0]?.plan_change
-							?.item_changes ?? [];
-					for (const expectedItem of expectedParent.nestedItemChanges) {
-						expect(actualItems).toContainEqual(
-							expect.objectContaining(expectedItem),
-						);
-					}
-				}
-				if (expectedParent.conflicts !== undefined) {
-					expectConflictsMatch({
-						actual: parent?.conflicts,
-						expected: expectedParent.conflicts,
-					});
-				}
-				if (expectedParent.siblingVersions !== undefined) {
-					expectSiblingVersionsMatch({
-						actual: parent?.sibling_versions,
-						expected: expectedParent.siblingVersions,
-						label: `${expectedParent.planId} sibling_versions`,
-					});
-				}
-			}
-		}
+		expectLicenseParentsMatch({
+			actual: row.license_parents,
+			expected: expected.licenseParents,
+		});
 	}
 	if (expected.variants !== undefined) {
 		if (expected.variants === null) {

--- a/server/tests/integration/catalog-v2/plans/preview/utils/expectPlanPreview.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/utils/expectPlanPreview.ts
@@ -397,15 +397,28 @@ export const findPlanPreviewRow = ({
 	planId: string;
 	currentVersion?: number;
 }): PlanPreviewRow => {
-	const row = preview.plans.find(
-		(candidate) =>
-			candidate.plan_id === planId &&
-			(currentVersion === undefined ||
-				candidate.versioning?.current_version === currentVersion),
-	);
+	const row = preview.plans.find((candidate) => {
+		if (candidate.plan_id !== planId) return false;
+		if (currentVersion === undefined) return true;
+		return (
+			candidate.version === currentVersion ||
+			candidate.versioning?.current_version === currentVersion
+		);
+	});
 	const label =
 		currentVersion === undefined ? planId : `${planId} v${currentVersion}`;
-	expect(row, `missing preview row for plan ${label}`).toBeDefined();
+	expect(
+		row,
+		`missing preview row for plan ${label} (have ${JSON.stringify(
+			preview.plans
+				.filter((candidate) => candidate.plan_id === planId)
+				.map((candidate) => ({
+					version: candidate.version,
+					current: candidate.versioning?.current_version,
+					action: candidate.action,
+				})),
+		)})`,
+	).toBeDefined();
 	if (!row) throw new Error(`missing preview row for plan ${label}`);
 	return row;
 };

--- a/server/tests/integration/catalog-v2/plans/variants/licenses/distributed-anchors.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/licenses/distributed-anchors.test.ts
@@ -1,0 +1,144 @@
+/**
+ * catalogV2.update — variant license links ride the same derive fold.
+ *
+ * Contract:
+ *   Team updates the child-v1 license + propagate.variants → EU's link
+ *   follows that write (same fold, no parallel path); both stay on v1.
+ *   Child v2 propagate while both parents still anchor v1 → no row reached.
+ */
+
+import { test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import { expectLicenseLinkCorrect } from "../../licenses/utils/expectLicenseLinkCorrect.js";
+import {
+	bumpChild,
+	getFullPlan,
+	messagesItem,
+	withCatalogPlans,
+} from "../../licenses/utils/seedLicensePlans.js";
+import { seedBaseVariantWithChildLicense } from "../utils/seedVariantPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants: parent v1 license write + propagate.variants rides the derive fold")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_anch_b");
+		const variantId = uniqueTestId("cv2_var_anch_eu");
+		const childId = uniqueTestId("cv2_var_anch_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId, childId],
+			run: async () => {
+				await seedBaseVariantWithChildLicense({
+					autumn: autumnV2_3,
+					baseId,
+					variantId,
+					childId,
+					customizeLicenses: false,
+				});
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					items: [messagesItem(50)],
+					versioning: "new_version",
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId, version: 1 });
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: baseId,
+							licenses: [
+								{
+									license_plan_id: childId,
+									included: 5,
+									version_slug: "v1",
+								},
+							],
+							propagate: { variants: [{ plan_id: variantId }] },
+						},
+					],
+				});
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: baseId,
+					licensePlanId: childId,
+					included: 5,
+					licenseInternalProductId: childV1.internal_id,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: variantId,
+					licensePlanId: childId,
+					included: 5,
+					licenseInternalProductId: childV1.internal_id,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants: child v2 propagate leaves variant parents anchored to v1")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_lag_b");
+		const variantId = uniqueTestId("cv2_var_lag_eu");
+		const childId = uniqueTestId("cv2_var_lag_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId, childId],
+			run: async () => {
+				await seedBaseVariantWithChildLicense({
+					autumn: autumnV2_3,
+					baseId,
+					variantId,
+					childId,
+					customizeLicenses: false,
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					items: [messagesItem(50)],
+					versioning: "new_version",
+				});
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							propagate: {
+								license_parents: [
+									{ plan_id: baseId },
+									{ plan_id: variantId },
+								],
+							},
+						},
+					],
+				});
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: baseId,
+					licensePlanId: childId,
+					customized: false,
+					messagesAllowance: 10,
+					licenseInternalProductId: childV1.internal_id,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: variantId,
+					licensePlanId: childId,
+					customized: false,
+					messagesAllowance: 10,
+					licenseInternalProductId: childV1.internal_id,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/scenarios/catalog/variants/team-eu-seat-distributed-anchors.test.ts
+++ b/server/tests/scenarios/catalog/variants/team-eu-seat-distributed-anchors.test.ts
@@ -1,0 +1,124 @@
+import { test } from "bun:test";
+import { messagesItem } from "@tests/integration/catalog-v2/plans/licenses/utils/seedLicensePlans.js";
+import { seedBaseVariantWithChildLicense } from "@tests/integration/catalog-v2/plans/variants/utils/seedVariantPlans.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	logPlaybook,
+	resetCatalogPlans,
+	seedNamedCustomer,
+} from "../utils/catalogScenario.js";
+
+const teamId = "qa-dva-team";
+const euId = "qa-dva-eu";
+const seatId = "qa-dva-seat";
+
+test(`${chalk.yellowBright("catalog-qa: Team/EU v1→Seat v1, v2→Seat v2")}`, async () => {
+	const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+	await resetCatalogPlans({ ctx, planIds: [teamId, euId, seatId] });
+	await seedBaseVariantWithChildLicense({
+		autumn: autumnV2_3,
+		baseId: teamId,
+		variantId: euId,
+		childId: seatId,
+		customizeLicenses: false,
+	});
+	await autumnV2_3.catalogV2.update({
+		plans: [
+			{ plan_id: teamId, name: "QA Anchor Team" },
+			{ plan_id: euId, name: "QA Anchor EU" },
+			{ plan_id: seatId, name: "QA Anchor Seat" },
+		],
+	});
+	await autumnV2_3.catalogV2.update({
+		plans: [
+			{
+				plan_id: seatId,
+				versioning: "new_version",
+				active: true,
+				items: [messagesItem(20)],
+			},
+		],
+	});
+	await autumnV2_3.catalogV2.update({
+		plans: [
+			{
+				plan_id: teamId,
+				versioning: "new_version",
+				active: true,
+				items: [messagesItem(200)],
+				licenses: [
+					{ license_plan_id: seatId, included: 2, version_slug: "v2" },
+				],
+			},
+		],
+	});
+	await autumnV2_3.catalogV2.update({
+		plans: [
+			{
+				plan_id: euId,
+				versioning: "new_version",
+				active: true,
+				licenses: [
+					{ license_plan_id: seatId, included: 2, version_slug: "v2" },
+				],
+			},
+		],
+	});
+	await seedNamedCustomer({
+		ctx,
+		planId: teamId,
+		customerId: "qa-dva-alice",
+		name: "Alice",
+		version: 1,
+	});
+	await seedNamedCustomer({
+		ctx,
+		planId: teamId,
+		customerId: "qa-dva-bob",
+		name: "Bob",
+		version: 2,
+	});
+	await seedNamedCustomer({
+		ctx,
+		planId: euId,
+		customerId: "qa-dva-dana",
+		name: "Dana",
+		version: 1,
+	});
+	await seedNamedCustomer({
+		ctx,
+		planId: euId,
+		customerId: "qa-dva-eve",
+		name: "Eve",
+		version: 2,
+	});
+	await seedNamedCustomer({
+		ctx,
+		planId: seatId,
+		customerId: "qa-dva-frank",
+		name: "Frank",
+		version: 1,
+	});
+	await seedNamedCustomer({
+		ctx,
+		planId: seatId,
+		customerId: "qa-dva-carol",
+		name: "Carol",
+		version: 2,
+	});
+
+	logPlaybook({
+		title:
+			"Team v1 (Alice) + v2 (Bob), EU v1 (Dana) + v2 (Eve), Seat v1 (Frank) + v2 (Carol). Team/EU v1→Seat v1; Team/EU v2→Seat v2.",
+		steps: [
+			`Open Team latest — Seat link is v2. Open Team v1 — Seat link is v1. Same split on EU.`,
+			`On Seat latest: bump 20→200, follow Team+EU, "Update existing version", migrate → Bob + Eve + Carol. Alice, Dana, Frank stay on Seat v1.`,
+			`Re-run, follow both, "Update all versions", migrate → each parent row follows the Seat version it anchors. All six customers move.`,
+			`On Seat v1: bump items, "Update this version", follow both, migrate → Alice + Dana + Frank. Bob/Eve/Carol stay.`,
+			`Re-run from Seat latest, follow EU only (pin Team) → EU v2 follows, Team v2 stays. Draft has EU + Carol, not Team.`,
+			`"Create new version" on Seat while following Team+EU → no draft. Latest parents re-point to Seat v3; v1 parents stay on Seat v1.`,
+			`Delete Seat This version (v1) → 400 (Team v1 + EU v1 still link). Unlink those parents, then delete works.`,
+		],
+	});
+});

--- a/server/tests/unit/migrations-v2/batch-operations/compute-license-operations.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/compute-license-operations.test.ts
@@ -344,7 +344,7 @@ describe("version link diff", () => {
 		expect(repoints[0]?.planLicenseId).toBe("plan_lic_custom");
 	});
 
-	test("a changed child product rejects the link transition", () => {
+	test("a parent version bump that crosses child versions rejects to per-customer", () => {
 		const { links, rejections } = diff({
 			fromLink: licenseLink({
 				id: "plan_lic_v1",
@@ -357,8 +357,12 @@ describe("version link diff", () => {
 		});
 
 		expect(links).toHaveLength(0);
-		expect(rejections.map(({ code }) => code)).toEqual([
-			"license_link_transition",
+		expect(rejections.map(({ code, message }) => ({ code, message }))).toEqual([
+			{
+				code: "license_link_transition",
+				message:
+					"The target version links a different license product version; runs per-customer.",
+			},
 		]);
 	});
 

--- a/shared/api/catalogV2/planUpdate/params/catalogPropagateParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogPropagateParams.ts
@@ -10,6 +10,10 @@ export const CatalogPropagateTargetParamsSchema = z.object({
 	version: z.number().int().min(1).optional().meta({
 		description: "Which version of the target follows. Omit to target latest.",
 	}),
+	version_slug: z.string().nonempty().regex(idRegex).optional().meta({
+		description:
+			"Which version of the target follows, by slug. Same pin as `version`; omit both to target latest.",
+	}),
 	versioning: CatalogPlanVersioningStrategySchema.optional().meta({
 		description:
 			"How this follow applies across the target's versions. Omit or `existing` = the resolved row only; `all_versions` = every other existing version of the target; `new_version` = mint max+1 on the target.",

--- a/shared/api/catalogV2/planUpdate/preview/catalogLicenseParentPreview.ts
+++ b/shared/api/catalogV2/planUpdate/preview/catalogLicenseParentPreview.ts
@@ -28,10 +28,9 @@ export const CatalogLicenseParentVersionPreviewSchema =
 	});
 
 /**
- * One license parent plan a child-plan edit fans out to, nested under the
- * child's direct preview row. Reports the latest linked version, with any
- * older linked versions under `sibling_versions`. License ops live on
- * plan_change (upsert_licenses / remove_licenses).
+ * One license parent plan whose planLicense points at this child version
+ * row. Older linked versions of the same parent nest under
+ * `sibling_versions`. License ops live on plan_change.
  */
 export const CatalogLicenseParentPreviewSchema =
 	CatalogCorePreviewSchema.extend({

--- a/shared/api/catalogV2/planUpdate/preview/catalogPlanPreview.ts
+++ b/shared/api/catalogV2/planUpdate/preview/catalogPlanPreview.ts
@@ -8,7 +8,7 @@ import {
 	CatalogPlanUsageSchema,
 	emptyCatalogPlanUsage,
 } from "./catalogPlanUsage.js";
-import { CatalogSiblingVersionPreviewSchema } from "./catalogSiblingVersionPreview.js";
+import { CatalogPlanSiblingVersionPreviewSchema } from "./catalogPlanSiblingVersionPreview.js";
 import { CatalogVariantPreviewSchema } from "./catalogVariantPreview.js";
 import { CatalogPlanVersioningSchema } from "./catalogVersioningPreview.js";
 import { PlanAliasReplacementSchema } from "./planAliasReplacement.js";
@@ -35,16 +35,16 @@ export const CatalogPlanUpdatePreviewSchema = CatalogCorePreviewSchema.extend({
 	}),
 	versioning: CatalogPlanVersioningSchema.nullable(),
 	sibling_versions: z
-		.array(CatalogSiblingVersionPreviewSchema)
+		.array(CatalogPlanSiblingVersionPreviewSchema)
 		.optional()
 		.meta({
 			description:
-				"Other existing versions of this plan. Omitted when there are none, or when more than one entry in this update targets the same plan (`all_versions` is unavailable then).",
+				"Other existing versions of this plan. Each may carry `license_parents` for links that still point at that version. Omitted when there are none, or when more than one entry in this update targets the same plan (`all_versions` is unavailable then).",
 		}),
 	license_parents: z.array(CatalogLicenseParentPreviewSchema).optional().meta({
 		internal: true,
 		description:
-			"Parents offering this plan as a license and how each one's planLicense resolves against this entry's change. Omitted when the plan is not a license.",
+			"Parents whose planLicense currently points at this version row, and how each resolves against this entry's change. Omitted when none do.",
 	}),
 	variants: z.array(CatalogVariantPreviewSchema).optional().meta({
 		internal: true,

--- a/shared/api/catalogV2/planUpdate/preview/catalogPlanSiblingVersionPreview.ts
+++ b/shared/api/catalogV2/planUpdate/preview/catalogPlanSiblingVersionPreview.ts
@@ -1,0 +1,23 @@
+import { z } from "zod/v4";
+import { CatalogLicenseParentPreviewSchema } from "./catalogLicenseParentPreview.js";
+import { CatalogSiblingVersionPreviewSchema } from "./catalogSiblingVersionPreview.js";
+
+/**
+ * Another version of a plan `plans[]` row. `license_parents` is who
+ * currently points at THIS version — not the edited row.
+ */
+export const CatalogPlanSiblingVersionPreviewSchema =
+	CatalogSiblingVersionPreviewSchema.extend({
+		license_parents: z
+			.array(CatalogLicenseParentPreviewSchema)
+			.optional()
+			.meta({
+				internal: true,
+				description:
+					"Parents whose planLicense still points at this sibling version. Omitted when none do, or when this version is itself a direct `plans[]` entry.",
+			}),
+	});
+
+export type CatalogPlanSiblingVersionPreview = z.infer<
+	typeof CatalogPlanSiblingVersionPreviewSchema
+>;

--- a/shared/api/models.ts
+++ b/shared/api/models.ts
@@ -20,6 +20,7 @@ export * from "./catalogV2/planUpdate/preview/catalogConflictPreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogCorePreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogLicenseParentPreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogPlanPreview.js";
+export * from "./catalogV2/planUpdate/preview/catalogPlanSiblingVersionPreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogPlanUsage.js";
 export * from "./catalogV2/planUpdate/preview/catalogSiblingVersionPreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogVariantPreview.js";

--- a/shared/api/products/apiPlanLicenseV1.ts
+++ b/shared/api/products/apiPlanLicenseV1.ts
@@ -9,6 +9,10 @@ export const ApiPlanLicenseV1Schema = z.object({
 	version: z.number().int().min(1).meta({
 		description: "The exact license-plan version pinned by this link.",
 	}),
+	version_slug: z.string().optional().meta({
+		description:
+			"Version slug of the license-plan row this link points at.",
+	}),
 	included: z.number().meta({
 		description:
 			"Number of license assignments included with this plan for free.",

--- a/shared/api/products/components/planChange/planLicenseChangeV0.ts
+++ b/shared/api/products/components/planChange/planLicenseChangeV0.ts
@@ -6,6 +6,7 @@ import { PlanChangeCoreV0Schema } from "./planChangeCoreV0.js";
 export const PlanLicensePreviousAttributesV0Schema = ApiPlanLicenseV1Schema.pick(
 	{
 		version: true,
+		version_slug: true,
 		included: true,
 		prepaid_only: true,
 	},

--- a/shared/api/products/crud/licenses/planLicenseParams.ts
+++ b/shared/api/products/crud/licenses/planLicenseParams.ts
@@ -5,6 +5,8 @@ import { LicenseCustomizeSchema } from "../../../../models/licenseModels/license
  * `customize` changes only this link; the license plan itself stays shared. */
 export const PlanLicenseParamsSchema = z.object({
 	license_plan_id: z.string(),
+	/** Child version to anchor to. Stated = that slug's row; omitted keeps the existing link (new links use the child's active row). */
+	version_slug: z.string().optional(),
 	included: z.number().int().min(0).optional(),
 	prepaid_only: z.boolean().optional(),
 	customize: LicenseCustomizeSchema.nullish(),

--- a/shared/models/licenseModels/licenseModels.ts
+++ b/shared/models/licenseModels/licenseModels.ts
@@ -26,6 +26,8 @@ export const PlanLicenseSchema = z.object({
 
 export const CustomizePlanLicenseSchema = z.object({
 	license_plan_id: z.string(),
+	/** Child version to anchor to. Stated = that slug's row; omitted keeps the existing link (new links use the child's active row). */
+	version_slug: z.string().optional(),
 	included: z.number().int().min(0).optional(),
 	prepaid_only: z.boolean().optional(),
 	customize: LicenseCustomizeSchema.nullish(),

--- a/shared/utils/planV1Utils/diff/comparePlanLicenses.ts
+++ b/shared/utils/planV1Utils/diff/comparePlanLicenses.ts
@@ -76,7 +76,8 @@ const metadatasAreSame = (
 	return true;
 };
 
-/** Link snapshot (`ApiPlanLicenseV1`). `version` and expanded `plan` are display. */
+/** Link snapshot (`ApiPlanLicenseV1`). Numeric `version` and expanded `plan` are
+ * display; `version_slug` is the version anchor and is a compared term. */
 export const planLicensesAreSame = ({
 	left,
 	right,
@@ -86,6 +87,7 @@ export const planLicensesAreSame = ({
 }): boolean => {
 	const diffs = {
 		licensePlanId: left.license_plan_id !== right.license_plan_id,
+		versionSlug: left.version_slug !== right.version_slug,
 		included: left.included !== right.included,
 		prepaidOnly: left.prepaid_only !== right.prepaid_only,
 		customize: !licenseCustomizesAreSame({
@@ -107,6 +109,7 @@ export const customizePlanLicensesAreSame = ({
 }): boolean => {
 	const diffs = {
 		licensePlanId: left.license_plan_id !== right.license_plan_id,
+		versionSlug: left.version_slug !== right.version_slug,
 		included: left.included !== right.included,
 		prepaidOnly: left.prepaid_only !== right.prepaid_only,
 		customize: !licenseCustomizePatchesAreSame({

--- a/shared/utils/planV1Utils/diff/diffPlanLicenses.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanLicenses.ts
@@ -16,6 +16,9 @@ const toUpsertLicense = ({
 	clearCustomize?: boolean;
 }): CustomizePlanLicense => ({
 	license_plan_id: license.license_plan_id,
+	...(license.version_slug !== undefined
+		? { version_slug: license.version_slug }
+		: {}),
 	included: license.included,
 	prepaid_only: license.prepaid_only,
 	...(clearCustomize
@@ -30,7 +33,8 @@ const byLicensePlanId = <T extends { license_plan_id: string }>(
 	right: T,
 ): number => left.license_plan_id.localeCompare(right.license_plan_id);
 
-/** Link-field patch. `version` / expanded `plan` are display — ignored.
+/** Link-field patch. Numeric `version` / expanded `plan` are display — ignored;
+ * `version_slug` (the version anchor) is a term.
  * New links are skipped unless `includeAdds` — those are lifecycle, not terms. */
 export const diffPlanLicenses = ({
 	from,

--- a/vite/src/components/plans/PlanVersionScopeItems.tsx
+++ b/vite/src/components/plans/PlanVersionScopeItems.tsx
@@ -17,12 +17,14 @@ export function PlanVersionScopeItems({
 	selectedKeys,
 	onChange,
 	renderVersionSuffix,
+	versionLabel,
 }: {
 	planId: string;
 	versions: number[];
 	selectedKeys: string[];
 	onChange: (next: string[]) => void;
 	renderVersionSuffix?: (version: number) => ReactNode;
+	versionLabel?: (version: number) => string;
 }) {
 	const isWholePlan = planScopeIsWholePlan({ selectedKeys, planId });
 
@@ -59,7 +61,9 @@ export function PlanVersionScopeItems({
 						className="border-border"
 						indeterminate={isWholePlan}
 					/>
-					<span className="flex-1">v{version}</span>
+					<span className="flex-1">
+						{versionLabel?.(version) ?? `v${version}`}
+					</span>
 					{renderVersionSuffix?.(version)}
 				</DropdownMenuItem>
 			))}

--- a/vite/src/views/products/plan/catalog/catalogPlanPreview.ts
+++ b/vite/src/views/products/plan/catalog/catalogPlanPreview.ts
@@ -114,6 +114,59 @@ export const catalogPreviewHasVersionSlugChange = ({
 	preview: CatalogPlanUpdatePreview | undefined;
 }): boolean => catalogPreviewVersionSlugChange({ preview }) !== undefined;
 
+const parentVersionsOf = ({
+	parent,
+}: {
+	parent: CatalogLicenseParentPreview;
+}): CatalogLicenseParentVersionPreview[] => {
+	const { sibling_versions: _siblings, ...row } = parent;
+	return [row, ...(parent.sibling_versions ?? [])];
+};
+
+/** Fold every parent version (direct row + sibling-linked) into one lane per plan. */
+export const catalogPlanLicenseParents = ({
+	preview,
+}: {
+	preview: CatalogPlanUpdatePreview | undefined;
+}): CatalogLicenseParentPreview[] => {
+	if (!preview) return [];
+	const byPlanId = new Map<
+		string,
+		{ name: string; versions: Map<number, CatalogLicenseParentVersionPreview> }
+	>();
+
+	const ingest = (parent: CatalogLicenseParentPreview) => {
+		const existing = byPlanId.get(parent.plan_id) ?? {
+			name: parent.name,
+			versions: new Map(),
+		};
+		existing.name = parent.name;
+		for (const version of parentVersionsOf({ parent })) {
+			existing.versions.set(version.version, version);
+		}
+		byPlanId.set(parent.plan_id, existing);
+	};
+
+	for (const sibling of preview.sibling_versions ?? []) {
+		for (const parent of sibling.license_parents ?? []) ingest(parent);
+	}
+	for (const parent of preview.license_parents ?? []) ingest(parent);
+
+	return [...byPlanId.entries()]
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([, { name, versions }]) => {
+			const newestFirst = [...versions.values()].sort(
+				(left, right) => right.version - left.version,
+			);
+			const [top, ...siblings] = newestFirst;
+			return {
+				...top,
+				name,
+				...(siblings.length > 0 ? { sibling_versions: siblings } : {}),
+			};
+		});
+};
+
 export const catalogPreviewOpensDialog = ({
 	preview,
 }: {
@@ -130,7 +183,7 @@ export const catalogPreviewOpensDialog = ({
 	return (
 		previewOpensStrategyStep({ preview }) ||
 		(preview?.variants?.length ?? 0) > 0 ||
-		(preview?.license_parents?.length ?? 0) > 0
+		catalogPlanLicenseParents({ preview }).length > 0
 	);
 };
 
@@ -449,6 +502,7 @@ export type LicenseParentTarget = {
 
 export type LicenseParentVersion = {
 	version: number;
+	versionSlug?: string;
 	key: string;
 	conflicts: CatalogConflictPreview[];
 } & CatalogPlanChangeDiff;
@@ -463,6 +517,7 @@ export const toLicenseParentTargets = ({
 		name: parent.name,
 		versions: licenseParentVersions({ parent }).map((entry) => ({
 			version: entry.version,
+			...(entry.version_slug ? { versionSlug: entry.version_slug } : {}),
 			key: getLicenseParentVersionKey(entry),
 			conflicts: entry.conflicts ?? [],
 			...planChangeToTargetDiff({ planChange: entry.plan_change }),
@@ -492,16 +547,24 @@ export const licenseParentVersionsInScope = ({
 /** Plan-selection keys → propagate targets. Whole plan means `all_versions`. */
 export const buildSelectedLicenseParentPropagate = ({
 	selectedKeys,
+	targets = [],
 }: {
 	selectedKeys: string[];
+	targets?: LicenseParentTarget[];
 }): NonNullable<CatalogPropagateParams["license_parents"]> =>
-	selectedKeys
-		.map(parsePlanKey)
-		.map(({ planId, version }) =>
-			version === undefined
-				? { plan_id: planId, versioning: "all_versions" as const }
-				: { plan_id: planId, version },
-		);
+	selectedKeys.map(parsePlanKey).map(({ planId, version }) => {
+		if (version === undefined) {
+			return { plan_id: planId, versioning: "all_versions" as const };
+		}
+		const versionSlug = targets
+			.find((target) => target.planId === planId)
+			?.versions.find((entry) => entry.version === version)?.versionSlug;
+		return {
+			plan_id: planId,
+			version,
+			...(versionSlug ? { version_slug: versionSlug } : {}),
+		};
+	});
 
 export type CatalogMigrateTargetRole = "base" | "variant" | "license_parent";
 
@@ -575,7 +638,7 @@ const buildLicenseParentMigrateTargets = ({
 	isNewVersion: boolean;
 }): CatalogMigrateTarget[] => {
 	const targets: CatalogMigrateTarget[] = [];
-	for (const parent of preview.license_parents ?? []) {
+	for (const parent of catalogPlanLicenseParents({ preview })) {
 		const selectedByScope = licenseParentVersions({ parent }).filter((entry) =>
 			licenseParentVersionIsSelected({
 				planId: parent.plan_id,

--- a/vite/src/views/products/plan/catalog/resolvePlanChangePreview.ts
+++ b/vite/src/views/products/plan/catalog/resolvePlanChangePreview.ts
@@ -14,6 +14,7 @@ import {
 import {
 	buildCatalogPropagate,
 	buildSelectedLicenseParentPropagate,
+	catalogPlanLicenseParents,
 	type CatalogVersionChoice,
 	isCatalogMetadataOnly,
 	type LicenseParentTarget,
@@ -145,7 +146,7 @@ export const resolvePlanChangePreview = ({
 		: EMPTY_SELECTION;
 
 	const licenseParentTargets = toLicenseParentTargets({
-		parents: preview?.license_parents,
+		parents: catalogPlanLicenseParents({ preview }),
 	});
 	const defaultLicenseParentKeys = getDefaultLicenseParentKeys({
 		targets: licenseParentTargets,
@@ -178,7 +179,7 @@ export const resolvePlanChangePreview = ({
 		showLicenseParentScope,
 		versionChoiceOnlyAffectsParents:
 			!preview?.state.has_customers &&
-			(preview?.license_parents ?? []).some((parent) =>
+			catalogPlanLicenseParents({ preview }).some((parent) =>
 				licenseParentVersions({ parent }).some(
 					(entry) => entry.state.has_customers,
 				),
@@ -188,6 +189,7 @@ export const resolvePlanChangePreview = ({
 			variantIds: effectiveVariantIds,
 			licenseParents: buildSelectedLicenseParentPropagate({
 				selectedKeys: effectiveLicenseParentKeys,
+				targets: licenseParentTargets,
 			}),
 		}),
 		settingsChanges: previousAttributesToSettingChanges(

--- a/vite/src/views/products/plan/catalog/usePlanChangeCatalogPreview.ts
+++ b/vite/src/views/products/plan/catalog/usePlanChangeCatalogPreview.ts
@@ -17,6 +17,7 @@ import {
 	applyLicenseParentScopedDiffs,
 	applyPropagationTargetDiffs,
 	buildCatalogMigrateTargets,
+	catalogPlanLicenseParents,
 	type CatalogVersionChoice,
 	getLicenseParentVersionKey,
 	hasCatalogMigrationTargets,
@@ -110,7 +111,7 @@ export const usePlanChangeCatalogPreview = ({
 		targets: model.licenseParentTargets,
 		fallbackDiff,
 		scopedByKey: new Map(
-			(scopedPreview?.license_parents ?? []).flatMap((parent) =>
+			catalogPlanLicenseParents({ preview: scopedPreview }).flatMap((parent) =>
 				licenseParentVersions({ parent }).map(
 					(entry) =>
 						[getLicenseParentVersionKey(entry), entry.plan_change ?? null] as [

--- a/vite/src/views/products/plan/components/VersionSlugBadge.tsx
+++ b/vite/src/views/products/plan/components/VersionSlugBadge.tsx
@@ -4,7 +4,7 @@ import { StackIcon } from "@phosphor-icons/react";
 /** Slugs are free text and can outgrow the header, so the tooltip carries the full value. */
 export const VersionSlugBadge = ({ slug }: { slug: string }) => (
 	<Tooltip>
-		<TooltipTrigger>
+		<TooltipTrigger className="shrink-0">
 			<IconBadge variant="muted" icon={<StackIcon />}>
 				<span className="max-w-30 text-tiny-id truncate">{slug}</span>
 			</IconBadge>

--- a/vite/src/views/products/plan/components/plan-licenses/BackToPlanButton.tsx
+++ b/vite/src/views/products/plan/components/plan-licenses/BackToPlanButton.tsx
@@ -1,9 +1,10 @@
 import { IconButton } from "@autumn/ui";
 import { ArrowLeftIcon } from "@phosphor-icons/react";
-import { parseAsString, useQueryStates } from "nuqs";
+import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useNavigate } from "react-router";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { pushPage } from "@/utils/genUtils";
+import { parentPlanEditorQueryParams } from "./planLicenseNavigation";
 
 /**
  * Shown on a license's editor page only when arrived from a plan (the `fromPlan`
@@ -11,7 +12,10 @@ import { pushPage } from "@/utils/genUtils";
  */
 export const BackToPlanButton = () => {
 	const navigate = useNavigate();
-	const [{ fromPlan }] = useQueryStates({ fromPlan: parseAsString });
+	const [{ fromPlan, fromPlanVersion }] = useQueryStates({
+		fromPlan: parseAsString,
+		fromPlanVersion: parseAsInteger,
+	});
 	const { products } = useProductsQuery();
 
 	if (!fromPlan) return null;
@@ -29,6 +33,9 @@ export const BackToPlanButton = () => {
 				pushPage({
 					navigate,
 					path: `/products/${fromPlan}`,
+					queryParams: parentPlanEditorQueryParams({
+						parentVersion: fromPlanVersion,
+					}),
 					preserveParams: false,
 				})
 			}

--- a/vite/src/views/products/plan/components/plan-licenses/LicensePlanCardHeader.tsx
+++ b/vite/src/views/products/plan/components/plan-licenses/LicensePlanCardHeader.tsx
@@ -25,6 +25,10 @@ import {
 import { cn } from "@/lib/utils";
 import { pushPage } from "@/utils/genUtils";
 import { checkItemIsValid } from "@/utils/product/entitlementUtils";
+import { useProductQuery } from "@/views/products/product/hooks/useProductQuery";
+import { VersionSlugBadge } from "../VersionSlugBadge";
+import { versionLabel } from "../versionLabel";
+import { licenseEditorQueryParams } from "./planLicenseNavigation";
 import { usePendingLicenseLinks } from "./PendingLicenseLinksContext";
 import { useLicenseDraft, useLicenseDraftStore } from "./useLicenseDraftStore";
 
@@ -40,6 +44,7 @@ export function LicensePlanCardHeader({
 }) {
 	const navigate = useNavigate();
 	const { product } = useProduct();
+	const { product: parentPlan } = useProductQuery();
 	const { setSheet } = useSheet();
 	const item = useCurrentItem();
 	const patchDraft = useLicenseDraftStore((s) => s.patch);
@@ -79,6 +84,18 @@ export function LicensePlanCardHeader({
 		setSheet({ type: "edit-plan", itemId: product.id });
 	};
 
+	const openLicense = () => {
+		pushPage({
+			navigate,
+			path: `/products/${license.id}`,
+			queryParams: licenseEditorQueryParams({
+				parentPlanId: planLicense.parent_plan_id,
+				parentVersion: parentPlan?.version,
+				licenseVersion: license.version,
+			}),
+		});
+	};
+
 	const removeCard = () => {
 		// A staged (unsaved) link has nothing to soft-delete — drop it outright.
 		if (isPendingLink) {
@@ -88,16 +105,24 @@ export function LicensePlanCardHeader({
 		patchDraft(license.id, { removed: true });
 	};
 
-	if (removed) {
-		return (
-			<CardHeader className="px-3">
-				<div className="flex items-center justify-between w-full gap-2 min-w-0">
-					<div className="flex items-center gap-2 text-xs min-w-0">
-						{licenseName}
+	return (
+		<CardHeader className="px-3">
+			<div className="flex items-center justify-between w-full gap-2 min-w-0">
+				<div className="flex items-center gap-2 text-xs min-w-0">
+					{licenseName}
+					<VersionSlugBadge
+						slug={versionLabel({
+							versionSlug: license.version_slug,
+							version: license.version,
+						})}
+					/>
+					{removed && (
 						<span className="shrink-0 text-tertiary-foreground">
 							Removed on save
 						</span>
-					</div>
+					)}
+				</div>
+				{removed ? (
 					<Button
 						variant="secondary"
 						size="sm"
@@ -106,72 +131,57 @@ export function LicensePlanCardHeader({
 					>
 						Undo
 					</Button>
-				</div>
-			</CardHeader>
-		);
-	}
-
-	return (
-		<CardHeader className="px-3">
-			<div className="flex items-center justify-between w-full gap-2 min-w-0">
-				<div className="flex items-center gap-2 text-xs min-w-0">
-					{licenseName}
-				</div>
-				<div className="flex items-center gap-1 shrink-0">
-					<DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-						<DropdownMenuTrigger asChild>
-							<IconButton
-								aria-label={`${license.name ?? license.id} actions`}
-								icon={<EllipsisVerticalIcon />}
-								iconOrientation="center"
-								size="mini"
-								variant="secondary"
-								className={cn(menuOpen && "btn-secondary-active")}
-							/>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end">
-							<DropdownMenuItem
-								className="flex items-center text-xs"
-								onClick={() => openSettings()}
-							>
-								<div className="flex items-center gap-2">
-									<PencilSimpleIcon
-										size={12}
-										className="text-tertiary-foreground"
-									/>
-									License Settings
-								</div>
-							</DropdownMenuItem>
-							<DropdownMenuItem
-								className="flex items-center text-xs"
-								onClick={() =>
-									pushPage({
-										navigate,
-										path: `/products/${license.id}`,
-										queryParams: { fromPlan: planLicense.parent_plan_id },
-									})
-								}
-							>
-								<div className="flex items-center gap-2">
-									<ArrowRightIcon
-										size={12}
-										className="text-tertiary-foreground"
-									/>
-									Go to License
-								</div>
-							</DropdownMenuItem>
-							<DropdownMenuItem
-								className="flex items-center text-xs"
-								onClick={() => removeCard()}
-							>
-								<div className="flex items-center gap-2">
-									<TrashIcon size={12} className="text-tertiary-foreground" />
-									Remove
-								</div>
-							</DropdownMenuItem>
-						</DropdownMenuContent>
-					</DropdownMenu>
-				</div>
+				) : (
+					<div className="flex items-center gap-1 shrink-0">
+						<DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+							<DropdownMenuTrigger asChild>
+								<IconButton
+									aria-label={`${license.name ?? license.id} actions`}
+									icon={<EllipsisVerticalIcon />}
+									iconOrientation="center"
+									size="mini"
+									variant="secondary"
+									className={cn(menuOpen && "btn-secondary-active")}
+								/>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end">
+								<DropdownMenuItem
+									className="flex items-center text-xs"
+									onClick={() => openSettings()}
+								>
+									<div className="flex items-center gap-2">
+										<PencilSimpleIcon
+											size={12}
+											className="text-tertiary-foreground"
+										/>
+										License Settings
+									</div>
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									className="flex items-center text-xs"
+									onClick={openLicense}
+								>
+									<div className="flex items-center gap-2">
+										<ArrowRightIcon
+											size={12}
+											className="text-tertiary-foreground"
+										/>
+										Go to License
+									</div>
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									className="flex items-center text-xs"
+									onClick={() => removeCard()}
+								>
+									<div className="flex items-center gap-2">
+										<TrashIcon size={12} className="text-tertiary-foreground" />
+										Remove
+									</div>
+								</DropdownMenuItem>
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</div>
+				)}
 			</div>
 		</CardHeader>
 	);

--- a/vite/src/views/products/plan/components/plan-licenses/planLicenseNavigation.ts
+++ b/vite/src/views/products/plan/components/plan-licenses/planLicenseNavigation.ts
@@ -1,0 +1,24 @@
+/** Opens the license editor on the anchored child row, with a return path to the parent version. */
+export const licenseEditorQueryParams = ({
+	parentPlanId,
+	parentVersion,
+	licenseVersion,
+}: {
+	parentPlanId: string;
+	parentVersion?: number;
+	licenseVersion: number;
+}): Record<string, string | undefined> => ({
+	fromPlan: parentPlanId,
+	fromPlanVersion:
+		parentVersion === undefined ? undefined : String(parentVersion),
+	version: String(licenseVersion),
+});
+
+export const parentPlanEditorQueryParams = ({
+	parentVersion,
+}: {
+	parentVersion?: number | null;
+}): Record<string, string> | undefined => {
+	if (parentVersion == null) return undefined;
+	return { version: String(parentVersion) };
+};

--- a/vite/src/views/products/plan/versioning/LicenseParentTargetsStep.tsx
+++ b/vite/src/views/products/plan/versioning/LicenseParentTargetsStep.tsx
@@ -111,9 +111,10 @@ function LicenseParentScopeControl({
 	onChange: (next: string[]) => void;
 }) {
 	if (versions.length <= 1) {
+		const only = versions[0];
 		return (
 			<span className="shrink-0 font-mono text-tertiary-foreground text-xs">
-				v{versions[0]?.version ?? 1}
+				{only?.versionSlug ?? `v${only?.version ?? 1}`}
 			</span>
 		);
 	}
@@ -144,6 +145,10 @@ function LicenseParentScopeControl({
 						) : null
 					}
 					selectedKeys={selectedKeys}
+					versionLabel={(version) =>
+						versions.find((entry) => entry.version === version)?.versionSlug ??
+						`v${version}`
+					}
 					versions={versions.map((entry) => entry.version)}
 				/>
 			</DropdownMenuContent>

--- a/vite/tests/views/products/plan/catalog/catalog-plan-preview.test.ts
+++ b/vite/tests/views/products/plan/catalog/catalog-plan-preview.test.ts
@@ -8,6 +8,7 @@ import {
 	buildCatalogMigrateTargets,
 	buildCatalogPropagate,
 	buildSelectedLicenseParentPropagate,
+	catalogPlanLicenseParents,
 	catalogPreviewAliasReplacements,
 	catalogPreviewHasPlanIdChange,
 	catalogPreviewHasPromotion,
@@ -246,6 +247,132 @@ describe("catalog plan preview helpers", () => {
 				}),
 			}),
 		).toBe(true);
+	});
+
+	test("flattens sibling_versions.license_parents for the dialog list", () => {
+		const preview = planPreview({
+			plan_id: "seat",
+			version: 2,
+			sibling_versions: [
+				{
+					plan_id: "seat",
+					version: 1,
+					state: { has_customers: false, will_archive: false },
+					license_parents: [
+						{
+							plan_id: "team",
+							name: "Team",
+							version: 1,
+							license_action: "unchanged",
+							state: { has_customers: true, will_archive: false },
+						},
+					],
+				},
+			],
+		});
+		expect(catalogPlanLicenseParents({ preview }).map((p) => p.plan_id)).toEqual(
+			["team"],
+		);
+	});
+
+	test("merges sibling-linked parent versions into the same parent plan", () => {
+		const preview = planPreview({
+			plan_id: "seat",
+			version: 2,
+			license_parents: [
+				{
+					plan_id: "team",
+					name: "QA Anchor Team",
+					version: 2,
+					version_slug: "v2",
+					license_action: "propagated",
+					state: { has_customers: true, will_archive: false },
+				},
+				{
+					plan_id: "eu",
+					name: "QA Anchor EU",
+					version: 2,
+					version_slug: "v2",
+					license_action: "propagated",
+					state: { has_customers: false, will_archive: false },
+				},
+			],
+			sibling_versions: [
+				{
+					plan_id: "seat",
+					version: 1,
+					state: { has_customers: false, will_archive: false },
+					license_parents: [
+						{
+							plan_id: "team",
+							name: "QA Anchor Team",
+							version: 1,
+							version_slug: "v1",
+							license_action: "propagated",
+							state: { has_customers: true, will_archive: false },
+						},
+						{
+							plan_id: "eu",
+							name: "QA Anchor EU",
+							version: 1,
+							version_slug: "v1",
+							license_action: "propagated",
+							state: { has_customers: false, will_archive: false },
+						},
+					],
+				},
+			],
+		});
+
+		const parents = catalogPlanLicenseParents({ preview });
+		expect(toLicenseParentTargets({ parents })).toEqual([
+			{
+				planId: "eu",
+				name: "QA Anchor EU",
+				versions: [
+					{
+						version: 2,
+						versionSlug: "v2",
+						key: "eu:2",
+						conflicts: [],
+						...emptyCatalogPlanChangeDiff(),
+					},
+					{
+						version: 1,
+						versionSlug: "v1",
+						key: "eu:1",
+						conflicts: [],
+						...emptyCatalogPlanChangeDiff(),
+					},
+				],
+			},
+			{
+				planId: "team",
+				name: "QA Anchor Team",
+				versions: [
+					{
+						version: 2,
+						versionSlug: "v2",
+						key: "team:2",
+						conflicts: [],
+						...emptyCatalogPlanChangeDiff(),
+					},
+					{
+						version: 1,
+						versionSlug: "v1",
+						key: "team:1",
+						conflicts: [],
+						...emptyCatalogPlanChangeDiff(),
+					},
+				],
+			},
+		]);
+		expect(
+			buildSelectedLicenseParentPropagate({
+				selectedKeys: ["team:1"],
+				targets: toLicenseParentTargets({ parents }),
+			}),
+		).toEqual([{ plan_id: "team", version: 1, version_slug: "v1" }]);
 	});
 
 	test("a version slug rename opens a confirm-only Review on its own", () => {

--- a/vite/tests/views/products/plan/catalog/resolve-plan-change-preview.test.ts
+++ b/vite/tests/views/products/plan/catalog/resolve-plan-change-preview.test.ts
@@ -191,6 +191,116 @@ describe("resolvePlanChangePreview", () => {
 		});
 	});
 
+	test("all_versions makes sibling-linked parent versions independently selectable", () => {
+		const preview = planPreview({
+			plan_id: "seat",
+			version: 2,
+			versioning: {
+				current_version: 2,
+				new_version: null,
+				resolved: "all_versions",
+				options: ["existing", "all_versions"],
+			},
+			license_parents: [
+				{
+					plan_id: "team",
+					name: "Team",
+					version: 2,
+					version_slug: "v2",
+					license_action: "propagated",
+					state: { has_customers: true, will_archive: false },
+					conflicts: [],
+				},
+			],
+			sibling_versions: [
+				{
+					plan_id: "seat",
+					version: 1,
+					state: { has_customers: false, will_archive: false },
+					license_parents: [
+						{
+							plan_id: "team",
+							name: "Team",
+							version: 1,
+							version_slug: "v1",
+							license_action: "propagated",
+							state: { has_customers: true, will_archive: false },
+							conflicts: [],
+						},
+					],
+				},
+			],
+		});
+
+		const model = resolvePlanChangePreview({
+			preview,
+			versionChoice: "all",
+			variantSelection: null,
+			licenseParentSelection: null,
+			isLatest: true,
+			namesByPlanId: {},
+		});
+
+		expect(model.licenseParentTargets[0]?.versions.map((v) => v.version)).toEqual(
+			[2, 1],
+		);
+		expect(model.defaultLicenseParentKeys).toEqual(["team"]);
+		expect(model.propagate).toEqual({
+			license_parents: [{ plan_id: "team", versioning: "all_versions" }],
+		});
+
+		const pinnedV1 = resolvePlanChangePreview({
+			preview,
+			versionChoice: "all",
+			variantSelection: null,
+			licenseParentSelection: ["team:1"],
+			isLatest: true,
+			namesByPlanId: {},
+		});
+		expect(pinnedV1.propagate).toEqual({
+			license_parents: [{ plan_id: "team", version: 1, version_slug: "v1" }],
+		});
+	});
+
+	test("discovers parents nested on sibling_versions of the edited child", () => {
+		const preview = planPreview({
+			plan_id: "seat",
+			version: 2,
+			license_parents: undefined,
+			sibling_versions: [
+				{
+					plan_id: "seat",
+					version: 1,
+					state: { has_customers: false, will_archive: false },
+					license_parents: [
+						{
+							plan_id: "team",
+							name: "Team",
+							version: 1,
+							license_action: "unchanged",
+							state: { has_customers: true, will_archive: false },
+							conflicts: [],
+						},
+					],
+				},
+			],
+		});
+
+		const model = resolvePlanChangePreview({
+			preview,
+			versionChoice: "update",
+			variantSelection: null,
+			licenseParentSelection: ["team:1"],
+			isLatest: true,
+			namesByPlanId: {},
+		});
+
+		expect(model.showLicenseParentScope).toBe(true);
+		expect(model.propagate).toEqual({
+			license_parents: [{ plan_id: "team", version: 1 }],
+		});
+	});
+
 	test("all_versions includes historical variant conflicts in default selection", () => {
 		const preview = planPreview({
 			versioning: {


### PR DESCRIPTION
## Summary
- Parent `plan_license` rows stay on the child version they point at. Child mint/promote no longer auto-repoints; follow is `propagate.license_parents`, and an explicit `licenses[].version_slug` is the only declared move.
- Child `all_versions` follow applies each parent version from the child sibling it is actually anchored to (content only — no relink). `version_slug` can pin a specific parent version.
- Dashboard: Go to License opens the anchored child version, the child card shows the slug badge, and Save plan changes → Parents lists sibling-linked parent versions (Team/EU v1 next to v2).

## Test plan
- [ ] `bun t server/tests/integration/catalog-v2/plans/licenses/mix/all-versions-parent-version-anchors.test.ts --headless`
- [ ] `bun t server/tests/integration/catalog-v2/plans/licenses/declared/declared-version-anchor.test.ts --headless`
- [ ] `bun t server/tests/integration/catalog-v2/plans/licenses/lifecycle/anchored-version-remove.test.ts --headless`
- [ ] On the dashboard: open a parent v1 whose seat is anchored to child v1, confirm the child badge and Go to License land on that version
- [ ] Edit child v2 in place with Update all versions; confirm Parents lists Team/EU v1 and v2, and following All versions does not relink v1 → child v2


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parent license links now stay anchored to the child version they point at instead of re-pointing to the newest child version when the child mints a new version or promotes. A `version_slug` in `licenses[]` is the only declared move; omitting it keeps the existing link, and new links default to the child's active row.

**Behavior changes**

- Child `all_versions` follow applies each parent version from the child sibling it is anchored to, leaving anchors in place.
- Removing or archiving a child version that parents still link to returns a 400 that names the parent plans.
- The dashboard "Go to License" opens the anchored child version, and the license parents list shows sibling-linked parent versions (for example Team/EU v1 next to v2).

Callers that relied on links automatically following a child mint or promote must now pass `version_slug` (or use propagate) to move them.

<sup>Written for commit e637862489ee75d4f4295607e40d108d9a2d79a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

