### PR TITLE
fix: unbreak from-scratch capy provisioning

### DIFF
--- a/scripts/capy/provision.ts
+++ b/scripts/capy/provision.ts
@@ -659,7 +659,7 @@ function ensureNeonBranch(
 // machine secret of whoever last booted against it — undecryptable here.
 function clearInheritedJwks(directUrl: string): void {
 	const res = sh("psql", [directUrl, "-v", "ON_ERROR_STOP=1"], {
-		stdin: `DELETE FROM jwks;\n`,
+		stdin: `DO $$ BEGIN IF to_regclass('public.jwks') IS NOT NULL THEN DELETE FROM public.jwks; END IF; END $$;\n`,
 	});
 	if (res.code !== 0) {
 		fatal(`clearing inherited jwks rows failed:\n${res.stderr}`);

--- a/scripts/preload-env.ts
+++ b/scripts/preload-env.ts
@@ -26,6 +26,10 @@ if (process.env.PW_MODE !== "1") {
 		for (const line of contents.split(/\r?\n/)) {
 			const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
 			if (!m) continue;
+			// AUTUMN_DB_DIRECT callers inject DATABASE_URL for a DB that
+			// .env.local may not describe yet (fresh branch provisioning).
+			if (process.env.AUTUMN_DB_DIRECT === "1" && m[1] === "DATABASE_URL")
+				continue;
 			process.env[m[1]] = m[2];
 		}
 	}


### PR DESCRIPTION
## What

Follow-up to #3199, found by actually provisioning a capy machine from scratch (`rm -rf ~/.autumn-capy` + fresh Neon branch). Two bugs prevented a genuinely fresh branch from working:

**1. `DELETE FROM jwks` fatals on a fresh fork.** `dw-template` has no `jwks` table (better-auth creates it at first server boot), so the #3199 cleanup aborted provisioning with `relation "jwks" does not exist`. The delete is now guarded with `to_regclass`.

**2. `preload-env.ts` clobbers the injected `DATABASE_URL`.** `applyCommittedMigrations` injects the new branch's URL with `AUTUMN_DB_DIRECT=1`, but the bunfig preload unconditionally overwrites `DATABASE_URL` from the stale `server/.env.local` — so "fresh branch" migrations silently ran against the *previous* machine's branch, and the new branch came up with zero tables (`setup-test` then failed with `relation "organizations" does not exist`). The preload now skips `DATABASE_URL` when `AUTUMN_DB_DIRECT=1`, which is that flag's documented contract. The hostname-collision adoption bug masked this for months: `.env.local` always happened to match the shared branch.

## Verification

Full from-scratch run on this machine: wiped `~/.autumn-capy`, provisioning minted a machine id, forked `capy-adb0aa7` off `dw-template`, applied all 75 migrations to the *correct* branch, seeded the test org, and the server boots with working auth (`get-session` 200, no `BAD_DECRYPT`, better-auth minted a fresh decryptable jwks row).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes from-scratch capy provisioning so a fresh machine and branch can boot without errors.

**Bug Fixes**
- Guards the `jwks` cleanup so it skips the table when it doesn't exist yet, instead of aborting provisioning with `relation "jwks" does not exist`.
- Stops `preload-env.ts` from overwriting the injected `DATABASE_URL` when `AUTUMN_DB_DIRECT=1`, so migrations run against the new branch rather than the stale `.env.local` URL.

<sup>Written for commit 5013b197c7e125a28a518db21034447a269e0777. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes fresh Capy provisioning by making inherited-key cleanup safe when the JWKS table is absent and by preserving the database URL explicitly supplied to direct database operations.
- **Bug fixes:** Guard deletion from `public.jwks` so provisioning does not fail when the table has not been created.
- **Bug fixes:** Prevent local environment files from replacing an explicitly injected `DATABASE_URL` during direct database operations.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with both fixes matching the existing database schema and direct-mode environment contract.

The guarded cleanup targets the configured `public.jwks` table using the database-owner connection, while all examined direct-mode callers explicitly provide the database URL that the preload now preserves.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/capy/provision.ts | Guards inherited JWKS cleanup with a schema-qualified existence check that matches the repository's PostgreSQL schema and provisioning flow. |
| scripts/preload-env.ts | Preserves caller-injected database URLs in direct mode, consistent with the existing requirement that direct-mode callers supply the URL. |

<sub>Reviews (1): Last reviewed commit: ["fix: make capy from-scratch provisioning..."](https://github.com/useautumn/autumn/commit/5013b197c7e125a28a518db21034447a269e0777) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59470439)</sub>

<!-- /greptile_comment -->