### PR TITLE
fix(billing): allocate amount-off discount remainder to the correct line item

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts
@@ -10,7 +10,7 @@ import { addDiscountTagToDescription } from "./addDiscountTagToDescription";
 import { discountAppliesToLineItem } from "./discountAppliesToLineItem";
 import { getBackdatedDiscountCycleCount } from "./getBackdatedDiscountCycleCount";
 
-const allocateAmountOffDiscounts = ({
+export const allocateAmountOffDiscounts = ({
 	lineItems,
 	amountOffMinorUnits,
 	currency,
@@ -44,9 +44,9 @@ const allocateAmountOffDiscounts = ({
 		return diff === 0 ? a.index - b.index : diff;
 	});
 
-	for (const { index } of byRemainder) {
+	for (const allocation of byRemainder) {
 		if (remaining <= 0) break;
-		allocations[index].minorUnits += 1;
+		allocation.minorUnits += 1;
 		remaining -= 1;
 	}
 

--- a/server/tests/unit/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.test.ts
+++ b/server/tests/unit/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import { type LineItem, stripeToAtmnAmount } from "@autumn/shared";
+import { allocateAmountOffDiscounts } from "@/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems";
+
+const lineItem = (amount: number): LineItem =>
+	({ amount }) as unknown as LineItem;
+
+// Weights are proportional to |amount|, so the 100-unit item has remainder 0.67
+// and the 50-unit item 0.33 for an off of 10 (6.67 -> 6 and 3.33 -> 3, one unit
+// left over). The leftover unit must go to the higher-remainder item (the 100
+// one). A zero-amount item is filtered out before allocation, which used to make
+// the leftover loop index the filtered array with the original line-item index.
+test("allocateAmountOffDiscounts gives the rounding remainder to the correct item when a zero-amount item is present", () => {
+	const zero = lineItem(0);
+	const big = lineItem(100);
+	const small = lineItem(50);
+
+	const result = allocateAmountOffDiscounts({
+		lineItems: [zero, big, small],
+		amountOffMinorUnits: 10,
+		currency: "usd",
+	});
+
+	expect(result.get(big)).toBe(stripeToAtmnAmount({ amount: 7, currency: "usd" }));
+	expect(result.get(small)).toBe(stripeToAtmnAmount({ amount: 3, currency: "usd" }));
+	expect(result.get(zero)).toBeUndefined();
+});
+
+test("allocateAmountOffDiscounts does not crash when the highest-remainder item follows a filtered zero-amount item", () => {
+	const zero = lineItem(0);
+	const a = lineItem(100);
+	const b = lineItem(200);
+
+	expect(() =>
+		allocateAmountOffDiscounts({
+			lineItems: [zero, a, b],
+			amountOffMinorUnits: 1,
+			currency: "usd",
+		}),
+	).not.toThrow();
+});


### PR DESCRIPTION
## What

`allocateAmountOffDiscounts` distributes an amount-off coupon across charge line items using the largest-remainder method. It first drops zero-weight items:

```ts
const weightedItems = lineItems
  .map((item, index) => ({ item, index, weight: atmnToStripeAmount({ amount: Math.abs(item.amount), currency }) }))
  .filter((item) => item.weight > 0);
```

so `index` is each item's position in the original `lineItems`, but `allocations` is built from the filtered `weightedItems`. The leftover-cent loop then indexes the filtered array with that original index:

```ts
for (const { index } of byRemainder) {
  if (remaining <= 0) break;
  allocations[index].minorUnits += 1;   // filtered array, original index
  remaining -= 1;
}
```

When a zero-amount charge item is present the two no longer line up, so:

- the leftover minor unit is added to the wrong line item (one item is over-discounted, another under-discounted), and
- when the highest-remainder item's original index is past the end of the filtered array, `allocations[index]` is `undefined` and `.minorUnits += 1` throws.

Zero-amount charge items are reachable in normal invoicing (a fully-discounted or comped line, a proration that nets to zero), so this is not a pathological input.

## Fix

`byRemainder` is `[...allocations].sort(...)`, a shallow copy that holds the same allocation objects, so mutate the allocation directly instead of indexing by the original index:

```ts
for (const allocation of byRemainder) {
  if (remaining <= 0) break;
  allocation.minorUnits += 1;
  remaining -= 1;
}
```

The leftover now lands on the actual highest-remainder allocation and there is no out-of-range access. With no filtered items the position and the object are the same allocation, so behavior is unchanged.

## Verifying

Driving the allocation directly (decimal.js, same as the code):

| input (amounts, off) | before | after |
|---|---|---|
| `[0, 100, 50]`, off 10 | `100 -> 6, 50 -> 4` (leftover to the wrong item) | `100 -> 7, 50 -> 3` |
| `[0, 100, 200]`, off 1 | `TypeError: Cannot read properties of undefined` | `100 -> 0, 200 -> 1` |
| `[100, 50]`, off 10 (no zero item) | `100 -> 7, 50 -> 3` | `100 -> 7, 50 -> 3` (unchanged) |

## Tests

Exported `allocateAmountOffDiscounts` and added `server/tests/unit/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.test.ts`: the mis-allocation case (leftover goes to the higher-remainder item, zero item absent from the map) and the crash case (does not throw). Both fail against the old code.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes amount-off discount allocation so leftover rounding amounts land on the correct line item and no longer throw when a zero-amount charge item is present.

Previously, zero-weight line items were filtered out before allocation, but the leftover-cent loop indexed the filtered array using each item's original position. That added the extra unit to the wrong line item, or crashed with `TypeError` when the index was out of range. The fix mutates the shared allocation objects directly, so behavior is unchanged when no items are filtered.

<sup>Written for commit c90a8d6c926164a8b804c0842fdeb484a6cbc269. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

