### PR TITLE
fix(billing): preserve free and multi-currency prices

### DIFF
--- a/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
@@ -34,19 +34,19 @@ const compactPlan = ({
 		version: productV2.version,
 		...(productV2.group ? { group: productV2.group } : {}),
 		...(productV2.is_add_on ? { is_add_on: true } : {}),
-		...(productV2.free_trial ? { free_trial: productV2.free_trial } : {}),
-		...(apiPlan.price
+		...(apiPlan.free_trial ? { free_trial: apiPlan.free_trial } : {}),
+		price: apiPlan.price
 			? {
-					price: {
-						amount: apiPlan.price.amount,
-						interval: apiPlan.price.interval,
-						...(apiPlan.price.interval_count &&
-						apiPlan.price.interval_count !== 1
-							? { interval_count: apiPlan.price.interval_count }
-							: {}),
-					},
+					amount: apiPlan.price.amount,
+					interval: apiPlan.price.interval,
+					...(apiPlan.price.interval_count && apiPlan.price.interval_count !== 1
+						? { interval_count: apiPlan.price.interval_count }
+						: {}),
+					...(apiPlan.price.additional_currencies?.length
+						? { additional_currencies: apiPlan.price.additional_currencies }
+						: {}),
 				}
-			: {}),
+			: null,
 		items: apiPlan.items.map((item) => toCreatePlanItemParams(item)),
 	};
 };

--- a/server/tests/evals/generateBillingRequest/fixtures.ts
+++ b/server/tests/evals/generateBillingRequest/fixtures.ts
@@ -1,4 +1,4 @@
-import type { ApiPlanV1 } from "@autumn/shared";
+import { type ApiPlanV1, BillingInterval } from "@autumn/shared";
 import type { GenerationContext } from "@/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext";
 
 const NOW_MS = Date.UTC(2026, 7, 24, 12, 0, 0);
@@ -58,7 +58,11 @@ export const saasContext = ({
 		],
 	}) as unknown as GenerationContext;
 
-export const versionedPlanContext = (): GenerationContext =>
+export const versionedPlanContext = ({
+	currentPrice = { amount: 20, interval: BillingInterval.Month },
+}: {
+	currentPrice?: ApiPlanV1["price"];
+} = {}): GenerationContext =>
 	({
 		customer: {
 			id: "cus_versioned",
@@ -75,7 +79,7 @@ export const versionedPlanContext = (): GenerationContext =>
 							},
 						],
 						name: "Generation Version Plan",
-						price: { amount: 20, interval: "month" },
+						price: currentPrice,
 						version: 2,
 					},
 					plan_id: "generation",

--- a/server/tests/evals/generateBillingRequest/generate-billing-request.eval.ts
+++ b/server/tests/evals/generateBillingRequest/generate-billing-request.eval.ts
@@ -9,6 +9,7 @@
 import {
 	type ApiPlanV1,
 	applyCustomizeToPlan,
+	BillingInterval,
 	composeMatchKey,
 	type DiffablePlanV1,
 } from "@autumn/shared";
@@ -420,6 +421,39 @@ const cases: EvalCase[] = [
 		},
 		expected: {
 			customize: { price: { amount: 20, interval: "month" } },
+			version: 3,
+		},
+	},
+	{
+		name: "update: change version while preserving a free price",
+		input: {
+			context: versionedPlanContext({ currentPrice: null }),
+			prompt: "update to v3 but keep it free",
+			tool: "update_subscription",
+		},
+		expected: { customize: { price: null }, version: 3 },
+	},
+	{
+		name: "update: preserve every currency price while changing version",
+		input: {
+			context: versionedPlanContext({
+				currentPrice: {
+					additional_currencies: [{ amount: 18, currency: "eur" }],
+					amount: 20,
+					interval: BillingInterval.Month,
+				},
+			}),
+			prompt: "update to v3 but keep the price the same in every currency",
+			tool: "update_subscription",
+		},
+		expected: {
+			customize: {
+				price: {
+					additional_currencies: [{ amount: 18, currency: "eur" }],
+					amount: 20,
+					interval: "month",
+				},
+			},
 			version: 3,
 		},
 	},


### PR DESCRIPTION
## Summary

- Represent free plans explicitly as price: null so generated version updates can preserve a free price.
- Include additional-currency amounts when preserving an effective customer price.
- Expose free-trial configuration in the same shape accepted by customize.free_trial.
- Add generation evals for free-price and multi-currency preservation.

## Validation

- bun run --cwd server ts
- 28 billing generation unit tests
- Both new preservation eval cases pass
- Applied-plan eval score: 100%
- Braintrust: https://www.braintrust.dev/app/autumn/p/generate-billing-request/experiments/charlie%2Fbilling-generate-preserve-terms-1788287885

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes billing generation so version updates preserve free and multi-currency prices instead of dropping them.

- Represents free plans as `price: null` so updated versions keep the free price.
- Passes through additional-currency amounts when preserving the effective customer price.
- Exposes free-trial configuration in the same shape expected by `customize.free_trial`.
- Adds generation eval cases for free-price and multi-currency preservation.

<sup>Written for commit b0dc33602798f7ac38491cca6186e1a6d3444804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

