### PR TITLE
fix: allow autumn-only cancel of RevenueCat-managed subscriptions

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
@@ -8,6 +8,7 @@ import { handleCancelEndOfCycleErrors } from "@/internal/billing/v2/actions/upda
 import { handleProrationBehaviorErrors } from "@/internal/billing/v2/common/errors/handleBillingBehaviorErrors";
 import { handleExternalPSPErrors } from "@/internal/billing/v2/common/errors/handleExternalPSPErrors";
 import { handleStripeBillingPlanErrors } from "@/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors";
+import { computeFieldUpdates } from "../compute/computeFieldUpdates";
 import { handleCurrentCustomerProductErrors } from "./handleCurrentCustomerProductErrors";
 import { handleCustomPlanErrors } from "./handleCustomPlanErrors";
 import { handleManualTopUpErrors } from "./handleManualTopUpErrors";
@@ -43,6 +44,7 @@ export const handleUpdateSubscriptionErrors = async ({
 		cancelAction: params.cancel_action,
 		noBillingChanges: params.no_billing_changes,
 		intent: billingContext.intent,
+		hasFieldUpdates: Object.keys(computeFieldUpdates({ params })).length > 0,
 	});
 
 	// 1. Current customer product errors

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
@@ -40,6 +40,8 @@ export const handleUpdateSubscriptionErrors = async ({
 	handleExternalPSPErrors({
 		customerProduct,
 		action: "update",
+		cancelAction: params.cancel_action,
+		noBillingChanges: params.no_billing_changes,
 	});
 
 	// 1. Current customer product errors

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
@@ -42,6 +42,7 @@ export const handleUpdateSubscriptionErrors = async ({
 		action: "update",
 		cancelAction: params.cancel_action,
 		noBillingChanges: params.no_billing_changes,
+		intent: billingContext.intent,
 	});
 
 	// 1. Current customer product errors

--- a/server/src/internal/billing/v2/common/errors/handleExternalPSPErrors.ts
+++ b/server/src/internal/billing/v2/common/errors/handleExternalPSPErrors.ts
@@ -1,4 +1,5 @@
 import {
+	type CancelAction,
 	cusProductToProcessorType,
 	type FullCusProduct,
 	type FullProduct,
@@ -33,6 +34,8 @@ export const handleExternalPSPErrors = ({
 	customerProducts,
 	attachProduct,
 	action,
+	cancelAction,
+	noBillingChanges,
 }: {
 	/** For `update`: the specific customer product being modified. */
 	customerProduct?: FullCusProduct;
@@ -41,9 +44,17 @@ export const handleExternalPSPErrors = ({
 	/** For `attach`: the product being attached. */
 	attachProduct?: FullProduct;
 	action: "attach" | "update";
+	/** For `update`: the request's cancel_action, if any. */
+	cancelAction?: CancelAction;
+	/** For `update`: the request's no_billing_changes flag. */
+	noBillingChanges?: boolean;
 }) => {
 	if (action === "update") {
 		if (!customerProduct) return;
+
+		// Autumn-only cancel: no Stripe write happens, so it cannot conflict
+		// with the external subscription.
+		if (cancelAction && noBillingChanges === true) return;
 
 		const processorType = cusProductToProcessorType(customerProduct);
 		if (processorType === ProcessorType.RevenueCat) {

--- a/server/src/internal/billing/v2/common/errors/handleExternalPSPErrors.ts
+++ b/server/src/internal/billing/v2/common/errors/handleExternalPSPErrors.ts
@@ -7,6 +7,7 @@ import {
 	isOneOffProduct,
 	ProcessorType,
 	RecaseError,
+	UpdateSubscriptionIntent,
 } from "@autumn/shared";
 
 /**
@@ -36,6 +37,7 @@ export const handleExternalPSPErrors = ({
 	action,
 	cancelAction,
 	noBillingChanges,
+	intent,
 }: {
 	/** For `update`: the specific customer product being modified. */
 	customerProduct?: FullCusProduct;
@@ -48,13 +50,22 @@ export const handleExternalPSPErrors = ({
 	cancelAction?: CancelAction;
 	/** For `update`: the request's no_billing_changes flag. */
 	noBillingChanges?: boolean;
+	/** For `update`: the resolved update intent. */
+	intent?: UpdateSubscriptionIntent;
 }) => {
 	if (action === "update") {
 		if (!customerProduct) return;
 
 		// Autumn-only cancel: no Stripe write happens, so it cannot conflict
-		// with the external subscription.
-		if (cancelAction && noBillingChanges === true) return;
+		// with the external subscription. Intent must be CancelAction so a
+		// cancel riding along with other mutations stays blocked; uncancel is
+		// excluded because RC would remain canceled while Autumn reactivates.
+		const isAutumnOnlyCancel =
+			intent === UpdateSubscriptionIntent.CancelAction &&
+			cancelAction !== undefined &&
+			cancelAction !== "uncancel" &&
+			noBillingChanges === true;
+		if (isAutumnOnlyCancel) return;
 
 		const processorType = cusProductToProcessorType(customerProduct);
 		if (processorType === ProcessorType.RevenueCat) {

--- a/server/src/internal/billing/v2/common/errors/handleExternalPSPErrors.ts
+++ b/server/src/internal/billing/v2/common/errors/handleExternalPSPErrors.ts
@@ -38,6 +38,7 @@ export const handleExternalPSPErrors = ({
 	cancelAction,
 	noBillingChanges,
 	intent,
+	hasFieldUpdates,
 }: {
 	/** For `update`: the specific customer product being modified. */
 	customerProduct?: FullCusProduct;
@@ -52,19 +53,22 @@ export const handleExternalPSPErrors = ({
 	noBillingChanges?: boolean;
 	/** For `update`: the resolved update intent. */
 	intent?: UpdateSubscriptionIntent;
+	/** For `update`: whether the request also mutates cusProduct fields (status, subscription linkage). */
+	hasFieldUpdates?: boolean;
 }) => {
 	if (action === "update") {
 		if (!customerProduct) return;
 
 		// Autumn-only cancel: no Stripe write happens, so it cannot conflict
-		// with the external subscription. Intent must be CancelAction so a
-		// cancel riding along with other mutations stays blocked; uncancel is
-		// excluded because RC would remain canceled while Autumn reactivates.
+		// with the external subscription. Intent must be CancelAction and no
+		// other mutation may ride along; uncancel is excluded because RC would
+		// remain canceled while Autumn reactivates.
 		const isAutumnOnlyCancel =
 			intent === UpdateSubscriptionIntent.CancelAction &&
 			cancelAction !== undefined &&
 			cancelAction !== "uncancel" &&
-			noBillingChanges === true;
+			noBillingChanges === true &&
+			!hasFieldUpdates;
 		if (isAutumnOnlyCancel) return;
 
 		const processorType = cusProductToProcessorType(customerProduct);

--- a/server/tests/integration/external-psps/revenuecat/revenuecat-cancel-no-billing.test.ts
+++ b/server/tests/integration/external-psps/revenuecat/revenuecat-cancel-no-billing.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Autumn-only cancel of an RC-managed subscription.
+ *
+ * Red (current):  billing.update with cancel_action + no_billing_changes on an
+ *                 RC-managed cusProduct throws 409 "managed by RevenueCat".
+ * Green (after):  the cancel goes through in Autumn only (no Stripe writes);
+ *                 a cancel WITHOUT no_billing_changes stays blocked.
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiCustomerV3, AppEnv } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService";
+import { OrgService } from "@/internal/orgs/OrgService";
+import { encryptData } from "@/utils/encryptUtils";
+import {
+	expectWebhookSuccess,
+	RevenueCatWebhookClient,
+} from "./utils/revenue-cat-webhook-client";
+
+const RC_WEBHOOK_SECRET = "test_rc_webhook_secret_cancel_nb";
+
+const setupRevenueCatOrg = async () => {
+	if (
+		ctx.org.processor_configs?.revenuecat?.sandbox_webhook_secret !==
+		RC_WEBHOOK_SECRET
+	) {
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				processor_configs: {
+					...ctx.org.processor_configs,
+					revenuecat: {
+						api_key: encryptData("mock_rc_api_key_live"),
+						sandbox_api_key: encryptData("mock_rc_api_key_sandbox"),
+						project_id: "mock_project_live",
+						sandbox_project_id: "mock_project_sandbox",
+						webhook_secret: RC_WEBHOOK_SECRET,
+						sandbox_webhook_secret: RC_WEBHOOK_SECRET,
+					},
+				},
+			},
+		});
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("revenuecat cancel no-billing: autumn-only cancel bypasses RC guard")}`,
+	async () => {
+		const customerId = "rc-cancel-nb-1";
+		const RC_PRO_MONTHLY_ID = "com.app.rc_cancel_nb_pro_monthly";
+
+		const proMonthly = products.base({
+			id: "rc-cancel-nb-pro",
+			items: [
+				items.monthlyMessages({ includedUsage: 100 }),
+				items.monthlyPrice({ price: 10 }),
+			],
+		});
+
+		await setupRevenueCatOrg();
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [proMonthly] }),
+			],
+			actions: [],
+		});
+
+		await RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: AppEnv.Sandbox,
+				autumn_product_id: proMonthly.id,
+				revenuecat_product_ids: [RC_PRO_MONTHLY_ID],
+			},
+		});
+
+		const rcClient = new RevenueCatWebhookClient({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			webhookSecret: RC_WEBHOOK_SECRET,
+		});
+
+		const result = await rcClient.initialPurchase({
+			productId: RC_PRO_MONTHLY_ID,
+			appUserId: customerId,
+			originalTransactionId: "rc_cancel_nb_tx_001",
+		});
+		expectWebhookSuccess(result);
+
+		let customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(customer.products).toHaveLength(1);
+		expect(customer.products[0].id).toBe(proMonthly.id);
+
+		// Guard still holds: a cancel WITHOUT no_billing_changes is blocked
+		await expect(
+			autumnV1.subscriptions.update({
+				customer_id: customerId,
+				product_id: proMonthly.id,
+				cancel_action: "cancel_end_of_cycle" as const,
+			}),
+		).rejects.toThrow(/managed by RevenueCat/i);
+
+		// Autumn-only cancel goes through
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: proMonthly.id,
+			cancel_action: "cancel_end_of_cycle" as const,
+			no_billing_changes: true,
+		});
+
+		customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(customer.products).toHaveLength(1);
+		expect(customer.products[0].canceled_at).toBeDefined();
+		expect(customer.products[0].canceled_at).not.toBeNull();
+	},
+);

--- a/server/tests/unit/billing/handle-external-psp-errors.spec.ts
+++ b/server/tests/unit/billing/handle-external-psp-errors.spec.ts
@@ -18,6 +18,7 @@ import {
 	PriceType,
 	ProcessorType,
 	type RecaseError,
+	UpdateSubscriptionIntent,
 } from "@autumn/shared";
 import { customerProducts } from "@tests/utils/fixtures/db/customerProducts";
 import { prices as priceFixtures } from "@tests/utils/fixtures/db/prices";
@@ -158,6 +159,7 @@ describe(
 					action: "update",
 					cancelAction: "cancel_end_of_cycle",
 					noBillingChanges: true,
+					intent: UpdateSubscriptionIntent.CancelAction,
 				}),
 			).not.toThrow();
 		});
@@ -170,6 +172,7 @@ describe(
 						customerProduct: cp,
 						action: "update",
 						cancelAction: "cancel_immediately",
+						intent: UpdateSubscriptionIntent.CancelAction,
 					}),
 				"managed by RevenueCat",
 			);
@@ -183,6 +186,37 @@ describe(
 						customerProduct: cp,
 						action: "update",
 						noBillingChanges: true,
+						intent: UpdateSubscriptionIntent.None,
+					}),
+				"managed by RevenueCat",
+			);
+		});
+
+		test("THROWS: uncancel + no_billing_changes on an RC-managed cusProduct", () => {
+			const cp = buildRcCusProduct();
+			expectThrows(
+				() =>
+					handleExternalPSPErrors({
+						customerProduct: cp,
+						action: "update",
+						cancelAction: "uncancel",
+						noBillingChanges: true,
+						intent: UpdateSubscriptionIntent.CancelAction,
+					}),
+				"managed by RevenueCat",
+			);
+		});
+
+		test("THROWS: cancel + no_billing_changes riding along a plan restructure (intent != CancelAction)", () => {
+			const cp = buildRcCusProduct();
+			expectThrows(
+				() =>
+					handleExternalPSPErrors({
+						customerProduct: cp,
+						action: "update",
+						cancelAction: "cancel_end_of_cycle",
+						noBillingChanges: true,
+						intent: UpdateSubscriptionIntent.UpdatePlan,
 					}),
 				"managed by RevenueCat",
 			);

--- a/server/tests/unit/billing/handle-external-psp-errors.spec.ts
+++ b/server/tests/unit/billing/handle-external-psp-errors.spec.ts
@@ -221,6 +221,22 @@ describe(
 				"managed by RevenueCat",
 			);
 		});
+
+		test("THROWS: cancel + no_billing_changes with internal field updates (status / processor_subscription_id)", () => {
+			const cp = buildRcCusProduct();
+			expectThrows(
+				() =>
+					handleExternalPSPErrors({
+						customerProduct: cp,
+						action: "update",
+						cancelAction: "cancel_end_of_cycle",
+						noBillingChanges: true,
+						intent: UpdateSubscriptionIntent.CancelAction,
+						hasFieldUpdates: true,
+					}),
+				"managed by RevenueCat",
+			);
+		});
 	},
 );
 

--- a/server/tests/unit/billing/handle-external-psp-errors.spec.ts
+++ b/server/tests/unit/billing/handle-external-psp-errors.spec.ts
@@ -2,7 +2,9 @@
  * Unit tests for handleExternalPSPErrors (V2 attach + update gate).
  *
  * Key invariants:
- *   - On `update`, fail when the targeted cusProduct is RC-managed.
+ *   - On `update`, fail when the targeted cusProduct is RC-managed — except
+ *     an autumn-only cancel (cancel_action + no_billing_changes), which never
+ *     touches Stripe and so cannot conflict with the external subscription.
  *   - On `attach`, scan ALL customer_products for non-Stripe processors.
  *   - On `attach`, bypass ONLY when attaching a true one-off (every price has
  *     interval === OneOff). Recurring add-ons take the strict path.
@@ -146,6 +148,44 @@ describe(
 
 		test("does not throw when no cusProduct is provided", () => {
 			expect(() => handleExternalPSPErrors({ action: "update" })).not.toThrow();
+		});
+
+		test("BYPASS: autumn-only cancel (cancel_action + no_billing_changes) on an RC-managed cusProduct", () => {
+			const cp = buildRcCusProduct();
+			expect(() =>
+				handleExternalPSPErrors({
+					customerProduct: cp,
+					action: "update",
+					cancelAction: "cancel_end_of_cycle",
+					noBillingChanges: true,
+				}),
+			).not.toThrow();
+		});
+
+		test("THROWS: cancel_action without no_billing_changes on an RC-managed cusProduct", () => {
+			const cp = buildRcCusProduct();
+			expectThrows(
+				() =>
+					handleExternalPSPErrors({
+						customerProduct: cp,
+						action: "update",
+						cancelAction: "cancel_immediately",
+					}),
+				"managed by RevenueCat",
+			);
+		});
+
+		test("THROWS: no_billing_changes without cancel_action on an RC-managed cusProduct", () => {
+			const cp = buildRcCusProduct();
+			expectThrows(
+				() =>
+					handleExternalPSPErrors({
+						customerProduct: cp,
+						action: "update",
+						noBillingChanges: true,
+					}),
+				"managed by RevenueCat",
+			);
 		});
 	},
 );


### PR DESCRIPTION
## Problem

Canceling an RC-managed subscription from the dashboard with **No Billing Changes** on still 409s with `Subscription for '<plan>' is managed by RevenueCat and cannot be updated directly`. The external-PSP guard in `handleExternalPSPErrors` blocked every `update` on an RC-managed cus_product, including cancels that never touch Stripe.

## Fix

Loosen the `update` branch of `handleExternalPSPErrors`: when the request carries a `cancel_action` **and** `no_billing_changes: true`, the guard bypasses — an Autumn-only cancel performs no Stripe write, so it cannot conflict with the external subscription. `no_billing_changes` already gates Stripe execution in `setupStripeBillingContext`, so the rest of the pipeline is safe.

Both `billing.update` and `billing.preview_update` flow through `handleUpdateSubscriptionErrors`, so the dashboard's Pricing Preview unblocks as well.

Every other case stays blocked: cancel without `no_billing_changes`, `no_billing_changes` without a cancel action, and all attach-side guards are unchanged.

## Tests

- Unit (`handle-external-psp-errors.spec.ts`): bypass for cancel + no_billing_changes; still throws for cancel alone and for no_billing_changes alone. Written red-first against the exact 409.
- Integration (`revenuecat-cancel-no-billing.test.ts`): RC initial purchase via webhook, cancel without the flag still 409s, cancel with the flag succeeds and sets `canceled_at`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the RevenueCat external-PSP guard so Autumn-only cancels (`cancel_action` + `no_billing_changes: true`) on RC-managed subscriptions no longer 409, while keeping every other RC-managed update blocked.

**Bug Fixes**

- Bypass applies only to pure cancels: intent must be `CancelAction`, `uncancel` stays blocked, and no internal field updates (status, `processor_subscription_id`) may ride along.
- Keeps blocking cancels without `no_billing_changes`, `no_billing_changes` without a cancel action, cancels combined with plan changes, and all attach-side cases.
- Unblocks `billing.preview_update` since both update paths share the same guard.
- Adds unit and integration tests covering the bypass and the still-blocked cases, including mixed field-update requests.

<sup>Written for commit 6ab44a4aa95e4c3596506f79630b618b0773e4e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR allows a RevenueCat-managed subscription to be canceled only in Autumn when billing changes are explicitly disabled, while preserving the ownership guard for every mixed update.

- **Bug fixes:** Allows cancel-only requests with `no_billing_changes: true` to pass without attempting to update RevenueCat.
- **Bug fixes, Improvements:** Blocks plan changes and internal field changes from accompanying the cancellation bypass.
- **Improvements:** Adds focused unit and integration coverage for allowed and rejected RevenueCat cancellation requests.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts | Derives whether internal subscription fields are being changed and passes that fact into the RevenueCat ownership guard. |
| server/src/internal/billing/v2/common/errors/handleExternalPSPErrors.ts | Adds a narrowly constrained bypass for cancel-only, no-billing-change updates while keeping mixed updates blocked. |
| server/tests/integration/external-psps/revenuecat/revenuecat-cancel-no-billing.test.ts | Verifies the RevenueCat cancellation flow rejects ordinary cancellation but permits the Autumn-only form. |
| server/tests/unit/billing/handle-external-psp-errors.spec.ts | Covers the permitted cancellation and the important cases that must continue to fail. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Update as Subscription update
    participant Guard as RevenueCat ownership guard
    participant Autumn as Autumn database
    participant PSP as RevenueCat
    Client->>Update: cancel_action + no_billing_changes
    Update->>Guard: intent and field-update checks
    alt Cancel-only request
        Guard-->>Update: Allow
        Update->>Autumn: Persist cancellation
        Note over Update,PSP: No external billing write
    else Mixed or billing-changing request
        Guard-->>Client: Reject with 409
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: block autumn-only cancel bypass whe..."](https://github.com/useautumn/autumn/commit/6ab44a4aa95e4c3596506f79630b618b0773e4e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59461790)</sub>

<!-- /greptile_comment -->