### PR TITLE
fix: grow customer products table with page size instead of inner scroll

### DIFF
--- a/packages/ui/src/components/table/table-context.tsx
+++ b/packages/ui/src/components/table/table-context.tsx
@@ -15,8 +15,8 @@ export type TableLinkComponent = ComponentType<{
 }>;
 
 export interface VirtualizationConfig {
-	/** Height of the scroll container, e.g., "calc(100vh - 240px)" */
-	containerHeight: string;
+	/** Height of the scroll container, e.g., "calc(100vh - 240px)". Omit to let the table grow with its rows. */
+	containerHeight?: string;
 	/** Height of each row in pixels (default: 40) */
 	rowHeight?: number;
 	/** Number of rows to render outside visible area (default: 30) - higher values improve fast scrolling smoothness */

--- a/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
@@ -216,7 +216,7 @@ export function CustomerProductsTable() {
 					flexibleTableColumns: true,
 					mobileCards: true,
 					selectedItemId,
-					virtualization: { containerHeight: "428px", skeletonRowCount: 3 },
+					virtualization: { skeletonRowCount: 3 },
 				}}
 			>
 				<Table.Container>


### PR DESCRIPTION
## What

The customer page's Plans table pinned its virtualized scroll container to `containerHeight: "428px"`. That fits the default page size of 10, but picking 25/50/100 rows per page kept the table visually identical and just added an inner scrollbar — it looked like the page-size change did nothing.

## How

- `VirtualizationConfig.containerHeight` is now optional: when omitted, the container gets no `maxHeight` and grows with its rows (the page scrolls instead of the table).
- `CustomerProductsTable` drops the `428px` cap, so the table height follows the selected page size.

All other virtualized tables (customer list, usage analytics, events, migrations) still pass an explicit `containerHeight` and are unchanged.

Verified with `tsc --noEmit` in both `packages/ui` and `vite`, plus biome on the touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the customer products table so selecting 25/50/100 rows per page now grows the table instead of showing an inner scrollbar.

The table previously pinned its scroll container to `428px`, which fit 10 rows but kept the same height for larger page sizes. `containerHeight` in `VirtualizationConfig` is now optional, and the customer products table omits it so the page scrolls naturally. All other virtualized tables still pass an explicit `containerHeight` and are unchanged.

<sup>Written for commit 56680c8970ffa76b365635227891059a32a03920. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

