### PR TITLE
fix(catalog-v2): address review feedback on the mappings stack

### DIFF
--- a/server/src/internal/catalogV2/actions/getCatalog/getCatalogV2.ts
+++ b/server/src/internal/catalogV2/actions/getCatalog/getCatalogV2.ts
@@ -42,7 +42,9 @@ export const getCatalogV2 = async ({
 	});
 
 	// One read for the whole catalog: RC mappings live in their own table, keyed
-	// by plan id with no version dimension.
+	// by plan id with no version dimension. Variants are their own products with
+	// their own plan ids, so their rows are in here too — hand the whole map down
+	// rather than a single row, or a variant's mapping can never be read back.
 	const revenuecatMappings = await RCMappingService.getAll({
 		db: ctx.db,
 		orgId: ctx.org.id,
@@ -57,7 +59,7 @@ export const getCatalogV2 = async ({
 			getPlanResponse({
 				ctx,
 				product: pruneArchivedVariants(product),
-				revenuecatMapping: revenuecatByPlanId.get(product.id),
+				revenuecatMappings: revenuecatByPlanId,
 				features: ctx.features,
 				currency: ctx.org.default_currency || undefined,
 				expandLicensePlans: true,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan.ts
@@ -199,9 +199,19 @@ export const intentToUpsertProductPlan = ({
 		planParams.propagate !== undefined
 			? { propagate: planParams.propagate }
 			: {}),
-		...(source === "direct" && planParams.processors?.revenuecat !== undefined
+		// Mappings are keyed by public plan id, and a variant is its own plan — so
+		// every source that names a concrete plan writes its own row. The version
+		// fan-out lanes are excluded: they restate the addressed row's plan id.
+		...((source === "direct" ||
+			source === "variant_link" ||
+			source === "variant_propagation") &&
+		planParams.processors?.revenuecat !== undefined
 			? { revenuecatProcessor: planParams.processors.revenuecat }
 			: {}),
+		// Every lane that carries the null needs the flag: the Stripe fan-out and
+		// the variant settings patch both restate `{ stripe: null }` on their own
+		// rows, and a sibling left without it gets a replacement product minted.
+		...(planParams.processors?.stripe === null ? { stripeUnlinked: true } : {}),
 		...(planParams.create_in_stripe !== undefined
 			? { createInStripe: planParams.create_in_stripe }
 			: {}),

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductsPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductsPlan.ts
@@ -5,6 +5,7 @@ import { computeUpsertProductPlan } from "@/internal/catalogV2/actions/updateCat
 import { indexDeclaredVariants } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/shouldUnlinkDirectVariant";
 import { deriveDirectIntents } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents";
 import { deriveIntents } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveIntents";
+import { mergeDeclaredProcessors } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/mergeDeclaredProcessors";
 import type { CatalogComputeStep } from "@/internal/catalogV2/actions/updateCatalog/types/catalogComputeState";
 import type { UpdateCatalogContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import {
@@ -14,8 +15,10 @@ import {
 import { createProductStatesFold } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/createProductStatesFold";
 
 /**
- * Derive direct intents → fold each → deriveIntents onto the same pending list.
- * First claim wins. planLicenses compute last, once all plan content is final.
+ * Derive direct intents → merge stated processors across each lineage → fold
+ * each → deriveIntents onto the same pending list. First claim wins, so the
+ * merge has to land before every direct intent is claimed. planLicenses
+ * compute last, once all plan content is final.
  */
 export const computeUpsertProductsPlan = ({
 	ctx,
@@ -28,7 +31,10 @@ export const computeUpsertProductsPlan = ({
 }): CatalogComputeStep => {
 	const { productStatesContext } = catalogContext;
 
-	const pendingIntents = deriveDirectIntents({
+	// A row the payload named is claimed before the fold, so the derived
+	// mapping fan-out can never reach it — fill it in up front instead.
+	const pendingIntents = mergeDeclaredProcessors({
+		intents: deriveDirectIntents({ params, productStatesContext }),
 		params,
 		productStatesContext,
 	});

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/mergeDeclaredProcessors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/mergeDeclaredProcessors.ts
@@ -1,0 +1,264 @@
+import {
+	type ApiRevenueCatPlanProcessor,
+	type ApiStripePlanProcessor,
+	ErrCode,
+	RecaseError,
+	type UpdateCatalogParams,
+} from "@autumn/shared";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import type { ProductUpsertIntent } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
+
+/** A stated Stripe mapping: an object links, `null` unlinks. Absent = not stated. */
+type StatedStripe = ApiStripePlanProcessor | null;
+
+/** Order-insensitive identity of a stated mapping, for collision detection. */
+const stripeMappingIdentity = (stated: StatedStripe): string =>
+	stated === null
+		? "null"
+		: `${stated.product_id}|${[...(stated.additional_product_ids ?? [])]
+				.sort()
+				.join(",")}`;
+
+const revenueCatMappingIdentity = (
+	stated: ApiRevenueCatPlanProcessor | null,
+): string =>
+	stated === null
+		? "null"
+		: stated.products
+				.map((product) =>
+					[
+						product.product_id,
+						(product.feature_quantities ?? [])
+							.map((entry) => `${entry.feature_id}=${entry.quantity ?? ""}`)
+							.sort()
+							.join(","),
+					].join(":"),
+				)
+				.sort()
+				.join("|");
+
+/**
+ * Two entries stating different mappings for one plan is an ambiguity, not a
+ * race — whichever the fold visited first would win silently.
+ */
+const claimStatedMapping = <T>({
+	statedByPlanId,
+	planId,
+	stated,
+	identity,
+	processorName,
+}: {
+	statedByPlanId: Map<string, T>;
+	planId: string;
+	stated: T;
+	identity: (stated: T) => string;
+	processorName: string;
+}): void => {
+	const existing = statedByPlanId.get(planId);
+	if (existing !== undefined && identity(existing) !== identity(stated)) {
+		throw new RecaseError({
+			message: `Conflicting processors.${processorName} for plan_id=${planId}: two entries state different mappings`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+	statedByPlanId.set(planId, stated);
+};
+
+type StatedStripeIndex = {
+	/** Stated on a plan's own entry — the strongest claim on that plan. */
+	byPlanId: Map<string, StatedStripe>;
+	/** Stated on someone's `variants[]` — an override of that base's mapping. */
+	byVariantPlanId: Map<string, StatedStripe>;
+};
+
+/**
+ * RevenueCat mappings are plan-wide, so they never fan out across a lineage —
+ * but two versions of one plan stating different product sets still race in
+ * the mappings table, which is the same ambiguity.
+ */
+const assertRevenueCatMappingsAgree = ({
+	plans,
+}: {
+	plans: UpdateCatalogParams["plans"];
+}): void => {
+	const statedByPlanId = new Map<string, ApiRevenueCatPlanProcessor | null>();
+	for (const entry of plans) {
+		const revenuecat = entry.processors?.revenuecat;
+		if (revenuecat === undefined) continue;
+		claimStatedMapping({
+			statedByPlanId,
+			planId: entry.plan_id,
+			stated: revenuecat,
+			identity: revenueCatMappingIdentity,
+			processorName: "revenuecat",
+		});
+	}
+};
+
+const indexStatedStripe = ({
+	plans,
+}: {
+	plans: UpdateCatalogParams["plans"];
+}): StatedStripeIndex => {
+	const byPlanId = new Map<string, StatedStripe>();
+	const byVariantPlanId = new Map<string, StatedStripe>();
+
+	for (const entry of plans) {
+		const stripe = entry.processors?.stripe;
+		if (stripe !== undefined) {
+			claimStatedMapping({
+				statedByPlanId: byPlanId,
+				planId: entry.plan_id,
+				stated: stripe,
+				identity: stripeMappingIdentity,
+				processorName: "stripe",
+			});
+		}
+
+		for (const variant of entry.variants ?? []) {
+			const variantStripe = variant.processors?.stripe;
+			if (variantStripe === undefined) continue;
+			claimStatedMapping({
+				statedByPlanId: byVariantPlanId,
+				planId: variant.variant_plan_id,
+				stated: variantStripe,
+				identity: stripeMappingIdentity,
+				processorName: "stripe",
+			});
+		}
+	}
+
+	return { byPlanId, byVariantPlanId };
+};
+
+/**
+ * Variant plan id → the plan it bills under. Persisted pointers first (newest
+ * row wins), then this call's own pointer writes, which are the state the
+ * mapping has to hold in.
+ */
+const indexBasePlanIds = ({
+	plans,
+	productStatesContext,
+}: {
+	plans: UpdateCatalogParams["plans"];
+	productStatesContext: ProductStatesContext;
+}): Map<string, string> => {
+	const basePlanIdByPlanId = new Map<string, string>();
+
+	for (const [planId, versions] of Object.entries(
+		productStatesContext.versionsByPlanId,
+	)) {
+		for (const product of versions) {
+			if (!product.base_internal_product_id) continue;
+			const base = findFullProductByInternalId({
+				internalId: product.base_internal_product_id,
+				productStatesContext,
+			});
+			if (!base || base.id === planId) continue;
+			basePlanIdByPlanId.set(planId, base.id);
+			break;
+		}
+	}
+
+	for (const entry of plans) {
+		for (const variant of entry.variants ?? []) {
+			if (variant.variant_plan_id === entry.plan_id) continue;
+			if (variant.base_variant_id === null) {
+				basePlanIdByPlanId.delete(variant.variant_plan_id);
+				continue;
+			}
+			basePlanIdByPlanId.set(variant.variant_plan_id, entry.plan_id);
+		}
+
+		if (entry.base_variant_id === null) {
+			basePlanIdByPlanId.delete(entry.plan_id);
+		} else if (entry.base_variant_id !== undefined) {
+			basePlanIdByPlanId.set(entry.plan_id, entry.base_variant_id);
+		}
+	}
+
+	return basePlanIdByPlanId;
+};
+
+/** Own entry, then an override aimed at it, then whatever its base states. */
+const resolveStatedStripe = ({
+	planId,
+	statedStripe,
+	basePlanIdByPlanId,
+}: {
+	planId: string;
+	statedStripe: StatedStripeIndex;
+	basePlanIdByPlanId: Map<string, string>;
+}): StatedStripe | undefined => {
+	const visitedPlanIds = new Set<string>();
+	let currentPlanId: string | undefined = planId;
+
+	while (currentPlanId !== undefined && !visitedPlanIds.has(currentPlanId)) {
+		visitedPlanIds.add(currentPlanId);
+		const ownStated = statedStripe.byPlanId.get(currentPlanId);
+		if (ownStated !== undefined) return ownStated;
+		const overrideStated = statedStripe.byVariantPlanId.get(currentPlanId);
+		if (overrideStated !== undefined) return overrideStated;
+		currentPlanId = basePlanIdByPlanId.get(currentPlanId);
+	}
+
+	return undefined;
+};
+
+/**
+ * Every version of a plan, and every variant that follows it, bills under one
+ * Stripe product. Derived `processor_sync` / `variant_propagation` intents
+ * carry that across the lineage, but they are dropped for any row the payload
+ * already named — first claim wins, and every direct entry is claimed before
+ * the fold starts. So fill the stated mapping into those pending direct
+ * intents here instead, leaving the derived fan-out to cover only the rows the
+ * payload did not name.
+ *
+ * A row that states its own `processors.stripe` keeps it, including a `null`
+ * unlink; only rows that stated nothing are filled.
+ */
+export const mergeDeclaredProcessors = ({
+	intents,
+	params,
+	productStatesContext,
+}: {
+	intents: ProductUpsertIntent[];
+	params: UpdateCatalogParams;
+	productStatesContext: ProductStatesContext;
+}): ProductUpsertIntent[] => {
+	assertRevenueCatMappingsAgree({ plans: params.plans });
+
+	const statedStripe = indexStatedStripe({ plans: params.plans });
+	if (
+		statedStripe.byPlanId.size === 0 &&
+		statedStripe.byVariantPlanId.size === 0
+	) {
+		return intents;
+	}
+
+	const basePlanIdByPlanId = indexBasePlanIds({
+		plans: params.plans,
+		productStatesContext,
+	});
+
+	return intents.map((intent) => {
+		if (intent.planParams.processors?.stripe !== undefined) return intent;
+
+		const stated = resolveStatedStripe({
+			planId: intent.productKey.planId,
+			statedStripe,
+			basePlanIdByPlanId,
+		});
+		if (stated === undefined) return intent;
+
+		return {
+			...intent,
+			planParams: {
+				...intent.planParams,
+				processors: { ...intent.planParams.processors, stripe: stated },
+			},
+		};
+	});
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/upsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/upsertProductPlan.ts
@@ -69,8 +69,15 @@ export type UpsertProductPlan = {
 	unlink?: boolean;
 	/** Who follows this row's content change. Copied from planParams so pass 2 can read it. */
 	propagate?: CatalogPropagateParams;
-	/** Stated `processors.revenuecat`. Plan-wide, so only the addressed row carries it. */
+	/** Stated `processors.revenuecat`. Plan-wide, so only rows naming a concrete plan carry it. */
 	revenuecatProcessor?: ApiRevenueCatPlanProcessor | null;
+	/**
+	 * Stated `processors.stripe: null` — the request asked for NO Stripe product.
+	 * Without it a cleared paid row is indistinguishable from a new paid plan, so
+	 * execute mints a replacement and the unlink dies inside its own request.
+	 * Attach mints lazily, so leaving the row bare is safe.
+	 */
+	stripeUnlinked?: boolean;
 	/** Absent = plan_license links untouched. Present (incl. []) = full-set replace. */
 	planLicenses?: PlanLicensePlan[];
 	/** false = execute may reuse Stripe ids but never create objects. */

--- a/server/src/internal/catalogV2/execute/executeInitStripeResources/initStripeResourcesForCatalog.ts
+++ b/server/src/internal/catalogV2/execute/executeInitStripeResources/initStripeResourcesForCatalog.ts
@@ -1,12 +1,11 @@
 import { hasMissingStripeResourcesForProduct } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { initStripeResourcesForProducts } from "@/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
-import { initStripeResourcesForProducts } from "@/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts";
 import { applyStripeResourceReuseForProduct } from "@/internal/products/stripeResourceUtils/applyStripeResourceReuseForProduct";
 import { hydratePlanLicenseProcessor } from "./hydratePlanLicenseProcessor";
 import { repointBasePricesToPlanProcessor } from "./repointBasePricesToPlanProcessor";
-import { validateAdoptedStripePrices } from "./validateAdoptedStripePrices";
 import {
 	catalogProductsByInternalId,
 	stripeCandidatesFromCatalog,
@@ -23,10 +22,29 @@ const stripeInitRank = ({ upsert }: { upsert: UpsertProductPlan }) => {
 };
 
 /**
+ * Rows Stripe init walks, in the order it walks them. Shared with the pre-write
+ * validation pass so a stated id is checked against exactly the set that would
+ * have consumed it.
+ */
+export const stripeInitTargets = ({
+	updateCatalogPlan,
+}: {
+	updateCatalogPlan: UpdateCatalogPlan;
+}): UpsertProductPlan[] =>
+	updateCatalogPlan.upsertProducts
+		.filter((upsert) => touchesStripeResources({ upsert }))
+		.sort(
+			(a, b) => stripeInitRank({ upsert: a }) - stripeInitRank({ upsert: b }),
+		);
+
+/**
  * Execute-phase Stripe init for written rows. Uses the projected catalog —
  * no product reads. Sequential so a later row sees Stripe ids mutated onto
  * an earlier nextFullProduct (family candidates, plan-license processors).
  * Creation guards live inside initStripeResourcesForProducts.
+ *
+ * Adopted-price validation runs earlier, before the first catalog write —
+ * see `validateCatalogBeforeWrites` in executeUpdateCatalogPlan.
  */
 export const initStripeResourcesForCatalog = async ({
 	ctx,
@@ -44,21 +62,19 @@ export const initStripeResourcesForCatalog = async ({
 		],
 	});
 
-	const targets = updateCatalogPlan.upsertProducts
-		.filter((upsert) => touchesStripeResources({ upsert }))
-		.sort(
-			(a, b) => stripeInitRank({ upsert: a }) - stripeInitRank({ upsert: b }),
-		);
+	const targets = stripeInitTargets({ updateCatalogPlan });
 
-	// Ahead of the completeness skip and the Live guard below, so a stated id
-	// is checked in every environment even when nothing needs creating.
-	await validateAdoptedStripePrices({ ctx, upsertProducts: targets });
 	// Ahead of init so a cleared price is minted under the new product below.
 	await repointBasePricesToPlanProcessor({ ctx, upsertProducts: targets });
 
 	for (const upsert of targets) {
 		const product = upsert.row.nextFullProduct;
 		catalogByInternalId.set(product.internal_id, product);
+		// The request asked for NO Stripe product on this row. A paid plan with a
+		// cleared processor reads as "missing resources", so init would mint a
+		// replacement and undo the unlink inside its own request. Attach mints
+		// lazily, so the plan is re-created under Stripe the next time it is sold.
+		if (upsert.stripeUnlinked) continue;
 		hydratePlanLicenseProcessor({ product, catalogByInternalId });
 		if (!hasMissingStripeResourcesForProduct({ product })) continue;
 

--- a/server/src/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices.ts
+++ b/server/src/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices.ts
@@ -2,6 +2,7 @@ import {
 	ErrCode,
 	type FullProduct,
 	type Price,
+	priceToRequiredStripeSlots,
 	RecaseError,
 } from "@autumn/shared";
 import type Stripe from "stripe";
@@ -27,70 +28,140 @@ type PriceConfigIds = Partial<
 	>
 >;
 
-type AdoptedPrice = { planId: string; price: Price; stripePriceId: string };
+type AdoptedPrice = {
+	planId: string;
+	price: Price;
+	product: FullProduct;
+	stripePriceId: string;
+	slot: (typeof PRICE_MAPPING_SLOTS)[number];
+};
 
 const configIds = ({ price }: { price: Price }): PriceConfigIds =>
 	(price.config ?? {}) as PriceConfigIds;
 
 /**
- * Every Stripe price this row already had, plus the row it was cloned from —
- * an id carried forward by a mint was real when Autumn wrote it.
+ * What each existing price row holds, per slot. Keyed by price id so an id
+ * MOVED from one row to another still counts as newly stated on the row that
+ * now claims it — a product-wide set would wave that through and leave the
+ * destination row pointing at the wrong Stripe product.
  */
-const knownStripePriceIds = ({
-	products,
+const currentSlotIdsByPriceId = ({
+	product,
 }: {
-	products: Array<FullProduct | null | undefined>;
+	product: FullProduct | null | undefined;
+}): Map<string, PriceConfigIds> => {
+	const byPriceId = new Map<string, PriceConfigIds>();
+	for (const price of product?.prices ?? []) {
+		if (price.id) byPriceId.set(price.id, configIds({ price }));
+	}
+	return byPriceId;
+};
+
+/**
+ * A mint clones the previous row's prices under fresh price ids, so per-row
+ * matching cannot see them. Those ids were real when Autumn wrote them, so the
+ * cloned-from row stays a product-wide exemption.
+ */
+const mintedStripePriceIds = ({
+	product,
+}: {
+	product: FullProduct | null | undefined;
 }): Set<string> =>
 	new Set(
-		products.flatMap((product) =>
-			(product?.prices ?? []).flatMap((price) =>
-				PRICE_MAPPING_SLOTS.map((slot) => configIds({ price })[slot]).filter(
-					(id): id is string => Boolean(id),
-				),
+		(product?.prices ?? []).flatMap((price) =>
+			PRICE_MAPPING_SLOTS.map((slot) => configIds({ price })[slot]).filter(
+				(id): id is string => Boolean(id),
 			),
 		),
 	);
 
-/** Stated ids only — an id Autumn minted earlier was real when it was written. */
-const newlyAdoptedPrices = ({
+/**
+ * Stated ids only — an id Autumn minted earlier was real when it was written.
+ * Emits one entry per newly-supplied SLOT: a price can state both an internal
+ * `stripe_price_id` and a `processors` id, and validating only the first would
+ * let the other through unchecked.
+ */
+export const newlyAdoptedPrices = ({
 	upsert,
 }: {
 	upsert: UpsertProductPlan;
 }): AdoptedPrice[] => {
 	const next: FullProduct = upsert.row.nextFullProduct;
-	const known = knownStripePriceIds({
-		products: [upsert.row.currentFullProduct, upsert.row.baseFullProduct],
+	const currentByPriceId = currentSlotIdsByPriceId({
+		product: upsert.row.currentFullProduct,
 	});
+	const minted = mintedStripePriceIds({ product: upsert.row.baseFullProduct });
 
 	return next.prices.flatMap((price) => {
 		const ids = configIds({ price });
-		const stripePriceId = PRICE_MAPPING_SLOTS.map((slot) => ids[slot])
-			.filter((id): id is string => Boolean(id))
-			.find((id) => !known.has(id));
-		if (!stripePriceId) return [];
-		return [{ planId: next.id, price, stripePriceId }];
+		const current =
+			(price.id ? currentByPriceId.get(price.id) : undefined) ?? {};
+		return PRICE_MAPPING_SLOTS.flatMap((slot) => {
+			const stripePriceId = ids[slot];
+			if (!stripePriceId) return [];
+			if (stripePriceId === current[slot]) return [];
+			if (minted.has(stripePriceId)) return [];
+			return [{ planId: next.id, price, product: next, stripePriceId, slot }];
+		});
 	});
 };
+
+/** Usage-based prices bill through a meter, so an adopted price must carry one. */
+export const priceRequiresMeter = ({
+	price,
+	product,
+}: {
+	price: Price;
+	product: FullProduct;
+}): boolean =>
+	priceToRequiredStripeSlots({ price, product }).includes("stripe_meter_id");
+
+export type MeterDecision =
+	| { type: "unchanged" }
+	| { type: "clear" }
+	| { type: "adopt"; meterId: string };
 
 /**
  * A metered price is bound to a Stripe meter, and usage is reported against
  * that meter's event name — so adopting the price has to adopt both, or usage
- * has nowhere to go. Derived from the price, never stated.
+ * has nowhere to go. Derived from the price, never stated. Re-mapping onto a
+ * price with NO meter has to clear the old one, or usage keeps reporting to a
+ * meter the plan no longer bills through.
  */
-const adoptedMeter = async ({
-	stripeCli,
+export const meterDecision = ({
 	stripePrice,
 	config,
 }: {
+	stripePrice: Pick<Stripe.Price, "recurring">;
+	config: PriceConfigIds;
+}): MeterDecision => {
+	const meterId = stripePrice.recurring?.meter;
+	if (!meterId) {
+		return config.stripe_meter_id || config.stripe_event_name
+			? { type: "clear" }
+			: { type: "unchanged" };
+	}
+	if (config.stripe_meter_id === meterId) return { type: "unchanged" };
+	return { type: "adopt", meterId };
+};
+
+const applyMeterDecision = async ({
+	stripeCli,
+	decision,
+	config,
+}: {
 	stripeCli: Stripe;
-	stripePrice: Stripe.Price;
+	decision: MeterDecision;
 	config: PriceConfigIds;
 }): Promise<boolean> => {
-	const meterId = stripePrice.recurring?.meter;
-	if (!meterId || config.stripe_meter_id === meterId) return false;
-
-	const meter = await stripeCli.billing.meters.retrieve(meterId);
-	config.stripe_meter_id = meterId;
+	if (decision.type === "unchanged") return false;
+	if (decision.type === "clear") {
+		config.stripe_meter_id = null;
+		config.stripe_event_name = null;
+		return true;
+	}
+	const meter = await stripeCli.billing.meters.retrieve(decision.meterId);
+	config.stripe_meter_id = decision.meterId;
 	config.stripe_event_name = meter.event_name;
 	return true;
 };
@@ -160,7 +231,26 @@ export const validateAdoptedStripePrices = async ({
 			Boolean(stripeProductId) && config.stripe_product_id !== stripeProductId;
 		if (productChanged) config.stripe_product_id = stripeProductId;
 
-		const meterChanged = await adoptedMeter({ stripeCli, stripePrice, config });
+		// A usage item bills through the meter bound to its price. Adopting a
+		// meterless price would leave the meter slot unfillable — init re-runs
+		// forever and `createStripeInArrearPrice` returns early on the existing
+		// price — so the item could never report usage. Reject it up front.
+		if (
+			!stripePrice.recurring?.meter &&
+			priceRequiresMeter({ price: entry.price, product: entry.product })
+		) {
+			throw new RecaseError({
+				code: ErrCode.InvalidRequest,
+				message: `Stripe price ${entry.stripePriceId} has no meter, so it cannot bill a usage-based item (plan ${entry.planId})`,
+				statusCode: 400,
+			});
+		}
+
+		const meterChanged = await applyMeterDecision({
+			stripeCli,
+			decision: meterDecision({ stripePrice, config }),
+			config,
+		});
 		if (!productChanged && !meterChanged) continue;
 
 		await PriceService.update({

--- a/server/src/internal/catalogV2/execute/executeRevenueCatMappings.ts
+++ b/server/src/internal/catalogV2/execute/executeRevenueCatMappings.ts
@@ -7,7 +7,7 @@ import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
 
-type StatedMapping = {
+type StatedRevenueCatMapping = {
 	planId: string;
 	processor: ApiRevenueCatPlanProcessor | null;
 };
@@ -16,11 +16,11 @@ type StatedMapping = {
  * RevenueCat mappings are plan-wide — the table has no version column — so only
  * the addressed row writes and version siblings are ignored.
  */
-const statedMappings = ({
+const statedRevenueCatMappings = ({
 	updateCatalogPlan,
 }: {
 	updateCatalogPlan: UpdateCatalogPlan;
-}): StatedMapping[] =>
+}): StatedRevenueCatMapping[] =>
 	updateCatalogPlan.upsertProducts.flatMap((upsert) => {
 		const processor = upsert.revenuecatProcessor;
 		if (processor === undefined) return [];
@@ -28,16 +28,40 @@ const statedMappings = ({
 	});
 
 /**
+ * Plan ids whose existing mapping row this request owns. `executeRenamePlans`
+ * moves `autumn_product_id` along with the plan, but this check runs BEFORE it,
+ * so a plan renaming itself still finds its row under the old id — counting
+ * that as someone else's claim would 400 a plan for restating its own mapping.
+ */
+const ownedPlanIds = ({
+	stated,
+	updateCatalogPlan,
+}: {
+	stated: StatedRevenueCatMapping[];
+	updateCatalogPlan: UpdateCatalogPlan;
+}): Set<string> => {
+	const owned = new Set(stated.map((entry) => entry.planId));
+	for (const { planId, toId } of updateCatalogPlan.renamePlans) {
+		if (owned.has(toId)) owned.add(planId);
+	}
+	return owned;
+};
+
+/**
  * A purchase resolves RC id → plan by scanning every mapping, so an id claimed
  * twice would attach whichever row the query happened to return first.
+ *
+ * Callable on its own: execute runs it before the first catalog write, so a
+ * collision cannot 400 a request that has already renamed a plan.
  */
-const assertRevenueCatIdsUnclaimed = async ({
+export const assertRevenueCatIdsUnclaimed = async ({
 	ctx,
-	stated,
+	updateCatalogPlan,
 }: {
 	ctx: AutumnContext;
-	stated: StatedMapping[];
+	updateCatalogPlan: UpdateCatalogPlan;
 }) => {
+	const stated = statedRevenueCatMappings({ updateCatalogPlan });
 	const claimedHere = new Map<string, string>();
 	for (const { planId, processor } of stated) {
 		for (const { product_id } of processor?.products ?? []) {
@@ -54,7 +78,7 @@ const assertRevenueCatIdsUnclaimed = async ({
 	}
 	if (claimedHere.size === 0) return;
 
-	const statedPlanIds = new Set(stated.map((entry) => entry.planId));
+	const owned = ownedPlanIds({ stated, updateCatalogPlan });
 	const existing = await RCMappingService.getAll({
 		db: ctx.db,
 		orgId: ctx.org.id,
@@ -63,7 +87,7 @@ const assertRevenueCatIdsUnclaimed = async ({
 
 	for (const row of existing) {
 		// A plan restating its own ids is the normal case, not a collision.
-		if (statedPlanIds.has(row.autumn_product_id)) continue;
+		if (owned.has(row.autumn_product_id)) continue;
 		for (const productId of row.revenuecat_product_ids) {
 			const claimant = claimedHere.get(productId);
 			if (!claimant) continue;
@@ -76,7 +100,10 @@ const assertRevenueCatIdsUnclaimed = async ({
 	}
 };
 
-/** Stated `processors.revenuecat` → the mappings table. Omitted keeps, null clears. */
+/**
+ * Stated `processors.revenuecat` → the mappings table. Omitted keeps, null clears.
+ * Collisions were already rejected before any write landed, so this only writes.
+ */
 export const executeRevenueCatMappings = async ({
 	ctx,
 	updateCatalogPlan,
@@ -84,10 +111,8 @@ export const executeRevenueCatMappings = async ({
 	ctx: AutumnContext;
 	updateCatalogPlan: UpdateCatalogPlan;
 }) => {
-	const stated = statedMappings({ updateCatalogPlan });
+	const stated = statedRevenueCatMappings({ updateCatalogPlan });
 	if (stated.length === 0) return;
-
-	await assertRevenueCatIdsUnclaimed({ ctx, stated });
 
 	for (const { planId, processor } of stated) {
 		const products = processor?.products ?? [];

--- a/server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts
+++ b/server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts
@@ -10,22 +10,29 @@ import {
 	executeCreditSystemSchemaRewrites,
 	executeFeatureReferenceRewrites,
 } from "@/internal/catalogV2/execute/executeFeatureReferenceRewrites";
-import { initStripeResourcesForCatalog } from "@/internal/catalogV2/execute/executeInitStripeResources/initStripeResourcesForCatalog";
+import {
+	initStripeResourcesForCatalog,
+	stripeInitTargets,
+} from "@/internal/catalogV2/execute/executeInitStripeResources/initStripeResourcesForCatalog";
+import { validateAdoptedStripePrices } from "@/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices";
 import { executeMigrationDrafts } from "@/internal/catalogV2/execute/executeMigrationDrafts";
-import { executeRevenueCatMappings } from "./executeRevenueCatMappings";
 import { executeRemovePlans } from "@/internal/catalogV2/execute/executeRemovePlans";
 import { executeRenamePlans } from "@/internal/catalogV2/execute/executeRenamePlans";
 import { executeUpsertProducts } from "@/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts";
 import { queueRewardMigrations } from "@/internal/catalogV2/execute/queueRewardMigrations";
 import { rewritePublicPlanIdsAfterRename } from "@/internal/catalogV2/execute/rewritePublicPlanIdsAfterRename";
 import { FeatureService } from "@/internal/features/FeatureService.js";
+import type { ClearCreditSystemCachePayload } from "@/internal/features/featureActions/runClearCreditSystemCacheTask.js";
 import { fillFeatureStripeMeterEventName } from "@/internal/features/utils/fillFeatureStripeMeterEventName.js";
 import { updateFeatureStripeProductName } from "@/internal/features/utils/updateFeatureStripeProductName.js";
-import type { ClearCreditSystemCachePayload } from "@/internal/features/featureActions/runClearCreditSystemCacheTask.js";
 import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
 import { workflows } from "@/queue/workflows.js";
+import {
+	assertRevenueCatIdsUnclaimed,
+	executeRevenueCatMappings,
+} from "./executeRevenueCatMappings";
 
 export type CatalogAppliedResult = { id: string; action: CatalogAction };
 
@@ -165,6 +172,34 @@ const executeRemoveFeatures = async ({
 	);
 };
 
+/**
+ * Every check that can still reject the request, run before the first write.
+ *
+ * The phase below is a straight sequence of independent, non-transactional
+ * writes, and it cannot be wrapped in a transaction because it calls Stripe. So
+ * a 400 thrown mid-sequence leaves whatever already committed — a rename that
+ * survives a rejected RevenueCat collision, say. Worse for adopted prices:
+ * `newlyAdoptedPrices` diffs against the CURRENT row, so once a failed attempt
+ * has persisted a bad Stripe price id, the retry reads it as already-known,
+ * skips the lookup and succeeds on an id that does not exist. Validating first
+ * closes both.
+ */
+const validateCatalogBeforeWrites = async ({
+	ctx,
+	updateCatalogPlan,
+}: {
+	ctx: AutumnContext;
+	updateCatalogPlan: UpdateCatalogPlan;
+}) => {
+	await assertRevenueCatIdsUnclaimed({ ctx, updateCatalogPlan });
+	// The same set Stripe init walks, so a stated id is checked against exactly
+	// the rows that would have consumed it.
+	await validateAdoptedStripePrices({
+		ctx,
+		upsertProducts: stripeInitTargets({ updateCatalogPlan }),
+	});
+};
+
 /** Persist the plan — dumb writers only, every op was computed upstream. */
 export const executeUpdateCatalogPlan = async ({
 	ctx,
@@ -175,6 +210,12 @@ export const executeUpdateCatalogPlan = async ({
 	updateCatalogPlan: UpdateCatalogPlan;
 	phases: CatalogPhases;
 }): Promise<CatalogResult> => {
+	await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "execute.validate",
+		run: () => validateCatalogBeforeWrites({ ctx, updateCatalogPlan }),
+	});
 	// Identity moves first: atomic per plan, so a later failure can never
 	// leave references split between old and new ids.
 	await timeCatalogPhase({

--- a/server/src/internal/products/actions/computeEntitlementPricesPlan/buildEntitlementPricesPlan/buildEntitlementPricesPlan.ts
+++ b/server/src/internal/products/actions/computeEntitlementPricesPlan/buildEntitlementPricesPlan/buildEntitlementPricesPlan.ts
@@ -1,4 +1,9 @@
-import type { Price } from "@autumn/shared";
+import {
+	type Price,
+	STRIPE_PRICE_MAPPING_SLOTS,
+	type StripePriceMappingSlot,
+} from "@autumn/shared";
+import type { StripeMappingUnlinks } from "../helpers/stripeMappingUnlinks";
 import type { ClaimResult } from "../types/claimResult";
 import type { EntitlementPricesPlanMode } from "../types/computeEntitlementPricesPlanParams";
 import {
@@ -12,15 +17,7 @@ import {
 	withFreshPriceId,
 } from "./buildEntitlementPricesPlanUtils";
 
-/** Fixed prices bill from the v1 slot, prepaid from the v2 slot. */
-const PRICE_MAPPING_SLOTS = [
-	"stripe_price_id",
-	"stripe_prepaid_price_v2_id",
-] as const;
-
-type PriceMapping = Partial<
-	Record<(typeof PRICE_MAPPING_SLOTS)[number], string | null>
->;
+type PriceMapping = Partial<Record<StripePriceMappingSlot, string | null>>;
 
 const mappingOf = ({ price }: { price?: Price }): PriceMapping =>
 	(price?.config ?? {}) as PriceMapping;
@@ -30,24 +27,41 @@ const mappingOf = ({ price }: { price?: Price }): PriceMapping =>
  * billing depends on that. So a re-stated mapping arrives as a claimed pair and
  * would be dropped; carry it onto the row we keep instead. Desired only carries
  * a slot the request stated, so a plain edit produces nothing here.
+ *
+ * A stated `null` is an unlink rather than a restate, and it cannot be read off
+ * the desired row — an untouched slot is nullish there too — so it arrives as
+ * `unlinkedSlots`. Only a slot that currently holds an id is worth writing.
  */
 const restatedMapping = ({
 	desired,
 	current,
+	unlinkedSlots,
 }: {
 	desired?: Price;
 	current?: Price;
+	unlinkedSlots?: StripePriceMappingSlot[];
 }): PriceMapping | undefined => {
 	if (!current) return undefined;
 
 	const desiredMapping = mappingOf({ price: desired });
 	const currentMapping = mappingOf({ price: current });
-	const restated = PRICE_MAPPING_SLOTS.filter(
-		(slot) => desiredMapping[slot] && desiredMapping[slot] !== currentMapping[slot],
+	const isUnlinked = ({ slot }: { slot: StripePriceMappingSlot }) =>
+		unlinkedSlots?.includes(slot) ?? false;
+
+	const restated = STRIPE_PRICE_MAPPING_SLOTS.filter((slot) =>
+		isUnlinked({ slot })
+			? Boolean(currentMapping[slot])
+			: Boolean(desiredMapping[slot]) &&
+				desiredMapping[slot] !== currentMapping[slot],
 	);
 	if (restated.length === 0) return undefined;
 
-	return Object.fromEntries(restated.map((slot) => [slot, desiredMapping[slot]]));
+	return Object.fromEntries(
+		restated.map((slot) => [
+			slot,
+			isUnlinked({ slot }) ? null : desiredMapping[slot],
+		]),
+	);
 };
 
 const withMapping = ({
@@ -68,9 +82,12 @@ const withMapping = ({
 export const buildEntitlementPricesPlan = ({
 	mode,
 	claims,
+	unlinks,
 }: {
 	mode: EntitlementPricesPlanMode;
 	claims: ClaimResult;
+	/** Stripe mapping slots the request stated as `null`, by current price id. */
+	unlinks?: StripeMappingUnlinks;
 }): EntitlementPricesPlan => {
 	const plan = emptyEntitlementPricesPlan();
 
@@ -81,6 +98,7 @@ export const buildEntitlementPricesPlan = ({
 		const mapping = restatedMapping({
 			desired: desired.price,
 			current: current.price,
+			unlinkedSlots: current.price && unlinks?.get(current.price.id),
 		});
 
 		if (!mapping || !current.price) {
@@ -118,8 +136,13 @@ export const buildEntitlementPricesPlan = ({
 
 	if (claims.basePriceClaim) {
 		const { desired, current } = claims.basePriceClaim;
-		const mapping = restatedMapping({ desired, current });
-		if (mapping) plan.prices.updated.push(withMapping({ price: current, mapping }));
+		const mapping = restatedMapping({
+			desired,
+			current,
+			unlinkedSlots: unlinks?.get(current.id),
+		});
+		if (mapping)
+			plan.prices.updated.push(withMapping({ price: current, mapping }));
 		else plan.prices.same.push(current);
 	}
 

--- a/server/src/internal/products/actions/computeEntitlementPricesPlan/computeEntitlementPricesPlan.ts
+++ b/server/src/internal/products/actions/computeEntitlementPricesPlan/computeEntitlementPricesPlan.ts
@@ -9,6 +9,7 @@ import { validateProductItems } from "@/internal/products/product-items/validate
 import { buildEntitlementPricesPlan } from "./buildEntitlementPricesPlan/buildEntitlementPricesPlan";
 import { claimCurrentRows } from "./claimCurrentRows/claimCurrentRows";
 import { carryForwardStripeResources } from "./helpers/carryForwardStripeResources";
+import { stripeMappingUnlinks } from "./helpers/stripeMappingUnlinks";
 import { resolveEntitlementPricesCustomize } from "./resolveEntitlementPricesCustomize";
 import type { ComputeEntitlementPricesPlanParams } from "./types/computeEntitlementPricesPlanParams";
 import type { EntitlementPricesPlan } from "./types/entitlementPricesPlan";
@@ -57,9 +58,16 @@ export const computeEntitlementPricesPlan = ({
 		desiredBasePriceAndEntitlementPrices,
 	});
 
+	const unlinks = stripeMappingUnlinks({
+		claims,
+		unlinkedStripeSlots:
+			desiredBasePriceAndEntitlementPrices.unlinkedStripeSlots,
+	});
+
 	const plan = buildEntitlementPricesPlan({
 		mode: params.mode,
 		claims,
+		unlinks,
 	});
 
 	const stripeCandidates = params.stripeCandidates ?? params.currentRows;
@@ -67,6 +75,7 @@ export const computeEntitlementPricesPlan = ({
 		plan,
 		candidatePrices: stripeCandidates?.prices ?? [],
 		candidateEntitlements: stripeCandidates?.entitlements ?? [],
+		unlinks,
 	});
 
 	plan.projected = {

--- a/server/src/internal/products/actions/computeEntitlementPricesPlan/helpers/carryForwardStripeResources.ts
+++ b/server/src/internal/products/actions/computeEntitlementPricesPlan/helpers/carryForwardStripeResources.ts
@@ -2,18 +2,23 @@ import {
 	copyStripeResourcesToMatchingPrice,
 	type Entitlement,
 	type Price,
+	type StripePriceMappingSlot,
 } from "@autumn/shared";
 import type { EntitlementPricesPlan } from "../types/entitlementPricesPlan";
+import type { StripeMappingUnlinks } from "./stripeMappingUnlinks";
 
 /** Mutates plan's new/updated prices in place, copying Stripe ids from matching current rows. */
 export const carryForwardStripeResources = ({
 	plan,
 	candidatePrices,
 	candidateEntitlements,
+	unlinks,
 }: {
 	plan: EntitlementPricesPlan;
 	candidatePrices: Price[];
 	candidateEntitlements: Entitlement[];
+	/** Stripe mapping slots the request stated as `null`, by price id. */
+	unlinks?: StripeMappingUnlinks;
 }) => {
 	const targetPrices = [...plan.prices.new, ...plan.prices.updated];
 	const targetEntitlements = [
@@ -29,5 +34,15 @@ export const carryForwardStripeResources = ({
 			targetEntitlements,
 			candidateEntitlements,
 		});
+
+		// The copy refills any nullish field from the row it matched — which for
+		// an updated row is the row itself, still holding the id the request
+		// asked to unlink. Re-clear the slots the plan deliberately emptied.
+		const config = targetPrice.config as Partial<
+			Record<StripePriceMappingSlot, string | null>
+		>;
+		for (const slot of unlinks?.get(targetPrice.id) ?? []) {
+			config[slot] = null;
+		}
 	}
 };

--- a/server/src/internal/products/actions/computeEntitlementPricesPlan/helpers/stripeMappingUnlinks.ts
+++ b/server/src/internal/products/actions/computeEntitlementPricesPlan/helpers/stripeMappingUnlinks.ts
@@ -1,0 +1,50 @@
+import type {
+	Price,
+	StripePriceMappingSlot,
+	UnlinkedStripeSlotsByPriceId,
+} from "@autumn/shared";
+import type { ClaimResult } from "../types/claimResult";
+
+/** Slots to clear, keyed by the id of the row the plan writes. */
+export type StripeMappingUnlinks = Map<string, StripePriceMappingSlot[]>;
+
+/**
+ * An unlink is stated on a desired row but has to land on the current row the
+ * claim paired it with — that is the row holding the mapping, and the one the
+ * plan writes. An unclaimed desired row has nothing to unlink: it is minted
+ * with no mapping either way.
+ */
+export const stripeMappingUnlinks = ({
+	claims,
+	unlinkedStripeSlots,
+}: {
+	claims: ClaimResult;
+	unlinkedStripeSlots: UnlinkedStripeSlotsByPriceId;
+}): StripeMappingUnlinks => {
+	const unlinks: StripeMappingUnlinks = new Map();
+
+	const record = ({
+		desired,
+		current,
+	}: {
+		desired?: Price;
+		current?: Price;
+	}) => {
+		if (!desired || !current) return;
+		const slots = unlinkedStripeSlots[desired.id];
+		if (slots?.length) unlinks.set(current.id, slots);
+	};
+
+	for (const claim of claims.entitlementPriceClaims) {
+		record({ desired: claim.desired.price, current: claim.current.price });
+	}
+
+	if (claims.basePriceClaim) {
+		record({
+			desired: claims.basePriceClaim.desired,
+			current: claims.basePriceClaim.current,
+		});
+	}
+
+	return unlinks;
+};

--- a/server/src/internal/products/productUtils/productResponseUtils/buildApiPlanVariant.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/buildApiPlanVariant.ts
@@ -3,6 +3,7 @@ import type {
 	ApiPlanVariantV1,
 	Feature,
 	FullProduct,
+	RevenueCatPlanMapping,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getPlanResponse } from "./getPlanResponse.js";
@@ -15,6 +16,7 @@ export const buildApiPlanVariant = async ({
 	features,
 	expand,
 	currency,
+	revenuecatMappings,
 }: {
 	ctx?: AutumnContext;
 	basePlan: ApiPlanV1;
@@ -22,6 +24,8 @@ export const buildApiPlanVariant = async ({
 	features: Feature[];
 	expand?: string[];
 	currency?: string;
+	/** Keyed by plan id — the variant owns its own `revenuecat_mappings` row. */
+	revenuecatMappings?: ReadonlyMap<string, RevenueCatPlanMapping>;
 }): Promise<ApiPlanVariantV1> => {
 	const variantPlan = await getPlanResponse({
 		ctx,
@@ -31,6 +35,7 @@ export const buildApiPlanVariant = async ({
 		currency,
 		basePlan,
 		resolveBaseFullProduct: false,
+		revenuecatMappings,
 	});
 
 	// The edge already carries customize; drop the plan's back-link to the base.

--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -15,9 +15,9 @@ import {
 	priceConfigToPriceProcessors,
 	productItemsToPlanItemsV1,
 	productToPlanProcessors,
-	type RevenueCatPlanMapping,
 	productV2ToBasePrice,
 	productV2ToFeatureItems,
+	type RevenueCatPlanMapping,
 	sortProductItems,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -59,6 +59,12 @@ type GetPlanResponseArgs = {
 	resolveBaseFullProduct?: boolean;
 	/** RevenueCat mappings live in their own table, so the row is read in. */
 	revenuecatMapping?: RevenueCatPlanMapping | null;
+	/**
+	 * Every mapping the caller loaded, keyed by plan id. A variant is its own
+	 * product with its own plan id, so it owns its own row — pass the map when
+	 * rendering variants so each nested plan can find its own mapping.
+	 */
+	revenuecatMappings?: ReadonlyMap<string, RevenueCatPlanMapping>;
 };
 
 type PlanExpansions = {
@@ -95,6 +101,7 @@ export async function getPlanResponse({
 	baseFullProduct,
 	resolveBaseFullProduct = true,
 	revenuecatMapping,
+	revenuecatMappings,
 	expandLicensePlans = false,
 	expandVariants = false,
 }: GetPlanResponseArgs & PlanExpansions): Promise<
@@ -186,7 +193,7 @@ export async function getPlanResponse({
 	// 9. Build Plan response
 	const planProcessors = productToPlanProcessors({
 		product,
-		revenuecatMapping,
+		revenuecatMapping: revenuecatMapping ?? revenuecatMappings?.get(product.id),
 	});
 	const plan = {
 		id: product.id,
@@ -240,6 +247,7 @@ export async function getPlanResponse({
 							features,
 							expand,
 							currency,
+							revenuecatMappings,
 						}),
 					),
 				)

--- a/server/tests/integration/catalog-v2/plans/create/create-plan-items-priced.test.ts
+++ b/server/tests/integration/catalog-v2/plans/create/create-plan-items-priced.test.ts
@@ -396,11 +396,19 @@ test.concurrent(
 		const stripeProduct = await ctx.stripeCli.products.create({
 			name: `Stripe Price Threaded ${planId}`,
 		});
+		// The item below is usage-based, and a usage-based price bills through the
+		// meter it is bound to — a plain recurring price could never report usage,
+		// so adoption rejects one. Mirrors what a sync flow would actually find.
+		const meter = await ctx.stripeCli.billing.meters.create({
+			display_name: `Threaded Meter ${planId}`,
+			event_name: `threaded_events_${planId}`,
+			default_aggregation: { formula: "sum" },
+		});
 		const stripePrice = await ctx.stripeCli.prices.create({
 			product: stripeProduct.id,
 			currency: "usd",
 			unit_amount: 50,
-			recurring: { interval: "month" },
+			recurring: { interval: "month", meter: meter.id, usage_type: "metered" },
 		});
 		const params = {
 			plans: [

--- a/server/tests/integration/catalog-v2/plans/processors/price-id-unlink.test.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/price-id-unlink.test.ts
@@ -1,0 +1,213 @@
+/**
+ * catalogV2.update — an explicit `processors.stripe: null` unlinks a price.
+ *
+ * Presence in the body is the signal. A normal plan edit re-sends every item
+ * without a `processors` key, so an omitted key has to leave the mapping
+ * exactly where it is; only a stated null unlinks. Unlike a plan's Stripe
+ * product, a paid price has to bill from SOME Stripe price, so init mints a
+ * replacement on the same request — what the unlink guarantees is that the
+ * adopted id is gone, not that the slot stays empty.
+ *
+ * Contract:
+ *   U1  `price.processors.stripe: null` drops an adopted id from the prepaid
+ *       v2 slot the item bills from
+ *   U2  the same on `plan.price` drops it from the base price's v1 slot
+ *   U3  an edit that omits `processors` keeps the adopted id — the routine
+ *       save must never read as an unlink
+ *
+ * Red (before): `price_id` was a bare string and `stripe` was `.optional()`,
+ *   so the request 400d before it could express an unlink at all.
+ * Green (after): the stated null clears the slot the mapping occupied, and an
+ *   omitted key still leaves it alone.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	BillingMethod,
+	type FullProduct,
+} from "@autumn/shared";
+import {
+	findBasePrice,
+	findFeaturePrice,
+	stripeConfigValue,
+} from "@tests/integration/utils/expectStripePriceResources.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { withCatalogPlans } from "../licenses/utils/seedLicensePlans.js";
+
+const BASE_AMOUNT = 20;
+
+const getFull = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}): Promise<FullProduct> =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+/** A price Autumn did not make — the shape a real import starts from. */
+const createExternalPrice = async ({
+	stripeCli,
+	label,
+}: {
+	stripeCli: Stripe;
+	label: string;
+}) => {
+	const product = await stripeCli.products.create({
+		name: `External ${label}`,
+	});
+	const price = await stripeCli.prices.create({
+		product: product.id,
+		currency: "usd",
+		unit_amount: 1000,
+		recurring: { interval: "month" },
+	});
+	return price.id;
+};
+
+/** `undefined` states nothing; `null` unlinks; a string adopts. */
+const prepaidItem = ({ priceId }: { priceId?: string | null }) => ({
+	feature_id: TestFeature.Messages,
+	included: 100,
+	price: {
+		amount: 10,
+		interval: BillingInterval.Month,
+		billing_method: BillingMethod.Prepaid,
+		billing_units: 100,
+		...(priceId === undefined
+			? {}
+			: { processors: { stripe: priceId ? { price_id: priceId } : null } }),
+	},
+});
+
+const basePrice = ({ priceId }: { priceId?: string | null }) => ({
+	amount: BASE_AMOUNT,
+	interval: BillingInterval.Month,
+	...(priceId === undefined
+		? {}
+		: { processors: { stripe: priceId ? { price_id: priceId } : null } }),
+});
+
+const v2PriceIdOf = ({ product }: { product: FullProduct }): string | null =>
+	stripeConfigValue({
+		price: findFeaturePrice({ product, featureId: TestFeature.Messages }),
+		field: "stripe_prepaid_price_v2_id",
+	});
+
+const basePriceIdOf = ({ product }: { product: FullProduct }): string | null =>
+	stripeConfigValue({
+		price: findBasePrice({ product }),
+		field: "stripe_price_id",
+	});
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors price: a stated null unlinks an adopted price id")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_price_unlink");
+		const adoptedPriceId = await createExternalPrice({
+			stripeCli: ctx.stripeCli,
+			label: `Prepaid ${planId}`,
+		});
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Price Unlink",
+							items: [prepaidItem({ priceId: adoptedPriceId })],
+						},
+					],
+				});
+				expect(
+					v2PriceIdOf({ product: await getFull({ ctx, planId }) }),
+					"starts mapped to the adopted price",
+				).toBe(adoptedPriceId);
+
+				// U3: the routine save — same definition, no `processors` key.
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: planId, items: [prepaidItem({})] }],
+				});
+				expect(
+					v2PriceIdOf({ product: await getFull({ ctx, planId }) }),
+					"an omitted processors key is not an unlink",
+				).toBe(adoptedPriceId);
+
+				// U1: the stated null is.
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: planId, items: [prepaidItem({ priceId: null })] }],
+				});
+				expect(
+					v2PriceIdOf({ product: await getFull({ ctx, planId }) }),
+					"the adopted price id is gone",
+				).not.toBe(adoptedPriceId);
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors price: a stated null unlinks an adopted base price id")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_base_unlink");
+		const adoptedPriceId = await createExternalPrice({
+			stripeCli: ctx.stripeCli,
+			label: `Base ${planId}`,
+		});
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Base Price Unlink",
+							price: basePrice({ priceId: adoptedPriceId }),
+						},
+					],
+				});
+				expect(
+					basePriceIdOf({ product: await getFull({ ctx, planId }) }),
+					"starts mapped to the adopted price",
+				).toBe(adoptedPriceId);
+
+				// U3 again, on the base lane.
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: planId, price: basePrice({}) }],
+				});
+				expect(
+					basePriceIdOf({ product: await getFull({ ctx, planId }) }),
+					"an omitted processors key is not an unlink",
+				).toBe(adoptedPriceId);
+
+				// U2: the stated null clears the v1 slot the base price bills from.
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: planId, price: basePrice({ priceId: null }) }],
+				});
+				expect(
+					basePriceIdOf({ product: await getFull({ ctx, planId }) }),
+					"the adopted base price id is gone",
+				).not.toBe(adoptedPriceId);
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/processors/product-id-unlink-paid.test.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/product-id-unlink-paid.test.ts
@@ -1,0 +1,169 @@
+/**
+ * catalogV2.update — an explicit Stripe unlink survives its own request on a
+ * PAID plan.
+ *
+ * `applyPlanProcessorsToProduct` clears `product.processor`, but a paid plan
+ * with no processor id reads as "missing Stripe resources"
+ * (hasMissingStripeResourcesForProduct), so the execute-phase init used to mint
+ * a REPLACEMENT Stripe product on the very same request. The plan came back
+ * mapped to a product the caller never asked for.
+ *
+ * The sibling file product-id-unlink.test.ts covers the same clear on a FREE
+ * fixture, where `isFreeProduct` short-circuits the completeness check and the
+ * bug cannot fire. This one carries a base price so it does.
+ *
+ * Contract:
+ *   P1  a paid plan is left with NO Stripe product after an unlink — attach
+ *       mints one lazily (attachRouter -> createStripePriceIFNotExist), so the
+ *       plan is re-created under Stripe the next time it is sold
+ *   P2  the fan-out rows obey it too: version siblings (processor_sync) and
+ *       variants (variant_propagation) each restate `{ stripe: null }` on their
+ *       own row and must not be re-minted either
+ *
+ * Red (before): every asserted row comes back holding a freshly minted
+ *   `prod_...` id instead of null.
+ * Green (after): every row's processor is null.
+ */
+
+import { expect, test } from "bun:test";
+import { BillingInterval } from "@autumn/shared";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	messagesItem,
+	withCatalogPlans,
+} from "../licenses/utils/seedLicensePlans.js";
+import { expectVersionProcessorCorrect } from "./utils/expectPlanProcessors.js";
+
+const BASE_AMOUNT = 20;
+
+const paidPrice = { amount: BASE_AMOUNT, interval: BillingInterval.Month };
+
+/** Autumn minted this when the paid plan was created — the id an unlink drops. */
+const mintedProcessorId = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	version?: number;
+}) => {
+	const product = await ProductService.get({
+		db: ctx.db,
+		id: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		...(version !== undefined ? { version } : {}),
+	});
+	const processorId = product?.processor?.id ?? null;
+	expect(
+		processorId,
+		`${planId} starts mapped to a Stripe product`,
+	).toBeTruthy();
+	return processorId;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors unlink: a paid plan is not re-minted after an unlink")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_proc_unlink_paid");
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Unlink Paid",
+							price: paidPrice,
+							items: [messagesItem(100)],
+						},
+					],
+				});
+				const minted = await mintedProcessorId({ ctx, planId });
+
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: planId, processors: { stripe: null } }],
+				});
+
+				// P1: cleared, and NOT swapped for a replacement product.
+				await expectVersionProcessorCorrect({
+					ctx,
+					planId,
+					version: 1,
+					productId: null,
+				});
+				const after = await ProductService.get({
+					db: ctx.db,
+					id: planId,
+					orgId: ctx.org.id,
+					env: ctx.env,
+				});
+				expect(
+					after?.processor?.id ?? null,
+					`${planId} must not be re-minted (was ${minted})`,
+				).toBeNull();
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors unlink: paid version siblings and variants are not re-minted")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_proc_unlink_paid_fan");
+		const variantId = uniqueTestId("cv2_proc_unlink_paid_eu");
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: baseId,
+							name: "Unlink Paid Base",
+							price: paidPrice,
+							items: [messagesItem(100)],
+							variants: [
+								{ variant_plan_id: variantId, name: "Unlink Paid EU" },
+							],
+						},
+					],
+				});
+				// A second version so the processor_sync fan-out lane has a sibling.
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: baseId, versioning: "new_version", active: true }],
+				});
+				await mintedProcessorId({ ctx, planId: baseId, version: 1 });
+				await mintedProcessorId({ ctx, planId: variantId, version: 1 });
+
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: baseId, processors: { stripe: null } }],
+				});
+
+				// P2: the addressed row, its history, and the variant all stay bare.
+				for (const row of [
+					{ planId: baseId, version: 2 },
+					{ planId: baseId, version: 1 },
+					{ planId: variantId, version: 1 },
+				]) {
+					await expectVersionProcessorCorrect({
+						ctx,
+						planId: row.planId,
+						version: row.version,
+						productId: null,
+					});
+				}
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/processors/revenuecat-variant-mappings.test.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/revenuecat-variant-mappings.test.ts
@@ -1,0 +1,126 @@
+/**
+ * catalogV2.update — a RevenueCat mapping stated on a VARIANT is persisted.
+ *
+ * `revenuecat_mappings` is keyed (org_id, env, autumn_product_id) where
+ * autumn_product_id is the public PLAN ID string — there is no version
+ * dimension and no base/variant dimension, so a variant is its own plan and
+ * legitimately owns its own mapping row. `CatalogVariantParamsSchema` shares
+ * `ApiPlanProcessorsSchema`, so a variant entry accepts `processors.revenuecat`
+ * and the Stripe half of it was already applied — but intentToUpsertProductPlan
+ * only carried `revenuecatProcessor` for `source === "direct"`, so the variant
+ * lanes dropped it and the request succeeded having written nothing.
+ *
+ * Contract:
+ *   RV1  a variant CREATE (`variant_link`) persists its stated RC mapping
+ *   RV2  an existing variant EDIT (`variant_propagation`) persists it too
+ *   RV3  the variant's mapping is its own — the base plan is unaffected
+ *
+ * Red (before): the variant's `processors.revenuecat` is undefined on GET.
+ * Green (after): both lanes echo the stated products.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiPlanExpandedV1 } from "@autumn/shared";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	messagesItem,
+	withCatalogPlans,
+} from "../licenses/utils/seedLicensePlans.js";
+
+const mappedIds = async ({
+	autumn,
+	planId,
+}: {
+	autumn: AutumnInt;
+	planId: string;
+}): Promise<string[] | undefined> => {
+	const catalog = await autumn.catalogV2.get({});
+	// Variants never surface top-level (getCatalogV2 filters them out); they hang
+	// off their base as `variants[].plan`, so look there before giving up.
+	const plan = (catalog.plans.find(
+		(row: { id: string }) => row.id === planId,
+	) ??
+		catalog.plans
+			.flatMap(
+				(row: { variants?: { variant_plan_id: string; plan?: unknown }[] }) =>
+					row.variants ?? [],
+			)
+			.find((variant) => variant.variant_plan_id === planId)?.plan) as
+		| ApiPlanExpandedV1
+		| undefined;
+	expect(plan, `GET catalog plan ${planId}`).toBeDefined();
+	return plan?.processors?.revenuecat?.products.map(
+		(product) => product.product_id,
+	);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors revenuecat: a variant owns its own mapping row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_rc_variant_base");
+		const variantId = uniqueTestId("cv2_rc_variant_eu");
+		const createdId = `rc_${variantId}_created`;
+		const editedId = `rc_${variantId}_edited`;
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId],
+			run: async () => {
+				// RV1: stated on the variant CREATE entry — the variant_link lane.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: baseId,
+							name: "RC Variant Base",
+							items: [messagesItem(100)],
+							variants: [
+								{
+									variant_plan_id: variantId,
+									name: "RC Variant EU",
+									processors: {
+										revenuecat: { products: [{ product_id: createdId }] },
+									},
+								},
+							],
+						},
+					],
+				});
+				expect(
+					await mappedIds({ autumn: autumnV2_3, planId: variantId }),
+					"variant_link persists the stated mapping",
+				).toEqual([createdId]);
+
+				// RV3: the mapping belongs to the variant, not to the base.
+				expect(
+					await mappedIds({ autumn: autumnV2_3, planId: baseId }),
+					"base plan has no mapping of its own",
+				).toBeUndefined();
+
+				// RV2: restated on the existing variant — the variant_propagation lane.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: baseId,
+							variants: [
+								{
+									variant_plan_id: variantId,
+									processors: {
+										revenuecat: { products: [{ product_id: editedId }] },
+									},
+								},
+							],
+						},
+					],
+				});
+				expect(
+					await mappedIds({ autumn: autumnV2_3, planId: variantId }),
+					"variant_propagation persists the stated mapping",
+				).toEqual([editedId]);
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/processors/validate-before-write.test.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/validate-before-write.test.ts
@@ -1,0 +1,182 @@
+/**
+ * catalogV2.update — a rejected request leaves the catalog untouched.
+ *
+ * executeUpdateCatalogPlan is a straight sequence of independent,
+ * non-transactional writes (rename -> features -> products -> remove ->
+ * revenuecat -> init_stripe), and it cannot be wrapped in a transaction because
+ * it calls Stripe. Two validators used to throw 400 from the tail of that
+ * sequence, after earlier writes had already committed:
+ *
+ *   - assertRevenueCatIdsUnclaimed, inside executeRevenueCatMappings
+ *   - validateAdoptedStripePrices, from initStripeResourcesForCatalog
+ *
+ * The Stripe one is worse than a partial write. `newlyAdoptedPrices` decides
+ * what to validate by diffing against the CURRENT row, so once a failed attempt
+ * has persisted the bad price id, the retry reads it as already-known, skips the
+ * Stripe lookup entirely and SUCCEEDS on an id that does not exist.
+ *
+ * Contract:
+ *   V1  a rename that also claims another plan's RevenueCat id is rejected with
+ *       the rename NOT applied
+ *   V2  a rename that also states a nonexistent Stripe price id is rejected
+ *       with the rename NOT applied
+ *   V3  retrying V2 verbatim is rejected again — the first attempt persisted
+ *       nothing for the diff to wave through
+ *
+ * Red (before): V1/V2 reject but the plan has already moved to its new id, and
+ *   V3 succeeds, leaving a price pointing at a Stripe id that does not exist.
+ * Green (after): both checks run ahead of execute.rename_plans, so all three
+ *   requests reject and the catalog is unchanged.
+ */
+
+import { expect, test } from "bun:test";
+import { BillingInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	messagesItem,
+	withCatalogPlans,
+} from "../licenses/utils/seedLicensePlans.js";
+
+const MISSING_STRIPE_PRICE_ID = "price_ThisStripePriceDoesNotExist";
+
+const planIds = async ({
+	autumn,
+}: {
+	autumn: AutumnInt;
+}): Promise<string[]> => {
+	const catalog = await autumn.catalogV2.get({});
+	return catalog.plans.map((plan: { id: string }) => plan.id);
+};
+
+const expectRenameNotApplied = async ({
+	autumn,
+	fromId,
+	toId,
+}: {
+	autumn: AutumnInt;
+	fromId: string;
+	toId: string;
+}) => {
+	const ids = await planIds({ autumn });
+	expect(ids, `${fromId} still exists under its own id`).toContain(fromId);
+	expect(ids, `${toId} was never created`).not.toContain(toId);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 validate-first: a rejected revenuecat claim rolls no rename forward")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const ownerId = uniqueTestId("cv2_vbw_owner");
+		const moverId = uniqueTestId("cv2_vbw_mover");
+		const renamedId = uniqueTestId("cv2_vbw_renamed");
+		const sharedId = `rc_${ownerId}_shared`;
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [ownerId, moverId, renamedId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: ownerId,
+							name: "RC Owner",
+							items: [{ feature_id: TestFeature.Messages, included: 0 }],
+							processors: {
+								revenuecat: { products: [{ product_id: sharedId }] },
+							},
+						},
+						{
+							plan_id: moverId,
+							name: "RC Mover",
+							items: [messagesItem(100)],
+						},
+					],
+				});
+
+				// V1: one request, two effects — the rename must not outlive the 400.
+				await expect(
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: moverId,
+								new_plan_id: renamedId,
+								processors: {
+									revenuecat: { products: [{ product_id: sharedId }] },
+								},
+							},
+						],
+					}),
+				).rejects.toThrow();
+
+				await expectRenameNotApplied({
+					autumn: autumnV2_3,
+					fromId: moverId,
+					toId: renamedId,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 validate-first: a nonexistent stripe price id rejects, and the retry rejects too")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vbw_price");
+		const renamedId = uniqueTestId("cv2_vbw_price_renamed");
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId, renamedId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Bad Price Adopt",
+							price: { amount: 20, interval: BillingInterval.Month },
+							items: [messagesItem(100)],
+						},
+					],
+				});
+
+				const badRequest = () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								new_plan_id: renamedId,
+								price: {
+									amount: 20,
+									interval: BillingInterval.Month,
+									processors: {
+										stripe: { price_id: MISSING_STRIPE_PRICE_ID },
+									},
+								},
+							},
+						],
+					});
+
+				// V2: rejected, and the rename it rode with never landed.
+				await expect(badRequest()).rejects.toThrow();
+				await expectRenameNotApplied({
+					autumn: autumnV2_3,
+					fromId: planId,
+					toId: renamedId,
+				});
+
+				// V3: the retry must not be waved through as "already known".
+				await expect(badRequest()).rejects.toThrow();
+				await expectRenameNotApplied({
+					autumn: autumnV2_3,
+					fromId: planId,
+					toId: renamedId,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/unit/catalogV2/executeInitStripeResources/validateAdoptedStripePrices.test.ts
+++ b/server/tests/unit/catalogV2/executeInitStripeResources/validateAdoptedStripePrices.test.ts
@@ -1,0 +1,194 @@
+/**
+ * newlyAdoptedPrices / meterDecision / priceRequiresMeter — the pure decisions
+ * behind adopted-price validation.
+ *
+ * Contract:
+ *   every newly-stated SLOT is validated, not just the first one found
+ *   "carried forward" is per price row + slot, so an id moved between rows is new
+ *   a mint's cloned ids stay exempt (Autumn wrote them, they were real)
+ *   adopting a metered price records the meter; adopting a meterless one CLEARS it
+ *   a usage-based price may not adopt a meterless Stripe price at all
+ */
+
+import { describe, expect, test } from "bun:test";
+import { BillWhen, PriceType } from "@autumn/shared";
+import {
+	meterDecision,
+	newlyAdoptedPrices,
+	priceRequiresMeter,
+} from "@/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices";
+
+const price = ({ id, config }: { id: string; config: object }) =>
+	({ id, config }) as never;
+
+const product = ({ prices }: { prices: unknown[] }) =>
+	({ id: "pro", prices }) as never;
+
+const upsert = ({
+	next,
+	current,
+	base,
+}: {
+	next: unknown;
+	current?: unknown;
+	base?: unknown;
+}) =>
+	({
+		row: {
+			nextFullProduct: next,
+			currentFullProduct: current ?? null,
+			baseFullProduct: base ?? null,
+		},
+	}) as never;
+
+describe("newlyAdoptedPrices", () => {
+	test("emits one entry per newly-stated slot", () => {
+		const adopted = newlyAdoptedPrices({
+			upsert: upsert({
+				next: product({
+					prices: [
+						price({
+							id: "p1",
+							config: {
+								stripe_price_id: "price_v1_new",
+								stripe_prepaid_price_v2_id: "price_v2_new",
+							},
+						}),
+					],
+				}),
+			}),
+		});
+
+		expect(adopted.map((entry) => entry.stripePriceId).sort()).toEqual([
+			"price_v1_new",
+			"price_v2_new",
+		]);
+	});
+
+	test("an id unchanged on its own row is carried forward, not re-validated", () => {
+		const adopted = newlyAdoptedPrices({
+			upsert: upsert({
+				next: product({
+					prices: [price({ id: "p1", config: { stripe_price_id: "price_a" } })],
+				}),
+				current: product({
+					prices: [price({ id: "p1", config: { stripe_price_id: "price_a" } })],
+				}),
+			}),
+		});
+
+		expect(adopted).toEqual([]);
+	});
+
+	test("an id moved to a different price row counts as newly stated", () => {
+		const adopted = newlyAdoptedPrices({
+			upsert: upsert({
+				next: product({
+					prices: [
+						price({ id: "p1", config: {} }),
+						price({ id: "p2", config: { stripe_price_id: "price_a" } }),
+					],
+				}),
+				current: product({
+					prices: [
+						price({ id: "p1", config: { stripe_price_id: "price_a" } }),
+						price({ id: "p2", config: {} }),
+					],
+				}),
+			}),
+		});
+
+		expect(adopted.map((entry) => entry.stripePriceId)).toEqual(["price_a"]);
+		expect(adopted[0]?.price.id).toBe("p2");
+	});
+
+	test("ids cloned by a mint stay exempt", () => {
+		const adopted = newlyAdoptedPrices({
+			upsert: upsert({
+				next: product({
+					prices: [
+						price({ id: "fresh", config: { stripe_price_id: "price_minted" } }),
+					],
+				}),
+				base: product({
+					prices: [
+						price({ id: "old", config: { stripe_price_id: "price_minted" } }),
+					],
+				}),
+			}),
+		});
+
+		expect(adopted).toEqual([]);
+	});
+});
+
+describe("meterDecision", () => {
+	test("adopts the meter a metered price carries", () => {
+		expect(
+			meterDecision({
+				stripePrice: { recurring: { meter: "mtr_new" } } as never,
+				config: {},
+			}),
+		).toEqual({ type: "adopt", meterId: "mtr_new" });
+	});
+
+	test("same meter is unchanged", () => {
+		expect(
+			meterDecision({
+				stripePrice: { recurring: { meter: "mtr_a" } } as never,
+				config: { stripe_meter_id: "mtr_a" },
+			}),
+		).toEqual({ type: "unchanged" });
+	});
+
+	test("re-mapping onto a meterless price clears the stale meter", () => {
+		expect(
+			meterDecision({
+				stripePrice: { recurring: null } as never,
+				config: { stripe_meter_id: "mtr_old", stripe_event_name: "old_event" },
+			}),
+		).toEqual({ type: "clear" });
+	});
+
+	test("meterless price with no stored meter is unchanged", () => {
+		expect(
+			meterDecision({
+				stripePrice: { recurring: null } as never,
+				config: {},
+			}),
+		).toEqual({ type: "unchanged" });
+	});
+});
+
+describe("priceRequiresMeter", () => {
+	const consumable = price({
+		id: "usage",
+		config: {
+			type: PriceType.Usage,
+			bill_when: BillWhen.EndOfPeriod,
+			interval: "month",
+		},
+	});
+
+	test("a usage-based price needs a meter", () => {
+		expect(
+			priceRequiresMeter({
+				price: consumable,
+				product: product({ prices: [consumable] }),
+			}),
+		).toBe(true);
+	});
+
+	test("a fixed base price does not", () => {
+		const fixed = price({
+			id: "base",
+			config: { type: PriceType.Fixed, amount: 20, interval: "month" },
+		});
+		expect(
+			priceRequiresMeter({
+				price: fixed,
+				product: product({ prices: [fixed] }),
+			}),
+		).toBe(false);
+	});
+});

--- a/server/tests/unit/catalogV2/planUpdate/intent-processors.test.ts
+++ b/server/tests/unit/catalogV2/planUpdate/intent-processors.test.ts
@@ -1,0 +1,164 @@
+/**
+ * intentToUpsertProductPlan — the processors half of an intent fold.
+ *
+ * Two review findings ride this function:
+ *
+ *   Fix 1  `processors: { stripe: null }` clears `product.processor`, but the
+ *          UpsertProductPlan carried no record that the clear was DELIBERATE.
+ *          A cleared paid row then looks like a brand-new paid plan to
+ *          `hasMissingStripeResourcesForProduct`, so execute mints a
+ *          replacement Stripe product and the unlink dies inside its own
+ *          request. The fan-out rows (`processor_sync`, `variant_propagation`)
+ *          carry the same `{ stripe: null }` and need the same flag.
+ *
+ *   Fix 3  a variant may state `processors.revenuecat` — the mappings table is
+ *          keyed by public plan id, and a variant is its own plan — but only
+ *          `source === "direct"` carried `revenuecatProcessor`, so a
+ *          `variant_link` create silently dropped the mapping.
+ *
+ * Red (before):  `stripeUnlinked` does not exist; `revenuecatProcessor` is
+ *   undefined on every non-direct source.
+ * Green (after): the unlink flag is set on every row that states the null, and
+ *   revenuecat rides direct / variant_link / variant_propagation.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	type ApiPlanProcessors,
+	AppEnv,
+	productKeyToString,
+} from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/db/products";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { intentToUpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import type { UpsertProductSource } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { emptyVersioningFlags } from "@/internal/customers/cusProducts/repos/getVersioningUsage.js";
+
+const PLAN_ID = "pro";
+
+const ctx = {
+	env: AppEnv.Sandbox,
+	org: { id: "org_test", planAliases: {}, config: {}, default_currency: "usd" },
+	features: [],
+} as unknown as AutumnContext;
+
+const currentRow = {
+	...products.createFull({ id: PLAN_ID, stripeProductId: "prod_old" }),
+	internal_id: `internal_${PLAN_ID}_v1`,
+};
+
+const productStatesContext = ({
+	withCurrent,
+}: {
+	withCurrent: boolean;
+}): ProductStatesContext => ({
+	statesByPlanVersion: withCurrent
+		? {
+				[productKeyToString({ productKey: { planId: PLAN_ID, version: 1 } })]: {
+					productKey: { planId: PLAN_ID, version: 1 },
+					currentFullProduct: currentRow,
+					customerUsage: emptyVersioningFlags(),
+				},
+			}
+		: {},
+	versionsByPlanId: withCurrent ? { [PLAN_ID]: [currentRow] } : {},
+	rewardProgramsByPlanId: {},
+});
+
+const fold = ({
+	source,
+	processors,
+	planId = PLAN_ID,
+	withCurrent = true,
+}: {
+	source: UpsertProductSource;
+	processors?: ApiPlanProcessors;
+	planId?: string;
+	withCurrent?: boolean;
+}) =>
+	intentToUpsertProductPlan({
+		ctx,
+		intent: {
+			productKey: { planId, version: 1 },
+			planParams: {
+				plan_id: planId,
+				version: 1,
+				...(processors !== undefined ? { processors } : {}),
+			},
+			source,
+		},
+		productStatesContext: productStatesContext({ withCurrent }),
+	});
+
+describe("stripe unlink flag", () => {
+	test("a direct `stripe: null` marks the row as deliberately unlinked", () => {
+		const upsert = fold({ source: "direct", processors: { stripe: null } });
+		expect(upsert.row.nextFullProduct.processor).toBeNull();
+		expect(upsert.stripeUnlinked).toBe(true);
+	});
+
+	test("the processor_sync fan-out row carries the flag too", () => {
+		const upsert = fold({
+			source: "processor_sync",
+			processors: { stripe: null },
+		});
+		expect(upsert.stripeUnlinked).toBe(true);
+	});
+
+	test("the variant_propagation row carries the flag too", () => {
+		const upsert = fold({
+			source: "variant_propagation",
+			processors: { stripe: null },
+		});
+		expect(upsert.stripeUnlinked).toBe(true);
+	});
+
+	test("a stated product_id is not an unlink", () => {
+		const upsert = fold({
+			source: "direct",
+			processors: { stripe: { product_id: "prod_new" } },
+		});
+		expect(upsert.stripeUnlinked).toBeUndefined();
+	});
+
+	test("omitted processors is not an unlink", () => {
+		expect(fold({ source: "direct" }).stripeUnlinked).toBeUndefined();
+	});
+});
+
+describe("revenuecat processor carry", () => {
+	const revenuecat = { products: [{ product_id: "rc_pro_monthly" }] };
+
+	test("a variant_link create carries the stated mapping", () => {
+		expect(
+			fold({
+				source: "variant_link",
+				processors: { revenuecat },
+				planId: "pro-eu",
+				withCurrent: false,
+			}).revenuecatProcessor,
+		).toEqual(revenuecat);
+	});
+
+	test("a variant_propagation edit carries the stated mapping", () => {
+		expect(
+			fold({ source: "variant_propagation", processors: { revenuecat } })
+				.revenuecatProcessor,
+		).toEqual(revenuecat);
+	});
+
+	test("a direct entry still carries it", () => {
+		expect(
+			fold({ source: "direct", processors: { revenuecat } })
+				.revenuecatProcessor,
+		).toEqual(revenuecat);
+	});
+
+	test("the stripe fan-out lane does not write a mapping", () => {
+		expect(
+			fold({ source: "processor_sync", processors: { revenuecat } })
+				.revenuecatProcessor,
+		).toBeUndefined();
+	});
+});

--- a/server/tests/unit/catalogV2/planUpdate/processor-lineage-merge.test.ts
+++ b/server/tests/unit/catalogV2/planUpdate/processor-lineage-merge.test.ts
@@ -1,0 +1,316 @@
+/**
+ * One catalogV2.update payload may name several rows of the same plan lineage.
+ * `computeUpsertProductsPlan` seeds `claimedProductKeys` from every direct
+ * intent before the fold, so the `processor_sync` / `variant_propagation`
+ * intents that carry a stated Stripe mapping onto the rest of the lineage are
+ * dropped as already-claimed.
+ *
+ * Red (pre-fix):  a sibling version / variant named in the same payload keeps
+ *                 its OLD stripe product id, so one plan bills under two.
+ * Green (after):  declared processors merge into the pending direct intents of
+ *                 the same lineage before the fold; rows that state their own
+ *                 mapping keep it, and two entries stating different mappings
+ *                 for one plan are a 400.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AppEnv, type UpdateCatalogParams } from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/db/products";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computeUpsertProductsPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductsPlan";
+import type {
+	ProductStatesContext,
+	UpdateCatalogContext,
+} from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { emptyVersioningFlags } from "@/internal/customers/cusProducts/repos/getVersioningUsage.js";
+
+const ctx = {
+	env: AppEnv.Sandbox,
+	features: [],
+	org: { id: "org_test", planAliases: {} },
+} as unknown as AutumnContext;
+
+const row = ({
+	planId,
+	version,
+	stripeProductId,
+	active = true,
+	baseInternalProductId = null,
+}: {
+	planId: string;
+	version: number;
+	stripeProductId: string | null;
+	active?: boolean;
+	baseInternalProductId?: string | null;
+}) => ({
+	...products.createFull({ id: planId }),
+	entitlements: [],
+	prices: [],
+	free_trial: null,
+	internal_id: `internal_${planId}_v${version}`,
+	version,
+	version_slug: `v${version}`,
+	active,
+	processor: stripeProductId ? { type: "stripe", id: stripeProductId } : null,
+	base_internal_product_id: baseInternalProductId,
+});
+
+const statesFor = ({ rows }: { rows: ReturnType<typeof row>[] }) => {
+	const versionsByPlanId: Record<string, ReturnType<typeof row>[]> = {};
+	const statesByPlanVersion: ProductStatesContext["statesByPlanVersion"] = {};
+	for (const product of rows) {
+		versionsByPlanId[product.id] = [
+			...(versionsByPlanId[product.id] ?? []),
+			product,
+		];
+		statesByPlanVersion[`${product.id}@${product.version}`] = {
+			productKey: { planId: product.id, version: product.version },
+			currentFullProduct: product,
+			customerUsage: emptyVersioningFlags(),
+		};
+	}
+	// versionsByPlanId is documented newest-first.
+	for (const planId of Object.keys(versionsByPlanId)) {
+		versionsByPlanId[planId]?.sort((a, b) => b.version - a.version);
+	}
+	return { statesByPlanVersion, versionsByPlanId, rewardProgramsByPlanId: {} };
+};
+
+const runCompute = ({
+	rows,
+	plans,
+}: {
+	rows: ReturnType<typeof row>[];
+	plans: UpdateCatalogParams["plans"];
+}): UpsertProductPlan[] => {
+	const catalogContext = {
+		featureStatesContext: {},
+		productStatesContext: statesFor({ rows }),
+		invoiceCreditProducts: [],
+		licenseStatesContext: { referencedPlanLicenseIds: new Set<string>() },
+	} as unknown as UpdateCatalogContext;
+
+	const { upsertProducts } = computeUpsertProductsPlan({
+		ctx,
+		catalogContext,
+		params: {
+			plans,
+			features: [],
+			remove_features: [],
+			remove_plans: [],
+		} as unknown as UpdateCatalogParams,
+	});
+
+	return upsertProducts ?? [];
+};
+
+const stripeIdFor = ({
+	upserts,
+	planId,
+	version,
+}: {
+	upserts: UpsertProductPlan[];
+	planId: string;
+	version: number;
+}) => {
+	const match = upserts.find(
+		(upsert) => upsert.row.planId === planId && upsert.row.version === version,
+	);
+	expect(match, `no upsert row for ${planId}@${version}`).toBeDefined();
+	return match?.row.nextFullProduct.processor?.id ?? null;
+};
+
+describe("processors merge across a plan lineage", () => {
+	test("sibling version named in the same payload adopts the stated mapping", () => {
+		const upserts = runCompute({
+			rows: [
+				row({
+					planId: "pro",
+					version: 1,
+					stripeProductId: "prod_old",
+					active: false,
+				}),
+				row({ planId: "pro", version: 2, stripeProductId: "prod_old" }),
+			],
+			plans: [
+				{
+					plan_id: "pro",
+					version: 1,
+					processors: { stripe: { product_id: "prod_new" } },
+				},
+				{ plan_id: "pro", version: 2, description: "unrelated edit" },
+			],
+		});
+
+		expect(stripeIdFor({ upserts, planId: "pro", version: 1 })).toBe(
+			"prod_new",
+		);
+		expect(stripeIdFor({ upserts, planId: "pro", version: 2 })).toBe(
+			"prod_new",
+		);
+	});
+
+	test("variant named in the same payload adopts the base's stated mapping", () => {
+		const base = row({
+			planId: "pro",
+			version: 1,
+			stripeProductId: "prod_old",
+		});
+		const upserts = runCompute({
+			rows: [
+				base,
+				row({
+					planId: "pro-eu",
+					version: 1,
+					stripeProductId: "prod_old",
+					baseInternalProductId: base.internal_id,
+				}),
+			],
+			plans: [
+				{
+					plan_id: "pro",
+					processors: { stripe: { product_id: "prod_new" } },
+				},
+				{ plan_id: "pro-eu", description: "unrelated edit" },
+			],
+		});
+
+		expect(stripeIdFor({ upserts, planId: "pro", version: 1 })).toBe(
+			"prod_new",
+		);
+		expect(stripeIdFor({ upserts, planId: "pro-eu", version: 1 })).toBe(
+			"prod_new",
+		);
+	});
+
+	test("a stated unlink clears the whole lineage, not just the named row", () => {
+		const base = row({
+			planId: "pro",
+			version: 1,
+			stripeProductId: "prod_old",
+			active: false,
+		});
+		const upserts = runCompute({
+			rows: [
+				base,
+				row({ planId: "pro", version: 2, stripeProductId: "prod_old" }),
+				row({
+					planId: "pro-eu",
+					version: 1,
+					stripeProductId: "prod_old",
+					baseInternalProductId: base.internal_id,
+				}),
+			],
+			plans: [
+				{ plan_id: "pro", version: 1, processors: { stripe: null } },
+				{ plan_id: "pro", version: 2, description: "unrelated edit" },
+				{ plan_id: "pro-eu", description: "unrelated edit" },
+			],
+		});
+
+		expect(stripeIdFor({ upserts, planId: "pro", version: 1 })).toBeNull();
+		expect(stripeIdFor({ upserts, planId: "pro", version: 2 })).toBeNull();
+		expect(stripeIdFor({ upserts, planId: "pro-eu", version: 1 })).toBeNull();
+	});
+
+	test("a variant stating its own mapping keeps it", () => {
+		const base = row({
+			planId: "pro",
+			version: 1,
+			stripeProductId: "prod_old",
+		});
+		const upserts = runCompute({
+			rows: [
+				base,
+				row({
+					planId: "pro-eu",
+					version: 1,
+					stripeProductId: "prod_old",
+					baseInternalProductId: base.internal_id,
+				}),
+			],
+			plans: [
+				{
+					plan_id: "pro",
+					processors: { stripe: { product_id: "prod_new" } },
+				},
+				{
+					plan_id: "pro-eu",
+					processors: { stripe: { product_id: "prod_eu" } },
+				},
+			],
+		});
+
+		expect(stripeIdFor({ upserts, planId: "pro", version: 1 })).toBe(
+			"prod_new",
+		);
+		expect(stripeIdFor({ upserts, planId: "pro-eu", version: 1 })).toBe(
+			"prod_eu",
+		);
+	});
+
+	test("variants[] override beats the base's fan-out for a directly named variant", () => {
+		const base = row({
+			planId: "pro",
+			version: 1,
+			stripeProductId: "prod_old",
+		});
+		const upserts = runCompute({
+			rows: [
+				base,
+				row({
+					planId: "pro-eu",
+					version: 1,
+					stripeProductId: "prod_old",
+					baseInternalProductId: base.internal_id,
+				}),
+			],
+			plans: [
+				{
+					plan_id: "pro",
+					processors: { stripe: { product_id: "prod_new" } },
+					variants: [
+						{
+							variant_plan_id: "pro-eu",
+							processors: { stripe: { product_id: "prod_eu" } },
+						},
+					],
+				},
+				{ plan_id: "pro-eu", description: "unrelated edit" },
+			],
+		});
+
+		expect(stripeIdFor({ upserts, planId: "pro-eu", version: 1 })).toBe(
+			"prod_eu",
+		);
+	});
+
+	test("two entries stating different mappings for one plan is a 400", () => {
+		expect(() =>
+			runCompute({
+				rows: [
+					row({
+						planId: "pro",
+						version: 1,
+						stripeProductId: "prod_old",
+						active: false,
+					}),
+					row({ planId: "pro", version: 2, stripeProductId: "prod_old" }),
+				],
+				plans: [
+					{
+						plan_id: "pro",
+						version: 1,
+						processors: { stripe: { product_id: "prod_a" } },
+					},
+					{
+						plan_id: "pro",
+						version: 2,
+						processors: { stripe: { product_id: "prod_b" } },
+					},
+				],
+			}),
+		).toThrow(/plan_id=pro/);
+	});
+});

--- a/server/tests/unit/catalogV2/processors-scope.test.ts
+++ b/server/tests/unit/catalogV2/processors-scope.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Stripe price adoption (`price.processors`) is scoped to the catalog path.
+ *
+ * `validateAdoptedStripePrices` only runs in the catalogV2 init flow, so any
+ * other path that persists a stated Stripe price id skips price creation
+ * (`hasUsableStripeId` sees a non-null string) and fails much later as a Stripe
+ * error at checkout instead of the documented hard error. Both price schemas
+ * are therefore split the same way: `CreatePlanItemParamsV1Schema` and
+ * `BasePriceParamsSchema` (attach / customize / migrations / licenses) have no
+ * `processors`, and `CatalogPlanItemParamsV1Schema` /
+ * `CatalogBasePriceParamsSchema` add it back for catalogV2 only.
+ *
+ * Red (before):  CreatePlanItemParamsV1Schema and BasePriceParamsSchema carried
+ *                `processors`, so customize / multi-attach / updatePlanOp
+ *                persisted the id.
+ * Green (after): only the catalog schemas keep it; every other path strips it.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { BillingInterval, BillingMethod, ResetInterval } from "@autumn/shared";
+import { MultiAttachParamsV0Schema } from "@autumn/shared/api/billing/attachV2/multiAttachParamsV0.js";
+import { CustomizePlanV1Schema } from "@autumn/shared/api/billing/common/customizePlan/customizePlanV1.js";
+import { CatalogBasePriceParamsSchema } from "@autumn/shared/api/catalogV2/planUpdate/params/catalogBasePriceParams.js";
+import {
+	type CatalogPlanItemParamsV1Input,
+	CatalogPlanItemParamsV1Schema,
+} from "@autumn/shared/api/catalogV2/planUpdate/params/catalogPlanItemParams.js";
+import { UpdateCatalogPlanParamsSchema } from "@autumn/shared/api/catalogV2/planUpdate/params/catalogPlanParams.js";
+import { MigrationUpdatePlanCustomizeSchema } from "@autumn/shared/api/migrations/operations/customer/updatePlan/updatePlanOp.js";
+import { BasePriceParamsSchema } from "@autumn/shared/api/products/components/basePrice/basePrice.js";
+import { basePriceToProductItem } from "@autumn/shared/api/products/components/basePrice/basePriceToProductItem.js";
+import { CreatePlanItemParamsV1Schema } from "@autumn/shared/api/products/items/crud/createPlanItemParamsV1.js";
+import { planItemV1ToV0 } from "@autumn/shared/api/products/items/mappers/planItemV1ToV0.js";
+import { contexts } from "@tests/utils/fixtures/db/contexts";
+import { features } from "@tests/utils/fixtures/db/features";
+
+const ADOPTED_PRICE_ID = "price_adopted_from_stripe";
+
+const basePrice = () => ({
+	amount: 20,
+	interval: BillingInterval.Month,
+	processors: { stripe: { price_id: ADOPTED_PRICE_ID } },
+});
+
+const seatsItem = (): CatalogPlanItemParamsV1Input => ({
+	feature_id: "seats",
+	included: 1,
+	price: {
+		amount: 10,
+		interval: BillingInterval.Month,
+		billing_units: 1,
+		billing_method: BillingMethod.Prepaid,
+		processors: { stripe: { price_id: ADOPTED_PRICE_ID } },
+	},
+});
+
+describe("price.processors is catalog-only", () => {
+	test("catalog item schema keeps the adopted price id", () => {
+		const parsed = CatalogPlanItemParamsV1Schema.parse(seatsItem());
+		expect(parsed.price?.processors?.stripe?.price_id).toBe(ADOPTED_PRICE_ID);
+	});
+
+	test("catalog plan params keep it through items[]", () => {
+		const parsed = UpdateCatalogPlanParamsSchema.parse({
+			plan_id: "pro",
+			items: [seatsItem()],
+		});
+		expect(parsed.items?.[0].price?.processors?.stripe?.price_id).toBe(
+			ADOPTED_PRICE_ID,
+		);
+	});
+
+	test("the generic plan item schema strips it", () => {
+		const parsed = CreatePlanItemParamsV1Schema.parse(seatsItem());
+		expect(parsed.price).toBeDefined();
+		expect(parsed.price).not.toHaveProperty("processors");
+	});
+
+	test("customize (items and add_items) strips it", () => {
+		const put = CustomizePlanV1Schema.parse({ items: [seatsItem()] });
+		expect(put.items?.[0].price).not.toHaveProperty("processors");
+
+		const patch = CustomizePlanV1Schema.parse({ add_items: [seatsItem()] });
+		expect(patch.add_items?.[0].price).not.toHaveProperty("processors");
+	});
+
+	test("multi-attach customize strips it", () => {
+		const parsed = MultiAttachParamsV0Schema.parse({
+			customer_id: "cus_1",
+			plans: [{ plan_id: "pro", customize: { items: [seatsItem()] } }],
+		});
+		expect(parsed.plans[0].customize?.items?.[0].price).not.toHaveProperty(
+			"processors",
+		);
+	});
+
+	test("the updatePlan migration operation strips it", () => {
+		const parsed = MigrationUpdatePlanCustomizeSchema.parse({
+			add_items: [seatsItem()],
+		});
+		expect(parsed.add_items?.[0].price).not.toHaveProperty("processors");
+	});
+});
+
+describe("the catalog item schema keeps the shared cross-field checks", () => {
+	// `.extend()` drops zod checks, so the catalog variant re-runs
+	// `planItemParamsIssues` rather than extending the finished schema.
+	test("amount and tiers cannot both be set", () => {
+		const result = CatalogPlanItemParamsV1Schema.safeParse({
+			feature_id: "seats",
+			price: {
+				amount: 10,
+				tiers: [{ to: "inf", amount: 5 }],
+				interval: BillingInterval.Month,
+				billing_method: BillingMethod.Prepaid,
+			},
+		});
+		expect(result.success).toBe(false);
+		expect(result.error?.issues.map((issue) => issue.message)).toContain(
+			"'amount' and 'tiers' cannot both be defined in 'price'.",
+		);
+	});
+
+	test("a price needs an amount or tiers", () => {
+		const result = CatalogPlanItemParamsV1Schema.safeParse({
+			feature_id: "seats",
+			price: {
+				interval: BillingInterval.Month,
+				billing_method: BillingMethod.Prepaid,
+			},
+		});
+		expect(result.success).toBe(false);
+		expect(result.error?.issues.map((issue) => issue.message)).toContain(
+			"If 'price' is present, either 'amount' or 'tiers' must be defined.",
+		);
+	});
+
+	test("reset and price intervals can only differ for prepaid", () => {
+		const result = CatalogPlanItemParamsV1Schema.safeParse({
+			feature_id: "seats",
+			included: 100,
+			reset: { interval: ResetInterval.Month },
+			price: {
+				amount: 1,
+				interval: BillingInterval.Year,
+				billing_method: BillingMethod.UsageBased,
+			},
+		});
+		expect(result.success).toBe(false);
+		expect(result.error?.issues.map((issue) => issue.message)).toContain(
+			"reset.interval and price.interval can only differ for prepaid prices.",
+		);
+	});
+});
+
+describe("catalog items still reach the product-item mapper", () => {
+	test("planItemV1ToV0 carries the adopted price id", () => {
+		const seatsFeature = features.create({
+			id: "seats",
+			internalId: "feat_internal_seats",
+			name: "Seats",
+		});
+		const ctx = contexts.create({ features: [seatsFeature] });
+
+		const item = CatalogPlanItemParamsV1Schema.parse(seatsItem());
+		const planItemV0 = planItemV1ToV0({ ctx, item });
+
+		expect(planItemV0.price?.processors?.stripe?.price_id).toBe(
+			ADOPTED_PRICE_ID,
+		);
+	});
+});
+
+describe("base price.processors is catalog-only", () => {
+	test("the catalog base price schema keeps the adopted price id", () => {
+		const parsed = CatalogBasePriceParamsSchema.parse(basePrice());
+		expect(parsed.processors?.stripe?.price_id).toBe(ADOPTED_PRICE_ID);
+	});
+
+	test("catalog plan params keep it through price", () => {
+		const parsed = UpdateCatalogPlanParamsSchema.parse({
+			plan_id: "pro",
+			price: basePrice(),
+		});
+		expect(parsed.price?.processors?.stripe?.price_id).toBe(ADOPTED_PRICE_ID);
+	});
+
+	test("the generic base price schema strips it", () => {
+		const parsed = BasePriceParamsSchema.parse(basePrice());
+		expect(parsed.amount).toBe(20);
+		expect(parsed).not.toHaveProperty("processors");
+	});
+
+	test("customize price strips it", () => {
+		const parsed = CustomizePlanV1Schema.parse({ price: basePrice() });
+		expect(parsed.price).not.toHaveProperty("processors");
+	});
+
+	test("multi-attach customize price strips it", () => {
+		const parsed = MultiAttachParamsV0Schema.parse({
+			customer_id: "cus_1",
+			plans: [{ plan_id: "pro", customize: { price: basePrice() } }],
+		});
+		expect(parsed.plans[0].customize?.price).not.toHaveProperty("processors");
+	});
+
+	test("the updatePlan migration operation strips it from both price slots", () => {
+		const parsed = MigrationUpdatePlanCustomizeSchema.parse({
+			price: basePrice(),
+			previous_price: basePrice(),
+		});
+		expect(parsed.price).not.toHaveProperty("processors");
+		expect(parsed.previous_price).not.toHaveProperty("processors");
+	});
+});
+
+describe("the catalog base price still reaches the product-item mapper", () => {
+	test("basePriceToProductItem bills the adopted id from the v1 slot", () => {
+		const ctx = contexts.create({});
+		const price = CatalogBasePriceParamsSchema.parse(basePrice());
+
+		const item = basePriceToProductItem({ ctx, basePrice: price });
+
+		expect(item.stripe_price_id).toBe(ADOPTED_PRICE_ID);
+	});
+});

--- a/server/tests/unit/products/computeEntitlementPricesPlan/stripe-price-mapping-unlink.test.ts
+++ b/server/tests/unit/products/computeEntitlementPricesPlan/stripe-price-mapping-unlink.test.ts
@@ -1,0 +1,303 @@
+/**
+ * `processors.stripe` on a catalog price states the Stripe price it bills as.
+ * Omitting the key keeps whatever the row is mapped to; stating `null` unlinks
+ * it. Presence in the body is the signal — a normal edit never sends the key.
+ *
+ * Red (before):  `price_id` was a bare string and `stripe` was `.optional()`,
+ *                so an unlink could not be expressed; and every mapper
+ *                optional-chained a null straight to undefined, so the planner
+ *                saw the same thing a plain edit sends and left the row in
+ *                `same` with its old Stripe id.
+ * Green (after): a stated null lands the row in `updated` with the slot
+ *                nulled, and carry-forward no longer refills it. An omitted
+ *                key still leaves a mapped price exactly as it was.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	AppEnv,
+	BillingInterval,
+	BillingMethod,
+	BillWhen,
+	EntInterval,
+	FeatureUsageType,
+	type Price,
+	ResetInterval,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+import {
+	type UpdateCatalogPlanParamsInput,
+	UpdateCatalogPlanParamsSchema,
+} from "@autumn/shared/api/catalogV2/planUpdate/params/catalogPlanParams";
+import { contexts } from "@tests/utils/fixtures/db/contexts";
+import { entitlements } from "@tests/utils/fixtures/db/entitlements";
+import { features } from "@tests/utils/fixtures/db/features";
+import { prices } from "@tests/utils/fixtures/db/prices";
+import { products } from "@tests/utils/fixtures/db/products";
+import {
+	computeEntitlementPricesPlan,
+	type EntitlementPricesPlan,
+} from "@/internal/products/actions/computeEntitlementPricesPlan";
+
+const BASE_STRIPE_PRICE_ID = "price_base_mapped";
+const USAGE_STRIPE_PRICE_ID = "price_usage_mapped";
+const PREPAID_STRIPE_PRICE_ID = "price_prepaid_mapped";
+
+const messagesFeature = features.create({
+	id: "messages",
+	internalId: "feat_internal_messages",
+	name: "Messages",
+	config: { usage_type: FeatureUsageType.Single },
+});
+
+const product = { ...products.create({ id: "pro" }), env: AppEnv.Sandbox };
+
+const ctx = contexts.create({
+	features: [messagesFeature],
+	org: {
+		id: "org_test",
+		name: "Test Organization",
+		slug: "test-org",
+		default_currency: "usd",
+		stripe_account_id: "acct_test",
+		config: { multi_currency: false },
+	} as never,
+});
+
+const currentEntitlement = entitlements.buildWithFeature({
+	id: "ent_messages",
+	internal_feature_id: messagesFeature.internal_id,
+	feature_id: messagesFeature.id,
+	feature: messagesFeature,
+	allowance: 100,
+	interval: EntInterval.Month,
+});
+
+/** A mapped base price: fixed prices bill from the v1 slot. */
+const currentBasePrice = prices.buildFixed({
+	overrides: { id: "pr_base" },
+	configOverrides: { amount: 50, stripe_price_id: BASE_STRIPE_PRICE_ID },
+});
+
+/** A mapped usage price: also the v1 slot. */
+const currentUsagePrice = prices.buildUsage({
+	overrides: { id: "pr_usage", entitlement_id: "ent_messages" },
+	configOverrides: { stripe_price_id: USAGE_STRIPE_PRICE_ID },
+});
+
+/** A mapped prepaid price: prepaid bills from the v2 slot. */
+const currentPrepaidPrice = prices.buildUsage({
+	overrides: {
+		id: "pr_prepaid",
+		entitlement_id: "ent_messages",
+		proration_config: {
+			on_increase: "prorate_immediately",
+			on_decrease: "prorate_immediately",
+		} as never,
+	},
+	configOverrides: {
+		bill_when: BillWhen.StartOfPeriod,
+		usage_tiers: [{ to: "inf", amount: 10 }],
+		stripe_price_id: null,
+		stripe_prepaid_price_v2_id: PREPAID_STRIPE_PRICE_ID,
+	},
+});
+
+type StatedProcessors = { stripe: { price_id: string } | null };
+
+const basePriceParams = (processors?: StatedProcessors) => ({
+	amount: 50,
+	interval: BillingInterval.Month,
+	...(processors ? { processors } : {}),
+});
+
+const usageItemParams = (processors?: StatedProcessors) => ({
+	feature_id: "messages",
+	included: 100,
+	reset: { interval: ResetInterval.Month },
+	price: {
+		amount: 1,
+		interval: BillingInterval.Month,
+		billing_units: 1,
+		billing_method: BillingMethod.UsageBased,
+		...(processors ? { processors } : {}),
+	},
+});
+
+const prepaidItemParams = (processors?: StatedProcessors) => ({
+	feature_id: "messages",
+	included: 100,
+	reset: { interval: ResetInterval.Month },
+	price: {
+		amount: 10,
+		interval: BillingInterval.Month,
+		billing_units: 1,
+		billing_method: BillingMethod.Prepaid,
+		...(processors ? { processors } : {}),
+	},
+});
+
+/** Runs the wire payload through the catalog schema, as the real path does. */
+const planFor = ({
+	payload,
+	currentPrices,
+}: {
+	payload: Omit<UpdateCatalogPlanParamsInput, "plan_id">;
+	currentPrices: Price[];
+}): EntitlementPricesPlan => {
+	const parsed = UpdateCatalogPlanParamsSchema.parse({
+		plan_id: "pro",
+		...payload,
+	});
+
+	return computeEntitlementPricesPlan({
+		ctx,
+		params: {
+			mode: { type: "update", protectReferencedRows: false },
+			product,
+			customize: {
+				...(parsed.price !== undefined ? { price: parsed.price } : {}),
+				...(parsed.items !== undefined ? { items: parsed.items } : {}),
+			},
+			currentRows: {
+				prices: currentPrices,
+				entitlements: [currentEntitlement],
+			},
+		},
+	});
+};
+
+const slotsOf = ({ price }: { price: Price }) => {
+	const config = price.config as UsagePriceConfig;
+	return {
+		stripe_price_id: config.stripe_price_id ?? null,
+		stripe_prepaid_price_v2_id: config.stripe_prepaid_price_v2_id ?? null,
+	};
+};
+
+const bucketOf = ({
+	plan,
+	priceId,
+}: {
+	plan: EntitlementPricesPlan;
+	priceId: string;
+}) =>
+	(["new", "updated", "same", "deleted", "retired"] as const).find((bucket) =>
+		plan.prices[bucket].some((price) => price.id === priceId),
+	);
+
+const plannedPrice = ({
+	plan,
+	priceId,
+}: {
+	plan: EntitlementPricesPlan;
+	priceId: string;
+}): Price => {
+	const price = plan.projected?.prices.find((entry) => entry.id === priceId);
+	if (!price)
+		throw new Error(`price ${priceId} missing from the projected plan`);
+	return price;
+};
+
+describe("stated null unlinks a price's Stripe mapping", () => {
+	test("base price — null clears the v1 slot and the row is written", () => {
+		const plan = planFor({
+			payload: { price: basePriceParams({ stripe: null }), items: [] },
+			currentPrices: [currentBasePrice],
+		});
+
+		expect(bucketOf({ plan, priceId: "pr_base" })).toBe("updated");
+		expect(
+			slotsOf({ price: plannedPrice({ plan, priceId: "pr_base" }) }),
+		).toEqual({
+			stripe_price_id: null,
+			stripe_prepaid_price_v2_id: null,
+		});
+	});
+
+	test("usage price — null clears the v1 slot", () => {
+		const plan = planFor({
+			payload: { items: [usageItemParams({ stripe: null })] },
+			currentPrices: [currentUsagePrice],
+		});
+
+		expect(bucketOf({ plan, priceId: "pr_usage" })).toBe("updated");
+		expect(
+			slotsOf({ price: plannedPrice({ plan, priceId: "pr_usage" }) }),
+		).toEqual({
+			stripe_price_id: null,
+			stripe_prepaid_price_v2_id: null,
+		});
+	});
+
+	test("prepaid price — null clears the v2 slot it bills from", () => {
+		const plan = planFor({
+			payload: { items: [prepaidItemParams({ stripe: null })] },
+			currentPrices: [currentPrepaidPrice],
+		});
+
+		expect(bucketOf({ plan, priceId: "pr_prepaid" })).toBe("updated");
+		expect(
+			slotsOf({ price: plannedPrice({ plan, priceId: "pr_prepaid" }) }),
+		).toEqual({
+			stripe_price_id: null,
+			stripe_prepaid_price_v2_id: null,
+		});
+	});
+});
+
+describe("an omitted processors key is not an unlink", () => {
+	test("a plain edit of every lane leaves each mapping exactly as it was", () => {
+		const v1Plan = planFor({
+			payload: { price: basePriceParams(), items: [usageItemParams()] },
+			currentPrices: [currentBasePrice, currentUsagePrice],
+		});
+
+		expect(bucketOf({ plan: v1Plan, priceId: "pr_base" })).toBe("same");
+		expect(bucketOf({ plan: v1Plan, priceId: "pr_usage" })).toBe("same");
+		expect(
+			slotsOf({ price: plannedPrice({ plan: v1Plan, priceId: "pr_base" }) })
+				.stripe_price_id,
+		).toBe(BASE_STRIPE_PRICE_ID);
+		expect(
+			slotsOf({ price: plannedPrice({ plan: v1Plan, priceId: "pr_usage" }) })
+				.stripe_price_id,
+		).toBe(USAGE_STRIPE_PRICE_ID);
+
+		const prepaidPlan = planFor({
+			payload: { items: [prepaidItemParams()] },
+			currentPrices: [currentPrepaidPrice],
+		});
+
+		expect(bucketOf({ plan: prepaidPlan, priceId: "pr_prepaid" })).toBe("same");
+		expect(
+			slotsOf({
+				price: plannedPrice({ plan: prepaidPlan, priceId: "pr_prepaid" }),
+			}).stripe_prepaid_price_v2_id,
+		).toBe(PREPAID_STRIPE_PRICE_ID);
+	});
+
+	test("a restated id still re-points the mapping", () => {
+		const plan = planFor({
+			payload: {
+				price: basePriceParams({ stripe: { price_id: "price_base_restated" } }),
+				items: [
+					prepaidItemParams({ stripe: { price_id: "price_prepaid_restated" } }),
+				],
+			},
+			currentPrices: [currentBasePrice, currentPrepaidPrice],
+		});
+
+		expect(bucketOf({ plan, priceId: "pr_base" })).toBe("updated");
+		expect(
+			slotsOf({ price: plannedPrice({ plan, priceId: "pr_base" }) })
+				.stripe_price_id,
+		).toBe("price_base_restated");
+
+		expect(bucketOf({ plan, priceId: "pr_prepaid" })).toBe("updated");
+		expect(
+			slotsOf({ price: plannedPrice({ plan, priceId: "pr_prepaid" }) })
+				.stripe_prepaid_price_v2_id,
+		).toBe("price_prepaid_restated");
+	});
+});

--- a/server/tests/unit/products/get-plan-response-revenuecat-variants.test.ts
+++ b/server/tests/unit/products/get-plan-response-revenuecat-variants.test.ts
@@ -1,0 +1,153 @@
+/**
+ * A RevenueCat mapping owned by a VARIANT plan is never exposed by catalog GET.
+ *
+ * `revenuecat_mappings` is keyed by the public plan id and has no version
+ * dimension, so a variant — which is its own product with its own plan id —
+ * legitimately owns its own row. getCatalogV2 loads every row into a
+ * plan-id map but only ever hands the base product's row to getPlanResponse,
+ * so the nested buildApiPlanVariant render gets nothing.
+ *
+ * Red (current):  variants[0].plan.processors is undefined even though the row exists
+ * Green (after):  each rendered plan looks its own product.id up in the map
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	AppEnv,
+	type FullProduct,
+	type RevenueCatPlanMapping,
+} from "@autumn/shared";
+import { getPlanResponse } from "@/internal/products/productUtils/productResponseUtils/getPlanResponse.js";
+
+const productFields = {
+	description: null,
+	group: "",
+	version: 1,
+	version_slug: "v1",
+	active: true,
+	deleted_at: null,
+	previous_version_slug: null,
+	env: AppEnv.Sandbox,
+	org_id: "org_123",
+	created_at: 1,
+	processor: null,
+	archived: false,
+	is_add_on: false,
+	is_default: false,
+	config: { ignore_past_due: false },
+	metadata: {},
+	prices: [],
+	entitlements: [],
+	free_trial: null,
+	free_trials: [],
+	free_trial_ids: [],
+};
+
+const basePlanId = "credits";
+const variantPlanId = "credits-eu";
+
+const variantProduct = {
+	...productFields,
+	id: variantPlanId,
+	name: "Credits (EU)",
+	internal_id: "prod_variant_internal",
+	base_variant_id: basePlanId,
+	base_internal_product_id: "prod_base_internal",
+} as unknown as FullProduct;
+
+const baseProduct = {
+	...productFields,
+	id: basePlanId,
+	name: "Credits",
+	internal_id: "prod_base_internal",
+	base_variant_id: null,
+	base_internal_product_id: null,
+	variants: [variantProduct],
+} as unknown as FullProduct;
+
+/** One Autumn plan holds N RevenueCat ids — quantity is the axis. */
+const variantMapping: RevenueCatPlanMapping = {
+	revenuecat_product_ids: ["rc_credits_eu_100", "rc_credits_eu_500"],
+	feature_quantities: {
+		rc_credits_eu_100: [{ feature_id: "credits", quantity: 100 }],
+		rc_credits_eu_500: [{ feature_id: "credits", quantity: 500 }],
+	},
+};
+
+const baseMapping: RevenueCatPlanMapping = {
+	revenuecat_product_ids: ["rc_credits_100"],
+	feature_quantities: {
+		rc_credits_100: [{ feature_id: "credits", quantity: 100 }],
+	},
+};
+
+describe("getPlanResponse revenuecat mappings across variants", () => {
+	test("renders the variant's own mapping onto the nested variant plan", async () => {
+		const response = await getPlanResponse({
+			product: baseProduct,
+			features: [],
+			revenuecatMappings: new Map([
+				[basePlanId, baseMapping],
+				[variantPlanId, variantMapping],
+			]),
+			expandVariants: true,
+			resolveBaseFullProduct: false,
+		});
+
+		expect(response.processors?.revenuecat).toEqual({
+			products: [
+				{
+					product_id: "rc_credits_100",
+					feature_quantities: [{ feature_id: "credits", quantity: 100 }],
+				},
+			],
+		});
+
+		const variant = response.variants?.[0];
+		expect(variant?.variant_plan_id).toBe(variantPlanId);
+		expect(variant?.plan?.processors?.revenuecat).toEqual({
+			products: [
+				{
+					product_id: "rc_credits_eu_100",
+					feature_quantities: [{ feature_id: "credits", quantity: 100 }],
+				},
+				{
+					product_id: "rc_credits_eu_500",
+					feature_quantities: [{ feature_id: "credits", quantity: 500 }],
+				},
+			],
+		});
+	});
+
+	test("a variant-only mapping does not leak onto the base plan", async () => {
+		const response = await getPlanResponse({
+			product: baseProduct,
+			features: [],
+			revenuecatMappings: new Map([[variantPlanId, variantMapping]]),
+			expandVariants: true,
+			resolveBaseFullProduct: false,
+		});
+
+		expect(response.processors).toBeUndefined();
+		expect(
+			response.variants?.[0]?.plan?.processors?.revenuecat?.products,
+		).toHaveLength(2);
+	});
+
+	test("the single-mapping argument still renders the base plan", async () => {
+		const response = await getPlanResponse({
+			product: baseProduct,
+			features: [],
+			revenuecatMapping: baseMapping,
+			expandVariants: true,
+			resolveBaseFullProduct: false,
+		});
+
+		expect(response.processors?.revenuecat?.products?.[0]?.product_id).toBe(
+			"rc_credits_100",
+		);
+		// Guard the optional chain below: the variant plan really was rendered.
+		expect(response.variants?.[0]?.plan).toBeDefined();
+		expect(response.variants?.[0]?.plan?.processors).toBeUndefined();
+	});
+});

--- a/server/tests/unit/shared/diffPlanV1PreviewFields.test.ts
+++ b/server/tests/unit/shared/diffPlanV1PreviewFields.test.ts
@@ -2,8 +2,8 @@ import { expect, test } from "bun:test";
 import {
 	ApiFeatureType,
 	type ApiPlanV1,
-	BillingInterval,
 	BILLING_CONTROL_KEYS,
+	BillingInterval,
 	diffPlanV1,
 	diffPlanV1PreviewFields,
 	PlanPreviousAttributesV0Schema,
@@ -277,9 +277,7 @@ const createdLanes = {
 			quantity: 100,
 		},
 	],
-	spend_limits: [
-		{ feature_id: "messages", enabled: true, overage_limit: 50 },
-	],
+	spend_limits: [{ feature_id: "messages", enabled: true, overage_limit: 50 }],
 	usage_limits: [
 		{
 			feature_id: "messages",
@@ -349,3 +347,34 @@ for (const key of BILLING_CONTROL_KEYS) {
 		).not.toThrow();
 	});
 }
+
+// Adding the first mapping to a plan that had none: the diff emits
+// `processors: null` (previous was undefined) so the key survives JSON, and the
+// picked schema has to accept that null the way free_trial already does.
+// Red (before): PlanPreviousAttributesV0Schema.parse throws invalid_type,
+// so handlePreviewUpdateCatalogV2 never returns for a first-time mapping.
+test("processors: first mapping on an unmapped plan parses", () => {
+	const diff = diffPlanV1PreviewFields({
+		from: plan({}),
+		to: plan({ processors: { stripe: { product_id: "prod_first" } } }),
+	});
+
+	expect(diff.previous_attributes).toEqual({ processors: null });
+	expect(() =>
+		PlanPreviousAttributesV0Schema.parse(diff.previous_attributes),
+	).not.toThrow();
+});
+
+test("processors: re-mapping keeps the previous mapping", () => {
+	const diff = diffPlanV1PreviewFields({
+		from: plan({ processors: { stripe: { product_id: "prod_old" } } }),
+		to: plan({ processors: { stripe: { product_id: "prod_new" } } }),
+	});
+
+	expect(diff.previous_attributes).toEqual({
+		processors: { stripe: { product_id: "prod_old" } },
+	});
+	expect(() =>
+		PlanPreviousAttributesV0Schema.parse(diff.previous_attributes),
+	).not.toThrow();
+});

--- a/shared/api/catalogV2/planUpdate/params/catalogBasePriceParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogBasePriceParams.ts
@@ -1,0 +1,28 @@
+import { BasePriceParamsSchema } from "@api/products/components/basePrice/basePrice.js";
+import { ApiPriceProcessorsSchema } from "@api/products/components/processors.js";
+import type { z } from "zod/v4";
+
+/**
+ * The base price params plus Stripe price adoption. Adoption is scoped to the
+ * catalog path: `validateAdoptedStripePrices` only runs in the catalogV2 init
+ * flow, so a stated price id on attach/customize/migration would be persisted
+ * unchecked and only surface as a Stripe error at checkout. Keep `processors`
+ * here rather than on `BasePriceParamsSchema`.
+ */
+export const CatalogBasePriceParamsSchema = BasePriceParamsSchema.extend({
+	processors: ApiPriceProcessorsSchema.optional().meta({
+		description:
+			"Adopt an existing Stripe price instead of creating one. The id must already exist in Stripe.",
+	}),
+}).meta({
+	title: "CatalogBasePrice",
+	description:
+		"Base price configuration for a catalog plan, including Stripe price adoption.",
+});
+
+export type CatalogBasePriceParams = z.infer<
+	typeof CatalogBasePriceParamsSchema
+>;
+export type CatalogBasePriceParamsInput = z.input<
+	typeof CatalogBasePriceParamsSchema
+>;

--- a/shared/api/catalogV2/planUpdate/params/catalogPlanItemParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogPlanItemParams.ts
@@ -1,0 +1,46 @@
+import { ApiPriceProcessorsSchema } from "@api/products/components/processors.js";
+import {
+	PLAN_ITEM_PRICE_DESCRIPTION,
+	PlanItemParamsObjectSchema,
+	PlanItemPriceParamsSchema,
+	planItemParamsIssues,
+} from "@api/products/items/crud/createPlanItemParamsV1.js";
+import type { z } from "zod/v4";
+
+/**
+ * The plan item schema plus Stripe price adoption. Adoption is scoped to the
+ * catalog path: `validateAdoptedStripePrices` only runs in the catalogV2 init
+ * flow, so a stated price id on attach/customize/migration would be persisted
+ * unchecked and only surface as a Stripe error at checkout. Keep `processors`
+ * here rather than on `CreatePlanItemParamsV1Schema`.
+ */
+export const CatalogPlanItemPriceParamsSchema =
+	PlanItemPriceParamsSchema.extend({
+		processors: ApiPriceProcessorsSchema.optional().meta({
+			description:
+				"Adopt an existing Stripe price instead of creating one. The id must already exist in Stripe.",
+		}),
+	});
+
+export const CatalogPlanItemParamsV1Schema = PlanItemParamsObjectSchema.extend({
+	price: CatalogPlanItemPriceParamsSchema.optional().meta({
+		description: PLAN_ITEM_PRICE_DESCRIPTION,
+	}),
+})
+	.check((ctx) => {
+		for (const { message, input } of planItemParamsIssues(ctx.value)) {
+			ctx.issues.push({ code: "custom", message, input });
+		}
+	})
+	.meta({
+		title: "CatalogPlanItem",
+		description:
+			"Configuration for a feature item in a catalog plan, including usage limits, pricing, rollover settings and Stripe price adoption.",
+	});
+
+export type CatalogPlanItemParamsV1 = z.infer<
+	typeof CatalogPlanItemParamsV1Schema
+>;
+export type CatalogPlanItemParamsV1Input = z.input<
+	typeof CatalogPlanItemParamsV1Schema
+>;

--- a/shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts
@@ -1,9 +1,9 @@
 import { FreeTrialParamsV1Schema } from "@api/common/freeTrial/freeTrialParamsV1.js";
-import { BasePriceParamsSchema } from "@api/products/components/basePrice/basePrice.js";
+import { CatalogBasePriceParamsSchema } from "./catalogBasePriceParams.js";
 import { ApiPlanProcessorsSchema } from "@api/products/components/processors.js";
 import { PlanLicenseParamsSchema } from "@api/products/crud/licenses/planLicenseParams.js";
 import { MigrationParamsSchema } from "@api/products/crud/migrationParams.js";
-import { CreatePlanItemParamsV1Schema } from "@api/products/items/crud/createPlanItemParamsV1.js";
+import { CatalogPlanItemParamsV1Schema } from "./catalogPlanItemParams.js";
 import { CustomerBillingControlsParamsSchema } from "@models/cusModels/billingControls/customerBillingControls.js";
 import { ProductConfigParamsSchema } from "@models/productModels/productConfig/productConfig.js";
 import { ProductMetadataSchema } from "@models/productModels/productMetadata.js";
@@ -55,11 +55,11 @@ export const UpdateCatalogPlanParamsSchema = z.object({
 		description:
 			"Payment processors this plan is connected to. Omit to keep.",
 	}),
-	price: BasePriceParamsSchema.nullable().optional().meta({
+	price: CatalogBasePriceParamsSchema.nullable().optional().meta({
 		description:
 			"Base recurring price. Omit to leave unchanged; null removes it.",
 	}),
-	items: z.array(CreatePlanItemParamsV1Schema).optional().meta({
+	items: z.array(CatalogPlanItemParamsV1Schema).optional().meta({
 		description: "Feature configurations for this plan.",
 	}),
 	free_trial: FreeTrialParamsV1Schema.nullable().optional().meta({

--- a/shared/api/products/components/basePrice/basePrice.ts
+++ b/shared/api/products/components/basePrice/basePrice.ts
@@ -2,7 +2,6 @@ import { BillingInterval } from "@models/productModels/intervals/billingInterval
 import { z } from "zod/v4";
 import { AdditionalCurrencyPriceArraySchema } from "../additionalCurrencies";
 import { DisplaySchema } from "../display";
-import { ApiPriceProcessorsSchema } from "../processors";
 
 export const BasePriceSchema = z.object({
 	amount: z.number().meta({
@@ -20,6 +19,12 @@ export const BasePriceSchema = z.object({
 	}),
 });
 
+/**
+ * The base price params, without any processor mapping. Adoption of an existing
+ * Stripe price is deliberately scoped to the catalog path, so the `processors`
+ * field is added by `CatalogBasePriceParamsSchema` instead of living here —
+ * attach/customize/migration paths must not be able to state one.
+ */
 export const BasePriceParamsSchema = BasePriceSchema.omit({
 	display: true,
 })
@@ -46,10 +51,6 @@ export const BasePriceParamsSchema = BasePriceSchema.omit({
 			description:
 				"Stripe price id this base price is billed under. Set by sync flows to capture the actual Stripe price when it differs from the catalog default.",
 			internal: true,
-		}),
-		processors: ApiPriceProcessorsSchema.optional().meta({
-			description:
-				"Adopt an existing Stripe price instead of creating one. The id must already exist in Stripe.",
 		}),
 	})
 	.meta({

--- a/shared/api/products/components/basePrice/basePriceToProductItem.ts
+++ b/shared/api/products/components/basePrice/basePriceToProductItem.ts
@@ -1,13 +1,14 @@
+import type { CatalogBasePriceParams } from "@api/catalogV2/planUpdate/params/catalogBasePriceParams";
 import { RecaseError } from "@api/errors/base/RecaseError";
 import { ProductErrorCode } from "@api/errors/codes/productErrCodes";
 import type {
-    BasePrice,
-    BasePriceParams,
+	BasePrice,
+	BasePriceParams,
 } from "@api/products/components/basePrice/basePrice";
 import { BillingInterval } from "@models/productModels/intervals/billingInterval";
 import {
-    type ProductItem,
-    ProductItemType,
+	type ProductItem,
+	ProductItemType,
 } from "@models/productV2Models/productItemModels/productItemModels";
 import { getProductItemDisplay } from "@utils/productDisplayUtils";
 import { billingToItemInterval } from "@utils/productV2Utils/productItemUtils/itemIntervalUtils";
@@ -18,7 +19,7 @@ export const basePriceToProductItem = ({
 	basePrice,
 }: {
 	ctx: SharedContext;
-	basePrice: BasePrice | BasePriceParams;
+	basePrice: BasePrice | BasePriceParams | CatalogBasePriceParams;
 }): ProductItem => {
 	const basePriceDisplay =
 		"display" in basePrice ? basePrice.display : undefined;
@@ -30,16 +31,18 @@ export const basePriceToProductItem = ({
 	const priceId =
 		"price_id" in basePrice ? (basePrice.price_id ?? undefined) : undefined;
 	// A base price is fixed, so an adopted id belongs in the v1 slot it bills
-	// from. The internal field stays as the sync flows' way in.
-	const statedStripePriceId =
-		"processors" in basePrice
-			? basePrice.processors?.stripe?.price_id
+	// from. The internal field stays as the sync flows' way in. Presence is the
+	// signal: an omitted `stripe` states nothing, an explicit null unlinks.
+	const statedStripe =
+		"processors" in basePrice ? basePrice.processors?.stripe : undefined;
+	const internalStripePriceId =
+		"stripe_price_id" in basePrice
+			? (basePrice.stripe_price_id ?? undefined)
 			: undefined;
 	const stripePriceId =
-		statedStripePriceId ??
-		("stripe_price_id" in basePrice
-			? (basePrice.stripe_price_id ?? undefined)
-			: undefined);
+		statedStripe === undefined
+			? internalStripePriceId
+			: (statedStripe?.price_id ?? null);
 
 	const additionalCurrencies =
 		"additional_currencies" in basePrice

--- a/shared/api/products/components/planChange/planPreviousAttributesV0.ts
+++ b/shared/api/products/components/planChange/planPreviousAttributesV0.ts
@@ -2,6 +2,7 @@ import { CustomerBillingControlsSchema } from "@models/cusModels/billingControls
 import type { z } from "zod/v4";
 import { ApiPlanV1Schema } from "../../apiPlanV1.js";
 import { ApiFreeTrialV2Schema } from "../apiFreeTrialV2.js";
+import { ApiPlanProcessorsSchema } from "../processors.js";
 
 /**
  * Sparse definition scalars that changed, holding their previous values.
@@ -22,6 +23,10 @@ export const PlanPreviousAttributesV0Schema = ApiPlanV1Schema.pick({
 	.partial()
 	.extend({
 		// Diff emits null when the previous value was unset so the key survives JSON.
+		processors: ApiPlanProcessorsSchema.nullable().optional().meta({
+			description:
+				"Previous payment processors when they changed. Null when the plan had none.",
+		}),
 		free_trial: ApiFreeTrialV2Schema.nullable().optional().meta({
 			description:
 				"Previous free trial when it changed. Null when the plan had none.",

--- a/shared/api/products/components/processors.ts
+++ b/shared/api/products/components/processors.ts
@@ -54,7 +54,8 @@ export const ApiPlanProcessorsSchema = z.object({
 });
 
 export const ApiPriceProcessorsSchema = z.object({
-	stripe: ApiStripePriceProcessorSchema.optional(),
+	/** Omit to keep the current mapping; null unlinks it. */
+	stripe: ApiStripePriceProcessorSchema.nullish(),
 });
 
 export type ApiStripePlanProcessor = z.infer<

--- a/shared/api/products/items/crud/createPlanItemParamsV1.ts
+++ b/shared/api/products/items/crud/createPlanItemParamsV1.ts
@@ -1,11 +1,9 @@
-import { ApiFeatureOverrideSchema } from "@api/features/apiFeatureOverride";
 import {
 	AdditionalCurrencyPriceArraySchema,
 	ApiUsageTierWithCurrenciesSchema,
 	additionalCurrencyPlanItemIssues,
 } from "@api/products/components/additionalCurrencies";
 import { BillingMethod } from "@api/products/components/billingMethod";
-import { ApiPriceProcessorsSchema } from "@api/products/components/processors";
 import { RolloverExpiryDurationType } from "@models/productModels/durationTypes/rolloverExpiryDurationType";
 import { BillingInterval } from "@models/productModels/intervals/billingInterval";
 import { ResetInterval } from "@models/productModels/intervals/resetInterval";
@@ -16,294 +14,301 @@ import {
 	OnIncrease,
 } from "@models/productV2Models/productItemModels/productItemEnums";
 import { z } from "zod/v4";
+import { ApiFeatureOverrideSchema } from "@api/features/apiFeatureOverride";
 
 export const IncludedUsageParamsSchema = z.number().max(10_000_000_000_000, {
 	error:
 		"Included usage cannot exceed 10 trillion; use unlimited usage instead",
 });
 
-export const CreatePlanItemParamsV1Schema = z
-	.object({
-		feature_id: z.string().meta({
-			description: "The ID of the feature to configure.",
-		}),
-		included: IncludedUsageParamsSchema.optional().meta({
+/**
+ * The `price` sub-object, without any processor mapping. Adoption of an
+ * existing Stripe price is deliberately scoped to the catalog path, so the
+ * `processors` field is added by `CatalogPlanItemParamsV1Schema` instead of
+ * living here — attach/customize/migration paths must not be able to state one.
+ */
+export const PlanItemPriceParamsSchema = z.object({
+	stripe_price_id: z
+		.string()
+		.nullish()
+		.transform((value) => value ?? undefined)
+		.optional()
+		.meta({
 			description:
-				"Number of free units included. Balance resets to this each interval for consumable features.",
-		}),
-		unlimited: z.boolean().optional().meta({
-			description: "If true, customer has unlimited access to this feature.",
-		}),
-		pooled: z.boolean().default(false).optional().meta({
-			description:
-				"Whether entity-level grants contribute to a shared customer balance.",
-		}),
-
-		reset: z
-			.object({
-				interval: z.enum(ResetInterval).meta({
-					description:
-						"Interval at which balance resets (e.g. 'month', 'year'). For consumable features only.",
-				}),
-				interval_count: z.number().optional().meta({
-					description: "Number of intervals between resets. Defaults to 1.",
-				}),
-			})
-			.optional()
-			.meta({
-				description:
-					"Reset configuration for consumable features. Omit for non-consumable features like seats.",
-			}),
-
-		price: z
-			.object({
-				stripe_price_id: z
-					.string()
-					.nullish()
-					.transform((value) => value ?? undefined)
-					.optional()
-					.meta({
-						description:
-							"Stripe price id this feature price is billed under. Set by sync flows to preserve an existing Stripe price.",
-						internal: true,
-					}),
-				processors: ApiPriceProcessorsSchema.optional().meta({
-					description:
-						"Adopt an existing Stripe price instead of creating one. The id must already exist in Stripe.",
-				}),
-				amount: z.number().optional().meta({
-					description:
-						"Price per billing_units after included usage. Either 'amount' or 'tiers' is required.",
-				}),
-				additional_currencies:
-					AdditionalCurrencyPriceArraySchema.optional().meta({
-						description:
-							"Amounts in additional currencies for this flat price. The base 'amount' is in the org's default currency. Only valid with 'amount', not 'tiers'.",
-					}),
-				tiers: z.array(ApiUsageTierWithCurrenciesSchema).optional().meta({
-					description:
-						"Tiered pricing.  Either 'amount' or 'tiers' is required.",
-				}),
-				tier_behavior: z.enum(TierBehavior).optional(),
-
-				interval: z.enum(BillingInterval).meta({
-					description:
-						"Billing interval. For consumable features, should match reset.interval.",
-				}),
-				interval_count: z.number().default(1).optional().meta({
-					description: "Number of intervals per billing cycle. Defaults to 1.",
-				}),
-
-				billing_units: z.number().default(1).optional().meta({
-					description:
-						"Units per price increment. Usage is rounded UP when billed (e.g. billing_units=100 means 101 rounds to 200).",
-				}),
-				billing_method: z.enum(BillingMethod).meta({
-					description:
-						"'prepaid' for upfront payment (seats), 'usage_based' for pay-as-you-go.",
-				}),
-				max_purchase: z.number().nullish().meta({
-					description:
-						"Max units purchasable beyond included. E.g. included=100, max_purchase=300 allows 400 total. Null for no limit.",
-				}),
-			})
-			.optional()
-			.meta({
-				description:
-					"Pricing for usage beyond included units. Omit for free features.",
-			}),
-
-		proration: z
-			.object({
-				on_increase: z.enum(OnIncrease).meta({
-					description: "Billing behavior when quantity increases mid-cycle.",
-				}),
-				on_decrease: z.enum(OnDecrease).meta({
-					description: "Credit behavior when quantity decreases mid-cycle.",
-				}),
-			})
-			.optional()
-			.meta({
-				description:
-					"Proration settings for prepaid features. Controls mid-cycle quantity change billing.",
-			}),
-
-		rollover: z
-			.object({
-				max: z.number().optional().meta({
-					description: "Max rollover units. Omit for unlimited rollover.",
-				}),
-				max_percentage: z.number().optional().meta({
-					description:
-						"Maximum rollover as a percentage (0-100) of included + prepaid grant. Mutually exclusive with max.",
-				}),
-				expiry_duration_type: z.enum(RolloverExpiryDurationType).meta({
-					description: "When rolled over units expire.",
-				}),
-				expiry_duration_length: z.number().optional().meta({
-					description: "Number of periods before expiry.",
-				}),
-			})
-			.optional()
-			.meta({
-				description:
-					"Rollover config for unused units. If set, unused included units carry over.",
-			}),
-
-		feature_override: ApiFeatureOverrideSchema.optional().meta({
-			description:
-				"Overrides fields of this item's feature for customers on this plan (e.g. a credit system's credit_schema).",
-		}),
-
-		entity_feature_id: z.string().optional().meta({
+				"Stripe price id this feature price is billed under. Set by sync flows to preserve an existing Stripe price.",
 			internal: true,
 		}),
+	amount: z.number().optional().meta({
+		description:
+			"Price per billing_units after included usage. Either 'amount' or 'tiers' is required.",
+	}),
+	additional_currencies: AdditionalCurrencyPriceArraySchema.optional().meta({
+		description:
+			"Amounts in additional currencies for this flat price. The base 'amount' is in the org's default currency. Only valid with 'amount', not 'tiers'.",
+	}),
+	tiers: z.array(ApiUsageTierWithCurrenciesSchema).optional().meta({
+		description: "Tiered pricing.  Either 'amount' or 'tiers' is required.",
+	}),
+	tier_behavior: z.enum(TierBehavior).optional(),
 
-		entitlement_id: z.string().optional().meta({
-			internal: true,
+	interval: z.enum(BillingInterval).meta({
+		description:
+			"Billing interval. For consumable features, should match reset.interval.",
+	}),
+	interval_count: z.number().default(1).optional().meta({
+		description: "Number of intervals per billing cycle. Defaults to 1.",
+	}),
+
+	billing_units: z.number().default(1).optional().meta({
+		description:
+			"Units per price increment. Usage is rounded UP when billed (e.g. billing_units=100 means 101 rounds to 200).",
+	}),
+	billing_method: z.enum(BillingMethod).meta({
+		description:
+			"'prepaid' for upfront payment (seats), 'usage_based' for pay-as-you-go.",
+	}),
+	max_purchase: z.number().nullish().meta({
+		description:
+			"Max units purchasable beyond included. E.g. included=100, max_purchase=300 allows 400 total. Null for no limit.",
+	}),
+});
+
+export const PLAN_ITEM_PRICE_DESCRIPTION =
+	"Pricing for usage beyond included units. Omit for free features.";
+
+/**
+ * Field shape only — no cross-field checks and no `.meta()` title. The catalog
+ * variant rebuilds from this so both schemas share one definition; run the
+ * checks through `planItemParamsIssues`.
+ */
+export const PlanItemParamsObjectSchema = z.object({
+	feature_id: z.string().meta({
+		description: "The ID of the feature to configure.",
+	}),
+	included: IncludedUsageParamsSchema.optional().meta({
+		description:
+			"Number of free units included. Balance resets to this each interval for consumable features.",
+	}),
+	unlimited: z.boolean().optional().meta({
+		description: "If true, customer has unlimited access to this feature.",
+	}),
+	pooled: z.boolean().default(false).optional().meta({
+		description:
+			"Whether entity-level grants contribute to a shared customer balance.",
+	}),
+
+	reset: z
+		.object({
+			interval: z.enum(ResetInterval).meta({
+				description:
+					"Interval at which balance resets (e.g. 'month', 'year'). For consumable features only.",
+			}),
+			interval_count: z.number().optional().meta({
+				description: "Number of intervals between resets. Defaults to 1.",
+			}),
+		})
+		.optional()
+		.meta({
+			description:
+				"Reset configuration for consumable features. Omit for non-consumable features like seats.",
 		}),
-		price_id: z.string().optional().meta({
-			internal: true,
+
+	price: PlanItemPriceParamsSchema.optional().meta({
+		description: PLAN_ITEM_PRICE_DESCRIPTION,
+	}),
+
+	proration: z
+		.object({
+			on_increase: z.enum(OnIncrease).meta({
+				description: "Billing behavior when quantity increases mid-cycle.",
+			}),
+			on_decrease: z.enum(OnDecrease).meta({
+				description: "Credit behavior when quantity decreases mid-cycle.",
+			}),
+		})
+		.optional()
+		.meta({
+			description:
+				"Proration settings for prepaid features. Controls mid-cycle quantity change billing.",
 		}),
-	})
-	.check((ctx) => {
-		const resetInterval = ctx.value.reset?.interval;
-		const priceInterval = ctx.value.price?.interval;
-		const resetIntervalCount = ctx.value.reset?.interval_count ?? 1;
-		const priceIntervalCount = ctx.value.price?.interval_count ?? 1;
-		const hasDifferentResetAndPriceInterval =
-			!!resetInterval &&
-			!!priceInterval &&
-			(String(resetInterval) !== String(priceInterval) ||
-				resetIntervalCount !== priceIntervalCount);
+
+	rollover: z
+		.object({
+			max: z.number().optional().meta({
+				description: "Max rollover units. Omit for unlimited rollover.",
+			}),
+			max_percentage: z.number().optional().meta({
+				description:
+					"Maximum rollover as a percentage (0-100) of included + prepaid grant. Mutually exclusive with max.",
+			}),
+			expiry_duration_type: z.enum(RolloverExpiryDurationType).meta({
+				description: "When rolled over units expire.",
+			}),
+			expiry_duration_length: z.number().optional().meta({
+				description: "Number of periods before expiry.",
+			}),
+		})
+		.optional()
+		.meta({
+			description:
+				"Rollover config for unused units. If set, unused included units carry over.",
+		}),
+
+	feature_override: ApiFeatureOverrideSchema.optional().meta({
+		description:
+			"Overrides fields of this item's feature for customers on this plan (e.g. a credit system's credit_schema).",
+	}),
+
+	entity_feature_id: z.string().optional().meta({
+		internal: true,
+	}),
+
+	entitlement_id: z.string().optional().meta({
+		internal: true,
+	}),
+	price_id: z.string().optional().meta({
+		internal: true,
+	}),
+});
+
+type PlanItemParamsCheckValue = z.infer<typeof PlanItemParamsObjectSchema>;
+
+/**
+ * Cross-field invariants for a plan item. Shared by the generic and the catalog
+ * item schemas so the rules can't drift; returns issues and lets each schema
+ * push them.
+ */
+export const planItemParamsIssues = (
+	value: PlanItemParamsCheckValue,
+): { message: string; input: unknown }[] => {
+	const issues: { message: string; input: unknown }[] = [];
+
+	const resetInterval = value.reset?.interval;
+	const priceInterval = value.price?.interval;
+	const resetIntervalCount = value.reset?.interval_count ?? 1;
+	const priceIntervalCount = value.price?.interval_count ?? 1;
+	const hasDifferentResetAndPriceInterval =
+		!!resetInterval &&
+		!!priceInterval &&
+		(String(resetInterval) !== String(priceInterval) ||
+			resetIntervalCount !== priceIntervalCount);
+
+	if (
+		hasDifferentResetAndPriceInterval &&
+		value.price?.billing_method !== BillingMethod.Prepaid
+	) {
+		issues.push({
+			message:
+				"reset.interval and price.interval can only differ for prepaid prices.",
+			input: value,
+		});
+	}
+
+	// At a minimum, if price is present, at least amount OR tiers must be defined, and not both
+	if (value.price) {
+		const { amount, tiers } = value.price;
 
 		if (
-			hasDifferentResetAndPriceInterval &&
-			ctx.value.price?.billing_method !== BillingMethod.Prepaid
+			value.proration &&
+			value.price.billing_method === BillingMethod.UsageBased
 		) {
-			ctx.issues.push({
-				code: "custom",
+			issues.push({
+				message: "proration is only supported for prepaid features.",
+				input: value.proration,
+			});
+		}
+
+		const hasAmount = typeof amount === "number";
+		const hasTiers = Array.isArray(tiers) && tiers.length > 0;
+
+		if (!(hasAmount || hasTiers)) {
+			issues.push({
 				message:
-					"reset.interval and price.interval can only differ for prepaid prices.",
-				input: ctx.value,
+					"If 'price' is present, either 'amount' or 'tiers' must be defined.",
+				input: value.price,
+			});
+		} else if (hasAmount && hasTiers) {
+			issues.push({
+				message: "'amount' and 'tiers' cannot both be defined in 'price'.",
+				input: value.price,
+			});
+		}
+	}
+
+	if (value.price?.tiers) {
+		const hasFlatAmount = value.price.tiers.some(
+			(t) => t.flat_amount && t.flat_amount > 0,
+		);
+
+		if (
+			hasFlatAmount &&
+			value.price.tier_behavior !== TierBehavior.VolumeBased
+		) {
+			issues.push({
+				message:
+					"flat_amount on tiers is only supported for volume-based pricing.",
+				input: value.price,
 			});
 		}
 
-		// At a minimum, if price is present, at least amount OR tiers must be defined, and not both
-		if (ctx.value.price) {
-			const { amount, tiers } = ctx.value.price;
-
-			if (
-				ctx.value.proration &&
-				ctx.value.price.billing_method === BillingMethod.UsageBased
-			) {
-				ctx.issues.push({
-					code: "custom",
-					message: "proration is only supported for prepaid features.",
-					input: ctx.value.proration,
-				});
-			}
-
-			const hasAmount = typeof amount === "number";
-			const hasTiers = Array.isArray(tiers) && tiers.length > 0;
-
-			if (!(hasAmount || hasTiers)) {
-				ctx.issues.push({
-					code: "custom",
-					message:
-						"If 'price' is present, either 'amount' or 'tiers' must be defined.",
-					input: ctx.value.price,
-				});
-			} else if (hasAmount && hasTiers) {
-				ctx.issues.push({
-					code: "custom",
-					message: "'amount' and 'tiers' cannot both be defined in 'price'.",
-					input: ctx.value.price,
-				});
-			}
-		}
-
-		if (ctx.value.price?.tiers) {
-			const hasFlatAmount = ctx.value.price.tiers.some(
-				(t) => t.flat_amount && t.flat_amount > 0,
-			);
-
-			if (
-				hasFlatAmount &&
-				ctx.value.price.tier_behavior !== TierBehavior.VolumeBased
-			) {
-				ctx.issues.push({
-					code: "custom",
-					message:
-						"flat_amount on tiers is only supported for volume-based pricing.",
-					input: ctx.value.price,
-				});
-			}
-
-			if (hasFlatAmount && ctx.value.price.tiers.length <= 1) {
-				ctx.issues.push({
-					code: "custom",
-					message: "flat_amount is not supported on single-tier pricing.",
-					input: ctx.value.price,
-				});
-			}
-
-			if (
-				ctx.value.price.tiers.some(
-					(t) => t.flat_amount != null && t.flat_amount < 0,
-				)
-			) {
-				ctx.issues.push({
-					code: "custom",
-					message: "flat_amount must be 0 or greater.",
-					input: ctx.value.price,
-				});
-			}
-
-			if (
-				ctx.value.price?.tier_behavior === TierBehavior.VolumeBased &&
-				ctx.value.price?.billing_method !== BillingMethod.Prepaid
-			) {
-				ctx.issues.push({
-					code: "custom",
-					message:
-						"volume-based pricing is only supported for prepaid features.",
-					input: ctx.value.price,
-				});
-			}
-
-			if (ctx.value.price?.tiers.length === 0) {
-				ctx.issues.push({
-					code: "custom",
-					message: "tiers cannot be empty.",
-					input: ctx.value.price,
-				});
-			} else if (
-				ctx.value.included &&
-				typeof ctx.value.price?.tiers[0].to === "number" &&
-				ctx.value.price?.tiers[0].to <= ctx.value.included
-			) {
-				ctx.issues.push({
-					code: "custom",
-					message: "tiers[0].to must be greater than included.",
-					input: ctx.value.price,
-				});
-			}
-		}
-
-		for (const message of additionalCurrencyPlanItemIssues(ctx.value.price)) {
-			ctx.issues.push({
-				code: "custom",
-				message,
-				input: ctx.value.price,
+		if (hasFlatAmount && value.price.tiers.length <= 1) {
+			issues.push({
+				message: "flat_amount is not supported on single-tier pricing.",
+				input: value.price,
 			});
 		}
-	})
-	.meta({
-		title: "PlanItem",
-		description:
-			"Configuration for a feature item in a plan, including usage limits, pricing, and rollover settings.",
-	});
+
+		if (
+			value.price.tiers.some((t) => t.flat_amount != null && t.flat_amount < 0)
+		) {
+			issues.push({
+				message: "flat_amount must be 0 or greater.",
+				input: value.price,
+			});
+		}
+
+		if (
+			value.price?.tier_behavior === TierBehavior.VolumeBased &&
+			value.price?.billing_method !== BillingMethod.Prepaid
+		) {
+			issues.push({
+				message: "volume-based pricing is only supported for prepaid features.",
+				input: value.price,
+			});
+		}
+
+		if (value.price?.tiers.length === 0) {
+			issues.push({ message: "tiers cannot be empty.", input: value.price });
+		} else if (
+			value.included &&
+			typeof value.price?.tiers[0].to === "number" &&
+			value.price?.tiers[0].to <= value.included
+		) {
+			issues.push({
+				message: "tiers[0].to must be greater than included.",
+				input: value.price,
+			});
+		}
+	}
+
+	for (const message of additionalCurrencyPlanItemIssues(value.price)) {
+		issues.push({ message, input: value.price });
+	}
+
+	return issues;
+};
+
+export const CreatePlanItemParamsV1Schema = PlanItemParamsObjectSchema.check(
+	(ctx) => {
+		for (const { message, input } of planItemParamsIssues(ctx.value)) {
+			ctx.issues.push({ code: "custom", message, input });
+		}
+	},
+).meta({
+	title: "PlanItem",
+	description:
+		"Configuration for a feature item in a plan, including usage limits, pricing, and rollover settings.",
+});
 export type CreatePlanItemParamsV1 = z.infer<
 	typeof CreatePlanItemParamsV1Schema
 >;

--- a/shared/api/products/items/mappers/planItemV0ToProductItem.ts
+++ b/shared/api/products/items/mappers/planItemV0ToProductItem.ts
@@ -145,9 +145,16 @@ export const planItemV0ToProductItem = ({
 	const resetUsageWhenEnabled = featureUtils.isConsumable(feature);
 
 	// One stated id, two slots: prepaid bills from v2, everything else from v1.
-	const statedStripePriceId = planItem.price?.processors?.stripe?.price_id;
+	// Presence is the signal: an omitted `stripe` states nothing and leaves the
+	// current mapping alone, while an explicit null unlinks it.
+	const statedStripe = planItem.price?.processors?.stripe;
+	const statedStripePriceId =
+		statedStripe === undefined ? undefined : (statedStripe?.price_id ?? null);
 	const billsFromPrepaidSlot =
 		planItem.price?.usage_model === UsageModel.Prepaid;
+	const statedForV1Slot = billsFromPrepaidSlot
+		? undefined
+		: statedStripePriceId;
 
 	return ProductItemSchema.parse({
 		type,
@@ -168,9 +175,10 @@ export const planItemV0ToProductItem = ({
 		price_interval_count: priceIntervalCount,
 
 		price: planItem.price?.amount,
-		stripe_price_id: billsFromPrepaidSlot
-			? planItem.price?.stripe_price_id
-			: (statedStripePriceId ?? planItem.price?.stripe_price_id),
+		stripe_price_id:
+			statedForV1Slot === undefined
+				? planItem.price?.stripe_price_id
+				: statedForV1Slot,
 		stripe_prepaid_price_v2_id: billsFromPrepaidSlot
 			? statedStripePriceId
 			: undefined,

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -74,6 +74,7 @@ export * from "./productUtils/priceUtils/match/copyStripeResourcesToMatchingPric
 export * from "./productUtils/priceUtils/match/getPriceStripeReuseLevel";
 export * from "./productUtils/priceUtils/match/priceStripeObjectsMatch";
 export * from "./productUtils/priceUtils/match/stripePriceIdForInitializedPrice";
+export * from "./productUtils/priceUtils/match/stripePriceMappingSlots";
 export * from "./productV2Utils/mapToProductV2";
 export * from "./productV2Utils/productItemUtils/classifyItemUtils";
 export * from "./productV2Utils/productItemUtils/getItemType";

--- a/shared/utils/planV1Utils/convertPlanV1/productItemsToEntitlementPrices.ts
+++ b/shared/utils/planV1Utils/convertPlanV1/productItemsToEntitlementPrices.ts
@@ -1,11 +1,15 @@
 import { findFeatureById } from "@utils/featureUtils/findFeatureUtils.js";
-import { enrichEntitlementWithFeature } from "@utils/productUtils/entUtils/enrichEntitlement.js";
 import type {
 	BasePriceAndEntitlementPrices,
 	EntitlementPrice,
 } from "@utils/productUtils/entitlementPriceUtils/entitlementPriceTypes.js";
+import { enrichEntitlementWithFeature } from "@utils/productUtils/entUtils/enrichEntitlement.js";
 import { isFixedPrice } from "@utils/productUtils/priceUtils/classifyPriceUtils.js";
 import { findPriceByFeatureId } from "@utils/productUtils/priceUtils/findPrice/findPriceByFeatureId.js";
+import {
+	type UnlinkedStripeSlotsByPriceId,
+	unlinkedStripeSlotsForItem,
+} from "@utils/productUtils/priceUtils/match/stripePriceMappingSlots.js";
 import {
 	isFeatureItem,
 	isPriceItem,
@@ -28,6 +32,12 @@ const stripeReusePriceForItem = ({
 	return findPriceByFeatureId({ prices, featureId: item.feature_id });
 };
 
+export type DesiredBasePriceAndEntitlementPrices =
+	BasePriceAndEntitlementPrices & {
+		/** Slots the request stated as `null`, keyed by desired price id. */
+		unlinkedStripeSlots: UnlinkedStripeSlotsByPriceId;
+	};
+
 /**
  * Mint desired base Price + EntitlementPrice rows from ProductItems.
  * Construction only — no claim/classification against current rows.
@@ -44,9 +54,10 @@ export const productItemsToEntitlementPrices = ({
 	features: Feature[];
 	/** Current/candidate prices used only to refuse a mismatched stripe_price_id. */
 	stripeReusePrices?: Price[];
-}): BasePriceAndEntitlementPrices => {
+}): DesiredBasePriceAndEntitlementPrices => {
 	let basePrice: Price | undefined;
 	const entitlementPrices: EntitlementPrice[] = [];
+	const unlinkedStripeSlots: UnlinkedStripeSlotsByPriceId = {};
 	const reusePrices = stripeReusePrices ?? [];
 
 	for (const item of items) {
@@ -74,6 +85,11 @@ export const productItemsToEntitlementPrices = ({
 				: {}),
 		});
 
+		if (newPrice) {
+			const unlinked = unlinkedStripeSlotsForItem({ item });
+			if (unlinked.length > 0) unlinkedStripeSlots[newPrice.id] = unlinked;
+		}
+
 		if (isPriceItem(item)) {
 			if (newPrice) basePrice = newPrice;
 			continue;
@@ -90,5 +106,5 @@ export const productItemsToEntitlementPrices = ({
 		});
 	}
 
-	return { basePrice, entitlementPrices };
+	return { basePrice, entitlementPrices, unlinkedStripeSlots };
 };

--- a/shared/utils/productUtils/priceUtils/match/stripePriceMappingSlots.ts
+++ b/shared/utils/productUtils/priceUtils/match/stripePriceMappingSlots.ts
@@ -1,0 +1,27 @@
+/** Fixed prices bill from the v1 slot, prepaid from the v2 slot. */
+export const STRIPE_PRICE_MAPPING_SLOTS = [
+	"stripe_price_id",
+	"stripe_prepaid_price_v2_id",
+] as const;
+
+export type StripePriceMappingSlot =
+	(typeof STRIPE_PRICE_MAPPING_SLOTS)[number];
+
+/**
+ * `itemToPriceAndEnt` writes a nullish slot both when the request said nothing
+ * and when it stated an unlink, so the price alone cannot tell them apart.
+ * The unlink therefore travels beside the desired rows, keyed by desired price
+ * id — the claim pairs that to the current row actually holding the mapping.
+ */
+export type UnlinkedStripeSlotsByPriceId = Record<
+	string,
+	StripePriceMappingSlot[]
+>;
+
+/** The slots this item's request stated as `null`, meaning "unlink". */
+export const unlinkedStripeSlotsForItem = ({
+	item,
+}: {
+	item: Partial<Record<StripePriceMappingSlot, string | null | undefined>>;
+}): StripePriceMappingSlot[] =>
+	STRIPE_PRICE_MAPPING_SLOTS.filter((slot) => item[slot] === null);

--- a/vite/src/hooks/queries/revcat/useRCMappings.tsx
+++ b/vite/src/hooks/queries/revcat/useRCMappings.tsx
@@ -17,11 +17,39 @@ interface RCMapping {
 	feature_quantities?: RCFeatureQuantities | null;
 }
 
-interface SaveMappingInput {
+export interface SaveMappingInput {
 	autumn_product_id: string;
 	revenuecat_product_ids: string[];
 	feature_quantities?: RCFeatureQuantities | null;
 }
+
+/**
+ * Writes go through catalogV2 so the catalog is the single writer and an RC id
+ * already claimed by another plan is rejected rather than silently shared.
+ *
+ * Every listed plan is restated, including the ones with nothing mapped: an
+ * omitted plan means "keep this mapping unchanged", so an empty `products` array
+ * is the only way to clear one (`executeRevenueCatMappings` deletes the row when
+ * `products.length === 0`).
+ */
+export const toCatalogParams = (
+	mappingsToSave: SaveMappingInput[],
+): UpdateCatalogParamsInput => ({
+	plans: mappingsToSave.map((mapping) => ({
+		plan_id: mapping.autumn_product_id,
+		processors: {
+			revenuecat: {
+				products: mapping.revenuecat_product_ids.map((productId) => {
+					const quantities = mapping.feature_quantities?.[productId];
+					return {
+						product_id: productId,
+						...(quantities?.length ? { feature_quantities: quantities } : {}),
+					};
+				}),
+			},
+		},
+	})),
+});
 
 export const useRCMappings = () => {
 	const axiosInstance = useAxiosInstance();
@@ -36,27 +64,6 @@ export const useRCMappings = () => {
 			);
 			return data.mappings;
 		},
-	});
-
-	// Writes go through catalogV2 so the catalog is the single writer and an RC
-	// id already claimed by another plan is rejected rather than silently shared.
-	const toCatalogParams = (
-		mappingsToSave: SaveMappingInput[],
-	): UpdateCatalogParamsInput => ({
-		plans: mappingsToSave.map((mapping) => ({
-			plan_id: mapping.autumn_product_id,
-			processors: {
-				revenuecat: {
-					products: mapping.revenuecat_product_ids.map((productId) => {
-						const quantities = mapping.feature_quantities?.[productId];
-						return {
-							product_id: productId,
-							...(quantities?.length ? { feature_quantities: quantities } : {}),
-						};
-					}),
-				},
-			},
-		})),
 	});
 
 	const saveMutation = useMutation({

--- a/vite/src/views/developer/configure-revenuecat/components/RevenueCatMappingSheet.tsx
+++ b/vite/src/views/developer/configure-revenuecat/components/RevenueCatMappingSheet.tsx
@@ -41,6 +41,57 @@ const hasUnsupportedUsagePrice = (product: ProductV2): boolean =>
 			isFeaturePriceItem(item) && item.usage_model !== UsageModel.Prepaid,
 	) ?? false;
 
+export type ListedRevenueCatProduct = {
+	product: ProductV2;
+	unsupported: boolean;
+};
+
+/**
+ * The unsupported filter governs CREATING mappings, not rendering them: a plan
+ * that became unsupported while still owning RevenueCat ids stays listed so
+ * those ids can be released. With no row, the catalog's one-plan-per-id rule
+ * would leave them claimed by an invisible plan forever.
+ */
+export const listRevenueCatProducts = ({
+	products,
+	existingMappings,
+}: {
+	products: ProductV2[];
+	existingMappings: {
+		autumn_product_id: string;
+		revenuecat_product_ids: string[];
+	}[];
+}): ListedRevenueCatProduct[] =>
+	products
+		.map((product) => ({
+			product,
+			unsupported: hasUnsupportedUsagePrice(product),
+		}))
+		.filter(
+			({ product, unsupported }) =>
+				!unsupported ||
+				(existingMappings.find((m) => m.autumn_product_id === product.id)
+					?.revenuecat_product_ids.length ?? 0) > 0,
+		);
+
+const UNSUPPORTED_NOTE =
+	"This plan bills usage at runtime, which RevenueCat purchases can't collect. Release the products below to map them to another plan.";
+
+// An unsupported plan keeps its row so its ids can be released, but nothing may
+// be added to it — the catalog rejects an id claimed by two plans, so a hidden
+// claim is otherwise unbreakable without editing the plan itself.
+const UnsupportedMappingNotice = () => (
+	<div className="text-tertiary-foreground text-xs py-1">
+		{UNSUPPORTED_NOTE}
+	</div>
+);
+
+const UnsupportedBadge = () => (
+	<span className="text-tiny text-amber-600 dark:text-amber-500 bg-muted px-1.5 py-0.5 rounded-md">
+		unsupported
+	</span>
+);
+
 interface PrepaidFeature {
 	featureId: string;
 	billingUnits: number;
@@ -54,6 +105,8 @@ interface ProductMapping {
 	autumnProductName: string;
 	revenueCatProductIds: string[];
 	featurePacks: FeaturePacks;
+	/** Listed read-only: it may only release the ids it already owns. */
+	unsupported: boolean;
 }
 
 interface RevenueCatMappingSheetProps {
@@ -165,6 +218,7 @@ const MappingRow = memo(function MappingRow({
 				<span className="text-tiny-id text-tertiary-foreground bg-muted px-1.5 py-0.5 rounded-md">
 					{mapping.autumnProductId}
 				</span>
+				{mapping.unsupported && <UnsupportedBadge />}
 			</div>
 
 			{/* Display selected products as tags */}
@@ -195,11 +249,15 @@ const MappingRow = memo(function MappingRow({
 				</div>
 			)}
 
-			<AddRcProductSelect
-				availableProducts={availableProducts}
-				hasNoRcProducts={rcProducts.length === 0}
-				onAdd={(value) => onAddProduct(mapping.autumnProductId, value)}
-			/>
+			{mapping.unsupported ? (
+				<UnsupportedMappingNotice />
+			) : (
+				<AddRcProductSelect
+					availableProducts={availableProducts}
+					hasNoRcProducts={rcProducts.length === 0}
+					onAdd={(value) => onAddProduct(mapping.autumnProductId, value)}
+				/>
+			)}
 		</div>
 	);
 });
@@ -251,6 +309,7 @@ const PrepaidMappingRow = memo(function PrepaidMappingRow({
 				<span className="text-tiny text-tertiary-foreground bg-muted px-1.5 py-0.5 rounded-md">
 					prepaid
 				</span>
+				{mapping.unsupported && <UnsupportedBadge />}
 			</div>
 
 			<div className="text-tertiary-foreground text-xs">
@@ -299,6 +358,7 @@ const PrepaidMappingRow = memo(function PrepaidMappingRow({
 												type="number"
 												min={0}
 												lang="en"
+												disabled={mapping.unsupported}
 												value={packs ?? ""}
 												placeholder="0"
 												onChange={(e) =>
@@ -332,11 +392,15 @@ const PrepaidMappingRow = memo(function PrepaidMappingRow({
 				</div>
 			)}
 
-			<AddRcProductSelect
-				availableProducts={availableProducts}
-				hasNoRcProducts={rcProducts.length === 0}
-				onAdd={(value) => onAddProduct(mapping.autumnProductId, value)}
-			/>
+			{mapping.unsupported ? (
+				<UnsupportedMappingNotice />
+			) : (
+				<AddRcProductSelect
+					availableProducts={availableProducts}
+					hasNoRcProducts={rcProducts.length === 0}
+					onAdd={(value) => onAddProduct(mapping.autumnProductId, value)}
+				/>
+			)}
 		</div>
 	);
 });
@@ -348,8 +412,15 @@ export function RevenueCatMappingSheet({
 	const { products: allProducts } = useProductsQuery();
 	const { products: rcProducts } = useRCProducts();
 
+	const {
+		mappings: existingMappings,
+		saveMappings,
+		isSaving,
+		isLoading: isLoadingMappings,
+	} = useRCMappings();
+
 	// Latest version of each product (stable identity for effects).
-	const products = useMemo(() => {
+	const latestProducts = useMemo(() => {
 		const productMap = new Map<string, ProductV2>();
 		for (const product of allProducts) {
 			const existing = productMap.get(product.id);
@@ -357,16 +428,24 @@ export function RevenueCatMappingSheet({
 				productMap.set(product.id, product);
 			}
 		}
-		return Array.from(productMap.values()).filter(
-			(product) => !hasUnsupportedUsagePrice(product),
-		);
+		return Array.from(productMap.values());
 	}, [allProducts]);
 
+	const listedProducts = useMemo(
+		() =>
+			listRevenueCatProducts({
+				products: latestProducts,
+				existingMappings,
+			}),
+		[latestProducts, existingMappings],
+	);
+
 	// productId -> prepaid features (featureId + billing units). Presence here
-	// switches the row to the per-SKU packs table.
+	// switches the row to the per-SKU packs table. Unsupported plans are included
+	// so their stored packs round-trip instead of being dropped on save.
 	const prepaidInfoByProduct = useMemo(() => {
 		const map = new Map<string, PrepaidFeature[]>();
-		for (const product of products) {
+		for (const { product } of listedProducts) {
 			const prepaidItems = getPrepaidItems(product);
 			if (prepaidItems.length === 0) continue;
 			map.set(
@@ -380,13 +459,8 @@ export function RevenueCatMappingSheet({
 			);
 		}
 		return map;
-	}, [products]);
+	}, [listedProducts]);
 
-	const {
-		mappings: existingMappings,
-		saveMappings,
-		isSaving,
-	} = useRCMappings();
 	const [mappings, setMappings] = useState<ProductMapping[]>([]);
 	const initializedRef = useRef(false);
 
@@ -397,11 +471,18 @@ export function RevenueCatMappingSheet({
 			return;
 		}
 
-		if (initializedRef.current || !products || products.length === 0) {
+		// Existing mappings decide which unsupported plans stay listed, and every
+		// listed plan is restated on save — snapshotting before they load would
+		// both hide those rows and read as clearing every mapping.
+		if (
+			initializedRef.current ||
+			isLoadingMappings ||
+			listedProducts.length === 0
+		) {
 			return;
 		}
 
-		const initialMappings = products.map((product) => {
+		const initialMappings = listedProducts.map(({ product, unsupported }) => {
 			const existingMapping = existingMappings.find(
 				(m) => m.autumn_product_id === product.id,
 			);
@@ -431,18 +512,26 @@ export function RevenueCatMappingSheet({
 				autumnProductName: product.name,
 				revenueCatProductIds: existingMapping?.revenuecat_product_ids || [],
 				featurePacks,
+				unsupported,
 			};
 		});
 
 		setMappings(initialMappings);
 		initializedRef.current = true;
-	}, [open, products, existingMappings, prepaidInfoByProduct]);
+	}, [
+		open,
+		listedProducts,
+		existingMappings,
+		prepaidInfoByProduct,
+		isLoadingMappings,
+	]);
 
 	const handleAddProduct = useCallback(
 		(autumnProductId: string, revenueCatProductId: string) => {
 			setMappings((prev) =>
 				prev.map((mapping) =>
-					mapping.autumnProductId === autumnProductId
+					// Unsupported rows can only release ids, never take new ones.
+					mapping.autumnProductId === autumnProductId && !mapping.unsupported
 						? {
 								...mapping,
 								revenueCatProductIds: [

--- a/vite/tests/views/developer/revenuecat-mapping-release.test.ts
+++ b/vite/tests/views/developer/revenuecat-mapping-release.test.ts
@@ -1,0 +1,140 @@
+/**
+ * A hidden plan's RevenueCat mapping could never be released.
+ *
+ * `hasUnsupportedUsagePrice` drops metered plans from the mapping sheet, and
+ * the sheet built both its rows and its save payload from that filtered list.
+ * A plan that gained a metered item after being mapped therefore vanished while
+ * still owning its RevenueCat ids — and because catalogV2 rejects an id claimed
+ * by two plans (`assertRevenueCatIdsUnclaimed`), those ids could never be
+ * reassigned and there was no row to release them from.
+ *
+ * Red (pre-fix):  `listRevenueCatProducts` did not exist; the sheet filtered
+ *                 every unsupported plan out unconditionally, mapped or not.
+ * Green (post-fix): the filter governs CREATING mappings, not rendering them —
+ *                 an unsupported plan that still owns ids stays listed (flagged
+ *                 `unsupported`, so the row goes read-only for adds), and
+ *                 clearing its ids sends `products: []`, which
+ *                 `executeRevenueCatMappings` reads as "delete the row".
+ *
+ * The React wiring (badge, hidden add-select, disabled packs input) is not
+ * covered here — only the two pure decisions the fix turns on.
+ */
+
+import { expect, test } from "bun:test";
+import { type ProductV2, UsageModel } from "@autumn/shared";
+import { toCatalogParams } from "@/hooks/queries/revcat/useRCMappings";
+import { listRevenueCatProducts } from "@/views/developer/configure-revenuecat/components/RevenueCatMappingSheet";
+
+const buildProduct = ({
+	id,
+	usageModel,
+}: {
+	id: string;
+	usageModel?: UsageModel;
+}) =>
+	({
+		id,
+		name: id,
+		version: 1,
+		items: [
+			{ price: 20 },
+			...(usageModel
+				? [{ feature_id: "credits", price: 1, usage_model: usageModel }]
+				: []),
+		],
+	}) as ProductV2;
+
+const proPlan = buildProduct({ id: "pro" });
+const prepaidPlan = buildProduct({
+	id: "packs",
+	usageModel: UsageModel.Prepaid,
+});
+const meteredPlan = buildProduct({
+	id: "usage",
+	usageModel: UsageModel.PayPerUse,
+});
+
+test("plans without a metered price are always listed and mappable", () => {
+	const listed = listRevenueCatProducts({
+		products: [proPlan, prepaidPlan],
+		existingMappings: [],
+	});
+
+	expect(listed.map(({ product }) => product.id)).toEqual(["pro", "packs"]);
+	expect(listed.every(({ unsupported }) => !unsupported)).toBe(true);
+});
+
+test("a metered plan with no mapping stays hidden — nothing to release", () => {
+	const listed = listRevenueCatProducts({
+		products: [proPlan, meteredPlan],
+		existingMappings: [
+			{ autumn_product_id: "usage", revenuecat_product_ids: [] },
+		],
+	});
+
+	expect(listed.map(({ product }) => product.id)).toEqual(["pro"]);
+});
+
+test("a metered plan still owning RevenueCat ids is listed as unsupported", () => {
+	const listed = listRevenueCatProducts({
+		products: [proPlan, meteredPlan],
+		existingMappings: [
+			{
+				autumn_product_id: "usage",
+				revenuecat_product_ids: ["rc_credits_100"],
+			},
+		],
+	});
+
+	expect(listed.map(({ product }) => product.id)).toEqual(["pro", "usage"]);
+	expect(
+		listed.find(({ product }) => product.id === "usage")?.unsupported,
+	).toBe(true);
+});
+
+test("clearing a listed plan's ids sends the empty products array that deletes the row", () => {
+	const params = toCatalogParams([
+		{ autumn_product_id: "usage", revenuecat_product_ids: [] },
+		{
+			autumn_product_id: "pro",
+			revenuecat_product_ids: ["rc_credits_100"],
+		},
+	]);
+
+	expect(params.plans).toEqual([
+		{
+			plan_id: "usage",
+			processors: { revenuecat: { products: [] } },
+		},
+		{
+			plan_id: "pro",
+			processors: {
+				revenuecat: { products: [{ product_id: "rc_credits_100" }] },
+			},
+		},
+	]);
+});
+
+test("one plan carries many RevenueCat ids, each with its own grant", () => {
+	const params = toCatalogParams([
+		{
+			autumn_product_id: "packs",
+			revenuecat_product_ids: ["rc_credits_100", "rc_credits_500"],
+			feature_quantities: {
+				rc_credits_100: [{ feature_id: "credits", quantity: 100 }],
+				rc_credits_500: [{ feature_id: "credits", quantity: 500 }],
+			},
+		},
+	]);
+
+	expect(params.plans?.[0]?.processors?.revenuecat?.products).toEqual([
+		{
+			product_id: "rc_credits_100",
+			feature_quantities: [{ feature_id: "credits", quantity: 100 }],
+		},
+		{
+			product_id: "rc_credits_500",
+			feature_quantities: [{ feature_id: "credits", quantity: 500 }],
+		},
+	]);
+});


### PR DESCRIPTION
Addresses the review threads across the mappings stack (#3124, #3125, #3129, #3155, #3156, #3165). Stacked on `feat/revenuecat-mappings-iac` so the fixes land together rather than being backported into six PRs.

24 threads deduped to 21 distinct findings. 13 fixed, 5 closed without code, 3 skipped or deferred by decision.

## Fixed

| Finding | Fix |
|---|---|
| Preview rejects a first-time mapping | `processors` is nullable in `PlanPreviousAttributesV0Schema`, mirroring `free_trial`. The diff emits `null` when the previous value was unset, and the picked schema now accepts it. |
| Fan-out dropped for directly targeted rows | New `mergeDeclaredProcessors` merges declared processors into pending direct intents before the fold, so `claimNewIntents` and first-claim-wins stay untouched. Spans the lineage (version siblings and variants); an unlink merges the same way; two entries declaring different mappings for one plan now 400. |
| Unlink undone by init on paid plans | `stripeUnlinked` on `UpsertProductPlan`, set when `processors.stripe` is explicitly null, skips Stripe init for that row. Attach mints lazily, so the plan is recreated the next time it is sold. |
| Validation ran after catalog writes | Both the RC collision check and adopted-price validation moved into a new `execute.validate` phase ahead of `rename_plans`. Also closes the retry hole where a persisted bad id was treated as already-validated. |
| Only the first stated slot validated | `newlyAdoptedPrices` emits one entry per newly-stated slot. |
| Carry-forward scoped product-wide | Now scoped per price row and slot, so an id moved between rows is revalidated and its product mapping stays consistent. |
| Stale meter survived a remap | `meterDecision` clears `stripe_meter_id` / `stripe_event_name` when the adopted price has no meter. |
| Meterless price on a usage item | Rejected with a 400. Previously the meter slot could never be filled, so init re-ran forever and the item could not report usage. |
| RevenueCat dropped on variant writes | `revenuecatProcessor` now carried for `variant_link` and `variant_propagation`. `all_versions` and `processor_sync` deliberately excluded — the mappings table has no version column. |
| RevenueCat invisible on variant reads | The mapping map is threaded into `buildApiPlanVariant`, so a variant resolves its own plan id. |
| Adoption accepted on unvalidated paths | Catalog-only schemas (`CatalogPlanItemParamsV1Schema`, `CatalogBasePriceParamsSchema`). Customize, attach, multi-attach, migrations and licenses now strip `processors`. |
| No way to unlink a price | `processors: { stripe: null }` unlinks. Presence is the signal; an omitted key still means unchanged. |
| Hidden RevenueCat mapping unreleasable | A plan hidden by `hasUnsupportedUsagePrice` that still owns RC ids stays listed, read-only, with release actions. The filter still governs creating mappings. |

## Closed without code

- Existence-only validation for adopted prices is the locked design (wire/08, 2026-08-27) — shape, currency, interval and livemode are deliberately unchecked.
- Stripe product ids were never validated against the org's account; out of scope.
- Base-price `processors` being a dead field was already fixed by #3155.
- Non-transactional execute phase: addressed by ordering, not a transaction — the phase makes Stripe calls.

## Skipped or deferred

- Slot preference in `itemStripePriceId` / `withItemStripePriceId` — skipped by decision.
- A clear affordance in the price picker — skipped; operators swap in place. Price unlink stays available through the API.
- RevenueCat claim serialisation is a real TOCTOU but needs DB-enforced uniqueness on an array column. `resolveMapping` already throws on ambiguity rather than guessing, so the runtime fails loudly.

## Testing

- 3971 unit tests pass across 549 files; `bun ts` clean in `server/` and `vite/`.
- Integration: `product-id-unlink-paid` (2), `validate-before-write` (2), `revenuecat-variant-mappings` (1), `price-id-unlink` (2).
- Every assertion was seen to fail first. Where a test passed on its first run it was broken deliberately to prove it bites; the unlink and RevenueCat variant fixes were each reverted to witness the red against a live stack.

## Notes for review

- `productItemsToEntitlementPrices` now returns a side map of unlinked slots. It is a wart on an otherwise clean mapper, taken because `null` in a persisted price config already means "unstated" — three different shapes across the base, feature and prepaid lanes — so redefining it was not safe.
- The RevenueCat variant test originally looked for the variant at the top level of `catalog.plans`. Variants only surface nested as `variants[].plan`; the lookup was fixed, not the assertion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the catalog v2 mappings stack so processor mappings survive lineage fan-out, variant writes, and the requests that unlink them.

**Bug Fixes**
- Declared processors merge into pending direct intents before the fold, so sibling versions and variants no longer keep stale Stripe ids; two conflicting mappings for one plan now 400.
- An explicit `processors.stripe: null` now unlinks a price and survives its own request — paid plans are left unmapped and mint a replacement lazily on next sale.
- RevenueCat mappings persist on variant create and edit, render back on catalog GET, and the plan preview accepts a first-time mapping.
- Stripe adoption validation runs before any catalog write, checks every newly stated slot per row, and revalidates ids moved between rows.
- Adopting a meterless Stripe price clears any stale meter and is rejected on usage-based items; existing usage-item tests now adopt a metered price.
- `processors` is stripped from attach, customize, migration, and license paths so adoption stays catalog-only.
- Plans hidden by unsupported usage prices stay listed read-only so their RevenueCat ids can still be released.

<sup>Written for commit f185c46b0f6fa8e9e8cb2c85a787706541b5ffc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Cloud swarm

`bun tw core catalog` at the branch tip (run `mtiua75t-4sgygg`, 618 files, ~200 workers): **4870 passed, 11 files failed (30 assertions)**.

**None of the 11 are in catalog-v2** — nothing in processors, mappings, plans/create, plans/preview or variants. They break down as:

| Area | Files |
|---|---|
| `billing/update-subscription` | 5 (`next-cycle-only`, `cancel-end-of-cycle`, `uncancel-combined`, `update-quantity-with-trial`, `update-quantity-prepaid-overage`) |
| `billing/attach` + `create-schedule` | 2 (`scheduled-switch-basic`, `create-schedule-phases`) |
| `billing/legacy/attach` | 2 (`legacy-new-oneoff-zero-decimal`, `legacy-upgrade-usage`) |
| `balances/track` | 1 (`track-entity-balances6`) |
| `billing/stripe-webhooks` | 1 (`sub-created-auto-sync`) |

`sub-created-auto-sync` is environmental: its headless browser never completed the Stripe checkout page, so no subscription was produced.

**Attribution is partly unresolved, and deliberately not claimed either way.** `computeEntitlementPricesPlan` — where this PR changes `buildEntitlementPricesPlan` and `carryForwardStripeResources` — has callers only inside catalogV2, so the update-subscription cluster cannot reach it. That is ruled out on caller topology.

What is **not** ruled out is the shared mapper layer. `basePriceToProductItem` (changed here for unlink presence and the `CatalogBasePriceParams` union) is reached by `handleCustomizePrice`, `customizePlanV1ToV0`, `planV1ToProductItems`, `planV0ToProductItems` and the migrations prepare module — the same surface the update-subscription failures sit on. Removing `processors` from `BasePriceParamsSchema` and `CreatePlanItemParamsV1Schema` touched those same consumers.

So: **these 11 are unverified, not confirmed pre-existing.** Reading alone cannot separate them from this diff. The baseline that would settle it — the same 11 paths in `activeTempPaths`, `bun tw temp`, run from `feat/revenuecat-mappings-iac` — is deferred by decision, not done. It is roughly two minutes of swarm time whenever someone wants the answer.

Note also that `catalogV2 defaults: both is_default`, known to fail on a clean parent, is not in the `core`/`catalog` groups, so this run says nothing about it either way.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR tightens catalog processor mappings, Stripe price adoption and unlink behavior, RevenueCat variant handling, and the mapping-management UI.

- **[Bug fixes, API changes]** Adds explicit Stripe price and product unlinking, mapping fan-out across plan lineages, and catalog-only processor input schemas.
- **[Bug fixes, Improvements]** Moves RevenueCat collision and Stripe adoption checks ahead of catalog writes, validates every newly adopted price slot, and synchronizes inferred Stripe product and meter data.
- **[Bug fixes]** Persists and returns RevenueCat mappings for variants and keeps unsupported-but-mapped plans visible so their mappings can be released.
- **[Improvements]** Adds unit and integration coverage for processor lineage, unlinks, validation ordering, schemas, and variant mappings.
</details>


<h3>Confidence Score: 3/5</h3>

The PR should not merge until validation stops making partial writes and conflicting direct-versus-variant Stripe mappings are rejected.

A rejected multi-price adoption can still mutate an earlier price, and a first-time variant link can silently discard one of two conflicting Stripe product declarations.

**Files Needing Attention:** server/src/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices.ts; server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/mergeDeclaredProcessors.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices.ts | Expands adopted-price and meter validation, but writes price configuration before all entries have passed validation. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/mergeDeclaredProcessors.ts | Adds lineage mapping propagation and conflict checks, but misses conflicts between direct and nested variant declarations. |
| server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts | Introduces an early validation phase, though one validator still performs database writes within that phase. |
| server/src/internal/catalogV2/execute/executeRevenueCatMappings.ts | Moves collision checking before writes and accounts for mappings owned by plans being renamed. |
| shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts | Restricts Stripe price adoption fields to the catalog update contract. |
| server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts | Threads the complete RevenueCat mapping map through nested variant rendering. |
| vite/src/views/developer/configure-revenuecat/components/RevenueCatMappingSheet.tsx | Keeps unsupported mapped plans visible in a release-only state and preserves prepaid quantities. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Catalog update request] --> B[Compute plan and mapping intents]
  B --> C[Validate RevenueCat claims]
  C --> D[Validate adopted Stripe prices]
  D --> E[Rename and persist catalog rows]
  E --> F[Write RevenueCat mappings]
  F --> G[Initialize remaining Stripe resources]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices.ts`, line 256-260 ([link](https://github.com/useautumn/autumn/blob/f185c46b0f6fa8e9e8cb2c85a787706541b5ffc1/server/src/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices.ts#L256-L260)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Validation writes partial state**

   When an update adopts multiple Stripe prices and an earlier valid price changes its inferred product or meter before a later price fails validation, this call persists the earlier change before returning 400, leaving the catalog partially modified despite running in the pre-write validation phase.

   **Knowledge Base Used:** [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices.ts
   Line: 256-260
   
   Comment:
   **Validation writes partial state**
   
   When an update adopts multiple Stripe prices and an earlier valid price changes its inferred product or meter before a later price fails validation, this call persists the earlier change before returning 400, leaving the catalog partially modified despite running in the pre-write validation phase.
   
   **Knowledge Base Used:** [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/catalogV2/execute/executeInitStripeResources/validateAdoptedStripePrices.ts:256-260
**Validation writes partial state**

When an update adopts multiple Stripe prices and an earlier valid price changes its inferred product or meter before a later price fails validation, this call persists the earlier change before returning 400, leaving the catalog partially modified despite running in the pre-write validation phase.

### Issue 2
server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/mergeDeclaredProcessors.ts:105-106
**Variant mapping conflicts escape**

When a standalone plan is first linked as a variant with Stripe product B while its top-level entry declares product A, the declarations enter separate maps and are never compared; the direct entry wins and the request silently ignores the variant override instead of returning the intended conflict error.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: 💍 meter the threaded stripe price..."](https://github.com/useautumn/autumn/commit/f185c46b0f6fa8e9e8cb2c85a787706541b5ffc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59051705)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)

<!-- /greptile_comment -->