### PR TITLE
fix: stop reporting idle SQS workers to Sentry

### DIFF
--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -223,10 +223,6 @@ export const startPollingLoop = async ({
 			queueUrl,
 			consecutiveIntervals: minutes,
 		});
-		Sentry.captureMessage(
-			`SQS Worker ${process.pid} (${queueUrl}): No messages processed for ${minutes} minutes`,
-			"warning",
-		);
 	};
 
 	const recycleWorkerIfNeeded = () => {


### PR DESCRIPTION
Stop emitting a Sentry warning every 20 minutes for each idle queue worker. Queue idleness remains available in structured logs, while existing backlog monitors continue to cover the actionable failure mode.

This removes the repeated warning events that dominate the Sentry error quota without affecting queue processing or worker recycling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops sending a Sentry warning every 20 minutes for each idle SQS worker, so Sentry is no longer flooded with repetitive events. Queue idleness remains in structured logs, and existing backlog monitors still cover the actionable failure mode. No impact on queue processing or worker recycling.

<sup>Written for commit f0c806412d3bb326e2a2c0af4f2eaeba5f874288. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

