### PR TITLE
fix: restarting the billing cycle grants a fresh balance

### DIFF
--- a/server/src/internal/billing/v2/compute/computeAutumnUtils/computeRetainedCustomerEntitlementUpdates.ts
+++ b/server/src/internal/billing/v2/compute/computeAutumnUtils/computeRetainedCustomerEntitlementUpdates.ts
@@ -5,6 +5,7 @@ import {
 	cusProductToProduct,
 	featureUtils,
 	isBooleanEntitlement,
+	isLifetimeEntitlement,
 	isOneOffPrepaidConsumableCustomerEntitlement,
 	isUnlimitedEntitlement,
 	type UpdateSubscriptionBillingContext,
@@ -39,12 +40,18 @@ export const computeRetainedCustomerEntitlementUpdates = ({
 	const updates: NonNullable<AutumnBillingPlan["updateCustomerEntitlements"]> =
 		[];
 
+	const grantsOnlyCycleBoundBalances =
+		updateSubscriptionContext.requestedBillingCycleAnchor === "now";
+
 	for (const customerEntitlement of finalCustomerProduct.customer_entitlements) {
 		const { entitlement } = customerEntitlement;
+		const outlivesBillingCycle =
+			grantsOnlyCycleBoundBalances && isLifetimeEntitlement({ entitlement });
 		const resetsCustomerEntitlementUsage =
 			!isBooleanEntitlement({ entitlement }) &&
 			!isUnlimitedEntitlement({ entitlement }) &&
 			!featureUtils.isAllocated(entitlement.feature) &&
+			!outlivesBillingCycle &&
 			!isOneOffPrepaidConsumableCustomerEntitlement(
 				addCusProductToCusEnt({
 					cusEnt: customerEntitlement,

--- a/server/tests/integration/billing/update-subscription/params/billing-cycle-anchor/update-sub-anchor-now-resets-usage.test.ts
+++ b/server/tests/integration/billing/update-subscription/params/billing-cycle-anchor/update-sub-anchor-now-resets-usage.test.ts
@@ -1,0 +1,71 @@
+import { test } from "bun:test";
+import type { UpdateSubscriptionV1ParamsInput } from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { addMonths } from "date-fns";
+
+/** `billing_cycle_anchor` is rejected alongside `feature_quantities`, so
+ * resizing a plan and restarting its cycle are necessarily two calls. This
+ * covers the anchor-only call that follows the resize. */
+test.concurrent(
+	`${chalk.yellowBright("update-sub anchor now: restarting the cycle on the same plan grants a fresh balance")}`,
+	async () => {
+		const customerId = "update-sub-anchor-now-resets-usage";
+		const pro = products.base({
+			id: "pro",
+			items: [
+				items.prepaidMessages({ billingUnits: 1, price: 0.34 }),
+				items.monthlyPrice({ price: 20 }),
+			],
+		});
+
+		const { autumnV2_3, advancedTo } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity: 1000 }],
+				}),
+				s.advanceTestClock({ days: 14 }),
+			],
+		});
+
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: 400,
+			},
+			{ timeout: 2000 },
+		);
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			billing_cycle_anchor: "now",
+		});
+
+		await expectBalanceCorrect({
+			customerId,
+			autumn: autumnV2_3,
+			featureId: TestFeature.Messages,
+			planId: pro.id,
+			nextResetAt: addMonths(advancedTo, 1).getTime(),
+		});
+		await expectBalanceCorrect({
+			customerId,
+			autumn: autumnV2_3,
+			featureId: TestFeature.Messages,
+			remaining: 1000,
+			usage: 0,
+		});
+	},
+);

--- a/shared/models/billingModels/context/billingContextResetsUsage.ts
+++ b/shared/models/billingModels/context/billingContextResetsUsage.ts
@@ -10,11 +10,12 @@ export const billingContextResetsUsage = (billingContext: unknown): boolean => {
 		intent?: unknown;
 		requestedBillingCycleAnchor?: number | "now";
 	} | null;
-	if (!context || context.carryOverUsages?.enabled === true) return false;
+	const carriesUsagesOver = context?.carryOverUsages?.enabled === true;
+	if (carriesUsagesOver) return false;
 
-	const restartsBillingCycle = context.requestedBillingCycleAnchor === "now";
+	const restartsBillingCycle = context?.requestedBillingCycleAnchor === "now";
 	const replacesPlan =
-		context.intent === UpdateSubscriptionIntent.UpdatePlan &&
+		context?.intent === UpdateSubscriptionIntent.UpdatePlan &&
 		context.carryOverUsages?.enabled === false;
 
 	return restartsBillingCycle || replacesPlan;

--- a/shared/models/billingModels/context/billingContextResetsUsage.ts
+++ b/shared/models/billingModels/context/billingContextResetsUsage.ts
@@ -8,9 +8,14 @@ export const billingContextResetsUsage = (billingContext: unknown): boolean => {
 	const context = billingContext as {
 		carryOverUsages?: CarryOverUsages;
 		intent?: unknown;
+		requestedBillingCycleAnchor?: number | "now";
 	} | null;
-	return (
-		context?.intent === UpdateSubscriptionIntent.UpdatePlan &&
-		context.carryOverUsages?.enabled === false
-	);
+	if (!context || context.carryOverUsages?.enabled === true) return false;
+
+	const restartsBillingCycle = context.requestedBillingCycleAnchor === "now";
+	const replacesPlan =
+		context.intent === UpdateSubscriptionIntent.UpdatePlan &&
+		context.carryOverUsages?.enabled === false;
+
+	return restartsBillingCycle || replacesPlan;
 };


### PR DESCRIPTION
Reported by Bloom: they restarted a customer's billing cycle, the customer was charged $340, and no new credits arrived. Ray had to top the balance up by hand.

## What happened

An update with `billing_cycle_anchor: "now"` moved `reset_cycle_anchor` and `next_reset_at` but left the balance untouched.

`billingContextResetsUsage` only treated a transition as usage-resetting when the intent was `UpdatePlan` **and** `carry_over_usages` was explicitly disabled. An anchor-only update resolves to intent `None`, and Bloom has no org transition rule, so both conditions failed. The computed plan carried cycle-anchor updates and no balance reset:

```
updateCustomerEntitlements: images: {"reset_cycle_anchor":...,"next_reset_at":...}
```

The deferred/invoice-mode webhook path was **not** at fault — it executed and applied exactly what the plan contained. The plan was already incomplete when computed, 12 minutes before payment.

## The fix

Treat an immediate anchor restart as usage-resetting on its own: it opens a new billing period the same way a renewal does. An explicit `carry_over_usages: { enabled: true }` still wins.

Anchor restarts refresh only cycle-bound grants, so lifetime balances are left alone — without that, the existing `lifetime entitlement stays lifetime` test regresses 60 → 100.

`billingContextResetsUsage` is shared by preview and executor by design, so both move together.

## Tests

New: `update-sub-anchor-now-resets-usage.test.ts`, reproducing the customer's exact request shape (anchor-only, no `carry_over_usages`).

- Pre-fix: `Expected: 1000, Received: 600` — the 400 consumed credits were never cleared.
- Post-fix: passes.

All 11 files in `params/billing-cycle-anchor/` pass (24 tests), plus `preview-resets-usage`.

`update-sub-anchor-renewal.test.ts` fails on this branch, but it fails identically on a clean `dev` — pre-existing and unrelated (verified by stashing).

## Notes

- `billing_cycle_anchor` is still rejected alongside `feature_quantities`, so resizing a plan and restarting its cycle remain two calls. This fixes the anchor-only second call. Whether to relax that guard is a separate decision.
- Bloom's affected customer was patched manually. No backfill has run for any other customer this may have hit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes billing cycle restarts so `billing_cycle_anchor: "now"` grants a fresh balance instead of charging customers without delivering new credits.

**Bug Fixes**
- Anchor-only updates previously moved `reset_cycle_anchor` and `next_reset_at` while leaving the balance consumed.
- Explicit `carry_over_usages: { enabled: true }` still wins and preserves usage.
- Lifetime entitlement balances are untouched; only cycle-bound grants refresh.
- `billing_cycle_anchor` is still rejected alongside `feature_quantities`, so resizing a plan and restarting its cycle remain two calls.
- Adds a regression test that reproduces the reported customer failure.

<sup>Written for commit 6dfddbdc68276926aea267e628cebf074bafd083. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes immediate billing-cycle restarts so cycle-bound credits receive a fresh balance while lifetime balances and explicitly carried-over usage remain unchanged.
- **Bug fixes:** Treats `billing_cycle_anchor: "now"` as a usage-resetting subscription update.
- **Bug fixes:** Limits anchor-triggered refreshes to cycle-bound entitlements.
- **Improvements:** Adds an integration test covering an anchor-only restart after credits have been consumed.
</details>


<h3>Confidence Score: 4/5</h3>

The PR does not appear safe to merge until attachment previews stop claiming that a newly attached plan resets existing usage.

Attachment contexts can carry `billing_cycle_anchor: "now"` into the shared reset predicate, which unconditionally sets the customer-facing `resets_usage` preview field even though a fresh attachment has no previous usage to reset.

**Files Needing Attention:** shared/models/billingModels/context/billingContextResetsUsage.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/models/billingModels/context/billingContextResetsUsage.ts | Adds immediate anchor restarts to the shared usage-reset predicate while preserving explicit carry-over. |
| server/src/internal/billing/v2/compute/computeAutumnUtils/computeRetainedCustomerEntitlementUpdates.ts | Excludes lifetime entitlements when refreshing balances for an immediate cycle restart. |
| server/tests/integration/billing/update-subscription/params/billing-cycle-anchor/update-sub-anchor-now-resets-usage.test.ts | Verifies that an anchor-only subscription update restores consumed cycle-bound credits. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Subscription update with anchor now] --> B{Carry usage over?}
    B -->|Yes| C[Preserve balances]
    B -->|No| D{Entitlement lifetime?}
    D -->|Yes| C
    D -->|No| E[Grant fresh cycle balance]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor: name the carry-over guard in b..."](https://github.com/useautumn/autumn/commit/6dfddbdc68276926aea267e628cebf074bafd083) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58574312)</sub>

<!-- /greptile_comment -->