### PR TITLE
fix(analytics): preserve billing cycle boundaries

### DIFF
--- a/server/src/internal/analytics/analyticsUtils.ts
+++ b/server/src/internal/analytics/analyticsUtils.ts
@@ -4,7 +4,6 @@ import {
 	ErrCode,
 	type FullCusProduct,
 	type FullCustomer,
-	type FullCustomerEntitlement,
 	type FullProduct,
 	RecaseError,
 	type Subscription,
@@ -310,6 +309,14 @@ function calculateBillingCycleResult(
 	const gap = currentEndDate.getTime() - currentStartDate.getTime();
 	const gapDays = Math.floor(gap / (1000 * 60 * 60 * 24));
 
+	if (intervalType === "1bc") {
+		return {
+			startDate: startDates[0],
+			endDate: endDates[0],
+			gap: gapDays,
+		};
+	}
+
 	if (intervalType === "last_cycle") {
 		const earliestCreation = createdDates.reduce((earliest, current) => {
 			const currentDate = new Date(current);
@@ -339,7 +346,7 @@ function calculateBillingCycleResult(
 		};
 	}
 
-	const gapMultiplier = intervalType === "1bc" ? 1 : 3;
+	const gapMultiplier = 3;
 	const now = new Date();
 
 	// For analytics, we look BACKWARD from today for N billing cycles

--- a/server/tests/unit/analytics/billing-cycle-range.test.ts
+++ b/server/tests/unit/analytics/billing-cycle-range.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, setSystemTime, test } from "bun:test";
+import {
+	BillingInterval,
+	BillWhen,
+	CusProductStatus,
+	type FullCustomer,
+	PriceType,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getBillingCycleStartDate } from "@/internal/analytics/analyticsUtils.js";
+
+const SUBSCRIPTION_ANCHOR = Date.UTC(2026, 1, 4);
+const SHORTEST_PERIOD_START = Date.UTC(2026, 7, 4);
+const SHORTEST_PERIOD_END = Date.UTC(2026, 8, 4);
+
+const mixedCadenceCustomer = () =>
+	({
+		customer_products: [
+			{
+				id: "cus_prod_enterprise",
+				status: CusProductStatus.Active,
+				created_at: SUBSCRIPTION_ANCHOR,
+				billing_cycle_anchor: SUBSCRIPTION_ANCHOR,
+				subscription_ids: ["sub_enterprise"],
+				product: { id: "enterprise", is_add_on: false },
+				customer_prices: [
+					{
+						price: {
+							id: "price_yearly_base",
+							config: {
+								type: PriceType.Fixed,
+								amount: 20_000,
+								interval: BillingInterval.Year,
+							},
+						},
+					},
+					{
+						price: {
+							id: "price_monthly_usage",
+							config: {
+								type: PriceType.Usage,
+								bill_when: BillWhen.EndOfPeriod,
+								interval: BillingInterval.Month,
+								internal_feature_id: "feature_credits",
+								feature_id: "credits",
+								usage_tiers: [{ to: -1, amount: 1 }],
+							},
+						},
+					},
+				],
+				customer_entitlements: [],
+			},
+		],
+		subscriptions: [
+			{
+				stripe_id: "sub_enterprise",
+				created_at: SUBSCRIPTION_ANCHOR / 1000,
+				current_period_start: SHORTEST_PERIOD_START / 1000,
+				current_period_end: SHORTEST_PERIOD_END / 1000,
+			},
+		],
+	}) as unknown as FullCustomer;
+
+afterEach(() => setSystemTime());
+
+describe("analytics billing-cycle ranges", () => {
+	test("keeps the shortest Stripe item period on its exact boundaries", async () => {
+		setSystemTime(new Date(Date.UTC(2026, 8, 1)));
+
+		const result = await getBillingCycleStartDate({
+			customer: mixedCadenceCustomer(),
+			db: {} as AutumnContext["db"],
+			ctx: {} as AutumnContext,
+			intervalType: "1bc",
+		});
+
+		expect(result).toEqual({
+			startDate: "2026-08-04 00:00:00",
+			endDate: "2026-09-04 00:00:00",
+			gap: 31,
+		});
+	});
+});


### PR DESCRIPTION
Fixes current-billing-cycle analytics shifting the shortest Stripe item period to end at request time.

- Keep the subscription period produced from the shortest current period across Stripe subscription items
- Return the exact stored start and end boundaries for `1bc` instead of treating its duration as a rolling window
- Preserve existing `3bc`, `last_cycle`, free-product, DB, and Stripe fallback behavior
- Cover a yearly base plus monthly usage subscription whose shortest period is August 4 to September 4