### PR TITLE
fix(billing): don't bill usage a grant covered when it becomes unlimited

### DIFF
--- a/server/src/internal/billing/v2/utils/handleExistingUsages/applyExistingUsages.ts
+++ b/server/src/internal/billing/v2/utils/handleExistingUsages/applyExistingUsages.ts
@@ -5,6 +5,7 @@ import {
 	type FullCusProduct,
 	isUnlimitedCusEnt,
 } from "@autumn/shared";
+import { Decimal } from "decimal.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { deductFromCusEntsTypescript } from "@/internal/balances/track/deductUtils/deductFromCusEntsTypescript";
 import { addToExtraLogs } from "@/utils/logging/addToExtraLogs";
@@ -29,6 +30,7 @@ const logExistingUsages = ({
 				featureId: ctx.features.find((f) => f.internal_id === internalFeatureId)
 					?.id,
 				usage: existingUsage.usage,
+				accruedOverage: existingUsage.accruedOverage,
 				entityUsages: entityUsages.length > 0 ? entityUsages : undefined,
 			};
 		},
@@ -79,29 +81,47 @@ export const applyExistingUsages = ({
 				)?.id ?? cusEnts[0]?.id)
 			: undefined;
 
-		// An unlimited grant has no allowance to exceed, so carried usage has
-		// nothing to bill against and would only land on a priced sibling.
-		const absorbedByUnlimitedGrant = cusEnts.some(isUnlimitedCusEnt);
+		// An unlimited grant absorbs the usage its allowance covers, so carried
+		// usage must not reach a priced sibling and become billable overage.
+		const unlimitedCusEnts = cusEnts.filter(isUnlimitedCusEnt);
+		const hasUnlimitedGrant = unlimitedCusEnts.length > 0;
+		const carryTargets = hasUnlimitedGrant ? unlimitedCusEnts : cusEnts;
 
-		if (!absorbedByUnlimitedGrant) {
-			// 1. Deduct entity usages
-			for (const [entityId, entityUsage] of Object.entries(
-				existingUsage.entityUsages,
-			)) {
-				deductFromCusEntsTypescript({
-					cusEnts,
-					amountToDeduct: entityUsage,
-					targetEntityId: entityId,
-					// Carried usage is never floored: prior usage above the new
-					// allowance lands as a negative balance, not a silent reset.
-					allowOverage: true,
-				});
-			}
+		// Overage already exceeded its allowance on the source, so it was owed
+		// before this transition and survives it even when the grant grows.
+		const accruedOverage = hasUnlimitedGrant
+			? (existingUsage.accruedOverage ?? 0)
+			: 0;
+		const absorbedUsage = new Decimal(existingUsage.usage)
+			.sub(accruedOverage)
+			.toNumber();
 
-			// 2. Deduct top level usages
+		// 1. Deduct entity usages
+		for (const [entityId, entityUsage] of Object.entries(
+			existingUsage.entityUsages,
+		)) {
 			deductFromCusEntsTypescript({
-				cusEnts,
-				amountToDeduct: existingUsage.usage,
+				cusEnts: carryTargets,
+				amountToDeduct: entityUsage,
+				targetEntityId: entityId,
+				// Carried usage is never floored: prior usage above the new
+				// allowance lands as a negative balance, not a silent reset.
+				allowOverage: true,
+			});
+		}
+
+		// 2. Deduct top level usages
+		deductFromCusEntsTypescript({
+			cusEnts: carryTargets,
+			amountToDeduct: absorbedUsage,
+			allowOverage: true,
+		});
+
+		// 3. Re-apply overage the source had already accrued to the priced rows
+		if (accruedOverage > 0) {
+			deductFromCusEntsTypescript({
+				cusEnts: cusEnts.filter((cusEnt) => !isUnlimitedCusEnt(cusEnt)),
+				amountToDeduct: accruedOverage,
 				allowOverage: true,
 			});
 		}

--- a/server/src/internal/billing/v2/utils/handleExistingUsages/applyExistingUsages.ts
+++ b/server/src/internal/billing/v2/utils/handleExistingUsages/applyExistingUsages.ts
@@ -3,6 +3,7 @@ import {
 	type Entity,
 	type ExistingUsages,
 	type FullCusProduct,
+	isUnlimitedCusEnt,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { deductFromCusEntsTypescript } from "@/internal/balances/track/deductUtils/deductFromCusEntsTypescript";
@@ -78,26 +79,32 @@ export const applyExistingUsages = ({
 				)?.id ?? cusEnts[0]?.id)
 			: undefined;
 
-		// 1. Deduct entity usages
-		for (const [entityId, entityUsage] of Object.entries(
-			existingUsage.entityUsages,
-		)) {
+		// An unlimited grant has no allowance to exceed, so carried usage has
+		// nothing to bill against and would only land on a priced sibling.
+		const absorbedByUnlimitedGrant = cusEnts.some(isUnlimitedCusEnt);
+
+		if (!absorbedByUnlimitedGrant) {
+			// 1. Deduct entity usages
+			for (const [entityId, entityUsage] of Object.entries(
+				existingUsage.entityUsages,
+			)) {
+				deductFromCusEntsTypescript({
+					cusEnts,
+					amountToDeduct: entityUsage,
+					targetEntityId: entityId,
+					// Carried usage is never floored: prior usage above the new
+					// allowance lands as a negative balance, not a silent reset.
+					allowOverage: true,
+				});
+			}
+
+			// 2. Deduct top level usages
 			deductFromCusEntsTypescript({
 				cusEnts,
-				amountToDeduct: entityUsage,
-				targetEntityId: entityId,
-				// Carried usage is never floored: prior usage above the new
-				// allowance lands as a negative balance, not a silent reset.
+				amountToDeduct: existingUsage.usage,
 				allowOverage: true,
 			});
 		}
-
-		// 2. Deduct top level usages
-		deductFromCusEntsTypescript({
-			cusEnts,
-			amountToDeduct: existingUsage.usage,
-			allowOverage: true,
-		});
 
 		for (const newCusEnt of cusEnts) {
 			const original = customerProduct.customer_entitlements.find(

--- a/server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts
+++ b/server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts
@@ -1,6 +1,7 @@
 import {
 	addCusProductToCusEnt,
 	cusEntsToUsage,
+	cusEntToBalance,
 	ErrCode,
 	type ExistingUsages,
 	type FullCusProduct,
@@ -61,6 +62,7 @@ export const cusProductToExistingUsages = ({
 		if (!existingUsages[internalFeatureId]) {
 			existingUsages[internalFeatureId] = {
 				usage: 0,
+				accruedOverage: 0,
 				entityUsages: {},
 			};
 		}
@@ -122,6 +124,21 @@ export const cusProductToExistingUsages = ({
 		)
 			.add(usage)
 			.toNumber();
+
+		// A negative balance is usage that already exceeded its allowance, so it
+		// was billable before this transition regardless of what replaces it.
+		const rowBalance = cusEntToBalance({
+			cusEnt: cusEntWithCusProduct,
+			entityId,
+		});
+
+		if (rowBalance < 0) {
+			currentExistingUsage.accruedOverage = new Decimal(
+				currentExistingUsage.accruedOverage ?? 0,
+			)
+				.sub(rowBalance)
+				.toNumber();
+		}
 	}
 
 	return existingUsages;

--- a/server/tests/integration/billing/update-subscription/custom-plan/update-to-unlimited-carryover.test.ts
+++ b/server/tests/integration/billing/update-subscription/custom-plan/update-to-unlimited-carryover.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Editing a plan's included grant to `unlimited` must not bill the usage that
+ * was already covered by that grant.
+ *
+ * The plan carries two items for one feature: a free included grant, and a
+ * separate metered price for overage. Flipping the grant to unlimited makes
+ * the carried usage un-billable by definition, but the carryover deducts it
+ * across the new product's entitlements and the metered row is the only one
+ * that keeps a negative balance.
+ *
+ * Red (current):  upcoming invoice gains a MESSAGES_TRACKED x OVERAGE_PRICE line
+ * Green (after):  no messages line — unlimited absorbs the carried usage
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiCustomerV5, CustomerExpand } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const MESSAGES_INCLUDED = 100;
+const MESSAGES_TRACKED = 100;
+const OVERAGE_PRICE = 0.5;
+
+test.concurrent(
+	`${chalk.yellowBright("p2p: included grant -> unlimited does not bill already-covered usage")}`,
+	async () => {
+		const grantItem = items.monthlyMessages({
+			includedUsage: MESSAGES_INCLUDED,
+		});
+		const meteredItem = items.consumableMessages({
+			includedUsage: 0,
+			price: OVERAGE_PRICE,
+		});
+		const pro = products.pro({
+			id: "unlim-carry-pro",
+			items: [grantItem, meteredItem],
+		});
+
+		const customerId = "update-to-unlimited-carryover";
+
+		const { autumnV1, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.billing.attach({ productId: pro.id }),
+				// Consume exactly the included grant: zero overage before the edit.
+				s.track({
+					featureId: TestFeature.Messages,
+					value: MESSAGES_TRACKED,
+					timeout: 2000,
+				}),
+			],
+		});
+
+		const beforeEdit = await autumnV2_2.customers.get<ApiCustomerV5>(
+			customerId,
+			{ expand: [CustomerExpand.InvoicePreviews] },
+		);
+		const messagesLineBefore =
+			beforeEdit.invoice_previews?.[0]?.line_items.find(
+				(lineItem) => lineItem.feature_id === TestFeature.Messages,
+			);
+		expect(
+			messagesLineBefore?.subtotal ?? 0,
+			"precondition: usage is fully covered by the grant, so nothing is billable",
+		).toBe(0);
+
+		// The edit: included grant becomes unlimited, metered price stays.
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			items: [items.unlimitedMessages(), meteredItem],
+		});
+
+		const afterEdit = await autumnV2_2.customers.get<ApiCustomerV5>(
+			customerId,
+			{
+				expand: [CustomerExpand.InvoicePreviews],
+			},
+		);
+		const messagesLineAfter = afterEdit.invoice_previews?.[0]?.line_items.find(
+			(lineItem) => lineItem.feature_id === TestFeature.Messages,
+		);
+
+		expect(
+			messagesLineAfter?.subtotal ?? 0,
+			"usage covered by the old grant must not become billable overage",
+		).toBe(0);
+	},
+);

--- a/server/tests/integration/billing/update-subscription/custom-plan/update-to-unlimited-carryover.test.ts
+++ b/server/tests/integration/billing/update-subscription/custom-plan/update-to-unlimited-carryover.test.ts
@@ -1,19 +1,22 @@
 /**
  * Editing a plan's included grant to `unlimited` must not bill the usage that
- * was already covered by that grant.
+ * grant already covered — and must not forgive overage accrued before the edit.
  *
  * The plan carries two items for one feature: a free included grant, and a
- * separate metered price for overage. Flipping the grant to unlimited makes
- * the carried usage un-billable by definition, but the carryover deducts it
- * across the new product's entitlements and the metered row is the only one
- * that keeps a negative balance.
+ * separate metered price for overage. Carryover collapses both into one usage
+ * figure, so the split matters:
  *
- * Red (current):  upcoming invoice gains a MESSAGES_TRACKED x OVERAGE_PRICE line
- * Green (after):  no messages line — unlimited absorbs the carried usage
+ *   grant-covered usage  -> absorbed by the unlimited grant, never billable
+ *   accrued overage      -> stays on the priced row, still owed
+ *
+ * Red (before the fix):
+ *   t1  upbeat invoice gains a MESSAGES_TRACKED x OVERAGE_PRICE line
+ *   t2  (with a blanket skip) the already-owed overage silently disappears
  */
 
 import { expect, test } from "bun:test";
 import { type ApiCustomerV5, CustomerExpand } from "@autumn/shared";
+import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
@@ -21,76 +24,129 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 
 const MESSAGES_INCLUDED = 100;
-const MESSAGES_TRACKED = 100;
 const OVERAGE_PRICE = 0.5;
 
-test.concurrent(
-	`${chalk.yellowBright("p2p: included grant -> unlimited does not bill already-covered usage")}`,
-	async () => {
-		const grantItem = items.monthlyMessages({
-			includedUsage: MESSAGES_INCLUDED,
-		});
-		const meteredItem = items.consumableMessages({
-			includedUsage: 0,
-			price: OVERAGE_PRICE,
-		});
-		const pro = products.pro({
-			id: "unlim-carry-pro",
-			items: [grantItem, meteredItem],
-		});
+const buildPlan = ({ id }: { id: string }) => {
+	const grantItem = items.monthlyMessages({ includedUsage: MESSAGES_INCLUDED });
+	const meteredItem = items.consumableMessages({
+		includedUsage: 0,
+		price: OVERAGE_PRICE,
+	});
+	return {
+		meteredItem,
+		plan: products.pro({ id, items: [grantItem, meteredItem] }),
+	};
+};
 
-		const customerId = "update-to-unlimited-carryover";
+const readMessagesSubtotal = async ({
+	autumn,
+	customerId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_2"];
+	customerId: string;
+}) => {
+	const customer = await autumn.customers.get<ApiCustomerV5>(customerId, {
+		expand: [CustomerExpand.InvoicePreviews],
+	});
+	const line = customer.invoice_previews?.[0]?.line_items.find(
+		(lineItem) => lineItem.feature_id === TestFeature.Messages,
+	);
+	return line?.subtotal ?? 0;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("p2p: grant -> unlimited does not bill usage the grant covered")}`,
+	async () => {
+		const customerId = "unlim-grant-covered";
+		const { meteredItem, plan } = buildPlan({ id: "unlim-grant-covered-pro" });
+		const tracked = 80; // comfortably inside the grant, no overage
 
 		const { autumnV1, autumnV2_2 } = await initScenario({
 			customerId,
 			setup: [
 				s.customer({ paymentMethod: "success" }),
-				s.products({ list: [pro] }),
+				s.products({ list: [plan] }),
 			],
 			actions: [
-				s.billing.attach({ productId: pro.id }),
-				// Consume exactly the included grant: zero overage before the edit.
+				s.billing.attach({ productId: plan.id }),
 				s.track({
 					featureId: TestFeature.Messages,
-					value: MESSAGES_TRACKED,
-					timeout: 2000,
+					value: tracked,
+					timeout: 5000,
 				}),
 			],
 		});
 
-		const beforeEdit = await autumnV2_2.customers.get<ApiCustomerV5>(
+		// Polls until the track lands, so the zero below can't pass vacuously.
+		await expectCustomerFeatureCorrect({
 			customerId,
-			{ expand: [CustomerExpand.InvoicePreviews] },
-		);
-		const messagesLineBefore =
-			beforeEdit.invoice_previews?.[0]?.line_items.find(
-				(lineItem) => lineItem.feature_id === TestFeature.Messages,
-			);
+			autumn: autumnV1,
+			featureId: TestFeature.Messages,
+			usage: tracked,
+			balance: MESSAGES_INCLUDED - tracked,
+		});
 		expect(
-			messagesLineBefore?.subtotal ?? 0,
-			"precondition: usage is fully covered by the grant, so nothing is billable",
+			await readMessagesSubtotal({ autumn: autumnV2_2, customerId }),
+			"precondition: usage is fully covered by the grant, nothing billable",
 		).toBe(0);
 
-		// The edit: included grant becomes unlimited, metered price stays.
 		await autumnV1.subscriptions.update({
 			customer_id: customerId,
-			product_id: pro.id,
+			product_id: plan.id,
 			items: [items.unlimitedMessages(), meteredItem],
 		});
 
-		const afterEdit = await autumnV2_2.customers.get<ApiCustomerV5>(
-			customerId,
-			{
-				expand: [CustomerExpand.InvoicePreviews],
-			},
-		);
-		const messagesLineAfter = afterEdit.invoice_previews?.[0]?.line_items.find(
-			(lineItem) => lineItem.feature_id === TestFeature.Messages,
-		);
-
 		expect(
-			messagesLineAfter?.subtotal ?? 0,
+			await readMessagesSubtotal({ autumn: autumnV2_2, customerId }),
 			"usage covered by the old grant must not become billable overage",
 		).toBe(0);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("p2p: grant -> unlimited keeps overage accrued before the edit")}`,
+	async () => {
+		const customerId = "unlim-carry-overage";
+		const { meteredItem, plan } = buildPlan({ id: "unlim-carry-overage-pro" });
+		const tracked = 150; // 100 covered by the grant, 50 genuine overage
+		const expectedOverage = (tracked - MESSAGES_INCLUDED) * OVERAGE_PRICE;
+
+		const { autumnV1, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.billing.attach({ productId: plan.id }),
+				s.track({
+					featureId: TestFeature.Messages,
+					value: tracked,
+					timeout: 5000,
+				}),
+			],
+		});
+
+		await expectCustomerFeatureCorrect({
+			customerId,
+			autumn: autumnV1,
+			featureId: TestFeature.Messages,
+			usage: tracked,
+		});
+		expect(
+			await readMessagesSubtotal({ autumn: autumnV2_2, customerId }),
+			"precondition: 50 units above the grant are already billable",
+		).toBe(expectedOverage);
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: plan.id,
+			items: [items.unlimitedMessages(), meteredItem],
+		});
+
+		expect(
+			await readMessagesSubtotal({ autumn: autumnV2_2, customerId }),
+			"overage owed before the edit survives the grant becoming unlimited",
+		).toBe(expectedOverage);
 	},
 );

--- a/shared/models/billingModels/customerProduct/existingUsages.ts
+++ b/shared/models/billingModels/customerProduct/existingUsages.ts
@@ -5,6 +5,9 @@ export const ExistingUsagesSchema = z.record(
 	z.string(),
 	z.object({
 		usage: z.number(),
+		// The slice of `usage` that had already exceeded its allowance on the
+		// source, so a more generous destination doesn't erase what was owed.
+		accruedOverage: z.number().optional(),
 		entityUsages: z.record(z.string(), z.number()),
 		usageAttribution: UsageAttributionSchema.optional(),
 	}),


### PR DESCRIPTION
## The bug

When a plan's included grant for a feature is edited to `unlimited`, the usage already consumed under the old grant is carried into the replacement customer product and lands on a **priced** entitlement as a negative balance — which the invoice engine then prices as overage. Usage that the grant covered becomes billable purely because the grant got *more* generous.

It needs two entitlements on one feature to reproduce: an included grant, and a separate metered price for overage.

```
Before the edit                    After the edit
┌───────────────────────────┐      ┌───────────────────────────┐
│ credits: N included       │      │ credits: unlimited        │
│   balance 0  (all used)   │ ──►  │   balance 0     ← should  │
├───────────────────────────┤      │                  land here│
│ credits: $X / credit      │      ├───────────────────────────┤
│   balance 0               │      │ credits: $X / credit      │
└───────────────────────────┘      │   balance -N     ← went   │
   carried usage = N               │                   here    │
                                   └───────────────────────────┘
```

`applyExistingUsages` computes the carried usage and hands it to `deductFromCusEntsTypescript`. That primitive's pass-2 sort puts `usage_allowed` rows first, so overage hits rows that accrued it. An unlimited entitlement has `usage_allowed: false`, so it sorts *last* — and the metered row absorbs the whole amount.

This also explains a related report of `usage: 0` on unlimited features over the API: the negative balance sits on a *finite* row, and the unlimited summariser only sums unlimited rows. Same bug, no API change needed.

## The fix

`existingUsage.usage` is an aggregate of two different things, and they need opposite treatment:

| slice | belongs where | why |
|---|---|---|
| covered by the old grant | absorbed by the unlimited grant | it was free, and the new grant is *more* generous |
| already above the old grant | stays on the priced row | it was owed before the edit; a bigger grant doesn't refund it |

So `cusProductToExistingUsages` now also reports `accruedOverage` — summed from the negative balance on each source row, which is exactly the portion that had already exceeded its allowance. `applyExistingUsages` splits on it: the unlimited rows take `usage - accruedOverage`, the priced rows take `accruedOverage`.

Falling out of this: the unlimited row's balance ends up populated rather than at zero, so the usage counter the API derives from it (and `set_usage` / refunds) starts from the right base.

**Deliberately scoped to this path.** The alternative — teaching `deductFromCusEntsTypescript`'s pass-2 sort about unlimited — touches a primitive shared by recalculate, auto top-up and update-quantity, and has no unit coverage at all. It also wouldn't have worked on its own: the unlimited row is often a pooled *contribution* row, and `normalizePooledBalanceContributionCustomerEntitlement` zeroes contribution balances after carryover runs.

## Testing

Two scenarios in `update-to-unlimited-carryover.test.ts`, both asserting on the `invoice_previews` line item (the customer-visible symptom) rather than internal balances, and both gated on a polled precondition that proves the tracked usage actually landed before the zero is asserted.

| scenario | without the fix | with it | correct |
|---|---|---|---|
| 80 used against a 100 grant | **\$40** (over-bills) | \$0 | \$0 |
| 150 used against a 100 grant | **\$75** (over-bills) | \$25 | \$25 |

Verified by neutralising the guard and re-running: both go red. Each assertion was also individually forced to fail to confirm it executes — the runner reports `✓0` in the passed column either way, so a green and a skip are otherwise indistinguishable.

Regression run, all green: `pooled-balance-unlimited`, `batch-license-item-unlimited-edit`, `version-entitlements`, `update-paid-features`, `update-paid-basic`, `update-paid-prepaid`, `update-paid-allocated`, `update-free-to-paid`.

## Follow-up (not in this PR)

`computeRecalculateBalance:127` shares the primitive, but `getRecalculableScopeKeys` gates on a scope having both a negative *and* a positive balance — so the shape above never reaches it. Where it is reachable the fix is different: `resetCusEntInPlace` zeroes the unlimited row's usage counter, so a skip there would lose data. Needs its own design decision.