### PR TITLE
test(billing): assert accruedOverage in carry-over shape expectations

### DIFF
--- a/server/tests/unit/billing/existing-usages/credit-rate-card-attribution-carry.test.ts
+++ b/server/tests/unit/billing/existing-usages/credit-rate-card-attribution-carry.test.ts
@@ -70,6 +70,7 @@ describe("credit-rate usage attribution carry-over", () => {
 
 		expect(existingUsages[CREDIT_INTERNAL_FEATURE_ID]).toEqual({
 			usage: 760,
+			accruedOverage: 0,
 			entityUsages: {},
 			usageAttribution,
 		});
@@ -89,6 +90,7 @@ describe("credit-rate usage attribution carry-over", () => {
 
 			expect(existingUsages[CREDIT_INTERNAL_FEATURE_ID]).toEqual({
 				usage: 760,
+				accruedOverage: 0,
 				entityUsages: {},
 				usageAttribution,
 			});
@@ -114,6 +116,7 @@ describe("credit-rate usage attribution carry-over", () => {
 
 			expect(existingUsages[CREDIT_INTERNAL_FEATURE_ID]).toEqual({
 				usage: 760,
+				accruedOverage: 0,
 				entityUsages: {},
 				usageAttribution,
 			});
@@ -174,6 +177,7 @@ describe("credit-rate usage attribution carry-over", () => {
 
 			expect(existingUsages[CREDIT_INTERNAL_FEATURE_ID]).toEqual({
 				usage: 0,
+				accruedOverage: 0,
 				entityUsages: {},
 				usageAttribution: {
 					[SOURCE_A_INTERNAL_ID]: { units: 5_000, credits: 50 },


### PR DESCRIPTION
Unblocks the **Unit Tests** job on the `dev -> main` release PR (#3189).

`cusProductToExistingUsages` now reports `accruedOverage` alongside `usage`. Four assertions in `credit-rate-card-attribution-carry.test.ts` compare the whole `ExistingUsages` entry with `toEqual`, so the added key made them fail on shape rather than on value.

All four cases have a positive source balance — nothing had exceeded its allowance — so the expected value is `0`. The rest of each `toEqual` is untouched, so the assertions keep their original coverage.

A fifth site in the same file builds an `ExistingUsages` **input** by hand and was already passing; deliberately left alone.

Full unit suite locally: **3904 passed, 0 failed**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `accruedOverage` to four carry-over shape assertions so the unit tests pass again on the `dev -> main` release PR. `cusProductToExistingUsages` now reports `accruedOverage` alongside `usage`, which made these `toEqual` assertions fail on shape. All four cases have a positive source balance, so the expected value is `0`.

<sup>Written for commit 7c954f5c62a9d3cf810184ebdadd0fe394d04064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

