### PR TITLE
fix(revenuecat): clear cancellation when a past-due product renews

### DIFF
--- a/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
@@ -69,13 +69,18 @@ export const handleRenewal = async ({
 		return { success: true };
 	}
 
-	// Past-due → active recovery.
+	// Past-due → active recovery. A product cancelled before it went past due
+	// needs uncancel, since markActive leaves the cancellation fields set.
 	if (curSameProduct && curSameProduct.status === CusProductStatus.PastDue) {
 		logger.info(
 			`Renewal for existing past due product ${product.id}, marking as active`,
 		);
 
-		await customerProductActions.markActive({
+		const recoverPastDueProduct = curSameProduct.canceled
+			? customerProductActions.uncancel
+			: customerProductActions.markActive;
+
+		await recoverPastDueProduct({
 			ctx: customerCtx,
 			customerProduct: curSameProduct,
 			fullCustomer: customer,

--- a/server/tests/integration/external-psps/revenuecat/revenuecat.test.ts
+++ b/server/tests/integration/external-psps/revenuecat/revenuecat.test.ts
@@ -713,3 +713,128 @@ test.concurrent(
 		await clearInvoiceTestData();
 	},
 );
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 4: RENEWAL on a product that is BOTH cancelled AND past due
+//
+// handleRenewal branches on status and only one branch runs, so PastDue matches
+// before the reactivation branch and a cancelled + past-due product took
+// markActive (status only), keeping canceled/canceled_at/ended_at from the
+// earlier CANCELLATION.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("revenuecat 4: renewal on cancelled + past due product clears cancellation")}`,
+	async () => {
+		const customerId = "rc-renewal-cancelled-pastdue";
+		const RC_PRO_MONTHLY_ID = "com.app.rc4_pro_monthly";
+		const RC_ORIGINAL_TX_ID = "rc4_tx_001";
+
+		const proMonthly = rcProMonthly({ id: "rc4-pro-monthly" });
+
+		await setupRevenueCatOrg();
+
+		await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [proMonthly] }),
+			],
+			actions: [],
+		});
+
+		await RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: AppEnv.Sandbox,
+				autumn_product_id: proMonthly.id,
+				revenuecat_product_ids: [RC_PRO_MONTHLY_ID],
+			},
+		});
+
+		const rcClient = new RevenueCatWebhookClient({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			webhookSecret: RC_WEBHOOK_SECRET,
+		});
+
+		const dbCustomer = await ctx.db.query.customers.findFirst({
+			where: eq(customers.id, customerId),
+		});
+		expect(dbCustomer).toBeDefined();
+		const internalCustomerId = dbCustomer!.internal_id;
+
+		const fetchCustomerProduct = async () => {
+			const cusProducts = await CusProductService.list({
+				db: ctx.db,
+				internalCustomerId,
+				inStatuses: [
+					CusProductStatus.Active,
+					CusProductStatus.PastDue,
+					CusProductStatus.Scheduled,
+					CusProductStatus.Expired,
+				],
+			});
+			const customerProduct = cusProducts.find(
+				(cp) => cp.product.id === proMonthly.id,
+			);
+			expect(customerProduct).toBeDefined();
+			return customerProduct!;
+		};
+
+		// ─── 1. Initial purchase establishes the cus_product ───────────────────
+		expectWebhookSuccess(
+			await rcClient.initialPurchase({
+				productId: RC_PRO_MONTHLY_ID,
+				appUserId: customerId,
+				originalTransactionId: RC_ORIGINAL_TX_ID,
+			}),
+		);
+
+		// ─── 2. Cancellation sets canceled + a future ended_at ─────────────────
+		const expirationAtMs = Date.now() + 1000 * 60 * 60 * 24 * 30;
+
+		expectWebhookSuccess(
+			await rcClient.cancellation({
+				productId: RC_PRO_MONTHLY_ID,
+				appUserId: customerId,
+				originalTransactionId: RC_ORIGINAL_TX_ID,
+				expirationAtMs,
+			}),
+		);
+
+		const afterCancellation = await fetchCustomerProduct();
+		expect(afterCancellation.canceled).toBe(true);
+		expect(afterCancellation.canceled_at).not.toBeNull();
+		expect(afterCancellation.ended_at).toBe(expirationAtMs);
+
+		// ─── 3. Billing issue flips it past due; cancellation fields survive ───
+		expectWebhookSuccess(
+			await rcClient.billingIssue({
+				productId: RC_PRO_MONTHLY_ID,
+				appUserId: customerId,
+				originalTransactionId: RC_ORIGINAL_TX_ID,
+			}),
+		);
+
+		const afterBillingIssue = await fetchCustomerProduct();
+		expect(afterBillingIssue.status).toBe(CusProductStatus.PastDue);
+		expect(afterBillingIssue.canceled).toBe(true);
+
+		// ─── 4. Renewal must recover the status AND clear the cancellation ─────
+		expectWebhookSuccess(
+			await rcClient.renewal({
+				productId: RC_PRO_MONTHLY_ID,
+				appUserId: customerId,
+				originalTransactionId: RC_ORIGINAL_TX_ID,
+			}),
+		);
+
+		const afterRenewal = await fetchCustomerProduct();
+		expect(afterRenewal.status).toBe(CusProductStatus.Active);
+		expect(afterRenewal.canceled).toBe(false);
+		expect(afterRenewal.canceled_at).toBeNull();
+		expect(afterRenewal.ended_at).toBeNull();
+	},
+);


### PR DESCRIPTION
A RevenueCat renewal recovers a past-due product's status but leaves the earlier cancellation on the row, so the subscription keeps reporting itself as cancelled with a stale expiry after the customer has already paid.

## What happens

`handleRenewal` branches on status and only one branch runs:

```
├─ Active   → renew()      no DB write
├─ PastDue  → markActive() writes { status: Active } ONLY          ← the bug
└─ else     → uncancel()   writes { status, canceled: false,
                                    canceled_at: null, ended_at: null }
```

When Google Play cancels for a billing error and then the payment recovers, the product is **both** cancelled and past due. `markCustomerProductActive` writes only `{ status: Active }`, so `canceled`, `canceled_at` and `ended_at` survive the renewal. The `uncancel` branch that would clear them sits below and is unreachable, because `PastDue` matches first.

`getApiSubscription` passes those straight through (`canceled_at: cusProduct.canceled_at`, `expires_at: cusProduct.ended_at`), so the API and the `billing.updated` webhook both report a live subscription as cancelled.

## The fix

Route the past-due recovery through `uncancel` when the product is also cancelled. `uncancelCustomerProduct` already sets `status: Active` on top of clearing the three fields, so it is a strict superset — no new action, and both paths dispatch the same `AttachScenario.Renew` webhook, so the payload shape consumers see is unchanged.

## Impact

Confirmed on 17 live customers for one org, all matched exactly against RevenueCat (`status: active`, `auto_renewal_status: will_renew`), each carrying an `ended_at` 24–31 days earlier than the access RevenueCat had actually sold. Their cancellations were cleared out of band; this stops new ones accruing at roughly one a day.

Access was never lost — nothing sweeps `ended_at` for RevenueCat products, so the damage was confined to the billing projection and the actions gated on it.

## Test

`revenuecat 4` in `revenuecat.test.ts` drives the server's own webhook endpoint (no RevenueCat key needed): INITIAL_PURCHASE → CANCELLATION → BILLING_ISSUE → RENEWAL, asserting the intermediate states and then all four post-renewal fields off the DB row. It fails on `main` at `expect(afterRenewal.canceled).toBe(false)` with the status assertion above it already passing — exactly the production symptom.

## Deliberately not in scope

- **No staleness guard.** RevenueCat delivers out of order (in the reported case the renewal was purchased 04:29 and delivered 18:27, after the 06:54 cancellation), so a late renewal could in principle clear a newer genuine cancellation. Guarding on `event.expiration_at_ms > ended_at` is the fix for that, but it is a separate decision.
- **The `Active` branch has the same latent bug.** `canceled=true` + `status=Active` + RENEWAL takes `renew()`, which writes `updates: {}` and leaves the cancellation equally stale. Untouched here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RevenueCat renewals leaving stale cancellation data on products that are both cancelled and past due. A paid renewal now clears `canceled`, `canceled_at`, and `ended_at` instead of reporting a live subscription as cancelled.

- `handleRenewal` branches on product status, and the PastDue branch ran before the uncancel branch, so a cancelled product that went past due only wrote `status: Active`.
- The fix routes past-due recovery through `uncancel` when the product is also cancelled; it already sets `status: Active` and both paths emit the same `AttachScenario.Renew` webhook, so the payload shape is unchanged.
- 17 live customers had stale cancellations; access was never lost, only the billing projection was affected.
- Adds an integration test driving purchase → cancellation → billing issue → renewal and asserting all four fields on the DB row.
- Deliberately not in scope: no staleness guard for out-of-order renewals, and the Active branch has the same latent bug.

<sup>Written for commit e63acf3abc107693fa3cf9fdd23d1c2b85b77b6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

