### PR TITLE
feat/catalog transitions

### DIFF
--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -189,7 +189,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 	};
 
 	const productContexts: MultiAttachProductContext[] = await Promise.all(
-		params.plans.map(async (plan) => {
+		(params.plans ?? []).map(async (plan) => {
 			const scopedFullCustomer = await getScopedFullCustomer(plan.entity_id);
 
 			const { fullProduct, customPrices, customEnts } =
@@ -369,7 +369,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 		featureQuantities: productContexts.flatMap(
 			(productContext) => productContext.featureQuantities,
 		),
-		adjustableFeatureQuantities: params.plans.flatMap(
+		adjustableFeatureQuantities: (params.plans ?? []).flatMap(
 			(plan) =>
 				plan.feature_quantities
 					?.filter((featureQuantity) => featureQuantity.adjustable === true)

--- a/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
+++ b/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
@@ -83,7 +83,7 @@ const upsertFeatures = async ({
 	let changed = false;
 	const skipFeatureIds = new Set(params.skip_feature_ids);
 
-	for (const feature of params.features) {
+	for (const feature of params.features ?? []) {
 		if (skipFeatureIds.has(feature.feature_id)) continue;
 
 		const existing = await FeatureService.get({
@@ -132,7 +132,7 @@ const upsertPlans = async ({
 }) => {
 	const { db, org, env } = ctx;
 	const skipPlanIds = new Set(params.skip_plan_ids);
-	const activePlans = params.plans.filter(
+	const activePlans = (params.plans ?? []).filter(
 		(plan) =>
 			!skipPlanIds.has(plan.plan_id) &&
 			(!plan.new_plan_id || !skipPlanIds.has(plan.new_plan_id)),
@@ -458,7 +458,7 @@ const resolveCatalogUpdateResponse = async ({
 }) => {
 	const { db, org, env } = ctx;
 	const resolvedPlans = await Promise.all(
-		params.plans.map(async (planParams) => {
+		(params.plans ?? []).map(async (planParams) => {
 			const product = await ProductService.getFull({
 				db,
 				idOrInternalId: planParams.new_plan_id ?? planParams.plan_id,
@@ -473,7 +473,7 @@ const resolveCatalogUpdateResponse = async ({
 	);
 
 	const resolvedFeatures = await Promise.all(
-		params.features.map(async (feature) => {
+		(params.features ?? []).map(async (feature) => {
 			const dbFeature = await FeatureService.get({
 				db,
 				orgId: org.id,
@@ -539,7 +539,7 @@ export const updateCatalog = async ({
 		? []
 		: deriveReplacePlanRemovals({
 				products: productsBeforeUpdate,
-				plans: params.plans,
+				plans: params.plans ?? [],
 			}).filter((removal) => !params.skip_plan_ids.includes(removal.planId));
 
 	await upsertFeatures({ ctx, params, products: productsBeforeUpdate });
@@ -551,7 +551,7 @@ export const updateCatalog = async ({
 		? []
 		: deriveReplaceFeatureIds({
 				features: ctx.features,
-				desiredFeatures: params.features,
+				desiredFeatures: params.features ?? [],
 			}).filter((featureId) => !params.skip_feature_ids.includes(featureId));
 	await applyMissingFeatureRemovals({ ctx, featureIds: replaceFeatureIds });
 

--- a/server/src/internal/catalog/actions/validateCatalogVariantUpdates.ts
+++ b/server/src/internal/catalog/actions/validateCatalogVariantUpdates.ts
@@ -1,8 +1,8 @@
 import {
-	ErrCode,
-	RecaseError,
 	type CatalogUpdateParams,
+	ErrCode,
 	type FullProduct,
+	RecaseError,
 } from "@autumn/shared";
 
 export const validateCatalogVariantUpdates = ({
@@ -11,13 +11,13 @@ export const validateCatalogVariantUpdates = ({
 	params: CatalogUpdateParams;
 }) => {
 	const planIds = new Set<string>();
-	for (const plan of params.plans) {
+	for (const plan of params.plans ?? []) {
 		planIds.add(plan.plan_id);
 		if (plan.new_plan_id) planIds.add(plan.new_plan_id);
 	}
 
 	const variantBaseById = new Map<string, string>();
-	for (const plan of params.plans) {
+	for (const plan of params.plans ?? []) {
 		for (const variant of plan.variants ?? []) {
 			if (variant.variant_plan_id === plan.plan_id) {
 				throw new RecaseError({
@@ -76,7 +76,7 @@ export const validateCatalogVariantVersionTargets = ({
 		);
 	}
 
-	for (const plan of params.plans) {
+	for (const plan of params.plans ?? []) {
 		if ((plan.variants ?? []).length === 0) continue;
 		if (plan.version === undefined) continue;
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeInsertFeaturesPlan/computeInsertFeaturesPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeInsertFeaturesPlan/computeInsertFeaturesPlan.ts
@@ -14,7 +14,9 @@ import { validateFeature } from "@/internal/features/utils/validateFeature.js";
 import { generateId } from "@/utils/genUtils.js";
 
 /** Credit systems last so schema refs see metered/boolean rows from this batch. */
-const sortFeaturesForInsert = <T extends { type: string }>(features: T[]): T[] =>
+const sortFeaturesForInsert = <T extends { type: string }>(
+	features: T[],
+): T[] =>
 	[...features].sort((left, right) => {
 		const leftCredit = isAnyCreditSystem(left.type as FeatureType);
 		const rightCredit = isAnyCreditSystem(right.type as FeatureType);
@@ -40,7 +42,7 @@ export const computeInsertFeaturesPlan = ({
 	);
 
 	const entries = sortFeaturesForInsert(
-		params.features.filter(
+		(params.features ?? []).filter(
 			(featureParams) => !originalById.has(featureParams.feature_id),
 		),
 	);

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts
@@ -72,13 +72,20 @@ export const matchingDraftPlanParams = ({
 			upsertMatchesDraftEntry({ upsertProductPlan, planParams }),
 	);
 
+/**
+ * A request-level draft claims every row, leaving `rowCanReceiveMigrationDraft`
+ * and the diff to decide which actually get one — a caller pushing a whole
+ * catalog cannot know which plans hold customers.
+ */
 export const upsertClaimsMigrationDraft = ({
 	upsertProductPlan,
 	params,
 }: {
 	upsertProductPlan: UpsertProductPlan;
 	params: UpdateCatalogParams;
-}): boolean => matchingDraftPlanParams({ upsertProductPlan, params }) != null;
+}): boolean =>
+	params.migration?.draft === true ||
+	matchingDraftPlanParams({ upsertProductPlan, params }) != null;
 
 export const includeCustomForMigrationDraft = ({
 	upsertProductPlan,
@@ -88,4 +95,4 @@ export const includeCustomForMigrationDraft = ({
 	params: UpdateCatalogParams;
 }): boolean =>
 	matchingDraftPlanParams({ upsertProductPlan, params })?.migration
-		?.include_custom === true;
+		?.include_custom === true || params.migration?.include_custom === true;

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts
@@ -66,7 +66,7 @@ export const matchingDraftPlanParams = ({
 	upsertProductPlan: UpsertProductPlan;
 	params: UpdateCatalogParams;
 }): UpdateCatalogPlanParams | undefined =>
-	params.plans.find(
+	(params.plans ?? []).find(
 		(planParams) =>
 			planParams.migration?.draft &&
 			upsertMatchesDraftEntry({ upsertProductPlan, planParams }),

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveFeaturesPlan/resolveAbsenteeFeatureIds.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveFeaturesPlan/resolveAbsenteeFeatureIds.ts
@@ -8,7 +8,7 @@ const statedFeatureIds = ({
 	params: UpdateCatalogParams;
 }): Set<string> =>
 	new Set([
-		...params.features.map((entry) => entry.feature_id),
+		...(params.features ?? []).map((entry) => entry.feature_id),
 		...params.remove_features.map((entry) => entry.feature_id),
 		...params.skip_feature_ids,
 	]);
@@ -25,7 +25,8 @@ const assertNotAWipe = ({
 	params: UpdateCatalogParams;
 	absentFeatureIds: string[];
 }): void => {
-	if (params.features.length > 0 || absentFeatureIds.length === 0) return;
+	if ((params.features ?? []).length > 0 || absentFeatureIds.length === 0)
+		return;
 	throw new RecaseError({
 		code: ErrCode.InvalidRequest,
 		message: `skip_deletions: false with no features would remove all ${absentFeatureIds.length} features. State the features you want, or pass them in skip_feature_ids.`,
@@ -46,6 +47,9 @@ export const resolveAbsenteeFeatureIds = ({
 	params: UpdateCatalogParams;
 }): string[] => {
 	if (params.skip_deletions !== false) return [];
+	// A payload that never mentioned features has no opinion about them — the
+	// rule the legacy path already follows for rewards and referral programs.
+	if (params.features === undefined) return [];
 
 	const stated = statedFeatureIds({ params });
 	const absent = ctx.features

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveProductsPlan/resolveAbsenteePlanTargets.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveProductsPlan/resolveAbsenteePlanTargets.ts
@@ -9,7 +9,7 @@ const statedPlanIds = ({
 	params: UpdateCatalogParams;
 }): Set<string> =>
 	new Set([
-		...params.plans.flatMap((plan) => [
+		...(params.plans ?? []).flatMap((plan) => [
 			plan.plan_id,
 			...(plan.new_plan_id ? [plan.new_plan_id] : []),
 			...(plan.variants ?? []).flatMap((variant) => [
@@ -37,7 +37,7 @@ const assertNotAWipe = ({
 	params: UpdateCatalogParams;
 	absentPlanIds: string[];
 }): void => {
-	if (params.plans.length > 0 || absentPlanIds.length === 0) return;
+	if ((params.plans ?? []).length > 0 || absentPlanIds.length === 0) return;
 	throw new RecaseError({
 		code: ErrCode.InvalidRequest,
 		message: `skip_deletions: false with no plans would remove all ${absentPlanIds.length} plans in the catalog. State the plans you want, or pass them in skip_plan_ids.`,
@@ -58,6 +58,9 @@ export const resolveAbsenteePlanTargets = ({
 	catalogContext: UpdateCatalogContext;
 }): RemovePlanTarget[] => {
 	if (params.skip_deletions !== false) return [];
+	// A payload that never mentioned plans has no opinion about them — the rule
+	// the legacy path already follows for rewards and referral programs.
+	if (params.plans === undefined) return [];
 
 	const stated = statedPlanIds({ params });
 	const absent = Object.entries(

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRenameProductIdsPlan/computeRenameProductIdsPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRenameProductIdsPlan/computeRenameProductIdsPlan.ts
@@ -43,7 +43,7 @@ const renameFromInternalId = ({
 	productStatesContext,
 	aliases,
 }: {
-	planParams: UpdateCatalogParams["plans"][number];
+	planParams: NonNullable<UpdateCatalogParams["plans"]>[number];
 	internalIdRefs: InternalIdRefs;
 	productStatesContext: ProductStatesContext;
 	aliases?: Record<string, string>;
@@ -70,7 +70,7 @@ export const computeRenameProductIdsPlan = ({
 	internalIdRefs: InternalIdRefs;
 	aliases?: Record<string, string>;
 }): RenameProductPlan[] =>
-	params.plans.flatMap((planParams) => [
+	(params.plans ?? []).flatMap((planParams) => [
 		...renameFromInternalId({
 			planParams,
 			internalIdRefs,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpdateFeaturesPlan/computeUpdateFeaturesPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpdateFeaturesPlan/computeUpdateFeaturesPlan.ts
@@ -36,7 +36,7 @@ export const computeUpdateFeaturesPlan = ({
 }): CatalogComputeStep => {
 	const pendingCreditSystemConfigs = new Map<string, Feature["config"]>();
 
-	const updateFeatures = params.features.flatMap((entry) => {
+	const updateFeatures = (params.features ?? []).flatMap((entry) => {
 		const resolved = resolveFeatureUpdateEntry({
 			features: ctx.features,
 			entry,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductsPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductsPlan.ts
@@ -44,7 +44,7 @@ export const computeUpsertProductsPlan = ({
 		internalIdRefs,
 	});
 	const declaredVariants = indexDeclaredVariants({
-		plans: params.plans,
+		plans: params.plans ?? [],
 		productStatesContext,
 	});
 	const claimedProductKeys = claimProductKeys({ intents: pendingIntents });

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/shouldUnlinkDirectVariant.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/shouldUnlinkDirectVariant.ts
@@ -16,7 +16,7 @@ export const indexDeclaredVariants = ({
 	plans,
 	productStatesContext,
 }: {
-	plans: UpdateCatalogParams["plans"];
+	plans: NonNullable<UpdateCatalogParams["plans"]>;
 	productStatesContext: ProductStatesContext;
 }): DeclaredVariantsMap => {
 	const rowToVariantPlanIds = new Map<string, Set<string>>();
@@ -79,5 +79,4 @@ export const declaredParentInternalIdForPlan = ({
 }: {
 	planId: string;
 	declaredVariants?: DeclaredVariantsMap;
-}): string | undefined =>
-	declaredVariants?.variantPlanIdToRow.get(planId);
+}): string | undefined => declaredVariants?.variantPlanIdToRow.get(planId);

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts
@@ -20,7 +20,7 @@ const groupPlanParamsByPlanId = ({
 	planParamsList,
 	internalIdRefs,
 }: {
-	planParamsList: UpdateCatalogParams["plans"];
+	planParamsList: NonNullable<UpdateCatalogParams["plans"]>;
 	internalIdRefs: InternalIdRefs;
 }): Map<string, UpdateCatalogPlanParams[]> => {
 	const byPlanId = new Map<string, UpdateCatalogPlanParams[]>();
@@ -159,7 +159,7 @@ export const deriveDirectIntents = ({
 }): ProductUpsertIntent[] =>
 	[
 		...groupPlanParamsByPlanId({
-			planParamsList: params.plans,
+			planParamsList: params.plans ?? [],
 			internalIdRefs,
 		}).entries(),
 	]

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/mergeDeclaredProcessors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/mergeDeclaredProcessors.ts
@@ -19,7 +19,7 @@ const currentPlanId = ({
 	entry,
 	internalIdRefs,
 }: {
-	entry: UpdateCatalogParams["plans"][number];
+	entry: NonNullable<UpdateCatalogParams["plans"]>[number];
 	internalIdRefs: InternalIdRefs;
 }): string =>
 	(entry.internal_id
@@ -99,7 +99,7 @@ const assertRevenueCatMappingsAgree = ({
 	plans,
 	internalIdRefs,
 }: {
-	plans: UpdateCatalogParams["plans"];
+	plans: NonNullable<UpdateCatalogParams["plans"]>;
 	internalIdRefs: InternalIdRefs;
 }): void => {
 	const statedByPlanId = new Map<string, ApiRevenueCatPlanProcessor | null>();
@@ -120,7 +120,7 @@ const indexStatedStripe = ({
 	plans,
 	internalIdRefs,
 }: {
-	plans: UpdateCatalogParams["plans"];
+	plans: NonNullable<UpdateCatalogParams["plans"]>;
 	internalIdRefs: InternalIdRefs;
 }): StatedStripeIndex => {
 	const byPlanId = new Map<string, StatedStripe>();
@@ -163,7 +163,7 @@ const indexBasePlanIds = ({
 	plans,
 	productStatesContext,
 }: {
-	plans: UpdateCatalogParams["plans"];
+	plans: NonNullable<UpdateCatalogParams["plans"]>;
 	productStatesContext: ProductStatesContext;
 }): Map<string, string> => {
 	const basePlanIdByPlanId = new Map<string, string>();
@@ -251,10 +251,10 @@ export const mergeDeclaredProcessors = ({
 	productStatesContext: ProductStatesContext;
 	internalIdRefs: InternalIdRefs;
 }): ProductUpsertIntent[] => {
-	assertRevenueCatMappingsAgree({ plans: params.plans, internalIdRefs });
+	assertRevenueCatMappingsAgree({ plans: params.plans ?? [], internalIdRefs });
 
 	const statedStripe = indexStatedStripe({
-		plans: params.plans,
+		plans: params.plans ?? [],
 		internalIdRefs,
 	});
 	if (
@@ -265,7 +265,7 @@ export const mergeDeclaredProcessors = ({
 	}
 
 	const basePlanIdByPlanId = indexBasePlanIds({
-		plans: params.plans,
+		plans: params.plans ?? [],
 		productStatesContext,
 	});
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/assertInternalIdAgrees.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/assertInternalIdAgrees.ts
@@ -18,7 +18,7 @@ export const assertInternalIdAgrees = ({
 	productStatesContext: ProductStatesContext;
 	internalIdRefs: InternalIdRefs;
 }): void => {
-	for (const planParams of params.plans) {
+	for (const planParams of params.plans ?? []) {
 		const { internal_id: internalId } = planParams;
 		if (!internalId) continue;
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/detectOrphanedActivePointers.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/detectOrphanedActivePointers.ts
@@ -23,11 +23,17 @@ const rowsByPlanId = ({
  * Projected plans still holding a live version while the version customers
  * attach to is archived. Archiving every version is a plan going away and is
  * left alone.
+ *
+ * Pinned `remove_plans` is exempt: it deliberately archives one version and
+ * leaves the pointer where it was (`version-identity-remove.test.ts:107`), and
+ * that is the remove machinery's call to make, not this one's.
  */
 export const detectOrphanedActivePointers = ({
 	products,
+	removedKeys,
 }: {
 	products: FullProduct[];
+	removedKeys: Set<string>;
 }): OrphanedActivePointer[] => {
 	const orphaned: OrphanedActivePointer[] = [];
 
@@ -37,6 +43,7 @@ export const detectOrphanedActivePointers = ({
 
 		const activeRow = rows.find((row) => row.active);
 		if (!activeRow?.archived) continue;
+		if (removedKeys.has(`${planId}:${activeRow.version}`)) continue;
 
 		orphaned.push({ planId, version: activeRow.version });
 	}

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/detectOrphanedActivePointers.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/detectOrphanedActivePointers.ts
@@ -1,0 +1,45 @@
+import type { FullProduct } from "@autumn/shared";
+
+export type OrphanedActivePointer = {
+	planId: string;
+	version: number;
+};
+
+const rowsByPlanId = ({
+	products,
+}: {
+	products: FullProduct[];
+}): Map<string, FullProduct[]> => {
+	const byPlanId = new Map<string, FullProduct[]>();
+	for (const product of products) {
+		const group = byPlanId.get(product.id) ?? [];
+		group.push(product);
+		byPlanId.set(product.id, group);
+	}
+	return byPlanId;
+};
+
+/**
+ * Projected plans still holding a live version while the version customers
+ * attach to is archived. Archiving every version is a plan going away and is
+ * left alone.
+ */
+export const detectOrphanedActivePointers = ({
+	products,
+}: {
+	products: FullProduct[];
+}): OrphanedActivePointer[] => {
+	const orphaned: OrphanedActivePointer[] = [];
+
+	for (const [planId, rows] of rowsByPlanId({ products })) {
+		const survivesArchive = rows.some((row) => !row.archived);
+		if (!survivesArchive) continue;
+
+		const activeRow = rows.find((row) => row.active);
+		if (!activeRow?.archived) continue;
+
+		orphaned.push({ planId, version: activeRow.version });
+	}
+
+	return orphaned;
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleActivePointerErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleActivePointerErrors.ts
@@ -10,6 +10,11 @@ export const handleActivePointerErrors = ({
 }): void => {
 	const [orphaned] = detectOrphanedActivePointers({
 		products: updateCatalogPlan.projected.products,
+		removedKeys: new Set(
+			updateCatalogPlan.removePlans.map(
+				(removePlan) => `${removePlan.planId}:${removePlan.version}`,
+			),
+		),
 	});
 	if (!orphaned) return;
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleActivePointerErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleActivePointerErrors.ts
@@ -1,0 +1,21 @@
+import { ErrCode, RecaseError } from "@autumn/shared";
+import { detectOrphanedActivePointers } from "@/internal/catalogV2/actions/updateCatalog/errors/detectOrphanedActivePointers";
+import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
+
+/** A plan keeping live versions must keep a live active one to attach to. */
+export const handleActivePointerErrors = ({
+	updateCatalogPlan,
+}: {
+	updateCatalogPlan: UpdateCatalogPlan;
+}): void => {
+	const [orphaned] = detectOrphanedActivePointers({
+		products: updateCatalogPlan.projected.products,
+	});
+	if (!orphaned) return;
+
+	throw new RecaseError({
+		message: `Cannot archive version ${orphaned.version} of plan ${orphaned.planId} while it is the active version and other versions remain. Promote another version first, or archive the whole plan.`,
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+	});
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleDeclaredVariantAnchorErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleDeclaredVariantAnchorErrors.ts
@@ -13,7 +13,7 @@ export const handleDeclaredVariantAnchorErrors = ({
 }): void => {
 	const parentByVariantKey = new Map<string, string>();
 
-	for (const entry of params.plans) {
+	for (const entry of params.plans ?? []) {
 		if (entry.variants === undefined) continue;
 		const parent = fullProductForPlanParams({
 			planParams: entry,

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
@@ -7,6 +7,7 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { assertInternalIdAgrees } from "@/internal/catalogV2/actions/updateCatalog/errors/assertInternalIdAgrees";
+import { handleActivePointerErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleActivePointerErrors";
 import { handleDeclaredVariantAnchorErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleDeclaredVariantAnchorErrors";
 import { handleLicenseAnchorLifecycleErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleLicenseAnchorLifecycleErrors";
 import { handleRemoveFeatureErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleRemoveFeatureErrors/handleRemoveFeatureErrors";
@@ -177,6 +178,7 @@ export const handleUpdateCatalogErrors = async ({
 	});
 	handleUpsertProductVersionSlugErrors({ updateCatalogPlan });
 	handleUpsertProductActiveErrors({ params });
+	handleActivePointerErrors({ updateCatalogPlan });
 	handleUpsertProductErrors({
 		updateCatalogPlan,
 		productStatesContext: catalogContext.productStatesContext,

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductActiveErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductActiveErrors.ts
@@ -8,7 +8,7 @@ export const handleUpsertProductActiveErrors = ({
 }): void => {
 	const planIdsTakingPointer = new Set<string>();
 
-	for (const planParams of params.plans) {
+	for (const planParams of params.plans ?? []) {
 		const allVersionsActive =
 			planParams.versioning === "all_versions" && planParams.active === true;
 		if (allVersionsActive) {
@@ -31,7 +31,7 @@ export const handleUpsertProductActiveErrors = ({
 		planIdsTakingPointer.add(planParams.plan_id);
 	}
 
-	for (const planParams of params.plans) {
+	for (const planParams of params.plans ?? []) {
 		if (planParams.active !== false) continue;
 		if (planIdsTakingPointer.has(planParams.plan_id)) continue;
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductRenameErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductRenameErrors.ts
@@ -1,8 +1,4 @@
-import {
-	ErrCode,
-	RecaseError,
-	type UpdateCatalogParams,
-} from "@autumn/shared";
+import { ErrCode, RecaseError, type UpdateCatalogParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
@@ -18,7 +14,7 @@ const renameTargetsFromParams = ({
 }: {
 	params: UpdateCatalogParams;
 }): RenameTarget[] =>
-	params.plans.flatMap((planParams) => [
+	(params.plans ?? []).flatMap((planParams) => [
 		...(planParams.new_plan_id && planParams.new_plan_id !== planParams.plan_id
 			? [{ fromId: planParams.plan_id, toId: planParams.new_plan_id }]
 			: []),
@@ -60,7 +56,7 @@ const takenPlanIdsForRename = ({
 	const persistedProducts = Object.values(
 		productStatesContext.versionsByPlanId,
 	).flat();
-	const siblingPlanIds = params.plans.flatMap((entry) => [
+	const siblingPlanIds = (params.plans ?? []).flatMap((entry) => [
 		...(entry.plan_id === fromId ? [] : [entry.plan_id]),
 		...(entry.variants ?? [])
 			.map((variant) => variant.variant_plan_id)

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts
@@ -120,7 +120,7 @@ export const handleUpsertProductVersioningErrors = ({
 	const unpinnedPlanIds = new Set<string>();
 	const mintedVersionsByPlanId = new Map<string, number>();
 
-	for (const planParams of params.plans) {
+	for (const planParams of params.plans ?? []) {
 		if (planParams.versioning === "new_version") {
 			if (
 				planParams.version !== undefined ||

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/preview/setupFeatureUsagePersisted.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/preview/setupFeatureUsagePersisted.ts
@@ -82,7 +82,7 @@ export const setupFeatureUsagePersisted = async ({
 		};
 	}
 
-	for (const entry of params.features) {
+	for (const entry of params.features ?? []) {
 		if (!summaries[entry.feature_id]) {
 			summaries[entry.feature_id] = emptyPersistedFeatureUsage();
 		}

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/resolveInternalIdRefs.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/resolveInternalIdRefs.ts
@@ -15,7 +15,7 @@ export const statedInternalIds = ({
 	params: UpdateCatalogParams;
 }): string[] => [
 	...new Set(
-		params.plans.flatMap((plan) => [
+		(params.plans ?? []).flatMap((plan) => [
 			...(plan.internal_id ? [plan.internal_id] : []),
 			...(plan.variants ?? []).flatMap((variant) =>
 				variant.internal_id ? [variant.internal_id] : [],

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/setupFeatureStatesContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/setupFeatureStatesContext.ts
@@ -49,7 +49,7 @@ export const setupFeatureStatesContext = async ({
 	});
 
 	const entryByFeatureId = new Map(
-		params.features.map((entry) => [entry.feature_id, entry]),
+		(params.features ?? []).map((entry) => [entry.feature_id, entry]),
 	);
 
 	const stateRows = await listFeatureStates({

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/setupInvoiceCreditProducts.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/setupInvoiceCreditProducts.ts
@@ -21,7 +21,7 @@ export const setupInvoiceCreditProducts = async ({
 	ctx: AutumnContext;
 	params: UpdateCatalogParams;
 }): Promise<FullProduct[]> => {
-	const internalFeatureIds = params.features.flatMap((entry) => {
+	const internalFeatureIds = (params.features ?? []).flatMap((entry) => {
 		if (entry.invoice_credit !== true) return [];
 		const feature = ctx.features.find(
 			(candidate) => candidate.id === entry.feature_id,

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/setupProductStatesContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/setupProductStatesContext.ts
@@ -28,7 +28,7 @@ const payloadPlanIds = ({
 	...new Set([
 		// A renamed row's current id is only known through its internal_id.
 		...[...internalIdRefs.values()].map((ref) => ref.planId),
-		...params.plans.flatMap((entry) => [
+		...(params.plans ?? []).flatMap((entry) => [
 			entry.plan_id,
 			...(entry.new_plan_id ? [entry.new_plan_id] : []),
 			...(typeof entry.base_variant_id === "string"

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/paramsToTouchedFeatures.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/paramsToTouchedFeatures.ts
@@ -9,7 +9,7 @@ export const paramsToTouchedFeatures = ({
 	params: UpdateCatalogParams;
 }): Feature[] => {
 	const touchedFeatureIds = new Set([
-		...params.features.map((entry) => entry.feature_id),
+		...(params.features ?? []).map((entry) => entry.feature_id),
 		...params.remove_features.map((entry) => entry.feature_id),
 	]);
 	return features.filter((feature) => touchedFeatureIds.has(feature.id));

--- a/server/tests/integration/catalog-v2/plans/full-state/full-state-absent-collections.test.ts
+++ b/server/tests/integration/catalog-v2/plans/full-state/full-state-absent-collections.test.ts
@@ -1,0 +1,155 @@
+/**
+ * catalogV2.update — under full state, a collection the payload never mentions
+ * is not managed by that payload.
+ *
+ * Full state means "what I state is the whole truth" — but only for the kinds
+ * of thing the caller actually spoke about. A client that has never heard of a
+ * catalog concept sends no key for it, and that must not read as "I have zero
+ * of those, delete them all". Otherwise every concept Autumn adds after a CLI
+ * ships turns that CLI into a deleter of things it cannot see.
+ *
+ * The legacy path already works this way — `catalogConfigResources.ts:233`
+ * gates its sweep on `params.rewards !== undefined`, and legacy's schema leaves
+ * `rewards` / `referral_programs` optional with no default. catalogV2's
+ * `features` and `plans` carry `.optional().default([])`, which erases the
+ * difference between "omitted" and "empty" before anyone can ask.
+ *
+ * Contract:
+ *   G1  stating plans while omitting features leaves features alone
+ *   G2  stating features while omitting plans leaves plans alone
+ *   G3  an explicit empty array still means "I manage this and it is empty",
+ *       so the wipe backstop still fires — omission and [] are not the same
+ *
+ * Red (current): the zod default turns an absent key into [], so the absentee
+ *   sweep runs over the whole collection and G1/G2 delete.
+ * Green (after): the sweep is skipped for a collection nobody stated.
+ */
+
+import { expect, test } from "bun:test";
+import { FeatureType } from "@autumn/shared";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+
+const booleanFeature = (featureId: string) => ({
+	feature_id: featureId,
+	name: featureId,
+	type: FeatureType.Boolean,
+});
+
+const featureExists = async ({
+	ctx,
+	featureId,
+}: {
+	ctx: AutumnContext;
+	featureId: string;
+}): Promise<boolean> => {
+	const features = await FeatureService.list({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+	return features.some(
+		(feature) => feature.id === featureId && !feature.archived,
+	);
+};
+
+const planExists = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}): Promise<boolean> => {
+	const product = await ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		allowNotFound: true,
+	});
+	return Boolean(product) && !product?.archived;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 full-state: a collection the payload omits is left alone")}`,
+	async () => {
+		// Full state speaks for a whole org, so it needs an org of its own.
+		const { autumnV2_3, ctx } = await initScenario({
+			setup: [
+				s.platform.create({
+					userEmail: `${uniqueTestId("fs")}@autumn.test`,
+				}),
+			],
+			actions: [],
+		});
+		const featureId = uniqueTestId("fs_absent_feat");
+		const planId = uniqueTestId("fs_absent_plan");
+
+		await autumnV2_3.catalogV2.update({
+			features: [booleanFeature(featureId)],
+			plans: [{ plan_id: planId, name: "Kept", items: [] }],
+		});
+
+		// G1: full state, but the payload only ever speaks about plans. Features
+		// were never mentioned, so this payload has no opinion about them.
+		await autumnV2_3.catalogV2.update({
+			skip_deletions: false,
+			plans: [{ plan_id: planId, name: "Kept", items: [] }],
+		});
+
+		expect(
+			await featureExists({ ctx, featureId }),
+			"unmentioned collection survived",
+		).toBe(true);
+
+		// G2: the same, the other way round.
+		await autumnV2_3.catalogV2.update({
+			skip_deletions: false,
+			features: [booleanFeature(featureId)],
+		});
+
+		expect(
+			await planExists({ ctx, planId }),
+			"unmentioned plans survived",
+		).toBe(true);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 full-state: an explicit empty collection is still managed")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({
+			setup: [
+				s.platform.create({
+					userEmail: `${uniqueTestId("fs")}@autumn.test`,
+				}),
+			],
+			actions: [],
+		});
+		const featureId = uniqueTestId("fs_stated_empty");
+
+		await autumnV2_3.catalogV2.update({
+			features: [booleanFeature(featureId)],
+			plans: [],
+		});
+
+		// G3: stating `features: []` is a claim about features — "I manage them
+		// and there are none" — which is the wipe the backstop exists to refuse.
+		// If omission and [] were the same thing, this would pass silently.
+		const wipe = autumnV2_3.catalogV2.update({
+			skip_deletions: false,
+			features: [],
+			plans: [],
+		});
+		await expect(wipe).rejects.toThrow();
+
+		expect(
+			await featureExists({ ctx, featureId }),
+			"stated-empty was refused, not applied",
+		).toBe(true);
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/full-state/minimal-push-touches-nothing.test.ts
+++ b/server/tests/integration/catalog-v2/plans/full-state/minimal-push-touches-nothing.test.ts
@@ -1,0 +1,86 @@
+/**
+ * catalogV2.update — a payload that mentions one field changes one field.
+ *
+ * Every field in the upsert path is gated on `!== undefined`, so omission means
+ * "unchanged". That is a convention held up by every writer choosing to follow
+ * it, and the schema test can only see the schema half: someone writing
+ * `bomboclart: planParams.bomboclart ?? []` inside a resolver would wipe the
+ * field with a perfectly clean schema.
+ *
+ * This is the other half of that net. It states nothing but a name against a
+ * fully-loaded plan and asserts everything else survived, so it fails for any
+ * field anyone adds later that reads absence as "empty" — including fields
+ * that do not exist yet, which is the entire point.
+ *
+ * Contract:
+ *   H1  items survive a push that never mentions them
+ *   H2  the base price survives
+ *   H3  the free trial survives
+ *   H4  the stated field does change, so the push was real
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	FreeTrialDuration,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 omission: a name-only push leaves every unmentioned field alone")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_minimal");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Loaded",
+						price: { amount: 20, interval: BillingInterval.Month },
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+							card_required: true,
+						},
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			// Everything except the name is absent. Under "omission is unchanged"
+			// this is a rename and nothing else.
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Renamed" }],
+			});
+
+			const full = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: planId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+
+			expect(full.name, "H4: the stated field changed").toBe("Renamed");
+			expect(full.entitlements.length, "H1: items survived").toBe(1);
+			expect(full.prices.length, "H2: base price survived").toBe(1);
+			expect(full.free_trial?.length, "H3: free trial survived").toBe(14);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/migrations/auto-draft.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/auto-draft.test.ts
@@ -1,0 +1,158 @@
+/**
+ * catalogV2.update — the server decides which rows need a migration draft.
+ *
+ * A draft has only ever appeared when the caller set `migration: { draft: true }`
+ * on the very entry it wanted drafted, which means the caller had to work out
+ * which plans carry customers. A config-file client cannot: it pushes the whole
+ * catalog and knows nothing about who is on what. Request-level `migration`
+ * says "draft wherever one is warranted" and hands that judgement to the
+ * server, which already answers it per row.
+ *
+ * Contract:
+ *   E1  a request-level draft covers a customered row no entry named
+ *   E2  the same push drafts nothing for a plan with no customers
+ *   E3  both edits still land in place — neither mints a version
+ *   E4  without the flag nothing drafts, so existing callers are untouched
+ *
+ * Red (current): the claim is per-entry only, so a request-level flag is
+ *   ignored and E1 finds no migration at all.
+ * Green (after): the request-level flag claims every row, and the existing row
+ *   gate — customers, not a mint, neither side archived, non-empty diff —
+ *   decides which of them actually produces one.
+ */
+
+import { test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { cleanupPlanCustomerRefs } from "../utils/cleanupPlanCustomerRefs.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+import {
+	deleteMigrations,
+	expectUpdateMigrations,
+} from "./utils/expectMigrationDrafts.js";
+import { seedVersionableCustomer } from "./utils/seedVersionableCustomer.js";
+
+const messagesItem = ({ included }: { included: number }) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 migration: a request-level draft covers the customered row only")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const customeredId = uniqueTestId("cv2_auto_held");
+		const quietId = uniqueTestId("cv2_auto_quiet");
+		await deleteDbPlans({ ctx, planIds: [customeredId, quietId] });
+
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: customeredId,
+						name: "Held",
+						items: [messagesItem({ included: 100 })],
+					},
+					{
+						plan_id: quietId,
+						name: "Quiet",
+						items: [messagesItem({ included: 100 })],
+					},
+				],
+			});
+			await seedVersionableCustomer({ ctx, planId: customeredId, version: 1 });
+
+			// Neither entry asks for a draft — the request as a whole does, which is
+			// all a config push can say. Only `customeredId` has anyone to move.
+			const response = await autumnV2_3.catalogV2.update({
+				migration: { draft: true },
+				plans: [
+					{ plan_id: customeredId, items: [messagesItem({ included: 250 })] },
+					{ plan_id: quietId, items: [messagesItem({ included: 250 })] },
+				],
+			});
+
+			// E1 + E2: exactly one draft, and it names the customered row.
+			expectUpdateMigrations({
+				response,
+				plans: [[{ plan_id: customeredId, versions: [1] }]],
+			});
+
+			// E3: a draft is what happens INSTEAD of blocking, so both edits applied
+			// to the row that was already there.
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: customeredId,
+						version: 1,
+						allowances: { [TestFeature.Messages]: 250 },
+					},
+					{
+						id: quietId,
+						version: 1,
+						allowances: { [TestFeature.Messages]: 250 },
+					},
+				],
+			});
+		} finally {
+			await deleteMigrations({ ctx, ids: [customeredId] });
+			await cleanupPlanCustomerRefs({
+				ctx,
+				planIds: [customeredId, quietId],
+			});
+			await deleteDbPlans({ ctx, planIds: [customeredId, quietId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 migration: a push with no migration params still drafts nothing")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_auto_optout");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Opt Out",
+						items: [messagesItem({ included: 100 })],
+					},
+				],
+			});
+			await seedVersionableCustomer({ ctx, planId, version: 1 });
+
+			// E4: the shape every existing caller sends. The row would qualify for a
+			// draft on every count except that nothing asked for one.
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, items: [messagesItem({ included: 250 })] }],
+			});
+
+			expectUpdateMigrations({ response, plans: [] });
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						allowances: { [TestFeature.Messages]: 250 },
+					},
+				],
+			});
+		} finally {
+			await deleteMigrations({ ctx, ids: [planId] });
+			await cleanupPlanCustomerRefs({ ctx, planIds: [planId] });
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/validation/transition-impossibilities.test.ts
+++ b/server/tests/integration/catalog-v2/plans/validation/transition-impossibilities.test.ts
@@ -1,0 +1,176 @@
+/**
+ * catalogV2.update — the one state no derivation can make coherent.
+ *
+ * Most of what looks like a rejection is really an outcome the server works
+ * out: an edit to a customered row needs a migration, an unknown slug mints,
+ * an absent plan is removed. What is left over is a payload describing a
+ * catalog that cannot exist, and that has to be an error because there is
+ * nothing correct to derive.
+ *
+ * Of the five candidates, four were already covered: two rows claiming active
+ * (handleUpsertProductActiveErrors), a slug landing on a row that still holds
+ * it (handleUpsertProductVersionSlugErrors, over the projected set so swaps
+ * stay legal), a variant orphaned by a base removal
+ * (handleRemovePlanVariantErrors), and a rename moving only part of a plan —
+ * which turns out to be unreachable, since an internal_id rename resolves to a
+ * plan-level rename that carries every version.
+ *
+ * Contract:
+ *   F1  archiving the active row while a live sibling remains is rejected —
+ *       the pointer would name a version nothing can attach to
+ *   F2  archiving every row of a plan still works, which is why F1 has to be
+ *       a rule about the pointer and not about archiving
+ *   F3  an internal_id rename carries the plan's whole history, pointer
+ *       included — the row addressed is the handle, not the scope
+ *
+ * Red (current): nothing inspects the projected active pointer, so F1 is
+ *   accepted and the plan is left current-versionless.
+ * Green (after): F1 is a 400 naming the row in the way.
+ */
+
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { withCatalogPlans } from "../licenses/utils/seedLicensePlans.js";
+
+const messagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+});
+
+const versionRow = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	version: number;
+}) =>
+	ProductService.get({
+		db: ctx.db,
+		id: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		version,
+	});
+
+/** Mint `count` versions, each taking the active pointer as it lands. */
+const seedVersions = async ({
+	autumn,
+	planId,
+	count,
+}: {
+	autumn: AutumnInt;
+	planId: string;
+	count: number;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: planId, name: "Seeded", items: [messagesItem(100)] }],
+	});
+	for (let version = 2; version <= count; version++) {
+		await autumn.catalogV2.update({
+			plans: [
+				{
+					plan_id: planId,
+					items: [messagesItem(100 * version)],
+					versioning: "new_version",
+					active: true,
+				},
+			],
+		});
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 transitions: archiving the active row is refused while a live sibling remains")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_imp_ptr");
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await seedVersions({ autumn: autumnV2_3, planId, count: 2 });
+
+				// F1: v2 holds the pointer. Archiving only v2 leaves the plan live —
+				// v1 is still there — pointing at a version nothing can attach to.
+				const orphanedPointer = autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: planId, version: 2, archived: true }],
+				});
+				await expect(orphanedPointer).rejects.toThrow();
+
+				expect(
+					(await versionRow({ ctx, planId, version: 2 }))?.archived,
+					"rejected push changed nothing",
+				).toBe(false);
+
+				// F2: the same archive is fine once nothing is left behind. This is
+				// what stops F1 from being a rule about archiving at all.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{ plan_id: planId, version: 1, archived: true },
+						{ plan_id: planId, version: 2, archived: true },
+					],
+				});
+
+				expect(
+					(await versionRow({ ctx, planId, version: 2 }))?.archived,
+					"whole-plan archive still allowed",
+				).toBe(true);
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 transitions: an internal_id rename carries the whole plan's history")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_imp_carry");
+		const renamedId = `${planId}_renamed`;
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId, renamedId],
+			run: async () => {
+				await seedVersions({ autumn: autumnV2_3, planId, count: 3 });
+				const v3 = await versionRow({ ctx, planId, version: 3 });
+
+				// F3: the config addresses ONE row and states a new plan_id. That is a
+				// handle, not a scope — the whole plan moves, so history cannot split
+				// across two ids and there is no partial-move case to guard.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: renamedId,
+							internal_id: v3?.internal_id,
+							name: "Carried",
+						},
+					],
+				});
+
+				for (const version of [1, 2, 3]) {
+					expect(
+						(await versionRow({ ctx, planId, version }))?.id,
+						`v${version} left the old id`,
+					).toBeUndefined();
+					expect(
+						(await versionRow({ ctx, planId: renamedId, version }))?.id,
+						`v${version} arrived under the new id`,
+					).toBe(renamedId);
+				}
+				expect(
+					(await versionRow({ ctx, planId: renamedId, version: 3 }))?.active,
+					"the pointer came with it",
+				).toBe(true);
+			},
+		});
+	},
+);

--- a/server/tests/unit/catalogV2/catalogParamsHaveNoDefaults.test.ts
+++ b/server/tests/unit/catalogV2/catalogParamsHaveNoDefaults.test.ts
@@ -1,0 +1,149 @@
+/**
+ * A catalog request field must not carry a schema default.
+ *
+ * A default is applied before any `!== undefined` gate can run, so it erases
+ * the difference between "the caller omitted this" and "the caller set this
+ * explicitly". Everywhere in the upsert path that difference IS the semantics:
+ * `planParamsToProductRowPatch` only writes fields that are defined, and
+ * `computeCatalogEntitlementPricesPlan` produces no writes at all when `items`
+ * is absent. Under `skip_deletions: false` it is the difference between "I
+ * have no opinion about features" and "delete every feature".
+ *
+ * That was a live bug: `features` and `plans` carried `.optional().default([])`,
+ * so a client that had never heard of a collection was indistinguishable from
+ * one demanding it be emptied.
+ *
+ * Anything on ALLOWED_DEFAULTS is a field whose default IS its meaning and
+ * which nothing needs to detect the absence of. Adding to it should be a
+ * deliberate act with a reason, which is the point of the list being here.
+ */
+
+import { expect, test } from "bun:test";
+import { UpdateCatalogParamsSchema } from "@autumn/shared";
+import chalk from "chalk";
+
+/**
+ * field path → why a default is safe here.
+ *
+ * Two shapes qualify. Top-level fields whose default IS their meaning, with no
+ * third state to detect. And fields nested inside an object that is itself
+ * presence-gated — you only reach `auto_topups.enabled` by stating
+ * `auto_topups`, and stating the parent is the command. A top-level collection
+ * has no such parent, which is exactly why `features` and `plans` were wrong.
+ *
+ * The gated ones still carry a smaller version of the same risk: add a field
+ * under `auto_topups` with a default and a client that states `auto_topups`
+ * without it loses that field. Worth knowing before adding one.
+ */
+const ALLOWED_DEFAULTS: Record<string, string> = {
+	skip_deletions: "absent means patch mode; there is no third state",
+	skip_plan_ids: "an exemption list nobody sweeps",
+	skip_feature_ids: "an exemption list nobody sweeps",
+	remove_plans: "imperative removals; absent and empty both mean 'none'",
+	remove_features: "imperative removals; absent and empty both mean 'none'",
+
+	// Gated by their parent's presence.
+	"plans.migration.draft": "gated by `migration`",
+	"plans.config.ignore_past_due": "gated by `config`",
+	"plans.free_trial.card_required": "gated by `free_trial`",
+	"plans.free_trial.duration_type": "gated by `free_trial`",
+	"plans.items.pooled": "gated by `items`",
+	"plans.items.price.billing_units": "gated by `items[].price`",
+	"plans.items.price.interval_count": "gated by `items[].price`",
+	"plans.billing_controls.auto_topups.enabled": "gated by `billing_controls`",
+	"plans.billing_controls.auto_topups.purchase_limit.interval_count":
+		"gated by `billing_controls`",
+	"plans.billing_controls.spend_limits.enabled": "gated by `billing_controls`",
+	"plans.billing_controls.usage_limits.enabled": "gated by `billing_controls`",
+	"plans.billing_controls.usage_alerts.enabled": "gated by `billing_controls`",
+	"plans.billing_controls.overage_allowed.enabled":
+		"gated by `billing_controls`",
+};
+
+type SchemaNode = {
+	_zod?: { def?: Record<string, unknown> };
+	def?: Record<string, unknown>;
+};
+
+const definitionOf = (node: unknown): Record<string, unknown> | undefined => {
+	const candidate = node as SchemaNode | null;
+	return candidate?._zod?.def ?? candidate?.def;
+};
+
+/** Field paths under `schema` whose definition chain includes a default. */
+const defaultedPaths = ({
+	schema,
+	path = "",
+	seen = new Set<unknown>(),
+}: {
+	schema: unknown;
+	path?: string;
+	seen?: Set<unknown>;
+}): string[] => {
+	if (schema === null || typeof schema !== "object") return [];
+	if (seen.has(schema)) return [];
+	seen.add(schema);
+
+	const def = definitionOf(schema);
+	if (!def) return [];
+
+	const found: string[] = [];
+	if (def.type === "default" || def.type === "prefault") {
+		if (path) found.push(path);
+	}
+
+	// Unwrap optional/nullable/default/array/etc. by walking known child slots.
+	for (const key of ["innerType", "element", "in", "out"]) {
+		const child = def[key];
+		if (child) found.push(...defaultedPaths({ schema: child, path, seen }));
+	}
+
+	const shape = def.shape as Record<string, unknown> | undefined;
+	if (shape) {
+		for (const [field, child] of Object.entries(shape)) {
+			found.push(
+				...defaultedPaths({
+					schema: child,
+					path: path ? `${path}.${field}` : field,
+					seen,
+				}),
+			);
+		}
+	}
+
+	for (const key of ["options", "items"]) {
+		const members = def[key];
+		if (Array.isArray(members)) {
+			for (const member of members) {
+				found.push(...defaultedPaths({ schema: member, path, seen }));
+			}
+		}
+	}
+
+	return found;
+};
+
+test(`${chalk.yellowBright("catalogV2 params: no field carries a schema default")}`, () => {
+	const offenders = [
+		...new Set(defaultedPaths({ schema: UpdateCatalogParamsSchema })),
+	].filter((path) => ALLOWED_DEFAULTS[path] === undefined);
+
+	expect(
+		offenders,
+		`these fields have a schema default, which erases "omitted" vs "explicitly set". Remove the default, or add it to ALLOWED_DEFAULTS with a reason: ${offenders.join(", ")}`,
+	).toEqual([]);
+});
+
+test(`${chalk.yellowBright("catalogV2 params: the walker actually finds defaults")}`, () => {
+	// Without this the test above passes just as happily on a broken walker.
+	const paths = defaultedPaths({ schema: UpdateCatalogParamsSchema });
+	expect(paths, "walker found the known-allowed defaults").toContain(
+		"skip_deletions",
+	);
+	expect(paths, "desired-state collections carry no default").not.toContain(
+		"features",
+	);
+	expect(paths, "desired-state collections carry no default").not.toContain(
+		"plans",
+	);
+});

--- a/shared/api/catalogV2/updateCatalogParams.ts
+++ b/shared/api/catalogV2/updateCatalogParams.ts
@@ -1,5 +1,6 @@
 import { ApiFeatureProcessorsSchema } from "@api/features/components/processors.js";
 import { CreateFeatureV2ParamsSchema } from "@api/features/crud/createFeatureParams.js";
+import { MigrationParamsSchema } from "@api/products/crud/migrationParams.js";
 import { z } from "zod/v4";
 import { UpdateCatalogPlanParamsSchema } from "./planUpdate/params/catalogPlanParams.js";
 
@@ -82,9 +83,10 @@ export const UpdateCatalogParamsSchema = z.object({
 		description: "Features to leave untouched under skip_deletions:false.",
 	}),
 
-	// migration: MigrationParamsSchema.optional().meta({
-	// 	description: "Catalog-wide migration default, overridable per plan.",
-	// }),
+	migration: MigrationParamsSchema.optional().meta({
+		description:
+			"Catalog-wide migration default, overridable per plan. draft: true asks the server to draft a migration for every row an edit leaves customers behind on.",
+	}),
 	// expand: z.array(CatalogExpandSchema).optional(),
 });
 

--- a/shared/api/catalogV2/updateCatalogParams.ts
+++ b/shared/api/catalogV2/updateCatalogParams.ts
@@ -51,12 +51,15 @@ export type RemoveCatalogPlanParams = z.infer<
 >;
 
 export const UpdateCatalogParamsSchema = z.object({
-	features: z.array(UpdateCatalogFeatureParamsSchema).optional().default([]),
+	// No .default([]) on the desired-state collections: a default would erase the
+	// difference between "I manage features and there are none" and "I never
+	// mentioned features", which under skip_deletions:false mean opposite things.
+	features: z.array(UpdateCatalogFeatureParamsSchema).optional(),
 	remove_features: z
 		.array(RemoveCatalogFeatureParamsSchema)
 		.optional()
 		.default([]),
-	plans: z.array(UpdateCatalogPlanParamsSchema).optional().default([]),
+	plans: z.array(UpdateCatalogPlanParamsSchema).optional(),
 	remove_plans: z.array(RemoveCatalogPlanParamsSchema).optional().default([]),
 
 	// rewards: z.array(CreateRewardParamsSchema).optional().meta({


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes full-state catalog pushes safe for clients that only see part of the catalog, and lets config-file clients request migration drafts without naming individual plans. Omitted `features`/`plans` are now left untouched (previously they defaulted to `[]` and read as "delete them all" under `skip_deletions: false`), and request-level `migration.draft: true` claims every row so the server drafts only where customers and a diff warrant it.

- Archiving the active version of a plan with live siblings returns a 400 naming the offending version; archiving the whole plan or a pinned `remove_plans` entry stays legal.
- A unit test rejects any schema default that would erase the "omitted" vs "explicitly set" difference.

<sup>Written for commit e2bb1079e730391d09df1d451209368ce647bf97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds safer partial catalog updates, catalog-wide migration-draft defaults, and validation for invalid active-version transitions. The previously reported per-plan migration override defect remains unresolved.
- [API changes] Treats omitted `features` and `plans` differently from explicitly empty collections.
- [Improvements] Allows catalog-wide migration-draft settings and adds coverage for partial catalog pushes.
- [Bug fixes] Rejects archiving an active plan version while live sibling versions remain.
- [Bug fixes] The intended per-plan overrides for catalog-wide migration settings are not yet honored.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because explicit per-plan migration opt-outs are ignored when the corresponding request-level setting is enabled.

A request with a global migration setting such as `include_custom: true` still overrides a plan’s explicit `include_custom: false`; similarly, global `draft: true` prevents a plan-level `draft: false` from opting out, causing migration behavior the caller explicitly disabled.

**Files Needing Attention:** server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts | Adds request-level migration defaults, but boolean OR prevents explicit per-plan false values from overriding them. |
| shared/api/catalogV2/updateCatalogParams.ts | Makes catalog collections optional and documents request-level migration settings as overridable per plan. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveFeaturesPlan/resolveAbsenteeFeatureIds.ts | Preserves omitted feature collections while retaining the explicit-empty wipe safeguard. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveProductsPlan/resolveAbsenteePlanTargets.ts | Preserves omitted plan collections while retaining the explicit-empty wipe safeguard. |
| server/src/internal/catalogV2/actions/updateCatalog/errors/detectOrphanedActivePointers.ts | Detects projected catalogs where an archived active version leaves live sibling versions without a usable active pointer. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Request[Catalog update request] --> Global[Request-level migration defaults]
  Request --> Plan[Per-plan migration settings]
  Global --> Resolve[Resolve effective migration settings]
  Plan --> Resolve
  Resolve --> Eligible{Customers and catalog diff warrant a draft?}
  Eligible -->|Yes| Draft[Create migration draft]
  Eligible -->|No| Update[Apply catalog update without a draft]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: 💍 hold omission semantics for fie..."](https://github.com/useautumn/autumn/commit/e2bb1079e730391d09df1d451209368ce647bf97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59147489)</sub>

<!-- /greptile_comment -->