### PR TITLE
fix: clear template-inherited jwks rows in capy provisioning

### DIFF
--- a/scripts/capy/provision.ts
+++ b/scripts/capy/provision.ts
@@ -42,6 +42,7 @@ import {
 	findBranchByName,
 	waitForNeonBranchOperations,
 } from "../dw/helpers/neon.ts";
+import { sh } from "../dw/helpers/shell.ts";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -645,6 +646,18 @@ function ensureNeonBranch(
 	};
 }
 
+// The template branch carries a better-auth `jwks` row encrypted with the
+// machine secret of whoever last booted against it — undecryptable here.
+function clearInheritedJwks(directUrl: string): void {
+	const res = sh("psql", [directUrl, "-v", "ON_ERROR_STOP=1"], {
+		stdin: `DELETE FROM jwks;\n`,
+	});
+	if (res.code !== 0) {
+		fatal(`clearing inherited jwks rows failed:\n${res.stderr}`);
+	}
+	log("cleared inherited jwks rows (better-auth re-mints on first boot)");
+}
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
@@ -675,6 +688,7 @@ async function main(): Promise<void> {
 	const directUrl = connectionString(nextState.branchName, { pooled: false });
 	applyCommittedMigrations(nextState.branchName, directUrl);
 	loadDbFunctions(nextState.branchName, directUrl);
+	if (created) clearInheritedJwks(directUrl);
 
 	// Per-machine secrets — mint on first run, then persist. Server can't
 	// boot without BETTER_AUTH_SECRET / ENCRYPTION_IV / ENCRYPTION_PASSWORD.

--- a/scripts/capy/provision.ts
+++ b/scripts/capy/provision.ts
@@ -28,7 +28,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { connect } from "node:net";
-import { homedir, hostname } from "node:os";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import {
 	applyCommittedMigrations,
@@ -96,8 +96,17 @@ function shortHash(input: string): string {
 }
 
 function getMachineId(): string {
-	// The hostname is assigned at runtime and remains stable when a VM wakes.
-	return process.env.HOSTNAME?.trim() || hostname();
+	// Hostnames repeat across VMs cloned from one image, so identity is a
+	// minted id persisted for the lifetime of this machine's filesystem.
+	const idPath = join(CAPY_PREFIX, "machine-id");
+	if (existsSync(idPath)) {
+		const existing = readFileSync(idPath, "utf-8").trim();
+		if (existing) return existing;
+	}
+	const minted = `capy-${randomBytes(8).toString("hex")}`;
+	mkdirSync(CAPY_PREFIX, { recursive: true });
+	writeFileSync(idPath, `${minted}\n`, { mode: 0o600 });
+	return minted;
 }
 
 function deriveBranchName(machineId: string): string {

--- a/scripts/capy/provision.ts
+++ b/scripts/capy/provision.ts
@@ -688,11 +688,15 @@ async function main(): Promise<void> {
 	const directUrl = connectionString(nextState.branchName, { pooled: false });
 	applyCommittedMigrations(nextState.branchName, directUrl);
 	loadDbFunctions(nextState.branchName, directUrl);
-	if (created) clearInheritedJwks(directUrl);
 
 	// Per-machine secrets — mint on first run, then persist. Server can't
 	// boot without BETTER_AUTH_SECRET / ENCRYPTION_IV / ENCRYPTION_PASSWORD.
+	const secretsMinted = !priorState?.secrets;
 	nextState.secrets = ensureSecrets(priorState);
+
+	// A fresh branch inherits the template's jwks row; a re-minted secret
+	// (lost state file) orphans an adopted branch's row the same way.
+	if (created || secretsMinted) clearInheritedJwks(directUrl);
 
 	saveState(nextState);
 	if (!nextState.databaseUrl) fatal("provisioning produced no databaseUrl");

--- a/scripts/setup/CAPY_README.md
+++ b/scripts/setup/CAPY_README.md
@@ -81,11 +81,13 @@ without repository preview configuration.
 
 ## Provisioning model
 
-`scripts/capy/provision.ts` hashes the VM's runtime hostname into a
-`capy-<hash>` Neon branch name, and stores non-secret branch metadata plus
-generated local auth secrets in the mode-`0600` file `~/.autumn-capy/state.json`.
-A resumed VM keeps its hostname and reuses that branch; a new VM derives a new
-branch even if it inherits a stale state file.
+`scripts/capy/provision.ts` mints a random machine id on first run, persists it
+to `~/.autumn-capy/machine-id`, and hashes it into a `capy-<hash>` Neon branch
+name. Non-secret branch metadata plus generated local auth secrets live in the
+mode-`0600` file `~/.autumn-capy/state.json`. A resumed VM keeps its minted id
+and reuses that branch; a fresh filesystem mints a new id and derives a new
+branch. Hostnames are not used: VMs cloned from one image share a hostname,
+which previously collapsed every machine onto one shared branch.
 
 The script writes managed values into:
 


### PR DESCRIPTION
## What

Every fresh capy machine currently boots into `BetterAuthError: Failed to decrypt private key` on every auth call, leaving the dashboard stuck on its loading spinner — and `GET /organization` 500s with `BAD_DECRYPT` when the inherited org row carries encrypted processor configs.

## Why

Two compounding issues:

1. **Machine identity is the hostname.** #2991 made the Neon branch name a hash of the runtime hostname, assuming each VM gets a unique one. VMs cloned from one image share a hostname (this machine reports a hardcoded one), so every capy machine hashed to the *same* branch and adopted the previous machine's used database instead of forking `dw-template`.
2. **Secrets are per-machine.** Each machine mints its own `BETTER_AUTH_SECRET` / `ENCRYPTION_PASSWORD`, so anything the previous machine encrypted (better-auth `jwks`, RevenueCat processor configs) is undecryptable on the next one.

## How

- `getMachineId()` now mints a random id on first provision and persists it to `~/.autumn-capy/machine-id` — hostnames are no longer trusted, so each machine genuinely gets its own branch forked off `dw-template`. Existing polluted machines self-heal: their next provision mints a fresh id and provisions a clean branch.
- As a safety net, provisioning deletes `jwks` rows whenever it creates the branch **or** mints replacement secrets (lost/unreadable state file), so better-auth re-mints a key under the current secret instead of failing to decrypt an inherited one.
- `CAPY_README.md` updated to describe the minted-id model.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes authentication startup failures on newly provisioned Capy machines by removing key material inherited from the database template and improves machine identity so cloned hostnames do not select the same database branch.
- **Bug fixes:** Clears inherited Better Auth JWKS rows when creating a branch or replacing lost machine secrets, allowing keys to be regenerated with the current machine’s secret.
- **Improvements:** Replaces hostname-derived identity with a persisted random machine ID and documents the updated provisioning lifecycle.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the new cleanup limited to cases where existing JWKS material cannot match the machine’s active secret.

New branches and branches whose secrets must be replaced now discard unusable inherited authentication keys before state is saved, while normal branch reuse with persisted secrets remains untouched.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/capy/provision.ts | Introduces persisted random machine identity and clears unusable inherited authentication keys under the intended new-branch and secret-recovery conditions. |
| scripts/setup/CAPY_README.md | Updates the provisioning documentation to describe random persisted machine IDs and why hostnames are no longer used. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant VM as Capy VM
  participant Provision as provision.ts
  participant Neon as Neon branch
  participant Auth as Better Auth
  VM->>Provision: Start provisioning
  Provision->>Provision: Load or mint machine ID
  Provision->>Neon: Reuse, adopt, or create branch
  Provision->>Neon: Apply migrations
  alt New branch or replacement secrets
    Provision->>Neon: Delete inherited JWKS rows
  end
  Provision->>Provision: Persist machine state
  Auth->>Neon: Mint JWKS using current secret
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: derive capy Neon branch from a pers..."](https://github.com/useautumn/autumn/commit/519efec04d5744a1ece064aa62e6283ac8b7449d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59192814)</sub>

<!-- /greptile_comment -->