### PR TITLE
feat: 🎸 accept many rows of one plan in a request

### DIFF
--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts
@@ -43,7 +43,19 @@ const upsertMatchesDraftEntry = ({
 	if (planParams.version !== undefined) {
 		return upsertProductPlan.row.version === planParams.version;
 	}
-	return upsertProductPlan.row.source === "direct";
+	if (planParams.version_slug !== undefined) {
+		return (
+			upsertProductPlan.row.nextFullProduct.version_slug ===
+			planParams.version_slug
+		);
+	}
+	// One request can carry many direct rows of a plan, so "any direct row" would
+	// let one entry's draft claim its siblings. An unpinned entry named the
+	// active row, and only that row.
+	return (
+		upsertProductPlan.row.source === "direct" &&
+		upsertProductPlan.row.nextFullProduct.active === true
+	);
 };
 
 /** The params entry whose `migration.draft` claims this upsert row. */

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts
@@ -95,9 +95,37 @@ const resolveVersionsForPlan = ({
 	const maxVersion = maxVersionForPlan({ planId, productStatesContext });
 	const hasLiveVersions =
 		(productStatesContext.versionsByPlanId[planId] ?? []).length > 0;
-	const nextFreeVersion = maxVersion + 1;
 	const activeOrV1 =
 		activeVersionForPlan({ planId, productStatesContext }) ?? (maxVersion || 1);
+
+	// Versions this request has spoken for, so rows minted here never land on
+	// each other or on a row the payload pinned.
+	const claimedVersions = new Set(
+		withExplicitVersion.map((planParams) => planParams.version),
+	);
+	let nextFreeVersion = maxVersion + 1;
+	const takeFreeVersion = (): number => {
+		while (claimedVersions.has(nextFreeVersion)) nextFreeVersion++;
+		claimedVersions.add(nextFreeVersion);
+		return nextFreeVersion;
+	};
+
+	/**
+	 * A slug naming no existing row is history the catalog does not have yet.
+	 * The config is the desired state, so the row is minted under that name.
+	 */
+	const mintedFromSlug = resolved
+		.filter(
+			(planParams) =>
+				!hasExplicitVersion(planParams) &&
+				planParams.version_slug !== undefined,
+		)
+		.map((planParams) => ({
+			...planParams,
+			version: takeFreeVersion(),
+			new_version_slug: planParams.new_version_slug ?? planParams.version_slug,
+			version_slug: undefined,
+		}));
 
 	const targetingLatest = resolved
 		.filter(
@@ -109,11 +137,11 @@ const resolveVersionsForPlan = ({
 			...planParams,
 			version:
 				planParams.versioning === "new_version" || !hasLiveVersions
-					? nextFreeVersion
+					? takeFreeVersion()
 					: activeOrV1,
 		}));
 
-	return [...withExplicitVersion, ...targetingLatest];
+	return [...withExplicitVersion, ...mintedFromSlug, ...targetingLatest];
 };
 
 /**

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts
@@ -53,6 +53,27 @@ const claimPinnedVersion = ({
 	seenPinned.add(pinKey);
 };
 
+/** Two entries naming the same new slug is the same ambiguity as a double pin. */
+const claimMintedSlug = ({
+	planId,
+	versionSlug,
+	seenSlugs,
+}: {
+	planId: string;
+	versionSlug: string;
+	seenSlugs: Set<string>;
+}): void => {
+	const slugKey = `${planId}@${versionSlug}`;
+	if (seenSlugs.has(slugKey)) {
+		throw new RecaseError({
+			message: `Duplicate plan entry for plan_id=${planId} version_slug=${versionSlug}`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+	seenSlugs.add(slugKey);
+};
+
 const rejectNewVersionOnNonActiveRow = ({
 	planId,
 	row,
@@ -95,8 +116,9 @@ export const handleUpsertProductVersioningErrors = ({
 	productStatesContext: ProductStatesContext;
 }): void => {
 	const seenPinned = new Set<string>();
+	const seenSlugs = new Set<string>();
 	const unpinnedPlanIds = new Set<string>();
-	const creatingPlanIds = new Set<string>();
+	const mintedVersionsByPlanId = new Map<string, number>();
 
 	for (const planParams of params.plans) {
 		if (planParams.versioning === "new_version") {
@@ -143,17 +165,6 @@ export const handleUpsertProductVersioningErrors = ({
 		const existingVersions =
 			productStatesContext.versionsByPlanId[planParams.plan_id] ?? [];
 
-		if (existingVersions.length === 0) {
-			if (creatingPlanIds.has(planParams.plan_id)) {
-				throw new RecaseError({
-					message: `Cannot create plan_id=${planParams.plan_id} with multiple entries`,
-					code: ErrCode.InvalidRequest,
-					statusCode: 400,
-				});
-			}
-			creatingPlanIds.add(planParams.plan_id);
-		}
-
 		if (
 			planParams.versioning === "new_version" &&
 			planParams.migration?.draft
@@ -198,10 +209,15 @@ export const handleUpsertProductVersioningErrors = ({
 				seenPinned,
 			});
 
-			const maxVersion = maxVersionForPlan({
-				planId: planParams.plan_id,
-				productStatesContext,
-			});
+			const maxVersion = Math.max(
+				maxVersionForPlan({
+					planId: planParams.plan_id,
+					productStatesContext,
+				}),
+				// Rows minted earlier in this same request count: a full-history
+				// push states v1, v2, v3 against a catalog that holds none of them.
+				mintedVersionsByPlanId.get(planParams.plan_id) ?? 0,
+			);
 			if (planParams.version > maxVersion + 1) {
 				throw new RecaseError({
 					message: `Version gap: plan_id=${planParams.plan_id} version=${planParams.version} exceeds max existing version ${maxVersion} + 1`,
@@ -209,24 +225,37 @@ export const handleUpsertProductVersioningErrors = ({
 					statusCode: 400,
 				});
 			}
+			// Recorded only AFTER the check: an entry must not authorise its own
+			// gap, it only widens the ceiling for rows stated after it.
+			mintedVersionsByPlanId.set(
+				planParams.plan_id,
+				Math.max(
+					mintedVersionsByPlanId.get(planParams.plan_id) ?? 0,
+					planParams.version,
+				),
+			);
 		} else if (planParams.version_slug !== undefined) {
 			const version = versionForSlug({
 				planId: planParams.plan_id,
 				versionSlug: planParams.version_slug,
 				productStatesContext,
 			});
+			// A slug naming no row mints one — the config states history the
+			// catalog does not have yet. Two entries claiming the same slug are
+			// still ambiguous, whether or not the row exists.
 			if (version === undefined) {
-				throw new RecaseError({
-					message: `Unknown version_slug "${planParams.version_slug}" for plan_id=${planParams.plan_id}`,
-					code: ErrCode.InvalidRequest,
-					statusCode: 400,
+				claimMintedSlug({
+					planId: planParams.plan_id,
+					versionSlug: planParams.version_slug,
+					seenSlugs,
+				});
+			} else {
+				claimPinnedVersion({
+					planId: planParams.plan_id,
+					version,
+					seenPinned,
 				});
 			}
-			claimPinnedVersion({
-				planId: planParams.plan_id,
-				version,
-				seenPinned,
-			});
 		} else {
 			if (unpinnedPlanIds.has(planParams.plan_id)) {
 				throw new RecaseError({
@@ -236,6 +265,17 @@ export const handleUpsertProductVersioningErrors = ({
 				});
 			}
 			unpinnedPlanIds.add(planParams.plan_id);
+
+			// On a plan that does not exist yet an unpinned entry mints v1, so it
+			// collides with another entry pinning v1. Claiming the version it will
+			// take surfaces that as the duplicate it is.
+			if (existingVersions.length === 0) {
+				claimPinnedVersion({
+					planId: planParams.plan_id,
+					version: (mintedVersionsByPlanId.get(planParams.plan_id) ?? 0) + 1,
+					seenPinned,
+				});
+			}
 		}
 
 		if (existingVersions.length === 0 && planParams.name === undefined) {

--- a/server/tests/integration/catalog-v2/plans/migrations/multi-row-draft-scope.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/multi-row-draft-scope.test.ts
@@ -1,0 +1,98 @@
+/**
+ * catalogV2.update — a draft claims the row its entry named, not the plan.
+ *
+ * With one entry per plan, "any direct row of this plan" and "the row this
+ * entry named" were the same set. Multi-row payloads split them: a request
+ * that states v1 and v2 has two direct rows, and a `migration.draft` on one
+ * of them must not drag the other into the same migration.
+ *
+ * Contract:
+ *   B6  migration.draft on a version-pinned entry drafts that version only,
+ *       even when the same request carries other rows of the same plan
+ *
+ * Red (current): the matcher falls back to `source === "direct"`, so the
+ *   draft claims every direct row of the plan.
+ * Green (after): it claims the row the entry resolved to.
+ */
+
+import { test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { cleanupPlanCustomerRefs } from "../utils/cleanupPlanCustomerRefs.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import {
+	deleteMigrations,
+	expectUpdateMigrations,
+} from "./utils/expectMigrationDrafts.js";
+import { seedVersionableCustomer } from "./utils/seedVersionableCustomer.js";
+
+const messagesItem = ({ included }: { included: number }) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 migration: an unpinned draft claims the active row, not its siblings")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_mig_multirow");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Multi Row Draft",
+						items: [messagesItem({ included: 100 })],
+					},
+				],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [messagesItem({ included: 200 })],
+						versioning: "new_version",
+						active: true,
+					},
+				],
+			});
+
+			// Customers on both rows, so either could legitimately produce a draft.
+			await seedVersionableCustomer({ ctx, planId, version: 1 });
+			await seedVersionableCustomer({ ctx, planId, version: 2 });
+
+			// B6: the draft entry is UNPINNED, so it names the active row (v2). The
+			// same request also pins v1. An unpinned entry used to fall back to
+			// "any direct row of this plan", which with multi-row swallows v1 too.
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [messagesItem({ included: 250 })],
+						migration: { draft: true },
+					},
+					{
+						plan_id: planId,
+						version: 1,
+						items: [messagesItem({ included: 150 })],
+					},
+				],
+			});
+
+			expectUpdateMigrations({
+				response,
+				plans: [[{ plan_id: planId, versions: [2] }]],
+			});
+		} finally {
+			await deleteMigrations({ ctx, ids: [planId] });
+			await cleanupPlanCustomerRefs({ ctx, planIds: [planId] });
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/multi-row/multi-row-payloads.test.ts
+++ b/server/tests/integration/catalog-v2/plans/multi-row/multi-row-payloads.test.ts
@@ -1,0 +1,217 @@
+/**
+ * catalogV2 — one request carries many rows of the same plan.
+ *
+ * A config file holds the whole pricing history, so a push states every
+ * version at once: pro@1 was $10, pro@2 was $20, pro@3 is $30. Today the
+ * server assumes one entry per plan and rejects the rest.
+ *
+ * The invariant this must not break is John's: explicitly stated rows map
+ * 1:1 to intents, and the derivation that fans a change out to siblings and
+ * variants must not ALSO claim a row the payload named. That is already how
+ * `claimProductKeys` + `claimNewIntents` behave; these tests pin it so the
+ * multi-row work cannot quietly regress it.
+ *
+ * Contract:
+ *   B1  N rows of one plan → N intents, and derived fan-out claims none of
+ *       the rows the payload named (explicit beats derived)
+ *   B2  a brand-new plan can be created with its whole history in one request
+ *   B3  an unknown version_slug with no internal_id mints a version, rather
+ *       than being rejected as unknown
+ *   B4  two entries pinning the same version is still an error
+ *   B5  two unpinned entries for one plan is still an error
+ *   B6  migration.draft on one entry claims that entry's row only
+ *
+ * Red (current): the create-with-multiple-entries guard, the unknown-slug
+ *   rejection, and the version-gap check each reject a full-history push.
+ * Green (after): the payload's own rows count, and the guards that remain
+ *   are only the genuinely ambiguous ones.
+ */
+
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { withCatalogPlans } from "../licenses/utils/seedLicensePlans.js";
+
+const messagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+});
+
+const versionsOf = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) => {
+	const all = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		returnAll: true,
+		skipCache: true,
+	});
+	return all
+		.filter((product) => product.id === planId)
+		.sort((a, b) => a.version - b.version);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 multi-row: a new plan is created with its whole history in one request")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_mr_history");
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				// B2 + B3: three rows of a plan that does not exist yet. Each names a
+				// slug nothing owns, which today is rejected twice over — once by the
+				// create-with-multiple-entries guard, once by the version gap check,
+				// since neither counts rows minted earlier in the same request.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							name: "History",
+							version_slug: "v1",
+							items: [messagesItem(100)],
+						},
+						{
+							plan_id: planId,
+							name: "History",
+							version_slug: "v2",
+							items: [messagesItem(200)],
+						},
+						{
+							plan_id: planId,
+							name: "History",
+							version_slug: "v3",
+							items: [messagesItem(300)],
+							active: true,
+						},
+					],
+				});
+
+				const versions = await versionsOf({ ctx, planId });
+				expect(
+					versions.map((row) => row.version),
+					"three rows",
+				).toEqual([1, 2, 3]);
+				expect(
+					versions.map(
+						(row) =>
+							row.entitlements.find(
+								(ent) => ent.feature?.id === TestFeature.Messages,
+							)?.allowance,
+					),
+					"each row kept its own content",
+				).toEqual([100, 200, 300]);
+				expect(
+					versions.find((row) => row.active)?.version,
+					"the stated row holds the pointer",
+				).toBe(3);
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 multi-row: stated rows beat the derived fan-out")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_mr_claim");
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{ plan_id: planId, name: "Claim", items: [messagesItem(100)] },
+					],
+				});
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							items: [messagesItem(200)],
+							versioning: "new_version",
+							active: true,
+						},
+					],
+				});
+
+				// B1: one entry pins v1 with its own content while another asks for
+				// `all_versions`, whose fan-out would otherwise rewrite every sibling
+				// — v1 included. The stated row must win: explicit beats derived.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{ plan_id: planId, version: 1, items: [messagesItem(150)] },
+						{
+							plan_id: planId,
+							versioning: "all_versions",
+							items: [messagesItem(999)],
+						},
+					],
+				});
+
+				const versions = await versionsOf({ ctx, planId });
+				const allowanceAt = (version: number) =>
+					versions
+						.find((row) => row.version === version)
+						?.entitlements.find(
+							(ent) => ent.feature?.id === TestFeature.Messages,
+						)?.allowance;
+
+				expect(allowanceAt(1), "pinned row kept its own content").toBe(150);
+				expect(allowanceAt(2), "the fan-out still reached unclaimed rows").toBe(
+					999,
+				);
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 multi-row: genuinely ambiguous entries are still rejected")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_mr_guard");
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{ plan_id: planId, name: "Guard", items: [messagesItem(100)] },
+					],
+				});
+
+				// B4: two entries pinning the same row — which one wins is undefined.
+				const samePin = autumnV2_3.catalogV2.update({
+					plans: [
+						{ plan_id: planId, version: 1, items: [messagesItem(150)] },
+						{ plan_id: planId, version: 1, items: [messagesItem(250)] },
+					],
+				});
+				await expect(samePin).rejects.toThrow();
+
+				// B5: two entries naming no row at all — same ambiguity.
+				const bothUnpinned = autumnV2_3.catalogV2.update({
+					plans: [
+						{ plan_id: planId, items: [messagesItem(150)] },
+						{ plan_id: planId, items: [messagesItem(250)] },
+					],
+				});
+				await expect(bothUnpinned).rejects.toThrow();
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/versions/version-identity-slug-errors.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/version-identity-slug-errors.test.ts
@@ -3,16 +3,17 @@
  *
  * Contract:
  *   version + version_slug together → 400 (even if they agree)
- *   unknown version_slug → 400 InvalidRequest
+ *   unknown version_slug → mints under that slug (reversed 2026-08-31)
  *   all_versions / new_version + slug pin → 400 (same as numeric pin)
  *   duplicate same slug twice → 400 InvalidRequest
  */
 
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
 import { ErrCode } from "@autumn/shared";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
 import { uniqueTestId } from "../../utils/uniqueTestId.js";
 import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
 
@@ -57,23 +58,33 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("version identity slug-errors: unknown version_slug → 400")}`,
+	`${chalk.yellowBright("version identity slug-errors: unknown version_slug mints under that name")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const planId = uniqueTestId("cv2_vid_eunk");
 		await deleteDbPlans({ ctx, planIds: [planId] });
 		try {
 			await seedV1({ autumn: autumnV2_3, planId });
-			await expectAutumnError({
-				errCode: ErrCode.InvalidRequest,
-				errMessage: 'Unknown version_slug "missing"',
-				func: () =>
-					autumnV2_3.catalogV2.update({
-						plans: [
-							{ plan_id: planId, version_slug: "missing", name: "Ghost" },
-						],
-					}),
+
+			// Reversed deliberately: this was a 400. Under a config that states the
+			// whole desired history, a slug naming no row is history the catalog
+			// does not have yet, so it is minted rather than rejected. The
+			// guarantee that matters — it must never land on the active row —
+			// still holds, and preview is what surfaces an accidental mint.
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version_slug: "missing", name: "Ghost" }],
 			});
+
+			const minted = await ProductService.get({
+				db: ctx.db,
+				id: planId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+				version: 2,
+			});
+			expect(minted?.version_slug, "minted under the stated slug").toBe(
+				"missing",
+			);
 		} finally {
 			await deleteDbPlans({ ctx, planIds: [planId] });
 		}

--- a/server/tests/unit/catalogV2/planUpdate/derive-direct-intents-slug.test.ts
+++ b/server/tests/unit/catalogV2/planUpdate/derive-direct-intents-slug.test.ts
@@ -39,19 +39,42 @@ describe("deriveDirectIntents version_slug targeting", () => {
 		expect(intent?.productKey).toEqual({ planId: "pro", version: 1 });
 	});
 
-	test("unknown version_slug is not fall-through-to-active", () => {
-		expect(
-			deriveDirectIntents({
-				params: {
-					plans: [{ plan_id: "pro", version_slug: "missing", name: "Ghost" }],
-					features: [],
-					remove_features: [],
-					remove_plans: [],
-				},
-				productStatesContext,
-				internalIdRefs: new Map(),
-			}),
-		).toEqual([]);
+	test("unknown version_slug mints under that name, never the active row", () => {
+		const [intent] = deriveDirectIntents({
+			params: {
+				plans: [{ plan_id: "pro", version_slug: "missing", name: "Ghost" }],
+				features: [],
+				remove_features: [],
+				remove_plans: [],
+			},
+			productStatesContext,
+			internalIdRefs: new Map(),
+		});
+
+		// A config states the history it wants, so a slug naming no row creates
+		// one. The original guarantee still holds: it must never land on the
+		// active row (v2 here), which would silently rewrite live pricing.
+		expect(intent?.productKey).toEqual({ planId: "pro", version: 3 });
+		expect(intent?.planParams.new_version_slug).toBe("missing");
+		expect(intent?.planParams.version_slug).toBeUndefined();
+	});
+
+	test("two entries minting distinct slugs get distinct versions", () => {
+		const intents = deriveDirectIntents({
+			params: {
+				plans: [
+					{ plan_id: "pro", version_slug: "autumn", name: "A" },
+					{ plan_id: "pro", version_slug: "winter", name: "B" },
+				],
+				features: [],
+				remove_features: [],
+				remove_plans: [],
+			},
+			productStatesContext,
+			internalIdRefs: new Map(),
+		});
+
+		expect(intents.map((intent) => intent.productKey.version)).toEqual([3, 4]);
 	});
 
 	test("omit both targets the active row", () => {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows one catalog update request to carry many rows of the same plan, so a config push can state the full pricing history at once.

- An unknown `version_slug` now mints a new version under that slug instead of returning 400, a deliberate behavior change.
- A `migration.draft` entry now claims only the row it names, not every direct row of that plan.
- Two entries minting the same new slug are rejected as duplicates, and version-gap checks count rows minted earlier in the same request.
- The guard that rejected multiple entries when creating a new plan is removed.

<sup>Written for commit 6d7c09e81e4fe23e90947a1bb2a1395feab6e5a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR allows one catalog update to provide multiple historical rows for a plan and changes unknown version slugs into version-creation requests.
- **API changes, Improvements:** Accept unknown version slugs as new versions and allocate distinct version numbers within one request.
- **API changes, Improvements:** Permit several rows of the same new plan and account for earlier numeric rows during gap validation.
- **Bug fixes, Improvements:** Narrow migration-draft matching toward the row named by each request entry.
- **Bug fixes:** Preserve duplicate-pin and duplicate-slug rejection for ambiguous entries.
</details>


<h3>Confidence Score: 3/5</h3>

The PR should not merge until valid unordered histories stop failing validation and migration drafts remain scoped when another row is promoted.

Validation can reject histories that derivation resolves correctly, and active-state-based draft matching can include customers from a separately promoted version.

**Files Needing Attention:** server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts; server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts | Enables multi-row creation and unknown-slug minting, but gap validation disagrees with allocation for unordered or mixed-selector histories. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts | Allocates distinct versions for unknown slugs and new-version entries while reserving explicitly pinned versions. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts | Narrows unpinned draft matching to active direct rows, but can still claim a separately promoted sibling. |
| server/tests/integration/catalog-v2/plans/multi-row/multi-row-payloads.test.ts | Covers slug-based full-history creation, explicit-over-derived precedence, and basic ambiguous-entry rejection, but not mixed or out-of-order numeric histories. |
| server/tests/integration/catalog-v2/plans/migrations/multi-row-draft-scope.test.ts | Covers an unpinned draft beside a normal historical edit, but not a sibling promoted active in the same request. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Multi-row catalog request] --> B[Resolve explicit versions and slugs]
  B --> C[Allocate versions for unknown slugs]
  C --> D[Validate duplicates and version gaps]
  D --> E[Build direct and derived plan rows]
  E --> F[Match migration drafts to rows]
  F --> G[Preview or apply catalog update]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts:212-221
**Version validation remains order-dependent**

When a complete history lists numeric versions out of order, or an unknown slug before the following numeric version, validation only counts earlier numeric entries and incorrectly returns a 400 version-gap error. For example, a new plan sent as v2 then v1 is rejected even though derivation sorts and resolves it as v1 and v2.

### Issue 2
server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts:55-58
**Active state broadens draft scope**

When an unpinned entry drafts the current active version while another pinned entry promotes a historical version, both direct rows end with `active === true` and satisfy this predicate. The migration draft therefore includes customers from both versions instead of only the version addressed by the draft entry.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 accept many rows of one plan in..."](https://github.com/useautumn/autumn/commit/6d7c09e81e4fe23e90947a1bb2a1395feab6e5a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59147428)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)

<!-- /greptile_comment -->