### PR TITLE
fix(ui): native tooltip on truncated copy chips

### DIFF
--- a/packages/ui/src/components/general/copy-button.tsx
+++ b/packages/ui/src/components/general/copy-button.tsx
@@ -103,7 +103,7 @@ export const CopyButton = ({
 						icon={<AnimatedCopyIcon copied={copied} />}
 						className={cn("", props.className)}
 					>
-						<span className={cn("truncate", innerClassName)}>
+						<span title={text} className={cn("truncate", innerClassName)}>
 							{children ?? text}
 						</span>
 					</IconButton>
@@ -168,6 +168,7 @@ export const MiniCopyButton = ({
 			{iconOrientation === "left" && copyIcon}
 			{children}
 			<span
+				title={text}
 				className={cn("text-sm text-tiny-id w-full truncate", innerClassName)}
 			>
 				{text}

--- a/packages/ui/src/components/general/copy-button.tsx
+++ b/packages/ui/src/components/general/copy-button.tsx
@@ -103,7 +103,10 @@ export const CopyButton = ({
 						icon={<AnimatedCopyIcon copied={copied} />}
 						className={cn("", props.className)}
 					>
-						<span title={text} className={cn("truncate", innerClassName)}>
+						<span
+							title={props.title ?? (children == null ? text : undefined)}
+							className={cn("truncate", innerClassName)}
+						>
 							{children ?? text}
 						</span>
 					</IconButton>

--- a/packages/ui/src/components/general/copy-text-button.tsx
+++ b/packages/ui/src/components/general/copy-text-button.tsx
@@ -29,6 +29,7 @@ export function CopyTextButton({
 
 	return (
 		<Button
+			title={text}
 			variant={variant as ButtonProps["variant"]}
 			size="icon"
 			className={cn(

--- a/packages/ui/src/components/general/copy-text-button.tsx
+++ b/packages/ui/src/components/general/copy-text-button.tsx
@@ -29,7 +29,7 @@ export function CopyTextButton({
 
 	return (
 		<Button
-			title={text}
+			title={typeof children === "string" ? children : undefined}
 			variant={variant as ButtonProps["variant"]}
 			size="icon"
 			className={cn(


### PR DESCRIPTION
## Problem

ID chips in the customer product sheet (Sub ID, Stripe ID, etc.) truncate long values with an ellipsis, but hovering them showed nothing — the truncating span had no `title`, so there was no way to see the full value without copying it.

## Change

- `CopyButton` / `MiniCopyButton` (`packages/ui/src/components/general/copy-button.tsx`): add `title={text}` to the truncating label span so the browser's native tooltip shows the full value on hover.
- `CopyTextButton` (`copy-text-button.tsx`): same `title={text}` on the button for parity.

The existing Radix "Copied!" tooltip is controlled (`open={copied}`) and unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native browser tooltip to truncated copy chips so hovering shows the full value instead of nothing. The tooltip only appears when the visible label is the copied text, so custom labels and icon-only buttons don't expose unrelated clipboard payloads.

<sup>Written for commit 52b1435d59edea52c7496ca97884d624e8ae8268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds native hover tooltips to copyable values while ensuring custom labels do not expose unrelated clipboard content.
- **[Bug fixes]** Shows the complete value when hovering truncated `CopyButton` and `MiniCopyButton` labels.
- **[Improvements]** Uses visible string content for `CopyTextButton` tooltips and suppresses the clipboard payload when `CopyButton` renders custom children.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/general/copy-button.tsx | Adds native titles to displayed copy values and resolves the prior custom-label issue by omitting the payload title when children provide the label. |
| packages/ui/src/components/general/copy-text-button.tsx | Adds a native tooltip only when the rendered child is a string, avoiding misleading tooltips for custom content. |

<sub>Reviews (2): Last reviewed commit: ["fix(ui): only title copy chips with the ..."](https://github.com/useautumn/autumn/commit/52b1435d59edea52c7496ca97884d624e8ae8268) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59169256)</sub>

<!-- /greptile_comment -->