### PR TITLE
feat(catalog-v2): keep license links version-anchored and follow per child sibling

### DIFF
--- a/server/src/internal/catalogV2/actions/buildPlanChange/buildPlanLicenseChanges/buildPlanLicensePreviousAttributes.ts
+++ b/server/src/internal/catalogV2/actions/buildPlanChange/buildPlanLicenseChanges/buildPlanLicensePreviousAttributes.ts
@@ -18,5 +18,8 @@ export const buildPlanLicensePreviousAttributes = ({
 	if (from.product.version !== to.product.version) {
 		previous.version = from.product.version;
 	}
+	if (from.product.version_slug !== to.product.version_slug) {
+		previous.version_slug = from.product.version_slug ?? undefined;
+	}
 	return Object.keys(previous).length > 0 ? previous : null;
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/propagateLicenseDraftUpserts.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/propagateLicenseDraftUpserts.ts
@@ -9,7 +9,11 @@ import {
 	licenseUpsertFromPlanLicense,
 	sortLicenseDraftUpserts,
 } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/licenseUpsertFromPlanLicense";
-import { shouldPropagate } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
+import {
+	parentLicenseLinkForChild,
+	propagateReachesLink,
+	shouldPropagate,
+} from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 
@@ -44,6 +48,10 @@ export const propagateLicenseDraftUpserts = ({
 		) {
 			continue;
 		}
+
+		const currentPlanLicense = parentLicenseLinkForChild({ parent, child });
+		if (!currentPlanLicense) continue;
+		if (!propagateReachesLink({ currentPlanLicense, child })) continue;
 
 		const planLicense = parent.planLicenses?.find(
 			(link) => link.licensePlanId === child.row.planId,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/assembleNextFullProduct.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/assembleNextFullProduct.ts
@@ -32,5 +32,6 @@ export const assembleNextFullProduct = ({
 		entitlements,
 		free_trial: freeTrial,
 		licenses: currentFullProduct?.licenses,
+		parent_plan_licenses: currentFullProduct?.parent_plan_licenses,
 	} as FullProduct;
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/declared/resolveDeclaredPlanLicenses.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/declared/resolveDeclaredPlanLicenses.ts
@@ -7,6 +7,8 @@ import type {
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { PlanLicensePlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
+import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
+import { fullProductForSlug } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/fullProductForSlug";
 
 const declaredLinkChanged = ({
 	currentPlanLicense,
@@ -38,6 +40,39 @@ const declaredLinkChanged = ({
 	return false;
 };
 
+/** Stated slug = that row. Omitted keeps the existing child id; new links use active. */
+const anchorFullProductForDeclared = ({
+	params,
+	currentPlanLicense,
+	productStatesContext,
+}: {
+	params: PlanLicenseParams;
+	currentPlanLicense: FullPlanLicense | null;
+	productStatesContext: ProductStatesContext;
+}): FullProduct | null => {
+	if (params.version_slug !== undefined) {
+		return fullProductForSlug({
+			planId: params.license_plan_id,
+			versionSlug: params.version_slug,
+			productStatesContext,
+		});
+	}
+
+	if (currentPlanLicense) {
+		return (
+			findFullProductByInternalId({
+				internalId: currentPlanLicense.license_internal_product_id,
+				productStatesContext,
+			}) ?? currentPlanLicense.product
+		);
+	}
+
+	return activeFullProductForPlan({
+		planId: params.license_plan_id,
+		productStatesContext,
+	});
+};
+
 /** Declared licenses[] vs current links → per-link write ops. */
 export const resolveDeclaredPlanLicenses = ({
 	declared,
@@ -58,12 +93,13 @@ export const resolveDeclaredPlanLicenses = ({
 	const declaredIds = new Set(declared.map((entry) => entry.license_plan_id));
 
 	const planned: PlanLicensePlan[] = declared.map((params) => {
-		const licenseProduct = activeFullProductForPlan({
-			planId: params.license_plan_id,
-			productStatesContext,
-		});
 		const currentPlanLicense =
 			currentPlanLicenseByPlanId.get(params.license_plan_id) ?? null;
+		const licenseProduct = anchorFullProductForDeclared({
+			params,
+			currentPlanLicense,
+			productStatesContext,
+		});
 
 		const op = !currentPlanLicense
 			? "create"
@@ -87,6 +123,7 @@ export const resolveDeclaredPlanLicenses = ({
 			prepaidOnly: params.prepaid_only ?? true,
 			metadata: params.metadata,
 			customize: params.customize,
+			declaredVersionSlug: params.version_slug,
 		};
 	});
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils.ts
@@ -1,6 +1,7 @@
 import {
 	type CatalogPropagateTargetParams,
 	type FullPlanLicense,
+	type FullProduct,
 	type LicenseCustomize,
 	productKeyToString,
 	productToProductKey,
@@ -9,6 +10,7 @@ import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCa
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { activeVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeVersionForPlan";
 import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
+import { versionForSlug } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/versionForSlug";
 
 /** Current plan_license links on this row. Minted versions fall back to the clone source. */
 export const upsertProductPlanToLicenses = ({
@@ -35,26 +37,13 @@ const childSourceInternalIds = ({
 	),
 ];
 
-/** Incoming links on the upserted child plus the demoted pointer (promote). */
-export const reverseLinksForChild = ({
-	upsert,
-	productStatesContext,
+const uniqueReverseLinks = ({
+	products,
 }: {
-	upsert: UpsertProductPlan;
-	productStatesContext: ProductStatesContext;
+	products: Array<FullProduct | null | undefined>;
 }) => {
-	const previousActive = upsert.previousActiveInternalId
-		? findFullProductByInternalId({
-				internalId: upsert.previousActiveInternalId,
-				productStatesContext,
-			})
-		: null;
 	const seen = new Set<string>();
-	return [
-		upsert.row.currentFullProduct,
-		upsert.row.baseFullProduct,
-		previousActive,
-	].flatMap((product) => {
+	return products.flatMap((product) => {
 		if (!product) return [];
 		return (product.parent_plan_licenses ?? []).filter((link) => {
 			const key = productKeyToString({
@@ -67,6 +56,65 @@ export const reverseLinksForChild = ({
 	});
 };
 
+/** Incoming links on every live version row of this child plan. */
+export const reverseLinksOnChildPlan = ({
+	planId,
+	productStatesContext,
+}: {
+	planId: string;
+	productStatesContext: ProductStatesContext;
+}) =>
+	uniqueReverseLinks({
+		products: productStatesContext.versionsByPlanId[planId] ?? [],
+	});
+
+/** Incoming links on one child version row. */
+export const reverseLinksOnChildProduct = ({
+	planId,
+	childInternalId,
+	productStatesContext,
+}: {
+	planId: string;
+	childInternalId: string;
+	productStatesContext: ProductStatesContext;
+}) => {
+	const childRow = (productStatesContext.versionsByPlanId[planId] ?? []).find(
+		(row) => row.internal_id === childInternalId,
+	);
+	return uniqueReverseLinks({ products: [childRow] });
+};
+
+/** Incoming links on the planned child row, plus the demoted pointer (promote). */
+export const reverseLinksForChild = ({
+	upsert,
+	productStatesContext,
+}: {
+	upsert: UpsertProductPlan;
+	productStatesContext: ProductStatesContext;
+}) => {
+	const plannedInternalId =
+		upsert.row.currentFullProduct?.internal_id ??
+		upsert.row.baseFullProduct?.internal_id ??
+		upsert.row.nextFullProduct.internal_id;
+	const hydrated = (
+		productStatesContext.versionsByPlanId[upsert.row.planId] ?? []
+	).find((row) => row.internal_id === plannedInternalId);
+	const previousActive = upsert.previousActiveInternalId
+		? findFullProductByInternalId({
+				internalId: upsert.previousActiveInternalId,
+				productStatesContext,
+			})
+		: null;
+	return uniqueReverseLinks({
+		products: [
+			hydrated,
+			upsert.row.currentFullProduct,
+			upsert.row.baseFullProduct,
+			previousActive,
+		],
+	});
+};
+
 export const parentLicenseLinkForChild = ({
 	parent,
 	child,
@@ -74,8 +122,14 @@ export const parentLicenseLinkForChild = ({
 	parent: UpsertProductPlan;
 	child: UpsertProductPlan;
 }): FullPlanLicense | undefined => {
+	const licenses = upsertProductPlanToLicenses({ upsert: parent });
+	// Adopt mint clones the old row's link; pair by child plan so follow can
+	// re-anchor onto the child's active row in this batch.
+	if (parent.row.source === "license_adopt") {
+		return licenses.find((link) => link.product.id === child.row.planId);
+	}
 	const sourceInternalIds = childSourceInternalIds({ child });
-	return upsertProductPlanToLicenses({ upsert: parent }).find(
+	return licenses.find(
 		(link) =>
 			link.product.id === child.row.planId &&
 			(sourceInternalIds.length === 0 ||
@@ -110,17 +164,25 @@ const propagateTargetMatchesParent = ({
 	target,
 	parent,
 	activeVersion,
+	productStatesContext,
 }: {
 	target: CatalogPropagateTargetParams;
 	parent: UpsertProductPlan;
 	activeVersion: number | undefined;
+	productStatesContext: ProductStatesContext;
 }): boolean => {
 	if (target.plan_id !== parent.row.planId) return false;
 	if (target.version !== undefined) return target.version === parent.row.version;
+	if (target.version_slug !== undefined) {
+		const version = versionForSlug({
+			planId: target.plan_id,
+			versionSlug: target.version_slug,
+			productStatesContext,
+		});
+		return version !== undefined && version === parent.row.version;
+	}
 	if (target.versioning === "all_versions") return true;
-	return (
-		activeVersion !== undefined && parent.row.version === activeVersion
-	);
+	return activeVersion !== undefined && parent.row.version === activeVersion;
 };
 
 export const childPropagatesToParent = ({
@@ -137,7 +199,12 @@ export const childPropagatesToParent = ({
 		productStatesContext,
 	});
 	return (child.propagate?.license_parents ?? []).some((target) =>
-		propagateTargetMatchesParent({ target, parent, activeVersion }),
+		propagateTargetMatchesParent({
+			target,
+			parent,
+			activeVersion,
+			productStatesContext,
+		}),
 	);
 };
 
@@ -153,17 +220,35 @@ export const movesActivePointer = ({
 	return nextIsActive && (mintedNewRow || promotedExisting);
 };
 
-/** In-place item writes, or the child taking the pointer. Draft-mint clones do not. */
-export const childTriggersLicenseRewrite = ({
+/** Pin-lane trigger: in-place item writes only. Mints/promotes leave anchored links alone. */
+export const childEditsItemsInPlace = ({
 	child,
 }: {
 	child: UpsertProductPlan;
 }): boolean => {
 	const mintedNewRow = child.row.versioning === "new_version";
 	const childHasItemWrites = child.entitlementPricesPlan != null;
-	const inPlaceItemWrites = childHasItemWrites && !mintedNewRow;
-	return inPlaceItemWrites || movesActivePointer({ upsert: child });
+	return childHasItemWrites && !mintedNewRow;
 };
+
+/** Propagate-lane trigger: in-place item writes, or the child taking the pointer. */
+export const childTriggersLicenseRewrite = ({
+	child,
+}: {
+	child: UpsertProductPlan;
+}): boolean =>
+	childEditsItemsInPlace({ child }) || movesActivePointer({ upsert: child });
+
+/** In-place follow only reaches the row this link already points at. Mint/promote still move it. */
+export const propagateReachesLink = ({
+	currentPlanLicense,
+	child,
+}: {
+	currentPlanLicense: FullPlanLicense;
+	child: UpsertProductPlan;
+}): boolean =>
+	movesActivePointer({ upsert: child }) ||
+	!needsRepoint({ currentPlanLicense, child });
 
 export const shouldPropagate = ({
 	parent,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/pinned/computePinnedPlanLicenses.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/pinned/computePinnedPlanLicenses.ts
@@ -1,27 +1,19 @@
-import type { FullPlanLicense, FullProduct } from "@autumn/shared";
+import type { FullPlanLicense } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type {
 	PlanLicensePlan,
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
-import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
-import { isExistingRowPromote } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/isExistingRowPromote";
 import { getEntsWithFeature } from "@/internal/products/entitlements/entitlementUtils.js";
 import {
-	childTriggersLicenseRewrite,
+	childEditsItemsInPlace,
 	needsRepoint,
 	parentLicenseLinkForChild,
 	shouldPropagate,
 	upsertProductPlansToChildPlans,
 } from "../licensePlanUtils";
 import { cloneFrozenChildAsLicenseOverlay } from "./cloneFrozenChildAsLicenseOverlay";
-
-const childIsPromote = ({ child }: { child: UpsertProductPlan }): boolean =>
-	isExistingRowPromote({
-		current: child.row.currentFullProduct,
-		next: child.row.nextFullProduct,
-	});
 
 const shouldPin = ({
 	parent,
@@ -35,84 +27,52 @@ const shouldPin = ({
 	productStatesContext: ProductStatesContext;
 }): boolean => {
 	const hasDeclaredLicenses = parent.declaredLicenses !== undefined;
-	const rewritesLicenses = childTriggersLicenseRewrite({ child });
-	const promote = childIsPromote({ child });
+	const editsInPlace = childEditsItemsInPlace({ child });
+	const anchorsEditedRow = !needsRepoint({ currentPlanLicense, child });
 	const followsViaPropagate = shouldPropagate({
 		parent,
 		child,
 		productStatesContext,
 	});
 	const alreadyCustomized = currentPlanLicense.customized;
-	const alreadyPinnedToNext = !needsRepoint({ currentPlanLicense, child });
 
 	if (hasDeclaredLicenses) return false;
 	if (followsViaPropagate) return false;
-	if (!rewritesLicenses) return false;
-	if (promote && alreadyCustomized) return false;
-	if (alreadyCustomized && alreadyPinnedToNext) return false;
+	if (!editsInPlace) return false;
+	if (!anchorsEditedRow) return false;
+	if (alreadyCustomized) return false;
 	return true;
-};
-
-const pinTargetProduct = ({
-	child,
-	productStatesContext,
-}: {
-	child: UpsertProductPlan;
-	productStatesContext: ProductStatesContext;
-}): FullProduct => {
-	const promote = childIsPromote({ child });
-	const demotedInternalId = child.previousActiveInternalId;
-	if (promote && demotedInternalId) {
-		return (
-			findFullProductByInternalId({
-				internalId: demotedInternalId,
-				productStatesContext,
-			}) ?? child.row.nextFullProduct
-		);
-	}
-	return child.row.nextFullProduct;
 };
 
 const pinnedPlanLicense = ({
 	ctx,
 	currentPlanLicense,
 	child,
-	productStatesContext,
 }: {
 	ctx: AutumnContext;
 	currentPlanLicense: FullPlanLicense;
 	child: UpsertProductPlan;
-	productStatesContext: ProductStatesContext;
 }): PlanLicensePlan | undefined => {
-	const childProduct = pinTargetProduct({ child, productStatesContext });
-	const entitlementPricesPlan = currentPlanLicense.customized
-		? undefined
-		: cloneFrozenChildAsLicenseOverlay({
-				ctx,
-				frozenChildProduct: currentPlanLicense.product,
-				childProduct,
-			});
-	const writesLink =
-		currentPlanLicense.license_internal_product_id !==
-		childProduct.internal_id;
-	if (!writesLink && !entitlementPricesPlan) return undefined;
+	const childProduct = child.row.nextFullProduct;
+	const entitlementPricesPlan = cloneFrozenChildAsLicenseOverlay({
+		ctx,
+		frozenChildProduct: currentPlanLicense.product,
+		childProduct,
+	});
+	if (!entitlementPricesPlan) return undefined;
 
 	return {
 		op: "update",
 		licensePlanId: child.row.planId,
 		licenseProduct: childProduct,
-		effectiveLicenseProduct: entitlementPricesPlan
-			? {
-					...childProduct,
-					prices: entitlementPricesPlan.projected.prices,
-					entitlements: getEntsWithFeature({
-						ents: entitlementPricesPlan.projected.entitlements,
-						features: ctx.features,
-					}),
-				}
-			: currentPlanLicense.customized
-				? currentPlanLicense.product
-				: childProduct,
+		effectiveLicenseProduct: {
+			...childProduct,
+			prices: entitlementPricesPlan.projected.prices,
+			entitlements: getEntsWithFeature({
+				ents: entitlementPricesPlan.projected.entitlements,
+				features: ctx.features,
+			}),
+		},
 		currentPlanLicense,
 		included: currentPlanLicense.included,
 		prepaidOnly: currentPlanLicense.prepaid_only,
@@ -121,8 +81,8 @@ const pinnedPlanLicense = ({
 };
 
 /**
- * Child-driven pin: clone the frozen child's items onto this parent if it
- * does not follow. Customized links and declared licenses[] are skipped.
+ * Child-driven pin: an in-place child edit freezes non-following links anchored
+ * to the edited row via an overlay. Mints/promotes never reach this lane.
  */
 export const computePinnedPlanLicenses = ({
 	ctx,
@@ -149,7 +109,6 @@ export const computePinnedPlanLicenses = ({
 			ctx,
 			currentPlanLicense,
 			child,
-			productStatesContext,
 		});
 		if (planLicense) pinned.push(planLicense);
 	}

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/propagated/computePropagatedPlanLicenses.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/propagated/computePropagatedPlanLicenses.ts
@@ -10,6 +10,7 @@ import {
 	needsNewParentLink,
 	needsRepoint,
 	parentLicenseLinkForChild,
+	propagateReachesLink,
 	shouldPropagate,
 	upsertProductPlansToChildPlans,
 } from "../licensePlanUtils";
@@ -94,8 +95,8 @@ const propagatedPlanLicense = ({
 		: propagatedStockPlanLicense({ currentPlanLicense, child, parent });
 
 /**
- * Child-driven adopt: parents listed in propagate.license_parents follow the
- * child's new items. In-place uncustomized share stock (`op: "none"`) for preview.
+ * Child-driven adopt: listed parents follow this child's next items.
+ * In-place uncustomized share stock; mint/promote may re-point.
  */
 export const computePropagatedPlanLicenses = ({
 	ctx,
@@ -113,7 +114,14 @@ export const computePropagatedPlanLicenses = ({
 	for (const child of upsertProductPlansToChildPlans({ upsertProducts })) {
 		const currentPlanLicense = parentLicenseLinkForChild({ parent, child });
 		if (!currentPlanLicense) continue;
+		if (
+			parent.row.source === "license_adopt" &&
+			!child.row.nextFullProduct.active
+		) {
+			continue;
+		}
 		if (!shouldPropagate({ parent, child, productStatesContext })) continue;
+		if (!propagateReachesLink({ currentPlanLicense, child })) continue;
 
 		const planLicense = propagatedPlanLicense({
 			ctx,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan.ts
@@ -1,13 +1,12 @@
-import {
-	productToProductKey,
-} from "@autumn/shared";
+import { productToProductKey } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { assembleNextFullProduct } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/assembleNextFullProduct";
-import { declaredVariantsForSource } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/declaredVariantsForSource";
 import { computeCatalogEntitlementPricesPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeCatalogEntitlementPricesPlan/computeCatalogEntitlementPricesPlan";
 import { computeFreeTrialPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeFreeTrialPlan/computeFreeTrialPlan";
 import { computeProductDetailsPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/computeProductDetailsPlan";
+import { declaredVariantsForSource } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/declaredVariantsForSource";
 import { resolveUpsertVariantPointer } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/resolveUpsertVariantPointer";
+import { planParamsFromEditDiff } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/planParamsFromEditDiff";
 import { resolveUpsertOp } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/resolveUpsertOp";
 import { resolveUpsertVersioning } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/resolveUpsertVersioning";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
@@ -15,7 +14,6 @@ import type {
 	ProductUpsertIntent,
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
-import { planParamsFromEditDiff } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/planParamsFromEditDiff";
 import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
 import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
 import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
@@ -172,8 +170,7 @@ export const intentToUpsertProductPlan = ({
 			versioning,
 			currentFullProduct,
 			// Mint-only clone source for preview; null on in-place writes.
-			baseFullProduct:
-				versioning === "new_version" ? baseFullProduct : null,
+			baseFullProduct: versioning === "new_version" ? baseFullProduct : null,
 			nextFullProduct,
 		},
 		...(details.changed ? { details } : {}),
@@ -194,7 +191,8 @@ export const intentToUpsertProductPlan = ({
 			: {}),
 		...(declaredVariants !== undefined ? { declaredVariants } : {}),
 		...(unlink ? { unlink: true } : {}),
-		...(source === "direct" && planParams.propagate !== undefined
+		...((source === "direct" || source === "all_versions") &&
+		planParams.propagate !== undefined
 			? { propagate: planParams.propagate }
 			: {}),
 		...(planParams.create_in_stripe !== undefined
@@ -215,8 +213,8 @@ export const intentToUpsertProductPlan = ({
 						})
 					: customerUsage.hasVersionableCustomerProducts,
 			planHadLiveVersions:
-				(productStatesContext.versionsByPlanId[productKey.planId] ?? []).length >
-				0,
+				(productStatesContext.versionsByPlanId[productKey.planId] ?? [])
+					.length > 0,
 		},
 	};
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentIntents.ts
@@ -1,7 +1,10 @@
 import { productKeyToString, productToProductKey } from "@autumn/shared";
 import {
+	childEditsItemsInPlace,
 	childTriggersLicenseRewrite,
+	movesActivePointer,
 	reverseLinksForChild,
+	reverseLinksOnChildPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
 import { deriveLicenseParentMintIntents } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentMintIntents";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
@@ -10,7 +13,12 @@ import type {
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 
-/** Links-only pin for parent versions not already in the batch. Skip all_versions plans — siblings cover them. */
+/**
+ * Pull absent parent versions into the batch. In-place edits pull every
+ * reverse-linked parent (pin candidates); mints/promotes pull only parents
+ * listed in propagate — anchored links stay untouched. Skip all_versions
+ * plans — siblings cover them.
+ */
 export const deriveLicenseParentIntents = ({
 	intent,
 	upsert,
@@ -25,10 +33,19 @@ export const deriveLicenseParentIntents = ({
 	const rewritesLicenses = childTriggersLicenseRewrite({ child: upsert });
 	if (!rewritesLicenses) return [];
 
-	const reverseLinks = reverseLinksForChild({
-		upsert,
-		productStatesContext: projectedProductStatesContext,
-	});
+	const editsInPlace = childEditsItemsInPlace({ child: upsert });
+	const propagatePlanIds = new Set(
+		(upsert.propagate?.license_parents ?? []).map((target) => target.plan_id),
+	);
+	const reverseLinks = movesActivePointer({ upsert })
+		? reverseLinksOnChildPlan({
+				planId: upsert.row.planId,
+				productStatesContext: projectedProductStatesContext,
+			})
+		: reverseLinksForChild({
+				upsert,
+				productStatesContext: projectedProductStatesContext,
+			});
 
 	return [
 		...deriveLicenseParentMintIntents({
@@ -39,6 +56,8 @@ export const deriveLicenseParentIntents = ({
 		...reverseLinks.flatMap((link) => {
 			const productKey = productToProductKey({ product: link.product });
 			if (allVersionsPlanIds.has(productKey.planId)) return [];
+			if (!editsInPlace && !propagatePlanIds.has(productKey.planId))
+				return [];
 			const parentIsLoaded =
 				projectedProductStatesContext.statesByPlanVersion[
 					productKeyToString({ productKey })

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentMintIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentMintIntents.ts
@@ -4,6 +4,7 @@ import type {
 	ProductUpsertIntent,
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { movesActivePointer } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
 import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
 import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
@@ -55,6 +56,9 @@ export const deriveLicenseParentMintIntents = ({
 }): ProductUpsertIntent[] => {
 	const mintedPlanIds = new Set<string>();
 	const intents: ProductUpsertIntent[] = [];
+	const childTakesActive =
+		upsert.row.nextFullProduct.active || movesActivePointer({ upsert });
+	if (!childTakesActive) return [];
 
 	for (const target of upsert.propagate?.license_parents ?? []) {
 		if (target.versioning !== "new_version") continue;

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleLicenseAnchorLifecycleErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleLicenseAnchorLifecycleErrors.ts
@@ -1,0 +1,71 @@
+import { ErrCode, RecaseError } from "@autumn/shared";
+import { StatusCodes } from "http-status-codes";
+import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
+
+const parentsAnchoredTo = ({
+	childInternalId,
+	updateCatalogPlan,
+}: {
+	childInternalId: string;
+	updateCatalogPlan: UpdateCatalogPlan;
+}): string[] => [
+	...new Set(
+		updateCatalogPlan.projected.products.flatMap((parent) =>
+			(parent.licenses ?? [])
+				.filter(
+					(link) =>
+						!link.is_custom &&
+						link.license_internal_product_id === childInternalId,
+				)
+				.map((link) => parent.id),
+		),
+	),
+];
+
+/**
+ * Block archive/remove of a child version that catalog links still point at.
+ * Named parents come from the projected catalog (same-call unlinks are gone).
+ */
+export const handleLicenseAnchorLifecycleErrors = ({
+	updateCatalogPlan,
+}: {
+	updateCatalogPlan: UpdateCatalogPlan;
+}): void => {
+	const retiring = [
+		...updateCatalogPlan.removePlans.flatMap((removePlan) =>
+			removePlan.current
+				? [
+						{
+							planId: removePlan.planId,
+							version: removePlan.version,
+							internalId: removePlan.current.internal_id,
+						},
+					]
+				: [],
+		),
+		...updateCatalogPlan.upsertProducts.flatMap((upsert) => {
+			const { currentFullProduct, nextFullProduct } = upsert.row;
+			if (!nextFullProduct.archived || currentFullProduct?.archived) return [];
+			return [
+				{
+					planId: upsert.row.planId,
+					version: upsert.row.version,
+					internalId: nextFullProduct.internal_id,
+				},
+			];
+		}),
+	];
+
+	for (const row of retiring) {
+		const parentIds = parentsAnchoredTo({
+			childInternalId: row.internalId,
+			updateCatalogPlan,
+		});
+		if (parentIds.length === 0) continue;
+		throw new RecaseError({
+			message: `Cannot archive or remove ${row.planId} version ${row.version} while ${parentIds.join(", ")} still ${parentIds.length === 1 ? "links" : "link"} to it`,
+			code: ErrCode.InvalidRequest,
+			statusCode: StatusCodes.BAD_REQUEST,
+		});
+	}
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
@@ -6,6 +6,7 @@ import {
 	type UpdateCatalogParams,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { handleLicenseAnchorLifecycleErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleLicenseAnchorLifecycleErrors";
 import { handleRemoveFeatureErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleRemoveFeatureErrors/handleRemoveFeatureErrors";
 import { handleRemovePlanErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleRemovePlanErrors/handleRemovePlanErrors";
 import { handleUpdateFeatureErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpdateFeatureErrors/handleUpdateFeatureErrors";
@@ -169,4 +170,5 @@ export const handleUpdateCatalogErrors = async ({
 		updateCatalogPlan,
 		productStatesContext: catalogContext.productStatesContext,
 	});
+	handleLicenseAnchorLifecycleErrors({ updateCatalogPlan });
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleLicenseParentPropagationErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleLicenseParentPropagationErrors.ts
@@ -1,10 +1,13 @@
 import { ErrCode, RecaseError } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
+import { reverseLinksOnChildPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
-import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
 
-/** propagate.license_parents must name plans that already offer this child. */
+/**
+ * propagate.license_parents must name plans that offer this child — links are
+ * version-anchored, so a link on ANY child version row qualifies the parent.
+ */
 export const handleLicenseParentPropagationErrors = ({
 	upsert,
 	productStatesContext,
@@ -15,20 +18,11 @@ export const handleLicenseParentPropagationErrors = ({
 	const targets = upsert.propagate?.license_parents ?? [];
 	if (targets.length === 0) return;
 
-	const previousActive = upsert.previousActiveInternalId
-		? findFullProductByInternalId({
-				internalId: upsert.previousActiveInternalId,
-				productStatesContext,
-			})
-		: null;
 	const parentIds = new Set(
-		[
-			upsert.row.currentFullProduct,
-			upsert.row.baseFullProduct,
-			previousActive,
-		].flatMap((product) =>
-			(product?.parent_plan_licenses ?? []).map((link) => link.product.id),
-		),
+		reverseLinksOnChildPlan({
+			planId: upsert.row.planId,
+			productStatesContext,
+		}).map((link) => link.product.id),
 	);
 
 	for (const target of targets) {

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handlePlanLicenseErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handlePlanLicenseErrors.ts
@@ -62,6 +62,24 @@ export const handlePlanLicenseErrors = ({
 	}
 
 	for (const planLicense of declared) {
+		// Declared anchor must resolve to a live row; drafts are allowed.
+		if (planLicense.declaredVersionSlug !== undefined) {
+			if (!planLicense.licenseProduct) {
+				throw new RecaseError({
+					message: `License ${planLicense.licensePlanId} has no version with slug ${planLicense.declaredVersionSlug}`,
+					code: ErrCode.InvalidRequest,
+					statusCode: StatusCodes.BAD_REQUEST,
+				});
+			}
+			if (planLicense.licenseProduct.archived) {
+				throw new RecaseError({
+					message: `Cannot anchor license ${planLicense.licensePlanId} to archived version ${planLicense.declaredVersionSlug}`,
+					code: ErrCode.InvalidRequest,
+					statusCode: StatusCodes.BAD_REQUEST,
+				});
+			}
+		}
+
 		if (!planLicense.effectiveLicenseProduct) {
 			throw new ProductNotFoundError({
 				productId: planLicense.licensePlanId,

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts
@@ -128,7 +128,22 @@ export const handleUpsertProductVersioningErrors = ({
 				planId: target.plan_id,
 				versioning: target.versioning,
 				version: target.version,
+				versionSlug: target.version_slug,
 			});
+			if (target.version_slug !== undefined && target.version === undefined) {
+				const version = versionForSlug({
+					planId: target.plan_id,
+					versionSlug: target.version_slug,
+					productStatesContext,
+				});
+				if (version === undefined) {
+					throw new RecaseError({
+						message: `Unknown version_slug "${target.version_slug}" for plan_id=${target.plan_id}`,
+						code: ErrCode.InvalidRequest,
+						statusCode: 400,
+					});
+				}
+			}
 			rejectNewVersionOnMissingPlan({
 				planId: target.plan_id,
 				versioning: target.versioning,

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicenseParentsPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicenseParentsPreview.ts
@@ -10,8 +10,11 @@ import { productToProductKey } from "@autumn/shared";
 import { buildPlanChangeFromFullProducts } from "@/internal/catalogV2/actions/buildPlanChange";
 import { catalogRowIdentity } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity";
 import {
+	childEditsItemsInPlace,
 	childPropagatesToParent,
-	reverseLinksForChild,
+	movesActivePointer,
+	reverseLinksOnChildPlan,
+	reverseLinksOnChildProduct,
 } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
 import { withCatalogConflicts } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/conflicts/withCatalogConflicts";
 import { customerUsageForPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/planUsage/buildPlanUsage";
@@ -38,6 +41,11 @@ const byVersionAscending = (
 
 /** A parent version plus the plan name, which only the top-level entry keeps. */
 type NamedParentVersion = CatalogLicenseParentVersionPreview & { name: string };
+
+type ReverseChildLink = {
+	license_internal_product_id: string;
+	product: FullProduct;
+};
 
 const parentVersioningOptions = ({
 	planId,
@@ -172,11 +180,26 @@ const parentPlanChange = ({
 			})
 		: undefined;
 
+/** This child edit will rewrite the catalog link (in-place on this row, or mint/promote). */
+const childEditRewritesLink = ({
+	link,
+	child,
+}: {
+	link: ReverseChildLink | undefined;
+	child: UpsertProductPlan;
+}): boolean => {
+	if (movesActivePointer({ upsert: child })) return true;
+	if (!childEditsItemsInPlace({ child })) return false;
+	if (!link) return false;
+	return link.license_internal_product_id === child.row.nextFullProduct.internal_id;
+};
+
 const buildParentVersionPreview = ({
 	parentUpsert,
 	stateProduct,
 	previewVersion,
 	child,
+	link,
 	upsertProducts,
 	productStatesContext,
 	previewContext,
@@ -185,6 +208,7 @@ const buildParentVersionPreview = ({
 	stateProduct: FullProduct;
 	previewVersion: number;
 	child: UpsertProductPlan;
+	link?: ReverseChildLink;
 	upsertProducts: UpsertProductPlan[];
 	productStatesContext: ProductStatesContext;
 	previewContext: PreviewCatalogContext | undefined;
@@ -199,11 +223,13 @@ const buildParentVersionPreview = ({
 		parentUpsert?.row.baseFullProduct ??
 		parentState.currentFullProduct ??
 		stateProduct;
-	const licenseAction = resolveLicenseAction({
-		parent: parentUpsert,
-		child,
-		productStatesContext,
-	});
+	const licenseAction = childEditRewritesLink({ link, child })
+		? resolveLicenseAction({
+				parent: parentUpsert,
+				child,
+				productStatesContext,
+			})
+		: ("unchanged" as const);
 	const planChange = parentPlanChange({ parentUpsert });
 	const preview = {
 		...catalogRowIdentity({
@@ -228,7 +254,12 @@ const buildParentVersionPreview = ({
 		license_action: licenseAction,
 		...(planChange ? { plan_change: planChange } : {}),
 	};
-	if (licenseAction === "explicit") return preview;
+	if (
+		licenseAction === "explicit" ||
+		!childEditRewritesLink({ link, child })
+	) {
+		return preview;
+	}
 	return withCatalogConflicts({
 		preview,
 		current: child.row.currentFullProduct,
@@ -274,9 +305,15 @@ const foldParentVersions = ({
 			.filter((version) => version.version !== active.version)
 			.map(({ name: _name, ...sibling }) => sibling)
 			.sort(byVersionAscending);
+		const minted = planVersions.find(
+			(version) => version.version > (activeVersion ?? active.version),
+		);
 
 		return {
 			...active,
+			...(minted?.plan_change && !active.plan_change
+				? { plan_change: minted.plan_change }
+				: {}),
 			versioning: parentVersioning({
 				planId: active.plan_id,
 				linkedVersions: planVersions,
@@ -289,23 +326,29 @@ const foldParentVersions = ({
 	});
 };
 
-/** Parents currently offering this child. Empty → omit the lane. */
+/** Parents whose planLicense points at this child version row. Empty → omit. */
 export const buildLicenseParentsPreview = ({
 	directUpsert,
+	childInternalId,
+	includeMintedParents = true,
 	upsertProducts,
 	productStatesContext,
 	previewContext,
 }: {
 	directUpsert: UpsertProductPlan;
+	childInternalId?: string;
+	includeMintedParents?: boolean;
 	upsertProducts: UpsertProductPlan[];
 	productStatesContext: ProductStatesContext;
 	previewContext: PreviewCatalogContext | undefined;
 }): CatalogLicenseParentPreview[] => {
-	const reverseLinks = reverseLinksForChild({
-		upsert: directUpsert,
+	const scopedInternalId =
+		childInternalId ?? directUpsert.row.nextFullProduct.internal_id;
+	const reverseLinks = reverseLinksOnChildProduct({
+		planId: directUpsert.row.planId,
+		childInternalId: scopedInternalId,
 		productStatesContext,
 	});
-	if (reverseLinks.length === 0) return [];
 
 	const existingVersions = reverseLinks
 		.filter((link) => !link.product.archived)
@@ -321,16 +364,78 @@ export const buildLicenseParentsPreview = ({
 				stateProduct: link.product,
 				previewVersion: parentKey.version,
 				child: directUpsert,
+				link,
 				upsertProducts,
 				productStatesContext,
 				previewContext,
 			});
 		});
+	if (!includeMintedParents) {
+		return foldParentVersions({
+			versions: existingVersions,
+			directUpsert,
+			upsertProducts,
+			productStatesContext,
+		}).sort(byPlanId);
+	}
+
+	const sourceInternalId =
+		directUpsert.row.currentFullProduct?.internal_id ??
+		directUpsert.row.baseFullProduct?.internal_id;
+	const followingFromSource =
+		sourceInternalId &&
+		sourceInternalId !== scopedInternalId &&
+		movesActivePointer({ upsert: directUpsert })
+			? reverseLinksOnChildProduct({
+					planId: directUpsert.row.planId,
+					childInternalId: sourceInternalId,
+					productStatesContext,
+				})
+					.filter((link) => !link.product.archived)
+					.flatMap((link): NamedParentVersion[] => {
+						const parentKey = productToProductKey({ product: link.product });
+						const parentUpsert = findParentUpsert({
+							upsertProducts,
+							planId: parentKey.planId,
+							version: parentKey.version,
+						});
+						const listedForPropagate = (
+							directUpsert.propagate?.license_parents ?? []
+						).some((target) => target.plan_id === parentKey.planId);
+						if (
+							!listedForPropagate &&
+							resolveLicenseAction({
+								parent: parentUpsert,
+								child: directUpsert,
+								productStatesContext,
+							}) === "unchanged"
+						) {
+							return [];
+						}
+						return [
+							buildParentVersionPreview({
+								parentUpsert,
+								stateProduct: link.product,
+								previewVersion: parentKey.version,
+								child: directUpsert,
+								link,
+								upsertProducts,
+								productStatesContext,
+								previewContext,
+							}),
+						];
+					})
+			: [];
+
 	const linkedParentPlanIds = new Set(
-		existingVersions.map((version) => version.plan_id),
+		reverseLinksOnChildPlan({
+			planId: directUpsert.row.planId,
+			productStatesContext,
+		}).map((link) => productToProductKey({ product: link.product }).planId),
 	);
 	const mintedVersions = upsertProducts.flatMap((parentUpsert) => {
 		if (!linkedParentPlanIds.has(parentUpsert.row.planId)) return [];
+		if (parentUpsert.row.source !== "license_adopt") return [];
 		const maxVersion = maxVersionForPlan({
 			planId: parentUpsert.row.planId,
 			productStatesContext,
@@ -361,7 +466,7 @@ export const buildLicenseParentsPreview = ({
 	});
 
 	return foldParentVersions({
-		versions: [...existingVersions, ...mintedVersions],
+		versions: [...existingVersions, ...followingFromSource, ...mintedVersions],
 		directUpsert,
 		upsertProducts,
 		productStatesContext,

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicensesPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicensesPreview.ts
@@ -18,6 +18,9 @@ const plannedLicensesPreview = ({
 			{
 				license_plan_id: planLicense.licensePlanId,
 				version: planLicense.licenseProduct.version,
+				...(planLicense.licenseProduct.version_slug
+					? { version_slug: planLicense.licenseProduct.version_slug }
+					: {}),
 				included: planLicense.included,
 				prepaid_only: planLicense.prepaidOnly,
 			},

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildSiblingVersionsPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildSiblingVersionsPreview.ts
@@ -1,5 +1,9 @@
-import type { CatalogSiblingVersionPreview, FullProduct } from "@autumn/shared";
+import type {
+	CatalogPlanSiblingVersionPreview,
+	FullProduct,
+} from "@autumn/shared";
 import { productToProductKey } from "@autumn/shared";
+import { buildLicenseParentsPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicenseParentsPreview";
 import { buildPlanChangeFromFullProducts } from "@/internal/catalogV2/actions/buildPlanChange";
 import { catalogRowIdentity } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity";
 import { withCatalogConflicts } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/conflicts/withCatalogConflicts";
@@ -12,8 +16,8 @@ import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatal
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
 
 const byVersionAscending = (
-	left: CatalogSiblingVersionPreview,
-	right: CatalogSiblingVersionPreview,
+	left: CatalogPlanSiblingVersionPreview,
+	right: CatalogPlanSiblingVersionPreview,
 ) => left.version - right.version;
 
 const selectedSiblingFromUpsert = ({
@@ -26,7 +30,7 @@ const selectedSiblingFromUpsert = ({
 	editedCurrent: FullProduct | null;
 	editedNext: FullProduct;
 	previewContext: PreviewCatalogContext | undefined;
-}): CatalogSiblingVersionPreview => {
+}): CatalogPlanSiblingVersionPreview => {
 	const planChange = buildPlanChangeFromFullProducts({
 		from: sibling.row.currentFullProduct ?? undefined,
 		to: sibling.row.nextFullProduct,
@@ -69,7 +73,7 @@ const unselectedSiblingFromVersion = ({
 	editedCurrent: FullProduct | null;
 	editedNext: FullProduct;
 	previewContext: PreviewCatalogContext | undefined;
-}): CatalogSiblingVersionPreview =>
+}): CatalogPlanSiblingVersionPreview =>
 	withCatalogConflicts({
 		preview: {
 			...catalogRowIdentity({
@@ -112,6 +116,35 @@ const isAllVersionsSiblingForPlan = ({
 	planId: string;
 }) => upsert.row.source === "all_versions" && upsert.row.planId === planId;
 
+const withSiblingLicenseParents = ({
+	sibling,
+	childInternalId,
+	childUpsert,
+	upsertProducts,
+	productStatesContext,
+	previewContext,
+}: {
+	sibling: CatalogPlanSiblingVersionPreview;
+	childInternalId: string;
+	childUpsert: UpsertProductPlan;
+	upsertProducts: UpsertProductPlan[];
+	productStatesContext: ProductStatesContext;
+	previewContext: PreviewCatalogContext | undefined;
+}): CatalogPlanSiblingVersionPreview => {
+	const licenseParents = buildLicenseParentsPreview({
+		directUpsert: childUpsert,
+		childInternalId,
+		includeMintedParents: false,
+		upsertProducts,
+		productStatesContext,
+		previewContext,
+	});
+	return {
+		...sibling,
+		...(licenseParents.length > 0 ? { license_parents: licenseParents } : {}),
+	};
+};
+
 /** Other existing versions of this direct entry's plan. Empty → omit the lane. */
 export const buildSiblingVersionsPreview = ({
 	directUpsert,
@@ -123,7 +156,7 @@ export const buildSiblingVersionsPreview = ({
 	upsertProducts: UpsertProductPlan[];
 	productStatesContext: ProductStatesContext;
 	previewContext: PreviewCatalogContext | undefined;
-}): CatalogSiblingVersionPreview[] => {
+}): CatalogPlanSiblingVersionPreview[] => {
 	const { planId, versioning, version } = directUpsert.row;
 	const hasExactlyOneDirectEntry =
 		upsertProducts.filter((upsert) => isDirectForPlan({ upsert, planId }))
@@ -132,16 +165,37 @@ export const buildSiblingVersionsPreview = ({
 
 	const editedCurrent = directUpsert.row.currentFullProduct;
 	const editedNext = directUpsert.row.nextFullProduct;
+	const attachParents = ({
+		sibling,
+		childInternalId,
+		childUpsert,
+	}: {
+		sibling: CatalogPlanSiblingVersionPreview;
+		childInternalId: string;
+		childUpsert: UpsertProductPlan;
+	}) =>
+		withSiblingLicenseParents({
+			sibling,
+			childInternalId,
+			childUpsert,
+			upsertProducts,
+			productStatesContext,
+			previewContext,
+		});
 
 	if (versioning === "all_versions") {
 		return upsertProducts
 			.filter((upsert) => isAllVersionsSiblingForPlan({ upsert, planId }))
 			.map((sibling) =>
-				selectedSiblingFromUpsert({
-					sibling,
-					editedCurrent,
-					editedNext,
-					previewContext,
+				attachParents({
+					sibling: selectedSiblingFromUpsert({
+						sibling,
+						editedCurrent,
+						editedNext,
+						previewContext,
+					}),
+					childInternalId: sibling.row.nextFullProduct.internal_id,
+					childUpsert: sibling,
 				}),
 			)
 			.sort(byVersionAscending);
@@ -155,7 +209,7 @@ export const buildSiblingVersionsPreview = ({
 					upsert.row.planId === product.id &&
 					upsert.row.version === product.version,
 			);
-			return sibling
+			const preview = sibling
 				? selectedSiblingFromUpsert({
 						sibling,
 						editedCurrent,
@@ -169,6 +223,13 @@ export const buildSiblingVersionsPreview = ({
 						editedNext,
 						previewContext,
 					});
+			return attachParents({
+				sibling: preview,
+				childInternalId: sibling
+					? sibling.row.nextFullProduct.internal_id
+					: product.internal_id,
+				childUpsert: sibling ?? directUpsert,
+			});
 		})
 		.sort(byVersionAscending);
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/planLicensePlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/planLicensePlan.ts
@@ -55,6 +55,8 @@ export type PlanLicensePlan = {
 	metadata?: Record<string, unknown>;
 	/** Declared customize: object = replace, null = clear, undefined = preserve. */
 	customize?: LicenseCustomize | null;
+	/** Declared anchor slug, kept for guard messages. */
+	declaredVersionSlug?: string;
 	/** Overlay vs the child's rows: `same` keeps stock ids, `new` is the is_custom inserts. */
 	entitlementPricesPlan?: EntitlementPricesPlan;
 	/** Absent = nothing to persist for this link. */

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/collectProductStateRows.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/collectProductStateRows.ts
@@ -1,6 +1,7 @@
 import type { FullProduct } from "@autumn/shared";
 
-/** Flatten listFull rows plus nested license parents and payload-base variants. */
+/** Flatten listFull rows plus nested license parents and payload-base variants.
+ * Prefer a row that already carries reverse `parent_plan_licenses`. */
 export const collectProductStateRows = ({
 	products,
 	payloadPlanIds,
@@ -12,8 +13,17 @@ export const collectProductStateRows = ({
 	const payloadIds = payloadPlanIds ? new Set(payloadPlanIds) : null;
 
 	const add = (product: FullProduct | null | undefined) => {
-		if (!product || byInternalId.has(product.internal_id)) return;
-		byInternalId.set(product.internal_id, product);
+		if (!product) return;
+		const existing = byInternalId.get(product.internal_id);
+		if (!existing) {
+			byInternalId.set(product.internal_id, product);
+			return;
+		}
+		const existingHasReverse = (existing.parent_plan_licenses ?? []).length > 0;
+		const incomingHasReverse = (product.parent_plan_licenses ?? []).length > 0;
+		if (!existingHasReverse && incomingHasReverse) {
+			byInternalId.set(product.internal_id, product);
+		}
 	};
 
 	for (const product of products) {

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/fullProductForSlug.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/fullProductForSlug.ts
@@ -1,0 +1,16 @@
+import type { FullProduct } from "@autumn/shared";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+
+/** The row that owns this plan_id + version_slug, or null. */
+export const fullProductForSlug = ({
+	planId,
+	versionSlug,
+	productStatesContext,
+}: {
+	planId: string;
+	versionSlug: string;
+	productStatesContext: ProductStatesContext;
+}): FullProduct | null =>
+	(productStatesContext.versionsByPlanId[planId] ?? []).find(
+		(product) => product.version_slug === versionSlug,
+	) ?? null;

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/versionForSlug.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/versionForSlug.ts
@@ -1,4 +1,5 @@
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import { fullProductForSlug } from "./fullProductForSlug";
 
 /** Version number for this plan_id + version_slug, or undefined if no row owns it. */
 export const versionForSlug = ({
@@ -10,6 +11,4 @@ export const versionForSlug = ({
 	versionSlug: string;
 	productStatesContext: ProductStatesContext;
 }): number | undefined =>
-	(productStatesContext.versionsByPlanId[planId] ?? []).find(
-		(product) => product.version_slug === versionSlug,
-	)?.version;
+	fullProductForSlug({ planId, versionSlug, productStatesContext })?.version;

--- a/server/src/internal/licenses/licenseUtils.ts
+++ b/server/src/internal/licenses/licenseUtils.ts
@@ -13,6 +13,9 @@ export const toApiPlanLicenses = (
 	licenses.map((license) => ({
 		license_plan_id: license.product.id,
 		version: license.product.version,
+		...(license.product.version_slug
+			? { version_slug: license.product.version_slug }
+			: {}),
 		included: license.included,
 		prepaid_only: license.prepaid_only,
 	}));

--- a/shared/api/catalogV2/planUpdate/params/catalogPropagateParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogPropagateParams.ts
@@ -10,6 +10,10 @@ export const CatalogPropagateTargetParamsSchema = z.object({
 	version: z.number().int().min(1).optional().meta({
 		description: "Which version of the target follows. Omit to target latest.",
 	}),
+	version_slug: z.string().nonempty().regex(idRegex).optional().meta({
+		description:
+			"Which version of the target follows, by slug. Same pin as `version`; omit both to target latest.",
+	}),
 	versioning: CatalogPlanVersioningStrategySchema.optional().meta({
 		description:
 			"How this follow applies across the target's versions. Omit or `existing` = the resolved row only; `all_versions` = every other existing version of the target; `new_version` = mint max+1 on the target.",

--- a/shared/api/catalogV2/planUpdate/preview/catalogLicenseParentPreview.ts
+++ b/shared/api/catalogV2/planUpdate/preview/catalogLicenseParentPreview.ts
@@ -28,10 +28,9 @@ export const CatalogLicenseParentVersionPreviewSchema =
 	});
 
 /**
- * One license parent plan a child-plan edit fans out to, nested under the
- * child's direct preview row. Reports the latest linked version, with any
- * older linked versions under `sibling_versions`. License ops live on
- * plan_change (upsert_licenses / remove_licenses).
+ * One license parent plan whose planLicense points at this child version
+ * row. Older linked versions of the same parent nest under
+ * `sibling_versions`. License ops live on plan_change.
  */
 export const CatalogLicenseParentPreviewSchema =
 	CatalogCorePreviewSchema.extend({

--- a/shared/api/catalogV2/planUpdate/preview/catalogPlanPreview.ts
+++ b/shared/api/catalogV2/planUpdate/preview/catalogPlanPreview.ts
@@ -8,7 +8,7 @@ import {
 	CatalogPlanUsageSchema,
 	emptyCatalogPlanUsage,
 } from "./catalogPlanUsage.js";
-import { CatalogSiblingVersionPreviewSchema } from "./catalogSiblingVersionPreview.js";
+import { CatalogPlanSiblingVersionPreviewSchema } from "./catalogPlanSiblingVersionPreview.js";
 import { CatalogVariantPreviewSchema } from "./catalogVariantPreview.js";
 import { CatalogPlanVersioningSchema } from "./catalogVersioningPreview.js";
 import { PlanAliasReplacementSchema } from "./planAliasReplacement.js";
@@ -35,16 +35,16 @@ export const CatalogPlanUpdatePreviewSchema = CatalogCorePreviewSchema.extend({
 	}),
 	versioning: CatalogPlanVersioningSchema.nullable(),
 	sibling_versions: z
-		.array(CatalogSiblingVersionPreviewSchema)
+		.array(CatalogPlanSiblingVersionPreviewSchema)
 		.optional()
 		.meta({
 			description:
-				"Other existing versions of this plan. Omitted when there are none, or when more than one entry in this update targets the same plan (`all_versions` is unavailable then).",
+				"Other existing versions of this plan. Each may carry `license_parents` for links that still point at that version. Omitted when there are none, or when more than one entry in this update targets the same plan (`all_versions` is unavailable then).",
 		}),
 	license_parents: z.array(CatalogLicenseParentPreviewSchema).optional().meta({
 		internal: true,
 		description:
-			"Parents offering this plan as a license and how each one's planLicense resolves against this entry's change. Omitted when the plan is not a license.",
+			"Parents whose planLicense currently points at this version row, and how each resolves against this entry's change. Omitted when none do.",
 	}),
 	variants: z.array(CatalogVariantPreviewSchema).optional().meta({
 		internal: true,

--- a/shared/api/catalogV2/planUpdate/preview/catalogPlanSiblingVersionPreview.ts
+++ b/shared/api/catalogV2/planUpdate/preview/catalogPlanSiblingVersionPreview.ts
@@ -1,0 +1,23 @@
+import { z } from "zod/v4";
+import { CatalogLicenseParentPreviewSchema } from "./catalogLicenseParentPreview.js";
+import { CatalogSiblingVersionPreviewSchema } from "./catalogSiblingVersionPreview.js";
+
+/**
+ * Another version of a plan `plans[]` row. `license_parents` is who
+ * currently points at THIS version — not the edited row.
+ */
+export const CatalogPlanSiblingVersionPreviewSchema =
+	CatalogSiblingVersionPreviewSchema.extend({
+		license_parents: z
+			.array(CatalogLicenseParentPreviewSchema)
+			.optional()
+			.meta({
+				internal: true,
+				description:
+					"Parents whose planLicense still points at this sibling version. Omitted when none do, or when this version is itself a direct `plans[]` entry.",
+			}),
+	});
+
+export type CatalogPlanSiblingVersionPreview = z.infer<
+	typeof CatalogPlanSiblingVersionPreviewSchema
+>;

--- a/shared/api/models.ts
+++ b/shared/api/models.ts
@@ -20,6 +20,7 @@ export * from "./catalogV2/planUpdate/preview/catalogConflictPreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogCorePreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogLicenseParentPreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogPlanPreview.js";
+export * from "./catalogV2/planUpdate/preview/catalogPlanSiblingVersionPreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogPlanUsage.js";
 export * from "./catalogV2/planUpdate/preview/catalogSiblingVersionPreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogVariantPreview.js";

--- a/shared/api/products/apiPlanLicenseV1.ts
+++ b/shared/api/products/apiPlanLicenseV1.ts
@@ -9,6 +9,10 @@ export const ApiPlanLicenseV1Schema = z.object({
 	version: z.number().int().min(1).meta({
 		description: "The exact license-plan version pinned by this link.",
 	}),
+	version_slug: z.string().optional().meta({
+		description:
+			"Version slug of the license-plan row this link points at.",
+	}),
 	included: z.number().meta({
 		description:
 			"Number of license assignments included with this plan for free.",

--- a/shared/api/products/components/planChange/planLicenseChangeV0.ts
+++ b/shared/api/products/components/planChange/planLicenseChangeV0.ts
@@ -6,6 +6,7 @@ import { PlanChangeCoreV0Schema } from "./planChangeCoreV0.js";
 export const PlanLicensePreviousAttributesV0Schema = ApiPlanLicenseV1Schema.pick(
 	{
 		version: true,
+		version_slug: true,
 		included: true,
 		prepaid_only: true,
 	},

--- a/shared/api/products/crud/licenses/planLicenseParams.ts
+++ b/shared/api/products/crud/licenses/planLicenseParams.ts
@@ -5,6 +5,8 @@ import { LicenseCustomizeSchema } from "../../../../models/licenseModels/license
  * `customize` changes only this link; the license plan itself stays shared. */
 export const PlanLicenseParamsSchema = z.object({
 	license_plan_id: z.string(),
+	/** Child version to anchor to. Stated = that slug's row; omitted keeps the existing link (new links use the child's active row). */
+	version_slug: z.string().optional(),
 	included: z.number().int().min(0).optional(),
 	prepaid_only: z.boolean().optional(),
 	customize: LicenseCustomizeSchema.nullish(),

--- a/shared/models/licenseModels/licenseModels.ts
+++ b/shared/models/licenseModels/licenseModels.ts
@@ -26,6 +26,8 @@ export const PlanLicenseSchema = z.object({
 
 export const CustomizePlanLicenseSchema = z.object({
 	license_plan_id: z.string(),
+	/** Child version to anchor to. Stated = that slug's row; omitted keeps the existing link (new links use the child's active row). */
+	version_slug: z.string().optional(),
 	included: z.number().int().min(0).optional(),
 	prepaid_only: z.boolean().optional(),
 	customize: LicenseCustomizeSchema.nullish(),

--- a/shared/utils/planV1Utils/diff/comparePlanLicenses.ts
+++ b/shared/utils/planV1Utils/diff/comparePlanLicenses.ts
@@ -76,7 +76,8 @@ const metadatasAreSame = (
 	return true;
 };
 
-/** Link snapshot (`ApiPlanLicenseV1`). `version` and expanded `plan` are display. */
+/** Link snapshot (`ApiPlanLicenseV1`). Numeric `version` and expanded `plan` are
+ * display; `version_slug` is the version anchor and is a compared term. */
 export const planLicensesAreSame = ({
 	left,
 	right,
@@ -86,6 +87,7 @@ export const planLicensesAreSame = ({
 }): boolean => {
 	const diffs = {
 		licensePlanId: left.license_plan_id !== right.license_plan_id,
+		versionSlug: left.version_slug !== right.version_slug,
 		included: left.included !== right.included,
 		prepaidOnly: left.prepaid_only !== right.prepaid_only,
 		customize: !licenseCustomizesAreSame({
@@ -107,6 +109,7 @@ export const customizePlanLicensesAreSame = ({
 }): boolean => {
 	const diffs = {
 		licensePlanId: left.license_plan_id !== right.license_plan_id,
+		versionSlug: left.version_slug !== right.version_slug,
 		included: left.included !== right.included,
 		prepaidOnly: left.prepaid_only !== right.prepaid_only,
 		customize: !licenseCustomizePatchesAreSame({

--- a/shared/utils/planV1Utils/diff/diffPlanLicenses.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanLicenses.ts
@@ -16,6 +16,9 @@ const toUpsertLicense = ({
 	clearCustomize?: boolean;
 }): CustomizePlanLicense => ({
 	license_plan_id: license.license_plan_id,
+	...(license.version_slug !== undefined
+		? { version_slug: license.version_slug }
+		: {}),
 	included: license.included,
 	prepaid_only: license.prepaid_only,
 	...(clearCustomize
@@ -30,7 +33,8 @@ const byLicensePlanId = <T extends { license_plan_id: string }>(
 	right: T,
 ): number => left.license_plan_id.localeCompare(right.license_plan_id);
 
-/** Link-field patch. `version` / expanded `plan` are display — ignored.
+/** Link-field patch. Numeric `version` / expanded `plan` are display — ignored;
+ * `version_slug` (the version anchor) is a term.
  * New links are skipped unless `includeAdds` — those are lifecycle, not terms. */
 export const diffPlanLicenses = ({
 	from,


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Catalog license links are now version-anchored: a link keeps pointing at the exact child version row it was created against instead of following the plan's active version.

- Declared `licenses[]` entries can pin the anchor with `version_slug`; omitted keeps the existing link, new links use the child's active row.
- A child edit rewrites a link only when it edits the anchored row in place or takes the active pointer; mints/promotes leave anchored links alone unless the parent is listed in `propagate.license_parents`.
- `propagate.license_parents` targets can name `version_slug` to pin the following version.
- A parent counts as offering a child when any version row of the child carries the link, not just the active one.
- Archiving or removing a child version is now blocked while non-custom license links still point at it.
- `version_slug` is included in API license snapshots and is a compared term in plan-change diffs.
- Preview shows, per sibling version, which parents' links still point at that version.

<sup>Written for commit 0641ac5eb9294c93f38c8c3cbdb28c7fba7ee66b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Catalog license links now retain their exact child-version anchor while allowing explicitly selected parent versions to follow child changes.

- **[Improvements, API changes]** Adds `version_slug` to license declarations, propagation targets, snapshots, previews, and plan-change comparisons.
- **[Bug fixes, Improvements]** Resolves pinning and propagation separately for each child and parent version so unrelated sibling links remain unchanged.
- **[Bug fixes]** Prevents non-custom license anchors from pointing at child versions that are archived or removed.
- **[Improvements]** Expands previews to show which parent links point to each sibling version.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no concrete blocking or independently actionable non-blocking defect remains.

Explicit anchors resolve to exact child rows, omitted anchors preserve existing links, invalid lifecycle operations are checked before writes, and parent-version propagation retains distinct sibling versions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils.ts | Introduces version-aware reverse-link collection and separates in-place pinning from explicit propagation behavior. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/declared/resolveDeclaredPlanLicenses.ts | Resolves explicit license version slugs while preserving the current anchor when the field is omitted. |
| server/src/internal/catalogV2/actions/updateCatalog/errors/handleLicenseAnchorLifecycleErrors.ts | Rejects archiving or removing child versions that remain referenced by projected non-custom catalog links. |
| server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicenseParentsPreview.ts | Expands license-parent previews to represent links and follow actions per child sibling version. |
| shared/api/products/crud/licenses/planLicenseParams.ts | Adds the public version-slug input used to anchor a declared license link to an exact child version. |
| shared/utils/planV1Utils/diff/comparePlanLicenses.ts | Includes the license version slug when determining whether license terms changed. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Parent license link] --> B[Anchored child version]
    C[Child catalog update] --> D{Update type}
    D -->|In-place edit| E{Parent selected to follow?}
    E -->|Yes| F[Update linked terms]
    E -->|No| G[Keep anchor and freeze prior terms]
    D -->|Mint or promote| H{Parent selected to follow?}
    H -->|Yes| I[Re-anchor to selected child version]
    H -->|No| J[Keep existing version anchor]
    K[Archive or remove child version] --> L{Non-custom links remain?}
    L -->|Yes| M[Reject catalog update]
    L -->|No| N[Allow lifecycle change]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(catalog-v2): keep license links ver..."](https://github.com/useautumn/autumn/commit/0641ac5eb9294c93f38c8c3cbdb28c7fba7ee66b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58593563)</sub>

<!-- /greptile_comment -->