### PR TITLE
feat: 🎸 address catalog rows by internal id

### DIFF
--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRenameProductIdsPlan/computeRenameProductIdsPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRenameProductIdsPlan/computeRenameProductIdsPlan.ts
@@ -1,7 +1,8 @@
 import type { UpdateCatalogParams } from "@autumn/shared";
-import { resolveAliasReplacement } from "@/internal/catalogV2/productAliases/resolveAliasReplacement";
-import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import type { InternalIdRefs } from "@/internal/catalogV2/actions/updateCatalog/setup/resolveInternalIdRefs";
 import type { RenameProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/renameProductPlan";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import { resolveAliasReplacement } from "@/internal/catalogV2/productAliases/resolveAliasReplacement";
 
 const renameIfExisting = ({
 	planId,
@@ -31,16 +32,51 @@ const renameIfExisting = ({
  * One rename per existing plan with a differing new_plan_id. Creates carry
  * the new id on the row itself — no references exist yet, nothing to move.
  */
+/**
+ * A row addressed by internal_id under a different plan_id IS a rename — the
+ * config states where the row should live now, and does not have to remember
+ * the name it used to use.
+ */
+const renameFromInternalId = ({
+	planParams,
+	internalIdRefs,
+	productStatesContext,
+	aliases,
+}: {
+	planParams: UpdateCatalogParams["plans"][number];
+	internalIdRefs: InternalIdRefs;
+	productStatesContext: ProductStatesContext;
+	aliases?: Record<string, string>;
+}): RenameProductPlan[] => {
+	if (!planParams.internal_id || planParams.new_plan_id) return [];
+	const ref = internalIdRefs.get(planParams.internal_id);
+	if (!ref) return [];
+	return renameIfExisting({
+		planId: ref.planId,
+		toId: planParams.plan_id,
+		productStatesContext,
+		aliases,
+	});
+};
+
 export const computeRenameProductIdsPlan = ({
 	params,
 	productStatesContext,
+	internalIdRefs,
 	aliases,
 }: {
 	params: UpdateCatalogParams;
 	productStatesContext: ProductStatesContext;
+	internalIdRefs: InternalIdRefs;
 	aliases?: Record<string, string>;
 }): RenameProductPlan[] =>
 	params.plans.flatMap((planParams) => [
+		...renameFromInternalId({
+			planParams,
+			internalIdRefs,
+			productStatesContext,
+			aliases,
+		}),
 		...(planParams.new_plan_id
 			? renameIfExisting({
 					planId: planParams.plan_id,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpdateCatalogPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpdateCatalogPlan.ts
@@ -86,6 +86,7 @@ export const computeUpdateCatalogPlan = ({
 		renamePlans: computeRenameProductIdsPlan({
 			params,
 			productStatesContext: catalogContext.productStatesContext,
+			internalIdRefs: catalogContext.internalIdRefs,
 			aliases: ctx.org.planAliases,
 		}),
 		migrationDrafts: computeMigrationDraftPlans({

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/planParamsToProductRowPatch.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/planParamsToProductRowPatch.ts
@@ -19,6 +19,15 @@ export const planParamsToProductRowPatch = ({
 	const patch: Partial<Product> = {};
 
 	if (planParams.new_plan_id !== undefined) patch.id = planParams.new_plan_id;
+	// Addressed by internal_id under a different plan_id: the row moves there.
+	// Without this the upsert writes the old id back over the rename.
+	if (
+		planParams.internal_id !== undefined &&
+		current !== null &&
+		planParams.plan_id !== current.id
+	) {
+		patch.id = planParams.plan_id;
+	}
 	if (planParams.name !== undefined) patch.name = planParams.name;
 	if (planParams.description !== undefined) {
 		patch.description = planParams.description;

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductsPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductsPlan.ts
@@ -29,14 +29,19 @@ export const computeUpsertProductsPlan = ({
 	catalogContext: UpdateCatalogContext;
 	params: UpdateCatalogParams;
 }): CatalogComputeStep => {
-	const { productStatesContext } = catalogContext;
+	const { productStatesContext, internalIdRefs } = catalogContext;
 
 	// A row the payload named is claimed before the fold, so the derived
 	// mapping fan-out can never reach it — fill it in up front instead.
 	const pendingIntents = mergeDeclaredProcessors({
-		intents: deriveDirectIntents({ params, productStatesContext }),
+		intents: deriveDirectIntents({
+			params,
+			productStatesContext,
+			internalIdRefs,
+		}),
 		params,
 		productStatesContext,
+		internalIdRefs,
 	});
 	const declaredVariants = indexDeclaredVariants({
 		plans: params.plans,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts
@@ -2,6 +2,7 @@ import type {
 	UpdateCatalogParams,
 	UpdateCatalogPlanParams,
 } from "@autumn/shared";
+import type { InternalIdRefs } from "@/internal/catalogV2/actions/updateCatalog/setup/resolveInternalIdRefs";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type {
 	ProductUpsertIntent,
@@ -17,28 +18,44 @@ const hasExplicitVersion = (
 
 const groupPlanParamsByPlanId = ({
 	planParamsList,
+	internalIdRefs,
 }: {
 	planParamsList: UpdateCatalogParams["plans"];
+	internalIdRefs: InternalIdRefs;
 }): Map<string, UpdateCatalogPlanParams[]> => {
 	const byPlanId = new Map<string, UpdateCatalogPlanParams[]>();
 	for (const planParams of planParamsList) {
-		const forPlan = byPlanId.get(planParams.plan_id) ?? [];
+		// Group under the row's CURRENT id: a rename states the new one.
+		const currentPlanId =
+			(planParams.internal_id
+				? internalIdRefs.get(planParams.internal_id)?.planId
+				: undefined) ?? planParams.plan_id;
+		const forPlan = byPlanId.get(currentPlanId) ?? [];
 		forPlan.push(planParams);
-		byPlanId.set(planParams.plan_id, forPlan);
+		byPlanId.set(currentPlanId, forPlan);
 	}
 	return byPlanId;
 };
 
-/** Numeric pin, or the version that owns `version_slug`. Unknown slugs stay unresolved. */
+/**
+ * The stable id wins: it is the only handle a rename cannot invalidate. A slug
+ * or numeric pin naming a different row alongside it is rejected in errors, so
+ * by here they either agree or the request never arrives.
+ */
 const resolvePinnedVersion = ({
 	planParams,
 	planId,
 	productStatesContext,
+	internalIdRefs,
 }: {
 	planParams: UpdateCatalogPlanParams;
 	planId: string;
 	productStatesContext: ProductStatesContext;
+	internalIdRefs: InternalIdRefs;
 }): number | undefined => {
+	if (planParams.internal_id !== undefined) {
+		return internalIdRefs.get(planParams.internal_id)?.version;
+	}
 	if (planParams.version !== undefined) return planParams.version;
 	if (planParams.version_slug === undefined) return undefined;
 	return versionForSlug({
@@ -54,16 +71,19 @@ const resolveVersionsForPlan = ({
 	planId,
 	planParamsList,
 	productStatesContext,
+	internalIdRefs,
 }: {
 	planId: string;
 	planParamsList: UpdateCatalogPlanParams[];
 	productStatesContext: ProductStatesContext;
+	internalIdRefs: InternalIdRefs;
 }): ResolvedPlanParams[] => {
 	const resolved = planParamsList.map((planParams) => {
 		const version = resolvePinnedVersion({
 			planParams,
 			planId,
 			productStatesContext,
+			internalIdRefs,
 		});
 		return version !== undefined ? { ...planParams, version } : planParams;
 	});
@@ -77,8 +97,7 @@ const resolveVersionsForPlan = ({
 		(productStatesContext.versionsByPlanId[planId] ?? []).length > 0;
 	const nextFreeVersion = maxVersion + 1;
 	const activeOrV1 =
-		activeVersionForPlan({ planId, productStatesContext }) ??
-		(maxVersion || 1);
+		activeVersionForPlan({ planId, productStatesContext }) ?? (maxVersion || 1);
 
 	const targetingLatest = resolved
 		.filter(
@@ -104,23 +123,29 @@ const resolveVersionsForPlan = ({
 export const deriveDirectIntents = ({
 	params,
 	productStatesContext,
+	internalIdRefs,
 }: {
 	params: UpdateCatalogParams;
 	productStatesContext: ProductStatesContext;
+	internalIdRefs: InternalIdRefs;
 }): ProductUpsertIntent[] =>
-	[...groupPlanParamsByPlanId({ planParamsList: params.plans }).entries()]
+	[
+		...groupPlanParamsByPlanId({
+			planParamsList: params.plans,
+			internalIdRefs,
+		}).entries(),
+	]
 		.flatMap(([planId, planParamsList]) =>
 			resolveVersionsForPlan({
 				planId,
 				planParamsList,
 				productStatesContext,
-			}),
+				internalIdRefs,
+			}).map((planParams) => ({ planId, planParams })),
 		)
-		.map((planParams) => ({
-			productKey: {
-				planId: planParams.plan_id,
-				version: planParams.version,
-			},
+		.map(({ planId, planParams }) => ({
+			// Key on the row's current id; `plan_id` may be the rename target.
+			productKey: { planId, version: planParams.version },
 			planParams,
 			source: "direct" as const,
 			...(planParams.base_variant_id === null ? { unlink: true } : {}),

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/mergeDeclaredProcessors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/mergeDeclaredProcessors.ts
@@ -5,9 +5,26 @@ import {
 	RecaseError,
 	type UpdateCatalogParams,
 } from "@autumn/shared";
+import type { InternalIdRefs } from "@/internal/catalogV2/actions/updateCatalog/setup/resolveInternalIdRefs";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { ProductUpsertIntent } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
+
+/**
+ * The id the row lives under right now. An entry addressed by `internal_id`
+ * states where the plan should END UP, so a rename would index the mapping
+ * under a name no intent carries yet.
+ */
+const currentPlanId = ({
+	entry,
+	internalIdRefs,
+}: {
+	entry: UpdateCatalogParams["plans"][number];
+	internalIdRefs: InternalIdRefs;
+}): string =>
+	(entry.internal_id
+		? internalIdRefs.get(entry.internal_id)?.planId
+		: undefined) ?? entry.plan_id;
 
 /** A stated Stripe mapping: an object links, `null` unlinks. Absent = not stated. */
 type StatedStripe = ApiStripePlanProcessor | null;
@@ -80,8 +97,10 @@ type StatedStripeIndex = {
  */
 const assertRevenueCatMappingsAgree = ({
 	plans,
+	internalIdRefs,
 }: {
 	plans: UpdateCatalogParams["plans"];
+	internalIdRefs: InternalIdRefs;
 }): void => {
 	const statedByPlanId = new Map<string, ApiRevenueCatPlanProcessor | null>();
 	for (const entry of plans) {
@@ -89,7 +108,7 @@ const assertRevenueCatMappingsAgree = ({
 		if (revenuecat === undefined) continue;
 		claimStatedMapping({
 			statedByPlanId,
-			planId: entry.plan_id,
+			planId: currentPlanId({ entry, internalIdRefs }),
 			stated: revenuecat,
 			identity: revenueCatMappingIdentity,
 			processorName: "revenuecat",
@@ -99,8 +118,10 @@ const assertRevenueCatMappingsAgree = ({
 
 const indexStatedStripe = ({
 	plans,
+	internalIdRefs,
 }: {
 	plans: UpdateCatalogParams["plans"];
+	internalIdRefs: InternalIdRefs;
 }): StatedStripeIndex => {
 	const byPlanId = new Map<string, StatedStripe>();
 	const byVariantPlanId = new Map<string, StatedStripe>();
@@ -110,7 +131,7 @@ const indexStatedStripe = ({
 		if (stripe !== undefined) {
 			claimStatedMapping({
 				statedByPlanId: byPlanId,
-				planId: entry.plan_id,
+				planId: currentPlanId({ entry, internalIdRefs }),
 				stated: stripe,
 				identity: stripeMappingIdentity,
 				processorName: "stripe",
@@ -223,14 +244,19 @@ export const mergeDeclaredProcessors = ({
 	intents,
 	params,
 	productStatesContext,
+	internalIdRefs,
 }: {
 	intents: ProductUpsertIntent[];
 	params: UpdateCatalogParams;
 	productStatesContext: ProductStatesContext;
+	internalIdRefs: InternalIdRefs;
 }): ProductUpsertIntent[] => {
-	assertRevenueCatMappingsAgree({ plans: params.plans });
+	assertRevenueCatMappingsAgree({ plans: params.plans, internalIdRefs });
 
-	const statedStripe = indexStatedStripe({ plans: params.plans });
+	const statedStripe = indexStatedStripe({
+		plans: params.plans,
+		internalIdRefs,
+	});
 	if (
 		statedStripe.byPlanId.size === 0 &&
 		statedStripe.byVariantPlanId.size === 0

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/assertInternalIdAgrees.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/assertInternalIdAgrees.ts
@@ -1,0 +1,53 @@
+import { ErrCode, RecaseError, type UpdateCatalogParams } from "@autumn/shared";
+import type { InternalIdRefs } from "@/internal/catalogV2/actions/updateCatalog/setup/resolveInternalIdRefs";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import { versionForSlug } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/versionForSlug";
+
+/**
+ * A stated `internal_id` and a stated version pin must name the same row.
+ * Silently preferring one would apply the write somewhere the caller did not
+ * ask for — and a config file that disagrees with itself is a bug worth
+ * surfacing, not resolving.
+ */
+export const assertInternalIdAgrees = ({
+	params,
+	productStatesContext,
+	internalIdRefs,
+}: {
+	params: UpdateCatalogParams;
+	productStatesContext: ProductStatesContext;
+	internalIdRefs: InternalIdRefs;
+}): void => {
+	for (const planParams of params.plans) {
+		const { internal_id: internalId } = planParams;
+		if (!internalId) continue;
+
+		const ref = internalIdRefs.get(internalId);
+		if (!ref) continue;
+
+		if (
+			planParams.version !== undefined &&
+			planParams.version !== ref.version
+		) {
+			throw new RecaseError({
+				code: ErrCode.InvalidRequest,
+				message: `internal_id ${internalId} is ${ref.planId} v${ref.version}, but version ${planParams.version} was also given`,
+				statusCode: 400,
+			});
+		}
+
+		if (planParams.version_slug === undefined) continue;
+		const slugVersion = versionForSlug({
+			planId: ref.planId,
+			versionSlug: planParams.version_slug,
+			productStatesContext,
+		});
+		if (slugVersion !== undefined && slugVersion !== ref.version) {
+			throw new RecaseError({
+				code: ErrCode.InvalidRequest,
+				message: `internal_id ${internalId} is ${ref.planId} v${ref.version}, but version_slug "${planParams.version_slug}" names v${slugVersion}`,
+				statusCode: 400,
+			});
+		}
+	}
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
@@ -6,6 +6,7 @@ import {
 	type UpdateCatalogParams,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { assertInternalIdAgrees } from "@/internal/catalogV2/actions/updateCatalog/errors/assertInternalIdAgrees";
 import { handleDeclaredVariantAnchorErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleDeclaredVariantAnchorErrors";
 import { handleLicenseAnchorLifecycleErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleLicenseAnchorLifecycleErrors";
 import { handleRemoveFeatureErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleRemoveFeatureErrors/handleRemoveFeatureErrors";
@@ -154,6 +155,11 @@ export const handleUpdateCatalogErrors = async ({
 	handleRemovePlanErrors({
 		updateCatalogPlan,
 		productStatesContext: catalogContext.productStatesContext,
+	});
+	assertInternalIdAgrees({
+		params,
+		productStatesContext: catalogContext.productStatesContext,
+		internalIdRefs: catalogContext.internalIdRefs,
 	});
 	handleUpsertProductVersioningErrors({
 		params,

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/resolveInternalIdRefs.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/resolveInternalIdRefs.ts
@@ -1,0 +1,81 @@
+import {
+	ErrCode,
+	type ProductKey,
+	products,
+	RecaseError,
+	type UpdateCatalogParams,
+} from "@autumn/shared";
+import { and, eq, inArray } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+/** Every `internal_id` the payload states, on plans and on nested variants. */
+export const statedInternalIds = ({
+	params,
+}: {
+	params: UpdateCatalogParams;
+}): string[] => [
+	...new Set(
+		params.plans.flatMap((plan) => [
+			...(plan.internal_id ? [plan.internal_id] : []),
+			...(plan.variants ?? []).flatMap((variant) =>
+				variant.internal_id ? [variant.internal_id] : [],
+			),
+		]),
+	),
+];
+
+export type InternalIdRefs = Map<string, ProductKey>;
+
+/**
+ * Resolve stated ids to `(plan_id, version)` BEFORE setup loads anything.
+ *
+ * Setup scopes its `listFull` by the plan ids in the payload, so a renamed row
+ * — the case internal_id exists for — names a plan that does not exist yet and
+ * its row would never load. This runs first so those rows are in scope, and so
+ * downstream matching never has to carry an id.
+ */
+export const resolveInternalIdRefs = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: UpdateCatalogParams;
+}): Promise<InternalIdRefs> => {
+	const internalIds = statedInternalIds({ params });
+	if (internalIds.length === 0) return new Map();
+
+	const rows = await ctx.db
+		.select({
+			internalId: products.internal_id,
+			planId: products.id,
+			version: products.version,
+		})
+		.from(products)
+		.where(
+			and(
+				eq(products.org_id, ctx.org.id),
+				eq(products.env, ctx.env),
+				inArray(products.internal_id, internalIds),
+			),
+		);
+
+	const refs: InternalIdRefs = new Map(
+		rows.map((row) => [
+			row.internalId,
+			{ planId: row.planId, version: row.version },
+		]),
+	);
+
+	// An id nothing owns is a caller bug — minting a fresh row under it would
+	// silently disconnect the config from the row it meant to address.
+	const unknown = internalIds.filter((id) => !refs.has(id));
+	if (unknown.length > 0) {
+		throw new RecaseError({
+			code: ErrCode.InvalidRequest,
+			message: `No plan row exists for internal_id ${unknown.join(", ")}`,
+			statusCode: 400,
+		});
+	}
+
+	return refs;
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/setupProductStatesContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/setupProductStatesContext.ts
@@ -1,5 +1,6 @@
 import type { UpdateCatalogParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import type { InternalIdRefs } from "@/internal/catalogV2/actions/updateCatalog/setup/resolveInternalIdRefs";
 import {
 	type CatalogPhases,
 	timeCatalogPhase,
@@ -19,10 +20,14 @@ import { rewardProgramRepo } from "@/internal/rewards/repos/index.js";
 
 const payloadPlanIds = ({
 	params,
+	internalIdRefs,
 }: {
 	params: UpdateCatalogParams;
+	internalIdRefs: InternalIdRefs;
 }): string[] => [
 	...new Set([
+		// A renamed row's current id is only known through its internal_id.
+		...[...internalIdRefs.values()].map((ref) => ref.planId),
 		...params.plans.flatMap((entry) => [
 			entry.plan_id,
 			...(entry.new_plan_id ? [entry.new_plan_id] : []),
@@ -51,13 +56,15 @@ export const setupProductStatesContext = async ({
 	ctx,
 	params,
 	phases,
+	internalIdRefs,
 }: {
 	ctx: AutumnContext;
 	params: UpdateCatalogParams;
 	phases: CatalogPhases;
+	internalIdRefs: InternalIdRefs;
 }): Promise<ProductStatesContext> => {
 	const { db, org, env } = ctx;
-	const loadedPlanIds = payloadPlanIds({ params });
+	const loadedPlanIds = payloadPlanIds({ params, internalIdRefs });
 	if (loadedPlanIds.length === 0) return emptyProductStatesContext();
 
 	const payloadVersions = await timeCatalogPhase({

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/setupUpdateCatalogContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/setupUpdateCatalogContext.ts
@@ -2,6 +2,7 @@ import type { UpdateCatalogParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { setupFeatureUsagePersisted } from "@/internal/catalogV2/actions/updateCatalog/setup/preview/setupFeatureUsagePersisted";
 import { setupPlanUsagePersisted } from "@/internal/catalogV2/actions/updateCatalog/setup/preview/setupPlanUsagePersisted";
+import { resolveInternalIdRefs } from "@/internal/catalogV2/actions/updateCatalog/setup/resolveInternalIdRefs";
 import { setupFeatureStatesContext } from "@/internal/catalogV2/actions/updateCatalog/setup/setupFeatureStatesContext";
 import { setupInvoiceCreditProducts } from "@/internal/catalogV2/actions/updateCatalog/setup/setupInvoiceCreditProducts";
 import { setupLicenseStatesContext } from "@/internal/catalogV2/actions/updateCatalog/setup/setupLicenseStatesContext";
@@ -23,6 +24,15 @@ export const setupUpdateCatalogContext = async ({
 	preview?: boolean;
 	phases: CatalogPhases;
 }): Promise<UpdateCatalogContext> => {
+	// Ahead of every load: a renamed row names a plan id that does not exist
+	// yet, so setup cannot scope to it until the stated ids are resolved.
+	const internalIdRefs = await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "internal_id_refs",
+		run: () => resolveInternalIdRefs({ ctx, params }),
+	});
+
 	const invoiceCreditProductsPromise = timeCatalogPhase({
 		ctx,
 		phases,
@@ -37,7 +47,7 @@ export const setupUpdateCatalogContext = async ({
 				phase: "feature_states",
 				run: () => setupFeatureStatesContext({ ctx, params }),
 			}),
-			setupProductStatesContext({ ctx, params, phases }),
+			setupProductStatesContext({ ctx, params, phases, internalIdRefs }),
 			preview
 				? timeCatalogPhase({
 						ctx,
@@ -71,6 +81,7 @@ export const setupUpdateCatalogContext = async ({
 	return {
 		featureStatesContext,
 		productStatesContext,
+		internalIdRefs,
 		invoiceCreditProducts,
 		licenseStatesContext,
 		previewContext: preview

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/updateCatalogContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/updateCatalogContext.ts
@@ -1,4 +1,5 @@
 import type { FullProduct } from "@autumn/shared";
+import type { InternalIdRefs } from "@/internal/catalogV2/actions/updateCatalog/setup/resolveInternalIdRefs";
 import type { FeatureState } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/featureState";
 import type { LicenseStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/licenseStatesContext";
 import type { PreviewCatalogContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/previewCatalogContext";
@@ -9,6 +10,8 @@ export interface UpdateCatalogContext {
 	/** Dependency + rewrite overflow flags, keyed by feature id. */
 	featureStatesContext: Record<string, FeatureState>;
 	productStatesContext: ProductStatesContext;
+	/** Stated `internal_id` → the row it names. Empty when none were stated. */
+	internalIdRefs: InternalIdRefs;
 	/** Persisted plan versions referencing a feature being enabled for invoice credits. */
 	invoiceCreditProducts: FullProduct[];
 	licenseStatesContext: LicenseStatesContext;

--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -197,6 +197,7 @@ export async function getPlanResponse({
 	});
 	const plan = {
 		id: product.id,
+		internal_id: product.internal_id,
 		name: product.name || "",
 		description: product.description || null,
 		group: product.group || null,

--- a/server/tests/integration/catalog-v2/plans/internal-id/address-by-internal-id.test.ts
+++ b/server/tests/integration/catalog-v2/plans/internal-id/address-by-internal-id.test.ts
@@ -1,0 +1,263 @@
+/**
+ * catalogV2 — `internal_id` addresses a row that renames cannot break.
+ *
+ * plan_id and version_slug are both things a config file can change, so
+ * neither is a stable handle. `internal_id` is: the server generates it, pull
+ * writes it back into fixtures, and a rename rides it instead of looking like
+ * a delete plus a create. It is tagged internal, so it never reaches the
+ * public spec — only the CLI, which reads the unstripped spec.
+ *
+ * Contract:
+ *   A1  GET echoes internal_id on plans and on nested variants
+ *   A2  a row addressed by internal_id is the row that changes — not the
+ *       active one, which is what an unaddressed request would hit
+ *   A3  internal_id with a different plan_id IS a rename: the row keeps its
+ *       identity and the old id survives as an alias
+ *   A4  the composite (plan_id, version_slug) still resolves when no id given
+ *   A5  an internal_id and a version_slug naming different rows is rejected,
+ *       not silently resolved in favour of one
+ *   A6  an internal_id nothing owns is rejected, not silently minted
+ *
+ * Red (current): `internal_id` is absent from the catalogV2 schemas entirely,
+ *   so it is stripped from requests and never echoed.
+ * Green (after): the id round-trips and addresses rows.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiPlanExpandedV1 } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { withCatalogPlans } from "../licenses/utils/seedLicensePlans.js";
+
+const messagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+});
+
+const getPlan = async ({
+	autumn,
+	planId,
+}: {
+	autumn: AutumnInt;
+	planId: string;
+}): Promise<ApiPlanExpandedV1> => {
+	const catalog = await autumn.catalogV2.get({});
+	const plan = catalog.plans.find((row: { id: string }) => row.id === planId);
+	expect(plan, `GET catalog plan ${planId}`).toBeDefined();
+	return plan!;
+};
+
+const versionRow = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	version: number;
+}) =>
+	ProductService.get({
+		db: ctx.db,
+		id: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		version,
+	});
+
+/** v1 keeps history, v2 takes the active pointer. */
+const seedTwoVersions = async ({
+	autumn,
+	planId,
+}: {
+	autumn: AutumnInt;
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{ plan_id: planId, name: "Internal Id", items: [messagesItem(100)] },
+		],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				items: [messagesItem(200)],
+				versioning: "new_version",
+				active: true,
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 internal_id: GET echoes it, and it addresses the row it names")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_iid_addr");
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await seedTwoVersions({ autumn: autumnV2_3, planId });
+
+				// A1: the id is on the response, or pull has nothing to write back.
+				const plan = await getPlan({ autumn: autumnV2_3, planId });
+				expect(plan.internal_id, "plan internal_id echoed").toMatch(/^prod_/);
+
+				const v1 = await versionRow({ ctx, planId, version: 1 });
+				expect(v1?.internal_id, "v1 has an internal id").toBeDefined();
+
+				// A2: address the HISTORY row. An unaddressed request would hit v2.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							internal_id: v1!.internal_id,
+							name: "Renamed V1 Only",
+						},
+					],
+				});
+
+				expect(
+					(await versionRow({ ctx, planId, version: 1 }))?.name,
+					"addressed row changed",
+				).toBe("Renamed V1 Only");
+				expect(
+					(await versionRow({ ctx, planId, version: 2 }))?.name,
+					"active row untouched",
+				).toBe("Internal Id");
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 internal_id: a differing plan_id on a known id is a rename")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_iid_rename");
+		const renamedId = `${planId}_renamed`;
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId, renamedId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{ plan_id: planId, name: "Before", items: [messagesItem(100)] },
+					],
+				});
+				const before = await versionRow({ ctx, planId, version: 1 });
+				const internalId = before!.internal_id;
+
+				// A3: the config states the NEW id and the row's id. No new_plan_id —
+				// that is the point: a config file should not have to remember the
+				// name it used to use.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: renamedId,
+							internal_id: internalId,
+							name: "After",
+							items: [messagesItem(100)],
+						},
+					],
+				});
+
+				const renamed = await versionRow({
+					ctx,
+					planId: renamedId,
+					version: 1,
+				});
+				expect(renamed?.internal_id, "same row, new id").toBe(internalId);
+				expect(renamed?.name, "content applied").toBe("After");
+
+				// A3: the old id resolves too — renames mint an alias.
+				const viaOldId = await ProductService.getFull({
+					db: ctx.db,
+					idOrInternalId: internalId,
+					orgId: ctx.org.id,
+					env: ctx.env,
+					allowNotFound: true,
+				});
+				expect(viaOldId?.id, "row now answers to the new id").toBe(renamedId);
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 internal_id: composite still resolves, conflicts and unknowns are rejected")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_iid_guard");
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Guarded",
+							items: [messagesItem(100)],
+						},
+					],
+				});
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							items: [messagesItem(200)],
+							versioning: "new_version",
+							new_version_slug: "v2",
+							active: true,
+						},
+					],
+				});
+				const v1 = await versionRow({ ctx, planId, version: 1 });
+
+				// A4: no internal_id — the composite still addresses the row.
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: planId, version_slug: "v1", name: "Via Slug" }],
+				});
+				expect(
+					(await versionRow({ ctx, planId, version: 1 }))?.name,
+					"composite fallback still works",
+				).toBe("Via Slug");
+
+				// A5: an id and a slug naming different rows is a caller bug.
+				const conflicting = autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							internal_id: v1!.internal_id,
+							version_slug: "v2",
+							name: "Ambiguous",
+						},
+					],
+				});
+				await expect(conflicting).rejects.toThrow();
+
+				// A6: an id nothing owns must not quietly become a new row.
+				const unknown = autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							internal_id: "prod_nothingownsthisid",
+							name: "Ghost",
+						},
+					],
+				});
+				await expect(unknown).rejects.toThrow();
+			},
+		});
+	},
+);

--- a/server/tests/unit/catalogV2/planUpdate/derive-direct-intents-slug.test.ts
+++ b/server/tests/unit/catalogV2/planUpdate/derive-direct-intents-slug.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { products } from "@tests/utils/fixtures/db/products";
 import { deriveDirectIntents } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
-import { products } from "@tests/utils/fixtures/db/products";
 
 const v1 = {
 	...products.createFull({ id: "pro" }),
@@ -34,6 +34,7 @@ describe("deriveDirectIntents version_slug targeting", () => {
 				remove_plans: [],
 			},
 			productStatesContext,
+			internalIdRefs: new Map(),
 		});
 		expect(intent?.productKey).toEqual({ planId: "pro", version: 1 });
 	});
@@ -48,6 +49,7 @@ describe("deriveDirectIntents version_slug targeting", () => {
 					remove_plans: [],
 				},
 				productStatesContext,
+				internalIdRefs: new Map(),
 			}),
 		).toEqual([]);
 	});
@@ -61,6 +63,7 @@ describe("deriveDirectIntents version_slug targeting", () => {
 				remove_plans: [],
 			},
 			productStatesContext,
+			internalIdRefs: new Map(),
 		});
 		expect(intent?.productKey).toEqual({ planId: "pro", version: 2 });
 	});
@@ -79,6 +82,7 @@ describe("deriveDirectIntents version_slug targeting", () => {
 				maxVersionByPlanId: { pro: 2 },
 				rewardProgramsByPlanId: {},
 			},
+			internalIdRefs: new Map(),
 		});
 		expect(intent?.productKey).toEqual({ planId: "pro", version: 3 });
 	});

--- a/shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts
@@ -26,6 +26,11 @@ export const UpdateCatalogPlanParamsSchema = z.object({
 		description:
 			"Rename the plan to this id. Blocked when any customer or reward program references it.",
 	}),
+	internal_id: z.string().nonempty().optional().meta({
+		description:
+			"Address an existing row by its stable id. Omit when creating — the server generates one. A differing plan_id alongside it is a rename.",
+		internal: true,
+	}),
 	name: z.string().nonempty().optional().meta({
 		description: "Display name of the plan. Required when creating.",
 	}),

--- a/shared/api/catalogV2/planUpdate/params/catalogVariantParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogVariantParams.ts
@@ -12,52 +12,60 @@ export const CatalogBaseVariantIdSchema = z
 	.optional();
 
 /** One `variants[]` entry: declared overlay on a variant of this base. Never follow. */
-export const CatalogVariantParamsSchema = z.object({
-	variant_plan_id: z.string().nonempty().regex(idRegex).meta({
-		description: "The variant plan this overlay applies to.",
-	}),
-	version: z.number().int().min(1).optional().meta({
-		description:
-			"Which version of the variant this overlay targets. At most one of `version` / `version_slug`; omit both to target latest.",
-	}),
-	version_slug: z.string().nonempty().regex(idRegex).optional().meta({
-		description:
-			"Which version of the variant this overlay targets, by slug. Same pin as `version`; omit both to target latest.",
-	}),
-	name: z.string().nonempty().optional().meta({
-		description: "Display name when creating the variant if it does not exist.",
-	}),
-	new_plan_id: z.string().nonempty().regex(idRegex).optional().meta({
-		description:
-			"Rename this variant to this id. Same execute path as a top-level new_plan_id.",
-	}),
-	archived: z.boolean().optional().meta({
-		description:
-			"Archive or unarchive this variant. Omit to leave archived state unchanged.",
-	}),
-	new_version_slug: z.string().nonempty().regex(idRegex).optional().meta({
-		description:
-			"Slug for the row this variant mints. Omit to inherit the base's `new_version_slug`, then `v{n}`. Ignored when this entry resolves to an existing row.",
-	}),
-	processors: ApiPlanProcessorsSchema.optional().meta({
-		description:
-			"Overrides the base plan's processors for this variant. Omit to inherit when the base processors change.",
-	}),
-	base_variant_id: CatalogBaseVariantIdSchema.meta({
-		description:
-			"Pointer write for this nested variant. Omit to link it to this base; `null` detaches it. A string must be this plan's id.",
-	}),
-	customize: CustomizePlanV1Schema.nullish().meta({
-		description:
-			"Declared overlay on this variant. `items` is PUT (replaces the list); `add_items` / `remove_items` are PATCH. Independent of `propagate`. Blocked on an archived variant unless `archived` is false in the same entry.",
-	}),
-}).refine(
-	(data) => data.version === undefined || data.version_slug === undefined,
-	{
-		message:
-			"Cannot specify both version and version_slug. Use one, or omit both to target the active row.",
-		path: ["version_slug"],
-	},
-);
+export const CatalogVariantParamsSchema = z
+	.object({
+		variant_plan_id: z.string().nonempty().regex(idRegex).meta({
+			description: "The variant plan this overlay applies to.",
+		}),
+		internal_id: z.string().nonempty().optional().meta({
+			description:
+				"Address an existing variant row by its stable id, instead of by plan id and version.",
+			internal: true,
+		}),
+		version: z.number().int().min(1).optional().meta({
+			description:
+				"Which version of the variant this overlay targets. At most one of `version` / `version_slug`; omit both to target latest.",
+		}),
+		version_slug: z.string().nonempty().regex(idRegex).optional().meta({
+			description:
+				"Which version of the variant this overlay targets, by slug. Same pin as `version`; omit both to target latest.",
+		}),
+		name: z.string().nonempty().optional().meta({
+			description:
+				"Display name when creating the variant if it does not exist.",
+		}),
+		new_plan_id: z.string().nonempty().regex(idRegex).optional().meta({
+			description:
+				"Rename this variant to this id. Same execute path as a top-level new_plan_id.",
+		}),
+		archived: z.boolean().optional().meta({
+			description:
+				"Archive or unarchive this variant. Omit to leave archived state unchanged.",
+		}),
+		new_version_slug: z.string().nonempty().regex(idRegex).optional().meta({
+			description:
+				"Slug for the row this variant mints. Omit to inherit the base's `new_version_slug`, then `v{n}`. Ignored when this entry resolves to an existing row.",
+		}),
+		processors: ApiPlanProcessorsSchema.optional().meta({
+			description:
+				"Overrides the base plan's processors for this variant. Omit to inherit when the base processors change.",
+		}),
+		base_variant_id: CatalogBaseVariantIdSchema.meta({
+			description:
+				"Pointer write for this nested variant. Omit to link it to this base; `null` detaches it. A string must be this plan's id.",
+		}),
+		customize: CustomizePlanV1Schema.nullish().meta({
+			description:
+				"Declared overlay on this variant. `items` is PUT (replaces the list); `add_items` / `remove_items` are PATCH. Independent of `propagate`. Blocked on an archived variant unless `archived` is false in the same entry.",
+		}),
+	})
+	.refine(
+		(data) => data.version === undefined || data.version_slug === undefined,
+		{
+			message:
+				"Cannot specify both version and version_slug. Use one, or omit both to target the active row.",
+			path: ["version_slug"],
+		},
+	);
 
 export type CatalogVariantParams = z.infer<typeof CatalogVariantParamsSchema>;

--- a/shared/api/products/apiPlanV1.ts
+++ b/shared/api/products/apiPlanV1.ts
@@ -4,6 +4,11 @@ import { BillingInterval } from "@models/productModels/intervals/billingInterval
 import { ProductConfigSchema } from "@models/productModels/productConfig/productConfig.js";
 import { ProductMetadataSchema } from "@models/productModels/productMetadata.js";
 import { z } from "zod/v4";
+import { ApiPlanLicenseV1Schema } from "./apiPlanLicenseV1.js";
+import {
+	ApiPlanVariantV1Schema,
+	VariantCustomizeSchema,
+} from "./apiPlanVariantV1.js";
 import { AdditionalCurrencyPriceArraySchema } from "./components/additionalCurrencies.js";
 import { ApiFreeTrialV2Schema } from "./components/apiFreeTrialV2.js";
 import { CustomerEligibilitySchema } from "./components/customerEligibility.js";
@@ -17,19 +22,14 @@ import {
 	API_PLAN_ITEM_USAGE_BASED_EXAMPLE,
 	ApiPlanItemV1Schema,
 } from "./items/apiPlanItemV1.js";
-import { ApiPlanLicenseV1Schema } from "./apiPlanLicenseV1.js";
-import {
-	ApiPlanVariantV1Schema,
-	VariantCustomizeSchema,
-} from "./apiPlanVariantV1.js";
 
 export {
-	ApiPlanLicenseV1Schema,
 	type ApiPlanLicenseV1,
+	ApiPlanLicenseV1Schema,
 } from "./apiPlanLicenseV1.js";
 export {
-	ApiPlanVariantV1Schema,
 	type ApiPlanVariantV1,
+	ApiPlanVariantV1Schema,
 	VariantCustomizeSchema,
 } from "./apiPlanVariantV1.js";
 
@@ -75,6 +75,11 @@ export const ApiPlanV1Schema = z.object({
 	// Identity
 	id: z.string().meta({
 		description: "Unique identifier for the plan.",
+	}),
+	internal_id: z.string().optional().meta({
+		description:
+			"Stable row id. Survives renames of plan_id and version_slug, so config files address rows by it.",
+		internal: true,
 	}),
 	name: z.string().meta({
 		description: "Display name of the plan.",


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stable `internal_id` handle for catalog plan and variant rows, so configs that change `plan_id` or `version_slug` can still address the same row. Addressing a row by its ID under a new `plan_id` renames it while keeping its identity, and the old `plan_id` survives as an alias.

**New Features**
- `internal_id` is accepted on plan and variant updates and echoed on plan GET responses; schemas mark it internal so it stays out of the public spec.
- The ID resolves to the row's current plan and version before any other setup, so renamed rows stay in scope for the rest of the request.
- Intents and processor mapping claims key on the row's current id, so a rename doesn't split the write across two identities.
- Unknown `internal_id` values are rejected with 400 instead of minting a fresh row.

**Validation**
- Requests fail with 400 when an `internal_id` and a version pin name different rows.

<sup>Written for commit 3dac499613b7f9b3e19c56103dff60a95ab12b74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds stable internal row identifiers to catalog plan and variant request/response contracts and uses them to resolve updates across plan or version-slug renames.

- **API changes, Improvements:** Exposes `internal_id` in internal plan responses and accepts it on plan and variant update entries.
- **Improvements:** Resolves plan internal IDs before catalog state loading and uses the resolved row identity for direct updates, processor mappings, and renames.
- **Bug fixes:** Adds validation for unknown top-level IDs and disagreement between top-level IDs and version selectors.
</details>


<h3>Confidence Score: 3/5</h3>

The PR should not merge until variant internal IDs actually select their named rows and conflicting destinations for one plan are rejected.

Nested variant IDs can currently update a different version than the identified row, while multiple entries for one plan can generate incompatible plan-wide rename operations.

**Files Needing Attention:** shared/api/catalogV2/planUpdate/params/catalogVariantParams.ts, server/src/internal/catalogV2/actions/updateCatalog/errors/assertInternalIdAgrees.ts, server/src/internal/catalogV2/actions/updateCatalog/compute/computeRenameProductIdsPlan/computeRenameProductIdsPlan.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeRenameProductIdsPlan/computeRenameProductIdsPlan.ts | Adds internal-ID-driven renames, but can emit conflicting plan-wide renames when sibling rows request different destinations. |
| server/src/internal/catalogV2/actions/updateCatalog/setup/resolveInternalIdRefs.ts | Resolves all stated plan and variant internal IDs within the organization and environment and rejects unknown identifiers. |
| server/src/internal/catalogV2/actions/updateCatalog/errors/assertInternalIdAgrees.ts | Correctly validates top-level plan IDs against row selectors but omits the newly supported nested variant IDs. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts | Uses resolved top-level identities to group and target direct plan updates by their current persisted row. |
| shared/api/catalogV2/planUpdate/params/catalogVariantParams.ts | Advertises stable internal-ID targeting for variants without corresponding target selection or agreement validation. |
| server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts | Echoes the stable internal identifier in internal plan responses as required by the new round-trip contract. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Catalog update with internal_id] --> Resolve[Resolve internal ID to current plan and version]
  Resolve --> Validate[Validate top-level row selectors]
  Resolve --> Load[Load current catalog rows]
  Load --> Plan[Compute renames and upserts]
  Plan --> Rename[Apply plan-wide renames]
  Rename --> Upsert[Apply row updates by internal ID]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
shared/api/catalogV2/planUpdate/params/catalogVariantParams.ts:20-24
**Variant IDs Do Not Select Rows**

When a variant entry uses `internal_id` to address a historical row, variant planning still selects by `variant_plan_id`, `version`, and `version_slug`, causing an omitted selector to update the active row instead and conflicting selectors to update the wrong row rather than being rejected.

### Issue 2
server/src/internal/catalogV2/actions/updateCatalog/compute/computeRenameProductIdsPlan/computeRenameProductIdsPlan.ts:73-79
**Sibling Rows Emit Conflicting Renames**

When multiple versions of one plan are addressed by `internal_id` with different `plan_id` destinations, this emits multiple plan-wide renames from the same source. The first moves every version, while later renames operate on a source that no longer exists, causing conflicting aliases or failed subsequent upserts.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 address catalog rows by interna..."](https://github.com/useautumn/autumn/commit/3dac499613b7f9b3e19c56103dff60a95ab12b74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59147419)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)
- Knowledge Base — [Usage and billing API platform](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/api-platform.md)

<!-- /greptile_comment -->