### PR TITLE
fix: prevent lazy usage-window reset stampedes

### DIFF
--- a/server/src/internal/customers/actions/resetUsageWindows/lazyResetSubjectUsageWindows.ts
+++ b/server/src/internal/customers/actions/resetUsageWindows/lazyResetSubjectUsageWindows.ts
@@ -52,11 +52,19 @@ export const lazyResetSubjectUsageWindows = async ({
 		const rolls = computeUsageWindowRolls({ usageWindows, limits, now });
 		if (rolls.length === 0) return false;
 
+		const didRoll = await usageWindowRepo.rollWindows({
+			db: ctx.db,
+			rolls,
+			now,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId: fullSubject.customerId,
+		});
+		if (!didRoll) return false;
+
 		ctx.logger.info(
 			`[lazyResetSubjectUsageWindows] customer: ${fullSubject.customerId}, rolling: ${rolls.length}`,
 		);
-
-		await usageWindowRepo.rollWindows({ db: ctx.db, rolls, now });
 		await rollUsageWindowsCache({
 			ctx,
 			customerId: fullSubject.customerId,

--- a/server/src/internal/customers/usageWindows/repos/rollUsageWindows.ts
+++ b/server/src/internal/customers/usageWindows/repos/rollUsageWindows.ts
@@ -1,4 +1,4 @@
-import { usageWindows } from "@autumn/shared";
+import { type AppEnv, usageWindows } from "@autumn/shared";
 import { eq, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle";
 import type { UsageWindowRoll } from "@/internal/customers/actions/resetUsageWindows/computeUsageWindowRolls.js";
@@ -12,21 +12,39 @@ export const rollUsageWindows = async ({
 	db,
 	rolls,
 	now,
+	orgId,
+	env,
+	customerId,
 }: {
 	db: DrizzleCli;
 	rolls: UsageWindowRoll[];
 	now: number;
-}): Promise<void> => {
-	for (const roll of rolls) {
-		await db
-			.update(usageWindows)
-			.set({
-				usage: roll.zero_usage ? 0 : sql`${usageWindows.usage}`,
-				window_start_at: roll.window_start_at,
-				window_end_at: roll.window_end_at,
-				anchor_customer_entitlement_id: roll.anchor_customer_entitlement_id,
-				updated_at: now,
-			})
-			.where(eq(usageWindows.id, roll.id));
-	}
+	orgId: string;
+	env: AppEnv;
+	customerId: string;
+}): Promise<boolean> => {
+	const lockKey = `usage-window-roll:${orgId}:${env}:${customerId}`;
+
+	return db.transaction(async (tx) => {
+		const txDb = tx as unknown as DrizzleCli;
+		const lockResult = await txDb.execute<{ acquired: boolean }>(
+			sql`SELECT pg_try_advisory_xact_lock(hashtextextended(${lockKey}, 0)) AS acquired`,
+		);
+		if (!lockResult[0]?.acquired) return false;
+
+		for (const roll of rolls) {
+			await txDb
+				.update(usageWindows)
+				.set({
+					usage: roll.zero_usage ? 0 : sql`${usageWindows.usage}`,
+					window_start_at: roll.window_start_at,
+					window_end_at: roll.window_end_at,
+					anchor_customer_entitlement_id: roll.anchor_customer_entitlement_id,
+					updated_at: now,
+				})
+				.where(eq(usageWindows.id, roll.id));
+		}
+
+		return true;
+	});
 };

--- a/server/tests/integration/balances/usage-windows/usage-window-reset.test.ts
+++ b/server/tests/integration/balances/usage-windows/usage-window-reset.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "bun:test";
-import { type ApiCustomerV5, ApiVersion } from "@autumn/shared";
+import {
+	type ApiCustomerV5,
+	ApiVersion,
+	type CheckResponseV3,
+} from "@autumn/shared";
 import { expectUsageLimitCorrect } from "@tests/integration/utils/expectUsageLimitCorrect.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
@@ -10,6 +14,8 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { sql } from "drizzle-orm";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { createHonoApp } from "@/initHono.js";
+import { CHECK_DB_HYDRATION_BUDGET_MS } from "@/internal/balances/check/getCheckDataV2.js";
 import { buildSharedFullSubjectBalanceKey } from "@/internal/customers/cache/fullSubject/builders/buildSharedFullSubjectBalanceKey.js";
 import { setCustomerUsageLimit } from "../utils/usage-limit-utils/customerUsageLimitUtils.js";
 import { expireUsageWindowForReset } from "../utils/usage-limit-utils/expireUsageWindowForReset.js";
@@ -30,6 +36,86 @@ const queryRows = (result: unknown): any[] =>
 	Array.isArray(result) ? result : ((result as { rows?: any[] })?.rows ?? []);
 
 const HOUR_MS = 60 * 60 * 1000;
+
+const createDeferred = () => {
+	let resolve!: () => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, reject, resolve };
+};
+
+const holdUsageWindowRowLock = ({
+	ctx,
+	customerId,
+	featureId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+	featureId: string;
+}) => {
+	const acquired = createDeferred();
+	const release = createDeferred();
+	const settled = ctx.db.transaction(async (tx) => {
+		const rows = queryRows(
+			await tx.execute(sql`
+				SELECT uw.id
+				FROM usage_windows uw
+				JOIN customers c ON c.internal_id = uw.internal_customer_id
+				WHERE c.id = ${customerId}
+					AND c.org_id = ${ctx.org.id}
+					AND c.env = ${ctx.env}
+					AND uw.feature_id = ${featureId}
+				FOR UPDATE OF uw
+			`),
+		);
+		if (rows.length !== 1) {
+			throw new Error(`Expected one usage window, found ${rows.length}`);
+		}
+		acquired.resolve();
+		await release.promise;
+	});
+	void settled.catch(acquired.reject);
+
+	return { acquired: acquired.promise, release: release.resolve, settled };
+};
+
+const waitForBlockedUsageWindowUpdate = async ({
+	ctx,
+}: {
+	ctx: TestContext;
+}) => {
+	for (let attempt = 0; attempt < 100; attempt++) {
+		const [result] = await ctx.db.execute<{ blocked: boolean }>(sql`
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_stat_activity
+				WHERE wait_event_type = 'Lock'
+					AND query ILIKE '%usage_windows%'
+			) AS blocked
+		`);
+		if (result?.blocked) return;
+		await timeout(10);
+	}
+
+	throw new Error("Timed out waiting for the first usage-window update");
+};
+
+const expectCheckAvoidedHydrationTimeout = async ({
+	response,
+	elapsedMs,
+}: {
+	response: Response;
+	elapsedMs: number;
+}) => {
+	const body = (await response.json()) as CheckResponseV3;
+	expect(response.status).toBe(200);
+	expect(body.allowed).toBe(true);
+	expect(body.balance).not.toBeNull();
+	expect(elapsedMs).toBeLessThan(CHECK_DB_HYDRATION_BUDGET_MS);
+};
 
 const fetchWindowRows = async ({
 	ctx,
@@ -381,3 +467,80 @@ test.concurrent(
 		expect(allRows).toHaveLength(2);
 	},
 );
+
+// Red: competing checks queue on one expired-window UPDATE until the 2s fail-open.
+// Green: one check rolls while advisory-lock losers skip persistence and continue.
+test(`${chalk.yellowBright("usage-window-reset4 (contention): competing checks do not queue behind the lazy roll")}`, async () => {
+	const freePlan = products.base({
+		id: "uw-reset-contention",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	const customerId = "uw-reset-contention-1";
+	const { ctx } = await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [freePlan] })],
+		actions: [s.billing.attach({ productId: freePlan.id })],
+	});
+
+	await setCustomerUsageLimit({
+		autumn: autumnV2_3,
+		customerId,
+		featureId: TestFeature.Messages,
+		limit: 5,
+	});
+	await autumnV2_3.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 3,
+	});
+	await timeout(4000);
+	await expireUsageWindowForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+
+	const rowLock = holdUsageWindowRowLock({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	let firstCheck: Promise<Response> | undefined;
+
+	try {
+		await rowLock.acquired;
+		const app = createHonoApp();
+		const check = () =>
+			app.fetch(
+				new Request("http://localhost/v1/balances.check", {
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${process.env.UNIT_TEST_AUTUMN_SECRET_KEY || ""}`,
+						"Content-Type": "application/json",
+						"x-api-version": ApiVersion.V2_3.toString(),
+					},
+					body: JSON.stringify({
+						customer_id: customerId,
+						feature_id: TestFeature.Messages,
+					}),
+				}),
+			);
+
+		const pendingFirstCheck = Promise.resolve(check());
+		firstCheck = pendingFirstCheck;
+		void pendingFirstCheck.catch(() => undefined);
+		await waitForBlockedUsageWindowUpdate({ ctx });
+
+		const startedAt = performance.now();
+		const response = await check();
+		await expectCheckAvoidedHydrationTimeout({
+			response,
+			elapsedMs: performance.now() - startedAt,
+		});
+	} finally {
+		rowLock.release();
+		await rowLock.settled;
+		if (firstCheck) await firstCheck;
+	}
+});


### PR DESCRIPTION
## Summary
- guard each customer's lazy usage-window roll with a non-blocking, transaction-scoped PostgreSQL advisory lock
- let contending requests skip persistence instead of queuing on the same `usage_windows` row
- keep the winning request's existing Postgres, Redis, and in-flight subject updates unchanged

## Regression coverage
- reproduces the check hydration timeout caused by concurrent lazy rolls
- verifies a contending check returns normally while the winning roll is blocked
- preserves the existing cached lazy-reset path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents concurrent lazy usage-window resets from stampeding the same `usage_windows` rows and timing out checks.

- Guards each customer's roll with a transaction-scoped PostgreSQL advisory lock so only one request persists the reset.
- Contending requests now skip persistence and return normally instead of queuing.
- Adds regression coverage that reproduces the timeout and verifies a competing check returns within the hydration budget.

<sup>Written for commit 1106275f72c86d4eb0479a210b3aa281d50e1fd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

