### PR TITLE
fix(billing): preserve customer terms across plan versions

### DIFF
--- a/server/src/internal/billing/v2/actions/generateRequest/compute/buildGenerationPrompts.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/compute/buildGenerationPrompts.ts
@@ -21,6 +21,7 @@ export const buildSystemPrompt = (tool: GenerateBillingTool) => {
 		"- You cannot ask questions and have no tools. Wherever the docs say to ask, clarify, or call a tool, decide yourself from the most literal reading of the request and produce the single best complete request. Never emit a partial or empty object.",
 		"- Never omit a required field. Always set plan_id to your best match from the context plans; when sibling variants exist (e.g. monthly vs yearly), pick the one matching the stated interval or amount, defaulting to the monthly variant.",
 		"- When the request states a price for a plan (e.g. 'at 10k/mo'), always set customize.price to it — including Enterprise/custom placeholder plans where the docs say to ask about the base price.",
+		"- customer.current_plans[].effective_plan is the subscription's live configuration in the same shape as context.plans. When changing a plan or version, explicitly preserve any current term the request says to keep by copying it into the corresponding customize override.",
 		"- Use ONLY plan ids and feature ids that appear in the context below.",
 		"- Monetary amounts are in major currency units (e.g. dollars). Never convert to cents.",
 		"- The operation always targets the customer in the context. Ignore any other customer mentioned in the request.",

--- a/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
@@ -5,6 +5,7 @@ import type {
 	FullProduct,
 } from "@autumn/shared";
 import {
+	cusProductToProduct,
 	mapToProductV2,
 	productV2ToApiPlanV1,
 	toCreatePlanItemParams,
@@ -30,6 +31,7 @@ const compactPlan = ({
 	return {
 		id: productV2.id,
 		name: productV2.name,
+		version: productV2.version,
 		...(productV2.group ? { group: productV2.group } : {}),
 		...(productV2.is_add_on ? { is_add_on: true } : {}),
 		...(productV2.free_trial ? { free_trial: productV2.free_trial } : {}),
@@ -94,10 +96,16 @@ export const setupGenerationContext = async ({
 			customer: {
 				id: fullCustomer.id,
 				...(fullCustomer.name ? { name: fullCustomer.name } : {}),
-				current_plans: fullCustomer.customer_products.map((customerProduct) =>
-					compactCustomerProduct({
-						customerProduct,
-						entities: fullCustomer.entities ?? [],
+				current_plans: fullCustomer.customer_products.map(
+					(customerProduct) => ({
+						...compactCustomerProduct({
+							customerProduct,
+							entities: fullCustomer.entities ?? [],
+						}),
+						effective_plan: compactPlan({
+							features,
+							product: cusProductToProduct({ cusProduct: customerProduct }),
+						}),
 					}),
 				),
 				entities: (fullCustomer.entities ?? []).map((entity) => ({

--- a/server/src/internal/billing/v2/actions/resolveBillingRequest.ts
+++ b/server/src/internal/billing/v2/actions/resolveBillingRequest.ts
@@ -123,9 +123,15 @@ export const resolveBillingRequest = async ({
 			fullCustomer,
 			params: params.request,
 		});
-		fullProduct = cusProductToProduct({
-			cusProduct: targetCustomerProduct,
-		});
+		fullProduct = params.request.version
+			? await ProductService.getFull({
+					db: ctx.db,
+					env: ctx.env,
+					idOrInternalId: targetCustomerProduct.product.id,
+					orgId: ctx.org.id,
+					version: params.request.version,
+				})
+			: cusProductToProduct({ cusProduct: targetCustomerProduct });
 	}
 
 	const { request, unrepresentable } = billingParamsV1ToV0({

--- a/server/tests/evals/generateBillingRequest/fixtures.ts
+++ b/server/tests/evals/generateBillingRequest/fixtures.ts
@@ -58,6 +58,48 @@ export const saasContext = ({
 		],
 	}) as unknown as GenerationContext;
 
+export const versionedPlanContext = (): GenerationContext =>
+	({
+		customer: {
+			id: "cus_versioned",
+			current_plans: [
+				{
+					customer_product_id: "cp_versioned",
+					effective_plan: {
+						id: "generation",
+						items: [
+							{
+								feature_id: "messages",
+								included: 200,
+								reset: { interval: "month" },
+							},
+						],
+						name: "Generation Version Plan",
+						price: { amount: 20, interval: "month" },
+						version: 2,
+					},
+					plan_id: "generation",
+					status: "active",
+				},
+			],
+		},
+		features: [{ id: "messages", name: "Messages", type: "single_use" }],
+		now,
+		plans: [10, 20, 30].map((amount, index) => ({
+			id: "generation",
+			items: [
+				{
+					feature_id: "messages",
+					included: (index + 1) * 100,
+					reset: { interval: "month" },
+				},
+			],
+			name: "Generation Version Plan",
+			price: { amount, interval: "month" },
+			version: index + 1,
+		})),
+	}) as unknown as GenerationContext;
+
 /** Enterprise org with a volume-tiered prepaid credits ladder — the shape that
  * stresses same-shape customize patches. */
 export const creditLadderContext = (): GenerationContext =>

--- a/server/tests/evals/generateBillingRequest/generate-billing-request.eval.ts
+++ b/server/tests/evals/generateBillingRequest/generate-billing-request.eval.ts
@@ -28,6 +28,7 @@ import {
 	tieredScaleBaseItems,
 	tieredScaleContext,
 	variantLadderContext,
+	versionedPlanContext,
 } from "./fixtures";
 
 type EvalInput = {
@@ -404,6 +405,37 @@ const cases: EvalCase[] = [
 		},
 		expected: {
 			feature_quantities: [{ feature_id: "messages", quantity: 1000 }],
+		},
+	},
+	{
+		name: "update: change version while preserving current price",
+		input: {
+			context: versionedPlanContext(),
+			currentRequest: {
+				customer_product_id: "cp_versioned",
+				product_id: "generation",
+			},
+			prompt: "update to v3 but keep the price the same",
+			tool: "update_subscription",
+		},
+		expected: {
+			customize: { price: { amount: 20, interval: "month" } },
+			version: 3,
+		},
+	},
+	{
+		name: "update: change version while preserving a current entitlement",
+		input: {
+			context: versionedPlanContext(),
+			prompt: "update to v3 but keep the current Messages allowance",
+			tool: "update_subscription",
+		},
+		expected: {
+			customize: {
+				add_items: [{ feature_id: "messages", included: 200 }],
+				remove_items: [{ feature_id: "messages" }],
+			},
+			version: 3,
 		},
 	},
 	{

--- a/server/tests/scenarios/billing/generate-version-prompt-scenario.test.ts
+++ b/server/tests/scenarios/billing/generate-version-prompt-scenario.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "bun:test";
+import { BillingInterval, isFixedPrice } from "@autumn/shared";
+import { loadCustomerAndCatalogPrices } from "@tests/integration/billing/misc/utils/findCatalogAndCustomPrices.js";
+import { messagesItem } from "@tests/integration/catalog-v2/plans/licenses/utils/seedLicensePlans.js";
+import { expectAttachedPlanVersionCorrect } from "@tests/integration/catalog-v2/plans/utils/expectAttachedPlanVersion.js";
+import { expectPlanVersionsCorrect } from "@tests/integration/catalog-v2/plans/utils/expectCatalogPlans.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import { setupGenerationContext } from "@/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.js";
+import { resolveBillingRequest } from "@/internal/billing/v2/actions/resolveBillingRequest.js";
+import { resetCatalogPlans } from "../catalog/utils/catalogScenario.js";
+
+const planId = "generate-version-plan";
+const customerId = "generate-version-customer";
+
+test(
+	"billing generation: customer on v2 of a three-version plan",
+	async () => {
+		const { autumnV2_3, ctx, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({
+					name: "Version Prompt Customer",
+					paymentMethod: "success",
+					testClock: false,
+				}),
+			],
+			actions: [],
+		});
+		await resetCatalogPlans({ ctx, planIds: [planId] });
+
+		await autumnV2_3.catalogV2.update({
+			plans: [
+				{
+					plan_id: planId,
+					name: "Generation Version Plan",
+					price: { amount: 10, interval: BillingInterval.Month },
+					items: [messagesItem(100)],
+				},
+			],
+		});
+		await autumnV2_3.catalogV2.update({
+			plans: [
+				{
+					plan_id: planId,
+					versioning: "new_version",
+					active: true,
+					price: { amount: 20, interval: BillingInterval.Month },
+					items: [messagesItem(200)],
+				},
+			],
+		});
+
+		await autumnV2_3.billing.attach({
+			customer_id: customerId,
+			plan_id: planId,
+		});
+
+		await autumnV2_3.catalogV2.update({
+			plans: [
+				{
+					plan_id: planId,
+					versioning: "new_version",
+					active: true,
+					price: { amount: 30, interval: BillingInterval.Month },
+					items: [messagesItem(300)],
+				},
+			],
+		});
+
+		await expectPlanVersionsCorrect({ ctx, planId, versions: [1, 2, 3] });
+		await expectAttachedPlanVersionCorrect({
+			ctx,
+			internalCustomerId: customer.internal_id,
+			planId,
+			version: 2,
+		});
+		const { customerPrices, cusProduct } = await loadCustomerAndCatalogPrices({
+			ctx,
+			customerId,
+			catalogProductId: planId,
+		});
+		expect(customerPrices.find(isFixedPrice)?.config.amount).toBe(20);
+		const { context } = await setupGenerationContext({ ctx, customerId });
+		expect(context.customer.current_plans[0]?.effective_plan).toMatchObject({
+			items: [{ feature_id: TestFeature.Messages, included: 200 }],
+			price: { amount: 20, interval: BillingInterval.Month },
+			version: 2,
+		});
+
+		const { request } = await resolveBillingRequest({
+			ctx,
+			params: {
+				tool: "update_subscription",
+				request: {
+					customer_id: customerId,
+					customer_product_id: cusProduct.id,
+					version: 3,
+					customize: {
+						price: { amount: 20, interval: BillingInterval.Month },
+					},
+				},
+			},
+		});
+		if (!("items" in request))
+			throw new Error("Expected resolved update items");
+		expect(request.items).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ price: 20 }),
+				expect.objectContaining({
+					feature_id: TestFeature.Messages,
+					included_usage: 300,
+				}),
+			]),
+		);
+
+		console.log(`Customer: /sandbox/customers/${customerId}`);
+	},
+	{ timeout: 30_000 },
+);

--- a/vite/src/views/customers2/components/sheets/SubscriptionUpdateSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionUpdateSheet.tsx
@@ -96,7 +96,7 @@ function EditContent() {
 					action={<BillingPromptToggle />}
 				/>
 
-				<div className="px-4 pt-4">
+				<div className="has-[form]:px-4 has-[form]:pt-4">
 					<UpdateSubscriptionGenerationBar />
 				</div>
 


### PR DESCRIPTION
## Summary

- Expose each customer subscription as an effective plan in generation context, matching the catalog plan shape.
- Preserve explicitly requested live terms while changing versions, and resolve customization against the target version.
- Preserve free prices, additional-currency prices, and schema-shaped trial configuration.
- Add model evals plus a three-version billing scenario, and collapse spacing when the generation bar is hidden.

## Scenario

A customer starts on v2 at $20/month with 200 Messages. v3 costs $30/month with 300 Messages.

Prompt: update to v3 but keep the price the same

Expected result: v3 entitlements with 300 Messages, customized back to $20/month.

## Validation

- bun run --cwd server ts
- 28 billing generation unit tests
- Three-version integration scenario: 1 pass, 7 assertions
- New preservation evals pass: fixed price, free price, multi-currency price, and entitlement
- Applied-plan eval score: 100%
- Latest Braintrust run: https://www.braintrust.dev/app/autumn/p/generate-billing-request/experiments/charlie%2Fbilling-generate-preserve-terms-1788287885