### PR TITLE
feat(catalog-v2): map revenuecat products through processors

### DIFF
--- a/server/src/internal/catalogV2/actions/getCatalog/getCatalogV2.ts
+++ b/server/src/internal/catalogV2/actions/getCatalog/getCatalogV2.ts
@@ -6,6 +6,7 @@ import {
 	type GetCatalogResponse,
 	LATEST_VERSION,
 } from "@autumn/shared";
+import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { getPlanResponse } from "@/internal/products/productUtils/productResponseUtils/getPlanResponse.js";
@@ -40,11 +41,23 @@ export const getCatalogV2 = async ({
 		),
 	});
 
+	// One read for the whole catalog: RC mappings live in their own table, keyed
+	// by plan id with no version dimension.
+	const revenuecatMappings = await RCMappingService.getAll({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+	const revenuecatByPlanId = new Map(
+		revenuecatMappings.map((mapping) => [mapping.autumn_product_id, mapping]),
+	);
+
 	const plans = await Promise.all(
 		baseProducts.map((product) =>
 			getPlanResponse({
 				ctx,
 				product: pruneArchivedVariants(product),
+				revenuecatMapping: revenuecatByPlanId.get(product.id),
 				features: ctx.features,
 				currency: ctx.org.default_currency || undefined,
 				expandLicensePlans: true,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan.ts
@@ -199,6 +199,9 @@ export const intentToUpsertProductPlan = ({
 		planParams.propagate !== undefined
 			? { propagate: planParams.propagate }
 			: {}),
+		...(source === "direct" && planParams.processors?.revenuecat !== undefined
+			? { revenuecatProcessor: planParams.processors.revenuecat }
+			: {}),
 		...(planParams.create_in_stripe !== undefined
 			? { createInStripe: planParams.create_in_stripe }
 			: {}),

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/upsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/upsertProductPlan.ts
@@ -1,4 +1,5 @@
 import type {
+	ApiRevenueCatPlanProcessor,
 	CatalogPlanVersioningStrategy,
 	CatalogPropagateParams,
 	CatalogVariantParams,
@@ -68,6 +69,8 @@ export type UpsertProductPlan = {
 	unlink?: boolean;
 	/** Who follows this row's content change. Copied from planParams so pass 2 can read it. */
 	propagate?: CatalogPropagateParams;
+	/** Stated `processors.revenuecat`. Plan-wide, so only the addressed row carries it. */
+	revenuecatProcessor?: ApiRevenueCatPlanProcessor | null;
 	/** Absent = plan_license links untouched. Present (incl. []) = full-set replace. */
 	planLicenses?: PlanLicensePlan[];
 	/** false = execute may reuse Stripe ids but never create objects. */

--- a/server/src/internal/catalogV2/execute/executeRevenueCatMappings.ts
+++ b/server/src/internal/catalogV2/execute/executeRevenueCatMappings.ts
@@ -1,0 +1,123 @@
+import {
+	type ApiRevenueCatPlanProcessor,
+	ErrCode,
+	RecaseError,
+} from "@autumn/shared";
+import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
+
+type StatedMapping = {
+	planId: string;
+	processor: ApiRevenueCatPlanProcessor | null;
+};
+
+/**
+ * RevenueCat mappings are plan-wide — the table has no version column — so only
+ * the addressed row writes and version siblings are ignored.
+ */
+const statedMappings = ({
+	updateCatalogPlan,
+}: {
+	updateCatalogPlan: UpdateCatalogPlan;
+}): StatedMapping[] =>
+	updateCatalogPlan.upsertProducts.flatMap((upsert) => {
+		const processor = upsert.revenuecatProcessor;
+		if (processor === undefined) return [];
+		return [{ planId: upsert.row.nextFullProduct.id, processor }];
+	});
+
+/**
+ * A purchase resolves RC id → plan by scanning every mapping, so an id claimed
+ * twice would attach whichever row the query happened to return first.
+ */
+const assertRevenueCatIdsUnclaimed = async ({
+	ctx,
+	stated,
+}: {
+	ctx: AutumnContext;
+	stated: StatedMapping[];
+}) => {
+	const claimedHere = new Map<string, string>();
+	for (const { planId, processor } of stated) {
+		for (const { product_id } of processor?.products ?? []) {
+			const owner = claimedHere.get(product_id);
+			if (owner && owner !== planId) {
+				throw new RecaseError({
+					code: ErrCode.InvalidRequest,
+					message: `RevenueCat product ${product_id} is mapped to both ${owner} and ${planId}`,
+					statusCode: 400,
+				});
+			}
+			claimedHere.set(product_id, planId);
+		}
+	}
+	if (claimedHere.size === 0) return;
+
+	const statedPlanIds = new Set(stated.map((entry) => entry.planId));
+	const existing = await RCMappingService.getAll({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+	for (const row of existing) {
+		// A plan restating its own ids is the normal case, not a collision.
+		if (statedPlanIds.has(row.autumn_product_id)) continue;
+		for (const productId of row.revenuecat_product_ids) {
+			const claimant = claimedHere.get(productId);
+			if (!claimant) continue;
+			throw new RecaseError({
+				code: ErrCode.InvalidRequest,
+				message: `RevenueCat product ${productId} is already mapped to ${row.autumn_product_id}`,
+				statusCode: 400,
+			});
+		}
+	}
+};
+
+/** Stated `processors.revenuecat` → the mappings table. Omitted keeps, null clears. */
+export const executeRevenueCatMappings = async ({
+	ctx,
+	updateCatalogPlan,
+}: {
+	ctx: AutumnContext;
+	updateCatalogPlan: UpdateCatalogPlan;
+}) => {
+	const stated = statedMappings({ updateCatalogPlan });
+	if (stated.length === 0) return;
+
+	await assertRevenueCatIdsUnclaimed({ ctx, stated });
+
+	for (const { planId, processor } of stated) {
+		const products = processor?.products ?? [];
+		if (products.length === 0) {
+			await RCMappingService.delete({
+				db: ctx.db,
+				orgId: ctx.org.id,
+				env: ctx.env,
+				autumnProductId: planId,
+			});
+			continue;
+		}
+
+		const featureQuantities = Object.fromEntries(
+			products
+				.filter((product) => product.feature_quantities?.length)
+				.map((product) => [product.product_id, product.feature_quantities!]),
+		);
+
+		await RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: ctx.env,
+				autumn_product_id: planId,
+				revenuecat_product_ids: products.map((product) => product.product_id),
+				feature_quantities: Object.keys(featureQuantities).length
+					? featureQuantities
+					: null,
+			},
+		});
+	}
+};

--- a/server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts
+++ b/server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts
@@ -12,6 +12,7 @@ import {
 } from "@/internal/catalogV2/execute/executeFeatureReferenceRewrites";
 import { initStripeResourcesForCatalog } from "@/internal/catalogV2/execute/executeInitStripeResources/initStripeResourcesForCatalog";
 import { executeMigrationDrafts } from "@/internal/catalogV2/execute/executeMigrationDrafts";
+import { executeRevenueCatMappings } from "./executeRevenueCatMappings";
 import { executeRemovePlans } from "@/internal/catalogV2/execute/executeRemovePlans";
 import { executeRenamePlans } from "@/internal/catalogV2/execute/executeRenamePlans";
 import { executeUpsertProducts } from "@/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts";
@@ -212,6 +213,12 @@ export const executeUpdateCatalogPlan = async ({
 		phases,
 		phase: "execute.remove_plans",
 		run: () => executeRemovePlans({ ctx, updateCatalogPlan }),
+	});
+	await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "execute.revenuecat_mappings",
+		run: () => executeRevenueCatMappings({ ctx, updateCatalogPlan }),
 	});
 	await timeCatalogPhase({
 		ctx,

--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -15,6 +15,7 @@ import {
 	priceConfigToPriceProcessors,
 	productItemsToPlanItemsV1,
 	productToPlanProcessors,
+	type RevenueCatPlanMapping,
 	productV2ToBasePrice,
 	productV2ToFeatureItems,
 	sortProductItems,
@@ -56,6 +57,8 @@ type GetPlanResponseArgs = {
 	basePlan?: ApiPlanV1;
 	baseFullProduct?: FullProduct;
 	resolveBaseFullProduct?: boolean;
+	/** RevenueCat mappings live in their own table, so the row is read in. */
+	revenuecatMapping?: RevenueCatPlanMapping | null;
 };
 
 type PlanExpansions = {
@@ -91,6 +94,7 @@ export async function getPlanResponse({
 	basePlan,
 	baseFullProduct,
 	resolveBaseFullProduct = true,
+	revenuecatMapping,
 	expandLicensePlans = false,
 	expandVariants = false,
 }: GetPlanResponseArgs & PlanExpansions): Promise<
@@ -182,6 +186,7 @@ export async function getPlanResponse({
 	// 9. Build Plan response
 	const planProcessors = productToPlanProcessors({
 		product,
+		revenuecatMapping,
 	});
 	const plan = {
 		id: product.id,

--- a/server/tests/integration/catalog-v2/plans/processors/revenuecat-mappings.test.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/revenuecat-mappings.test.ts
@@ -1,0 +1,190 @@
+/**
+ * catalogV2.update — RevenueCat mappings ride the `processors` envelope.
+ *
+ * RC sells quantity as separate store products, so many RC ids map to one
+ * Autumn plan and each carries the grant it represents. The mapping is a
+ * read-time lookup for inbound webhooks — Autumn never bills through RC — so
+ * there is no version dimension and nothing to create on the RC side.
+ *
+ * Contract:
+ *   R1  a plan states its RC products; GET echoes them with their quantities
+ *   R2  restating replaces the set, and an empty list clears the mapping
+ *   R3  an RC id already claimed by another plan is a hard error — a purchase
+ *       resolves by scanning every mapping, so a duplicate would attach to
+ *       whichever row came back first
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiPlanExpandedV1 } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { withCatalogPlans } from "../licenses/utils/seedLicensePlans.js";
+
+const getPlan = async ({
+	autumn,
+	planId,
+}: {
+	autumn: AutumnInt;
+	planId: string;
+}): Promise<ApiPlanExpandedV1> => {
+	const catalog = await autumn.catalogV2.get({});
+	const plan = catalog.plans.find((row: { id: string }) => row.id === planId);
+	expect(plan, `GET catalog plan ${planId}`).toBeDefined();
+	return plan!;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors revenuecat: many ids map to one plan, each with its grant")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_rc_map");
+		const small = `rc_${planId}_100`;
+		const large = `rc_${planId}_500`;
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "RC Mapped",
+							items: [{ feature_id: TestFeature.Messages, included: 0 }],
+							processors: {
+								revenuecat: {
+									products: [
+										{
+											product_id: small,
+											feature_quantities: [
+												{ feature_id: TestFeature.Messages, quantity: 100 },
+											],
+										},
+										{
+											product_id: large,
+											feature_quantities: [
+												{ feature_id: TestFeature.Messages, quantity: 500 },
+											],
+										},
+									],
+								},
+							},
+						},
+					],
+				});
+
+				// R1: both ids echo back, each keeping the quantity it represents.
+				const plan = await getPlan({ autumn: autumnV2_3, planId });
+				const products = plan.processors?.revenuecat?.products ?? [];
+				expect(
+					products.map((product) => product.product_id).sort(),
+					"mapped RC ids",
+				).toEqual([small, large].sort());
+				expect(
+					products.find((product) => product.product_id === large)
+						?.feature_quantities,
+					"grant for the large pack",
+				).toEqual([{ feature_id: TestFeature.Messages, quantity: 500 }]);
+
+				// R2: the stated set replaces, it does not merge.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							processors: { revenuecat: { products: [{ product_id: small }] } },
+						},
+					],
+				});
+				expect(
+					(
+						await getPlan({ autumn: autumnV2_3, planId })
+					).processors?.revenuecat?.products.map(
+						(product) => product.product_id,
+					),
+					"restated set replaces",
+				).toEqual([small]);
+
+				// R2: an empty list clears the mapping entirely.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{ plan_id: planId, processors: { revenuecat: { products: [] } } },
+					],
+				});
+				expect(
+					(await getPlan({ autumn: autumnV2_3, planId })).processors
+						?.revenuecat,
+					"cleared mapping",
+				).toBeUndefined();
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors revenuecat: an id claimed by another plan is rejected")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const ownerId = uniqueTestId("cv2_rc_owner");
+		const thiefId = uniqueTestId("cv2_rc_thief");
+		const sharedId = `rc_${ownerId}_shared`;
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [ownerId, thiefId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: ownerId,
+							name: "RC Owner",
+							items: [{ feature_id: TestFeature.Messages, included: 0 }],
+							processors: {
+								revenuecat: { products: [{ product_id: sharedId }] },
+							},
+						},
+						{
+							plan_id: thiefId,
+							name: "RC Thief",
+							items: [{ feature_id: TestFeature.Messages, included: 0 }],
+						},
+					],
+				});
+
+				// R3: a second plan cannot claim an id the first already owns.
+				const update = autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: thiefId,
+							processors: {
+								revenuecat: { products: [{ product_id: sharedId }] },
+							},
+						},
+					],
+				});
+				await expect(update).rejects.toThrow();
+
+				// R3: two plans claiming it in the same request is rejected too.
+				const sameRequest = autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: ownerId,
+							processors: {
+								revenuecat: { products: [{ product_id: sharedId }] },
+							},
+						},
+						{
+							plan_id: thiefId,
+							processors: {
+								revenuecat: { products: [{ product_id: sharedId }] },
+							},
+						},
+					],
+				});
+				await expect(sameRequest).rejects.toThrow();
+			},
+		});
+	},
+);

--- a/shared/api/products/components/processors.ts
+++ b/shared/api/products/components/processors.ts
@@ -18,9 +18,39 @@ export const ApiStripePriceProcessorSchema = z.object({
 	}),
 });
 
+/**
+ * RevenueCat sells quantity as separate store products, so many RC ids map to
+ * one Autumn plan and each carries the grant it represents.
+ */
+export const ApiRevenueCatProductSchema = z.object({
+	product_id: z.string().meta({
+		description: "RevenueCat product ID that grants this plan when purchased.",
+	}),
+	feature_quantities: z
+		.array(
+			z.object({
+				feature_id: z.string(),
+				quantity: z.number().nonnegative().optional(),
+			}),
+		)
+		.optional()
+		.meta({
+			description:
+				"Prepaid quantities granted when this specific RevenueCat product is purchased, in feature units.",
+		}),
+});
+
+export const ApiRevenueCatPlanProcessorSchema = z.object({
+	products: z.array(ApiRevenueCatProductSchema).meta({
+		description:
+			"Every RevenueCat product that maps to this plan. Replaces the current set.",
+	}),
+});
+
 export const ApiPlanProcessorsSchema = z.object({
 	/** Omit to keep the current mapping; null unlinks it. */
 	stripe: ApiStripePlanProcessorSchema.nullish(),
+	revenuecat: ApiRevenueCatPlanProcessorSchema.nullish(),
 });
 
 export const ApiPriceProcessorsSchema = z.object({
@@ -35,3 +65,8 @@ export type ApiStripePriceProcessor = z.infer<
 >;
 export type ApiPlanProcessors = z.infer<typeof ApiPlanProcessorsSchema>;
 export type ApiPriceProcessors = z.infer<typeof ApiPriceProcessorsSchema>;
+
+export type ApiRevenueCatProduct = z.infer<typeof ApiRevenueCatProductSchema>;
+export type ApiRevenueCatPlanProcessor = z.infer<
+	typeof ApiRevenueCatPlanProcessorSchema
+>;

--- a/shared/utils/productUtils/convertProduct/productToPlanProcessors.ts
+++ b/shared/utils/productUtils/convertProduct/productToPlanProcessors.ts
@@ -1,19 +1,54 @@
-import type { ApiPlanProcessors } from "@api/products/components/processors";
+import type {
+	ApiPlanProcessors,
+	ApiRevenueCatProduct,
+} from "@api/products/components/processors";
 import type { Product } from "@models/productModels/productModels";
+
+/** The `revenuecat_mappings` row for this plan — a separate table, so it is read in. */
+export type RevenueCatPlanMapping = {
+	revenuecat_product_ids: string[];
+	feature_quantities?: Record<
+		string,
+		Array<{ feature_id: string; quantity?: number }>
+	> | null;
+};
+
+const revenuecatProducts = ({
+	mapping,
+}: {
+	mapping: RevenueCatPlanMapping;
+}): ApiRevenueCatProduct[] =>
+	mapping.revenuecat_product_ids.map((productId) => {
+		const quantities = mapping.feature_quantities?.[productId];
+		return {
+			product_id: productId,
+			...(quantities?.length ? { feature_quantities: quantities } : {}),
+		};
+	});
 
 export const productToPlanProcessors = ({
 	product,
+	revenuecatMapping,
 }: {
 	product: Pick<Product, "processor">;
+	revenuecatMapping?: RevenueCatPlanMapping | null;
 }): ApiPlanProcessors | undefined => {
 	const processor = product.processor;
-	if (!processor?.id) return undefined;
+	const stripe = processor?.id
+		? {
+				product_id: processor.id,
+				...(processor.additional_ids?.length
+					? { additional_product_ids: processor.additional_ids }
+					: {}),
+			}
+		: undefined;
+	const revenuecat = revenuecatMapping?.revenuecat_product_ids?.length
+		? { products: revenuecatProducts({ mapping: revenuecatMapping }) }
+		: undefined;
+
+	if (!stripe && !revenuecat) return undefined;
 	return {
-		stripe: {
-			product_id: processor.id,
-			...(processor.additional_ids?.length
-				? { additional_product_ids: processor.additional_ids }
-				: {}),
-		},
+		...(stripe ? { stripe } : {}),
+		...(revenuecat ? { revenuecat } : {}),
 	};
 };

--- a/vite/src/hooks/queries/revcat/useRCMappings.tsx
+++ b/vite/src/hooks/queries/revcat/useRCMappings.tsx
@@ -1,7 +1,10 @@
+import type { UpdateCatalogParamsInput } from "@autumn/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
+import { CatalogV2Service } from "@/services/CatalogV2Service";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
 
 export type RCFeatureQuantity = { feature_id: string; quantity?: number };
 export type RCFeatureQuantities = Record<string, RCFeatureQuantity[]>;
@@ -35,20 +38,39 @@ export const useRCMappings = () => {
 		},
 	});
 
+	// Writes go through catalogV2 so the catalog is the single writer and an RC
+	// id already claimed by another plan is rejected rather than silently shared.
+	const toCatalogParams = (
+		mappingsToSave: SaveMappingInput[],
+	): UpdateCatalogParamsInput => ({
+		plans: mappingsToSave.map((mapping) => ({
+			plan_id: mapping.autumn_product_id,
+			processors: {
+				revenuecat: {
+					products: mapping.revenuecat_product_ids.map((productId) => {
+						const quantities = mapping.feature_quantities?.[productId];
+						return {
+							product_id: productId,
+							...(quantities?.length ? { feature_quantities: quantities } : {}),
+						};
+					}),
+				},
+			},
+		})),
+	});
+
 	const saveMutation = useMutation({
-		mutationFn: async (mappingsToSave: SaveMappingInput[]) => {
-			const { data } = await axiosInstance.post<{ mappings: RCMapping[] }>(
-				"/v1/organization/revenuecat/mappings",
-				{ mappings: mappingsToSave },
-			);
-			return data.mappings;
-		},
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["revenuecat-mappings"] });
+		mutationFn: (mappingsToSave: SaveMappingInput[]) =>
+			CatalogV2Service.update(axiosInstance, toCatalogParams(mappingsToSave)),
+		onSuccess: async () => {
+			await Promise.all([
+				queryClient.invalidateQueries({ queryKey: ["revenuecat-mappings"] }),
+				queryClient.invalidateQueries({ queryKey: ["products"] }),
+			]);
 			toast.success("Mappings saved successfully");
 		},
-		onError: () => {
-			toast.error("Failed to save mappings");
+		onError: (error) => {
+			toast.error(getBackendErr(error, "Failed to save mappings"));
 		},
 	});
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves RevenueCat plan mappings into the `processors.revenuecat` envelope of catalogV2 updates so catalog writes are the single writer for plan mappings.

- Catalog GET now echoes each plan's RevenueCat mappings with per-product feature quantities.
- The dashboard's RC save flow now calls catalogV2 update instead of the legacy mappings endpoint.
- Stating `revenuecat` replaces the mapping set; an empty list clears it; omitting it keeps the existing mapping.
- An RC product id claimed by more than one plan is rejected with a 400, since purchases resolve by scanning all mappings.

<sup>Written for commit a71a459c4b0f8d4f93d82536930c5add4822f3ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves RevenueCat product mappings into catalog v2 plan processors so catalog reads and writes expose one processor-based contract.
- **API changes:** Adds `processors.revenuecat.products`, including optional per-product feature quantities.
- **Improvements:** Catalog GET responses now include RevenueCat mappings, and the dashboard saves them through catalog v2.
- **Bug fixes:** Rejects RevenueCat product IDs assigned to multiple plans and supports replacing or clearing a plan’s mapping set.
</details>


<h3>Confidence Score: 3/5</h3>

The PR does not appear safe to merge until concurrent duplicate mapping claims and dashboard reassignment of mappings owned by hidden plans are fixed.

RevenueCat uniqueness is enforced with a separate read and later write without a database uniqueness backstop, so concurrent requests can create ambiguous mappings; additionally, dashboard saves omit hidden plans while the backend retains their mappings, leaving operators unable to reassign those RevenueCat IDs.

**Files Needing Attention:** server/src/internal/catalogV2/execute/executeRevenueCatMappings.ts, vite/src/hooks/queries/revcat/useRCMappings.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/execute/executeRevenueCatMappings.ts | Adds replacement, clearing, and uniqueness validation for RevenueCat mappings, but the previously reported concurrent uniqueness race remains. |
| server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts | Adds RevenueCat mapping execution after other catalog mutations; whether an outer transaction prevents the previously reported partial-write behavior remains unconfirmed. |
| vite/src/hooks/queries/revcat/useRCMappings.tsx | Moves dashboard saves to catalog v2, while the previously reported hidden-owner reassignment problem remains. |
| server/src/internal/catalogV2/actions/getCatalog/getCatalogV2.ts | Loads mappings once and attaches each mapping to its corresponding catalog plan response. |
| shared/api/products/components/processors.ts | Defines the public RevenueCat processor schema and per-product feature quantity contract. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Dashboard/API client
    participant Catalog as Catalog v2 update
    participant Plans as Plan execution phases
    participant RC as RevenueCat mappings
    participant DB as Database
    UI->>Catalog: Update plans with processors.revenuecat
    Catalog->>Plans: Apply catalog mutations
    Plans->>DB: Persist plan and feature changes
    Catalog->>RC: Validate RevenueCat IDs
    RC->>DB: Read existing mappings
    alt Mapping IDs are available
        RC->>DB: Replace or clear mappings
        Catalog-->>UI: Success
    else Mapping ID conflicts
        RC-->>Catalog: 400 invalid request
        Catalog-->>UI: Save failed
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat: 🎸 map revenuecat products through..."](https://github.com/useautumn/autumn/commit/a71a459c4b0f8d4f93d82536930c5add4822f3ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58595946)</sub>

<!-- /greptile_comment -->