### PR TITLE
Default trial-on-end to revert, swap the checkbox for a select

### DIFF
--- a/vite/src/components/forms/attach-v2/components/AttachPlanOptions.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachPlanOptions.tsx
@@ -1,3 +1,4 @@
+import type { TrialOnEnd } from "@autumn/shared";
 import {
 	Button,
 	DropdownMenu,
@@ -20,7 +21,7 @@ export function AttachPlanOptions() {
 		formValues,
 		numVersions,
 		product,
-		hasActiveSubscription,
+		supportsTrialRevert,
 		attachCurrency,
 		additionalPlans: { isMultiPlan },
 	} = useAttachFormContext();
@@ -28,10 +29,9 @@ export function AttachPlanOptions() {
 	const [versionOpen, setVersionOpen] = useState(false);
 
 	const showVersionSelector = numVersions > 1 && !isMultiPlan;
-	const handleTrialOnEndChange =
-		hasActiveSubscription && !isMultiPlan
-			? (value: "bill" | "revert") => form.setFieldValue("trialOnEnd", value)
-			: undefined;
+	const handleTrialOnEndChange = supportsTrialRevert
+		? (value: TrialOnEnd) => form.setFieldValue("trialOnEnd", value)
+		: undefined;
 
 	return (
 		<div className="flex flex-col gap-4">

--- a/vite/src/components/forms/attach-v2/components/AttachUpdatesSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachUpdatesSection.tsx
@@ -63,14 +63,8 @@ function OutgoingPlans({
 }
 
 export function AttachUpdatesSection() {
-	const {
-		previewQuery,
-		formValues,
-		product,
-		products,
-		hasActiveSubscription,
-		additionalPlans,
-	} = useAttachFormContext();
+	const { previewQuery, formValues, product, products, supportsTrialRevert } =
+		useAttachFormContext();
 
 	const hasProductSelected = !!formValues.productId;
 	const { data: previewData, isPending } = previewQuery;
@@ -85,10 +79,7 @@ export function AttachUpdatesSection() {
 	if (isPending) return <AttachUpdatesSkeleton />;
 	if (!product) return null;
 
-	const isPausing =
-		!additionalPlans.isMultiPlan &&
-		formValues.trialOnEnd === "revert" &&
-		hasActiveSubscription;
+	const isPausing = supportsTrialRevert && formValues.trialOnEnd === "revert";
 
 	return (
 		<SheetSection withSeparator={false} className="pb-0">

--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -7,6 +7,7 @@ import type {
 	FullCustomer,
 	ProductItem,
 	ProductV2,
+	TrialOnEnd,
 } from "@autumn/shared";
 import {
 	ACTIVE_STATUSES,
@@ -85,6 +86,7 @@ interface AttachFormContextValue {
 	previewPrepaidOptions: Record<string, number>;
 
 	hasActiveSubscription: boolean;
+	supportsTrialRevert: boolean;
 	isAutoSelectingImmediateSchedule: boolean;
 	billingOptions: UseAttachBillingOptionsStateReturn;
 
@@ -303,6 +305,13 @@ export function AttachFormProvider({
 	});
 	const { isMultiPlan } = additionalPlans;
 
+	// Reverting needs an existing subscription to fall back to, and multi-plan
+	// attaches don't support it — everywhere else the trial must bill on end.
+	const supportsTrialRevert = hasActiveSubscription && !isMultiPlan;
+	const effectiveTrialOnEnd: TrialOnEnd = supportsTrialRevert
+		? trialOnEnd
+		: "bill";
+
 	// The currency must be offered by every plan being attached, so feed the
 	// hook all selected plans' items — it intersects across charging items.
 	const currencyItems = useMemo(() => {
@@ -380,7 +389,7 @@ export function AttachFormProvider({
 			form.setFieldValue("trialLength", null);
 			form.setFieldValue("trialDuration", FreeTrialDuration.Day);
 			form.setFieldValue("trialCardRequired", true);
-			form.setFieldValue("trialOnEnd", "bill");
+			form.setFieldValue("trialOnEnd", "revert");
 			form.setFieldValue("grantFree", false);
 			form.setFieldValue("currency", null);
 		}
@@ -408,7 +417,7 @@ export function AttachFormProvider({
 				"trialCardRequired",
 				Boolean(product.free_trial.card_required),
 			);
-			form.setFieldValue("trialOnEnd", product.free_trial.on_end ?? "bill");
+			form.setFieldValue("trialOnEnd", product.free_trial.on_end ?? "revert");
 		}
 	}, [productId, product, form]);
 
@@ -474,7 +483,7 @@ export function AttachFormProvider({
 		trialDuration,
 		trialEnabled,
 		trialCardRequired,
-		trialOnEnd,
+		trialOnEnd: effectiveTrialOnEnd,
 		planSchedule,
 		startDate,
 		endDate,
@@ -514,7 +523,7 @@ export function AttachFormProvider({
 		trialDuration,
 		trialEnabled,
 		trialCardRequired,
-		trialOnEnd,
+		trialOnEnd: effectiveTrialOnEnd,
 		prorationBehavior,
 		redirectMode,
 		discounts,
@@ -620,6 +629,7 @@ export function AttachFormProvider({
 			initialPrepaidOptions,
 			previewPrepaidOptions,
 			hasActiveSubscription,
+			supportsTrialRevert,
 			isAutoSelectingImmediateSchedule,
 			billingOptions,
 			additionalPlans,
@@ -654,6 +664,7 @@ export function AttachFormProvider({
 			initialPrepaidOptions,
 			previewPrepaidOptions,
 			hasActiveSubscription,
+			supportsTrialRevert,
 			isAutoSelectingImmediateSchedule,
 			billingOptions,
 			additionalPlans,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachForm.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachForm.ts
@@ -33,7 +33,7 @@ export function useAttachForm({
 			trialDuration: FreeTrialDuration.Day,
 			trialEnabled: false,
 			trialCardRequired: true,
-			trialOnEnd: "bill",
+			trialOnEnd: "revert",
 			planSchedule: null,
 			startDate: null,
 			endDate: null,

--- a/vite/src/components/forms/shared/FreeTrialConfigRow.tsx
+++ b/vite/src/components/forms/shared/FreeTrialConfigRow.tsx
@@ -4,6 +4,7 @@ import type { UseAttachForm } from "@/components/forms/attach-v2/hooks/useAttach
 import { TRIAL_DURATION_OPTIONS } from "@/components/forms/update-subscription-v2/constants/trialConstants";
 import type { UseUpdateSubscriptionForm } from "@/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionForm";
 import { ConfigRow } from "./ConfigRow";
+import { TrialOnEndSelect } from "./TrialOnEndSelect";
 
 const DEFAULT_TRIAL_LENGTH = 7;
 
@@ -26,7 +27,7 @@ export function FreeTrialConfigRow({
 	onToggle: (enabled: boolean) => void;
 	description?: string;
 }) {
-	const showRevert = !!onTrialOnEndChange;
+	const showTrialOnEnd = !!onTrialOnEndChange;
 
 	return (
 		<ConfigRow
@@ -65,7 +66,7 @@ export function FreeTrialConfigRow({
 							/>
 						)}
 					</form.AppField>
-					{!showRevert && (
+					{!showTrialOnEnd && (
 						<div className="mx-2">
 							<TextCheckbox
 								checked={trialCardRequired}
@@ -78,19 +79,16 @@ export function FreeTrialConfigRow({
 						</div>
 					)}
 				</div>
-				{showRevert && (
-					<TextCheckbox
-						checked={trialOnEnd === "revert"}
-						onCheckedChange={(checked) => {
-							const revert = checked as boolean;
-							onTrialOnEndChange(revert ? "revert" : "bill");
-							if (revert) {
+				{showTrialOnEnd && (
+					<TrialOnEndSelect
+						value={trialOnEnd ?? "revert"}
+						onChange={(value) => {
+							onTrialOnEndChange(value);
+							if (value === "revert") {
 								form.setFieldValue("trialCardRequired", false);
 							}
 						}}
-					>
-						Revert to previous plan after trial ends
-					</TextCheckbox>
+					/>
 				)}
 			</div>
 		</ConfigRow>

--- a/vite/src/components/forms/shared/TrialOnEndSelect.tsx
+++ b/vite/src/components/forms/shared/TrialOnEndSelect.tsx
@@ -1,0 +1,70 @@
+import type { TrialOnEnd } from "@autumn/shared";
+import {
+	SearchableSelect,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@autumn/ui";
+import { QuestionIcon } from "@phosphor-icons/react";
+import { CheckIcon } from "lucide-react";
+
+type TrialOnEndOption = {
+	label: string;
+	value: TrialOnEnd;
+	tooltip?: string;
+};
+
+const TRIAL_ON_END_OPTIONS: TrialOnEndOption[] = [
+	{ label: "Revert to previous plan", value: "revert" },
+	{
+		label: "Bill customer",
+		value: "bill",
+		tooltip:
+			"This will add a trial to the stripe subscription. When the trial ends, the billing cycle will be reset and the customer will be charged in full",
+	},
+];
+
+export function TrialOnEndSelect({
+	value,
+	onChange,
+}: {
+	value: TrialOnEnd;
+	onChange: (value: TrialOnEnd) => void;
+}) {
+	return (
+		<div className="flex items-center gap-2">
+			<span className="text-sm font-semibold text-muted-foreground whitespace-nowrap">
+				On trial end
+			</span>
+			<SearchableSelect
+				value={value}
+				onValueChange={(next) => onChange(next as TrialOnEnd)}
+				options={TRIAL_ON_END_OPTIONS}
+				getOptionValue={(option) => option.value}
+				getOptionLabel={(option) => option.label}
+				triggerClassName="w-56"
+				renderOption={(option, isSelected) => (
+					<>
+						<span className="flex flex-1 items-center gap-1.5 min-w-0">
+							<span className="truncate min-w-0">{option.label}</span>
+							{option.tooltip && (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<QuestionIcon
+											className="size-3.5 shrink-0 cursor-help text-tertiary-foreground"
+											onClick={(event) => event.stopPropagation()}
+										/>
+									</TooltipTrigger>
+									<TooltipContent className="max-w-64">
+										{option.tooltip}
+									</TooltipContent>
+								</Tooltip>
+							)}
+						</span>
+						{isSelected && <CheckIcon className="size-4 shrink-0" />}
+					</>
+				)}
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
## What

The attach sheet's **Revert to previous plan after trial ends** checkbox opened unchecked, so adding a trial onto an existing subscription defaulted to billing on end — which resets the billing cycle and prorates away the customer's already-paid time.

- Default is now **Revert** everywhere the control is shown: the form default, the reset when you switch plans, and plans whose own `free_trial` doesn't set `on_end`.
- The checkbox is now an **On trial end** select (`Revert to previous plan` / `Bill customer`). The Bill option has a `?` tooltip: *"This will add a trial to the stripe subscription. When the trial ends, the billing cycle will be reset and the customer will be charged in full"*.

## Request body

Unchanged when the control is hidden. The select still only renders for single-plan attaches on an active subscription; everywhere else there is nothing to revert to, so `AttachFormProvider` forces the sent value back to `bill` and `getFreeTrial` keeps omitting `on_end`.

`hasActiveSubscription && !isMultiPlan` is now a named `supportsTrialRevert` on the attach context, shared by the select and the "pausing" preview icon.

## Note

Attaching a plan that configures its own free trial with no explicit `on_end` will now revert instead of bill. Plans that set `on_end: "bill"` are still respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults trial-on-end behavior to revert to the previous plan instead of billing the customer, and swaps the checkbox for a select. The old checkbox opened unchecked, so adding a trial to an existing subscription billed on end by default, which reset the billing cycle and prorated away already-paid time.

- The new "On trial end" select offers Revert to previous plan and Bill customer; Bill has a tooltip explaining that the billing cycle resets and the customer is charged in full.
- The form initial state, plan-switch resets, and plans whose `free_trial` doesn't set `on_end` now default to "revert"; explicit `on_end: "bill"` plans are still respected.
- When there's no active subscription or on a multi-plan attach, the select stays hidden and the sent value is forced back to "bill".
- Extracted `supportsTrialRevert` (`hasActiveSubscription && !isMultiPlan`) on the attach context, shared by the select and the pausing preview icon.

<sup>Written for commit 9360b2bf6c96b15ab331cb5629ec3b7adf3e7ab5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

