### PR TITLE
fix(attach): only say "pausing" when a revert trial is attached

### DIFF
--- a/vite/src/components/forms/attach-v2/components/AttachUpdatesSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachUpdatesSection.tsx
@@ -79,7 +79,13 @@ export function AttachUpdatesSection() {
 	if (isPending) return <AttachUpdatesSkeleton />;
 	if (!product) return null;
 
-	const isPausing = supportsTrialRevert && formValues.trialOnEnd === "revert";
+	// The outgoing plan is only paused when a revert-on-end trial is actually
+	// attached — matching getFreeTrial, which omits the trial (and so its
+	// on_end) unless the toggle is on with a positive length. Without one the
+	// plan is replaced, so trialOnEnd's "revert" default must not leak in here.
+	const hasTrial = formValues.trialEnabled && (formValues.trialLength ?? 0) > 0;
+	const isPausing =
+		hasTrial && supportsTrialRevert && formValues.trialOnEnd === "revert";
 
 	return (
 		<SheetSection withSeparator={false} className="pb-0">

--- a/vite/src/components/forms/shared/TrialOnEndSelect.tsx
+++ b/vite/src/components/forms/shared/TrialOnEndSelect.tsx
@@ -49,11 +49,15 @@ export function TrialOnEndSelect({
 							<span className="truncate min-w-0">{option.label}</span>
 							{option.tooltip && (
 								<Tooltip>
+									{/* The option row sets [&_svg]:pointer-events-none, so the icon
+									    itself never sees a hover — the wrapper takes the trigger. */}
 									<TooltipTrigger asChild>
-										<QuestionIcon
-											className="size-3.5 shrink-0 cursor-help text-tertiary-foreground"
+										<span
+											className="flex shrink-0 items-center cursor-help text-tertiary-foreground"
 											onClick={(event) => event.stopPropagation()}
-										/>
+										>
+											<QuestionIcon className="size-3.5" />
+										</span>
 									</TooltipTrigger>
 									<TooltipContent className="max-w-64">
 										{option.tooltip}


### PR DESCRIPTION
The attach review sheet read "Attaching **Growth** and pausing **Pro**" on a plain Pro→Growth upgrade with no trial configured. Two frontend fixes.

## "pausing" on an attach with no trial

`AttachUpdatesSection` derived the verb from `trialOnEnd` alone:

```ts
const isPausing = supportsTrialRevert && formValues.trialOnEnd === "revert";
```

`trialOnEnd` defaults to `"revert"` whether or not the Free Trial toggle is on (`useAttachForm.ts`, and re-set on every product change in `AttachFormProvider`), and `supportsTrialRevert` only means "has an active subscription and isn't multi-plan". So every single-plan attach onto a live subscription claimed to pause the outgoing plan.

Preview copy only — the request body was correct throughout: `getFreeTrial` returns `undefined` when the toggle is off, so `buildAttachRequestBody` sends `free_trial: null` with no `on_end`, and the attach replaces the plan as expected. Regression from 9360b2bf, which flipped the field's default from `"bill"` to `"revert"`; before that the banner only claimed to pause if revert had been ticked explicitly.

Now gated on a trial actually being attached, mirroring `getFreeTrial`'s own condition:

```ts
const hasTrial = formValues.trialEnabled && (formValues.trialLength ?? 0) > 0;
const isPausing = hasTrial && supportsTrialRevert && formValues.trialOnEnd === "revert";
```

## "Bill customer" tooltip never opened

Not z-index — `TooltipContent` already sits at `z-[400]`, above the popover's `z-200`. `CommandItem` carries `[&_svg]:pointer-events-none`, so the `QuestionIcon` never received a hover and the trigger never fired. The icon is now wrapped in a `<span>` that carries the tooltip trigger; the span is not an `svg`, so it hovers, and the icon's disabled pointer events fall through to it.

## Testing

Biome clean on both touched files. No typecheck run — `node_modules` isn't installed in this environment; the changes are confined to two files and use existing typed fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUWciecs2ruRJZiXyb67oo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUWciecs2ruRJZiXyb67oo)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the attach review sheet mislabeling upgrades without a trial as "pausing", and fixes the "Bill customer" tooltip never opening.

**Bug Fixes**
- The pause label was derived from `trialOnEnd` alone, which defaults to `"revert"` even with the Free Trial toggle off; it now requires a trial with positive length to be attached. The attach request body was always correct, so only the copy was wrong.
- In `TrialOnEndSelect`, `CommandItem` applies `[&_svg]:pointer-events-none`, blocking the icon's hover; the tooltip trigger now lives on a wrapper span, so the tooltip opens on hover.

<sup>Written for commit 764468204a1513b8008f1635aae9b296e156e56b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects two misleading or inaccessible details in the attach-plan review UI.

- **[Bug fixes]** Shows “pausing” only when a positive-length, revert-on-end trial is actually attached.
- **[Bug fixes, Improvements]** Restores hover interaction for the “Bill customer” help tooltip by moving its trigger to a wrapper unaffected by the option row’s SVG pointer-event rule.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with both UI fixes aligned to the existing form and interaction behavior.

The trial preview now uses the same condition as request construction, and the tooltip change restores hover handling without altering billing data or option values.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/forms/attach-v2/components/AttachUpdatesSection.tsx | Aligns the outgoing-plan wording with the same enabled-and-positive-length condition used to include a free trial in the attach request. |
| vite/src/components/forms/shared/TrialOnEndSelect.tsx | Wraps the tooltip icon in a pointer-reachable trigger without changing the trial-end option’s value or selection behavior. |

<sub>Reviews (1): Last reviewed commit: ["fix(attach): only say &quot;pausing&quot; when a r..."](https://github.com/useautumn/autumn/commit/764468204a1513b8008f1635aae9b296e156e56b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59459576)</sub>

**Context used:**

- Knowledge Base — [Operational web applications and UI primitives](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/operational-web-applications.md)

<!-- /greptile_comment -->