### PR TITLE
fix(billing): preserve generated schedule edits

### DIFF
--- a/server/src/internal/billing/v2/actions/generateRequest/compute/buildGenerationPrompts.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/compute/buildGenerationPrompts.ts
@@ -22,6 +22,7 @@ export const buildSystemPrompt = (tool: GenerateBillingTool) => {
 		"- Never omit a required field. Always set plan_id to your best match from the context plans; when sibling variants exist (e.g. monthly vs yearly), pick the one matching the stated interval or amount, defaulting to the monthly variant.",
 		"- When the request states a price for a plan (e.g. 'at 10k/mo'), always set customize.price to it — including Enterprise/custom placeholder plans where the docs say to ask about the base price.",
 		"- customer.current_plans[].effective_plan is the subscription's live configuration in the same shape as context.plans. When changing a plan or version, explicitly preserve any current term the request says to keep by copying it into the corresponding customize override.",
+		"- customer.schedules shows the persisted phase topology; each customer_product_id references customer.current_plans. Preserve it unless the request explicitly changes it.",
 		"- Use ONLY plan ids and feature ids that appear in the context below.",
 		"- Monetary amounts are in major currency units (e.g. dollars). Never convert to cents.",
 		"- The operation always targets the customer in the context. Ignore any other customer mentioned in the request.",

--- a/server/src/internal/billing/v2/actions/generateRequest/setup/loadGenerationScheduleContext.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/setup/loadGenerationScheduleContext.ts
@@ -1,0 +1,78 @@
+import type { FullCustomer, FullCustomerSchedule } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import { getCustomerSchedulesByScope } from "@/internal/customers/cusUtils/getFullCustomerSchedule";
+
+export const loadGenerationScheduleContext = async ({
+	ctx,
+	fullCustomer,
+}: {
+	ctx: AutumnContext;
+	fullCustomer: FullCustomer;
+}) => {
+	const [{ customerSchedule, entitySchedules }, allCustomerProducts] =
+		await Promise.all([
+			getCustomerSchedulesByScope({
+				ctx,
+				internalCustomerId: fullCustomer.internal_id,
+			}),
+			CusProductService.list({
+				db: ctx.db,
+				internalCustomerId: fullCustomer.internal_id,
+			}),
+		]);
+	const schedulesByScope = [
+		customerSchedule,
+		...Object.values(entitySchedules),
+	];
+	const scheduledProductIds = new Set(
+		schedulesByScope.flatMap(
+			(schedule) =>
+				schedule?.phases.flatMap((phase) => phase.customer_product_ids) ?? [],
+		),
+	);
+	const loadedProductIds = new Set(
+		fullCustomer.customer_products.map((product) => product.id),
+	);
+	const customerProducts = allCustomerProducts.filter(
+		(product) =>
+			loadedProductIds.has(product.id) || scheduledProductIds.has(product.id),
+	);
+	const customerProductById = new Map(
+		customerProducts.map((product) => [product.id, product]),
+	);
+	const entityIdByInternalId = new Map(
+		customerProducts.flatMap((product) =>
+			product.internal_entity_id && product.entity_id
+				? [[product.internal_entity_id, product.entity_id]]
+				: [],
+		),
+	);
+	const compactSchedule = (
+		schedule: FullCustomerSchedule,
+		entityId?: string,
+	) => ({
+		...(entityId ? { entity_id: entityId } : {}),
+		phases: schedule.phases.map(({ starts_at, customer_product_ids }) => ({
+			starts_at,
+			customer_product_ids,
+			...(customer_product_ids.some(
+				(id) =>
+					customerProductById.get(id)?.billing_cycle_anchor_resets_at ===
+					starts_at,
+			)
+				? { billing_cycle_anchor: "phase_start" as const }
+				: {}),
+		})),
+	});
+
+	return {
+		customerProducts,
+		schedules: [
+			...(customerSchedule ? [compactSchedule(customerSchedule)] : []),
+			...Object.entries(entitySchedules).map(([internalEntityId, schedule]) =>
+				compactSchedule(schedule, entityIdByInternalId.get(internalEntityId)),
+			),
+		],
+	};
+};

--- a/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
@@ -12,6 +12,7 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { CusService } from "@/internal/customers/CusService";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import { getCustomerSchedulesByScope } from "@/internal/customers/cusUtils/getFullCustomerSchedule";
 import { FeatureService } from "@/internal/features/FeatureService";
 import { ProductService } from "@/internal/products/ProductService";
@@ -62,11 +63,12 @@ export const compactCustomerProduct = ({
 	const entity = entities.find(
 		(candidate) => candidate.internal_id === customerProduct.internal_entity_id,
 	);
+	const entityId = entity?.id ?? customerProduct.entity_id;
 	return {
 		customer_product_id: customerProduct.id,
 		plan_id: customerProduct.product.id,
 		status: customerProduct.status,
-		...(entity?.id ? { entity_id: entity.id } : {}),
+		...(entityId ? { entity_id: entityId } : {}),
 		...(customerProduct.canceled ? { canceled: true } : {}),
 		...(customerProduct.trial_ends_at
 			? { trial_ends_at: customerProduct.trial_ends_at }
@@ -87,22 +89,66 @@ export const setupGenerationContext = async ({
 	const [fullProducts, features, fullCustomer] = await Promise.all([
 		ProductService.listFull({ db: ctx.db, env: ctx.env, orgId: ctx.org.id }),
 		FeatureService.list({ db: ctx.db, env: ctx.env, orgId: ctx.org.id }),
-		CusService.getFull({ ctx, idOrInternalId: customerId }),
+		CusService.getFull({ ctx, idOrInternalId: customerId, withEntities: true }),
 	]);
-	const { customerSchedule, entitySchedules } =
-		await getCustomerSchedulesByScope({
-			ctx,
-			internalCustomerId: fullCustomer.internal_id,
-		});
-	const schedules = [customerSchedule, ...Object.values(entitySchedules)]
-		.filter((schedule) => schedule !== undefined)
-		.map((schedule) => ({
-			...(schedule.entity_id ? { entity_id: schedule.entity_id } : {}),
-			phases: schedule.phases.map(({ starts_at, customer_product_ids }) => ({
-				starts_at,
-				customer_product_ids,
-			})),
-		}));
+	const [{ customerSchedule, entitySchedules }, allCustomerProducts] =
+		await Promise.all([
+			getCustomerSchedulesByScope({
+				ctx,
+				internalCustomerId: fullCustomer.internal_id,
+			}),
+			CusProductService.list({
+				db: ctx.db,
+				internalCustomerId: fullCustomer.internal_id,
+			}),
+		]);
+	const scheduledProductIds = new Set(
+		[customerSchedule, ...Object.values(entitySchedules)].flatMap(
+			(schedule) =>
+				schedule?.phases.flatMap((phase) => phase.customer_product_ids) ?? [],
+		),
+	);
+	const loadedProductIds = new Set(
+		fullCustomer.customer_products.map((product) => product.id),
+	);
+	const customerProducts = allCustomerProducts.filter(
+		(product) =>
+			loadedProductIds.has(product.id) || scheduledProductIds.has(product.id),
+	);
+	const entities = fullCustomer.entities ?? [];
+	const customerProductById = new Map(
+		customerProducts.map((product) => [product.id, product]),
+	);
+	const entityIdByInternalId = new Map(
+		customerProducts.flatMap((product) =>
+			product.internal_entity_id && product.entity_id
+				? [[product.internal_entity_id, product.entity_id]]
+				: [],
+		),
+	);
+	const compactSchedule = (
+		schedule: NonNullable<typeof customerSchedule>,
+		entityId?: string,
+	) => ({
+		...(entityId ? { entity_id: entityId } : {}),
+		phases: schedule.phases.map(({ starts_at, customer_product_ids }) => ({
+			starts_at,
+			customer_product_ids,
+			...(customer_product_ids.some(
+				(id) =>
+					customerProductById.get(id)?.billing_cycle_anchor_resets_at ===
+					starts_at,
+			)
+				? { billing_cycle_anchor: "phase_start" as const }
+				: {}),
+		})),
+	});
+	const schedules = [
+		...(customerSchedule ? [compactSchedule(customerSchedule)] : []),
+		...Object.entries(entitySchedules).map(([internalEntityId, schedule]) =>
+			compactSchedule(schedule, entityIdByInternalId.get(internalEntityId)),
+		),
+	];
 
 	const now = Date.now();
 
@@ -111,19 +157,17 @@ export const setupGenerationContext = async ({
 			customer: {
 				id: fullCustomer.id,
 				...(fullCustomer.name ? { name: fullCustomer.name } : {}),
-				current_plans: fullCustomer.customer_products.map(
-					(customerProduct) => ({
-						...compactCustomerProduct({
-							customerProduct,
-							entities: fullCustomer.entities ?? [],
-						}),
-						effective_plan: compactPlan({
-							features,
-							product: cusProductToProduct({ cusProduct: customerProduct }),
-						}),
+				current_plans: customerProducts.map((customerProduct) => ({
+					...compactCustomerProduct({
+						customerProduct,
+						entities,
 					}),
-				),
-				entities: (fullCustomer.entities ?? []).map((entity) => ({
+					effective_plan: compactPlan({
+						features,
+						product: cusProductToProduct({ cusProduct: customerProduct }),
+					}),
+				})),
+				entities: entities.map((entity) => ({
 					id: entity.id,
 					...(entity.name ? { name: entity.name } : {}),
 					...(entity.feature_id ? { feature_id: entity.feature_id } : {}),

--- a/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
@@ -12,6 +12,7 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { CusService } from "@/internal/customers/CusService";
+import { getCustomerSchedulesByScope } from "@/internal/customers/cusUtils/getFullCustomerSchedule";
 import { FeatureService } from "@/internal/features/FeatureService";
 import { ProductService } from "@/internal/products/ProductService";
 
@@ -88,6 +89,20 @@ export const setupGenerationContext = async ({
 		FeatureService.list({ db: ctx.db, env: ctx.env, orgId: ctx.org.id }),
 		CusService.getFull({ ctx, idOrInternalId: customerId }),
 	]);
+	const { customerSchedule, entitySchedules } =
+		await getCustomerSchedulesByScope({
+			ctx,
+			internalCustomerId: fullCustomer.internal_id,
+		});
+	const schedules = [customerSchedule, ...Object.values(entitySchedules)]
+		.filter((schedule) => schedule !== undefined)
+		.map((schedule) => ({
+			...(schedule.entity_id ? { entity_id: schedule.entity_id } : {}),
+			phases: schedule.phases.map(({ starts_at, customer_product_ids }) => ({
+				starts_at,
+				customer_product_ids,
+			})),
+		}));
 
 	const now = Date.now();
 
@@ -113,6 +128,7 @@ export const setupGenerationContext = async ({
 					...(entity.name ? { name: entity.name } : {}),
 					...(entity.feature_id ? { feature_id: entity.feature_id } : {}),
 				})),
+				...(schedules.length ? { schedules } : {}),
 			},
 			features: features.map((feature) => ({
 				id: feature.id,

--- a/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
@@ -2,8 +2,6 @@ import type {
 	Entity,
 	Feature,
 	FullCusProduct,
-	FullCustomer,
-	FullCustomerSchedule,
 	FullProduct,
 } from "@autumn/shared";
 import {
@@ -14,10 +12,9 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { CusService } from "@/internal/customers/CusService";
-import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
-import { getCustomerSchedulesByScope } from "@/internal/customers/cusUtils/getFullCustomerSchedule";
 import { FeatureService } from "@/internal/features/FeatureService";
 import { ProductService } from "@/internal/products/ProductService";
+import { loadGenerationScheduleContext } from "./loadGenerationScheduleContext";
 
 const compactPlan = ({
 	product,
@@ -78,80 +75,6 @@ export const compactCustomerProduct = ({
 		...(customerProduct.options?.length
 			? { prepaid_quantities: customerProduct.options }
 			: {}),
-	};
-};
-
-const loadGenerationScheduleContext = async ({
-	ctx,
-	fullCustomer,
-}: {
-	ctx: AutumnContext;
-	fullCustomer: FullCustomer;
-}) => {
-	const [{ customerSchedule, entitySchedules }, allCustomerProducts] =
-		await Promise.all([
-			getCustomerSchedulesByScope({
-				ctx,
-				internalCustomerId: fullCustomer.internal_id,
-			}),
-			CusProductService.list({
-				db: ctx.db,
-				internalCustomerId: fullCustomer.internal_id,
-			}),
-		]);
-	const schedulesByScope = [
-		customerSchedule,
-		...Object.values(entitySchedules),
-	];
-	const scheduledProductIds = new Set(
-		schedulesByScope.flatMap(
-			(schedule) =>
-				schedule?.phases.flatMap((phase) => phase.customer_product_ids) ?? [],
-		),
-	);
-	const loadedProductIds = new Set(
-		fullCustomer.customer_products.map((product) => product.id),
-	);
-	const customerProducts = allCustomerProducts.filter(
-		(product) =>
-			loadedProductIds.has(product.id) || scheduledProductIds.has(product.id),
-	);
-	const customerProductById = new Map(
-		customerProducts.map((product) => [product.id, product]),
-	);
-	const entityIdByInternalId = new Map(
-		customerProducts.flatMap((product) =>
-			product.internal_entity_id && product.entity_id
-				? [[product.internal_entity_id, product.entity_id]]
-				: [],
-		),
-	);
-	const compactSchedule = (
-		schedule: FullCustomerSchedule,
-		entityId?: string,
-	) => ({
-		...(entityId ? { entity_id: entityId } : {}),
-		phases: schedule.phases.map(({ starts_at, customer_product_ids }) => ({
-			starts_at,
-			customer_product_ids,
-			...(customer_product_ids.some(
-				(id) =>
-					customerProductById.get(id)?.billing_cycle_anchor_resets_at ===
-					starts_at,
-			)
-				? { billing_cycle_anchor: "phase_start" as const }
-				: {}),
-		})),
-	});
-
-	return {
-		customerProducts,
-		schedules: [
-			...(customerSchedule ? [compactSchedule(customerSchedule)] : []),
-			...Object.entries(entitySchedules).map(([internalEntityId, schedule]) =>
-				compactSchedule(schedule, entityIdByInternalId.get(internalEntityId)),
-			),
-		],
 	};
 };
 

--- a/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
@@ -2,6 +2,8 @@ import type {
 	Entity,
 	Feature,
 	FullCusProduct,
+	FullCustomer,
+	FullCustomerSchedule,
 	FullProduct,
 } from "@autumn/shared";
 import {
@@ -79,18 +81,13 @@ export const compactCustomerProduct = ({
 	};
 };
 
-export const setupGenerationContext = async ({
+const loadGenerationScheduleContext = async ({
 	ctx,
-	customerId,
+	fullCustomer,
 }: {
 	ctx: AutumnContext;
-	customerId: string;
+	fullCustomer: FullCustomer;
 }) => {
-	const [fullProducts, features, fullCustomer] = await Promise.all([
-		ProductService.listFull({ db: ctx.db, env: ctx.env, orgId: ctx.org.id }),
-		FeatureService.list({ db: ctx.db, env: ctx.env, orgId: ctx.org.id }),
-		CusService.getFull({ ctx, idOrInternalId: customerId, withEntities: true }),
-	]);
 	const [{ customerSchedule, entitySchedules }, allCustomerProducts] =
 		await Promise.all([
 			getCustomerSchedulesByScope({
@@ -102,8 +99,12 @@ export const setupGenerationContext = async ({
 				internalCustomerId: fullCustomer.internal_id,
 			}),
 		]);
+	const schedulesByScope = [
+		customerSchedule,
+		...Object.values(entitySchedules),
+	];
 	const scheduledProductIds = new Set(
-		[customerSchedule, ...Object.values(entitySchedules)].flatMap(
+		schedulesByScope.flatMap(
 			(schedule) =>
 				schedule?.phases.flatMap((phase) => phase.customer_product_ids) ?? [],
 		),
@@ -115,7 +116,6 @@ export const setupGenerationContext = async ({
 		(product) =>
 			loadedProductIds.has(product.id) || scheduledProductIds.has(product.id),
 	);
-	const entities = fullCustomer.entities ?? [];
 	const customerProductById = new Map(
 		customerProducts.map((product) => [product.id, product]),
 	);
@@ -127,7 +127,7 @@ export const setupGenerationContext = async ({
 		),
 	);
 	const compactSchedule = (
-		schedule: NonNullable<typeof customerSchedule>,
+		schedule: FullCustomerSchedule,
 		entityId?: string,
 	) => ({
 		...(entityId ? { entity_id: entityId } : {}),
@@ -143,12 +143,35 @@ export const setupGenerationContext = async ({
 				: {}),
 		})),
 	});
-	const schedules = [
-		...(customerSchedule ? [compactSchedule(customerSchedule)] : []),
-		...Object.entries(entitySchedules).map(([internalEntityId, schedule]) =>
-			compactSchedule(schedule, entityIdByInternalId.get(internalEntityId)),
-		),
-	];
+
+	return {
+		customerProducts,
+		schedules: [
+			...(customerSchedule ? [compactSchedule(customerSchedule)] : []),
+			...Object.entries(entitySchedules).map(([internalEntityId, schedule]) =>
+				compactSchedule(schedule, entityIdByInternalId.get(internalEntityId)),
+			),
+		],
+	};
+};
+
+export const setupGenerationContext = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+}) => {
+	const [fullProducts, features, fullCustomer] = await Promise.all([
+		ProductService.listFull({ db: ctx.db, env: ctx.env, orgId: ctx.org.id }),
+		FeatureService.list({ db: ctx.db, env: ctx.env, orgId: ctx.org.id }),
+		CusService.getFull({ ctx, idOrInternalId: customerId, withEntities: true }),
+	]);
+	const { customerProducts, schedules } = await loadGenerationScheduleContext({
+		ctx,
+		fullCustomer,
+	});
+	const entities = fullCustomer.entities ?? [];
 
 	const now = Date.now();
 

--- a/server/tests/evals/generateBillingRequest/fixtures.ts
+++ b/server/tests/evals/generateBillingRequest/fixtures.ts
@@ -104,22 +104,178 @@ export const versionedPlanContext = ({
 		})),
 	}) as unknown as GenerationContext;
 
-export const versionedScheduleContext = (): GenerationContext => {
-	const context = versionedPlanContext();
-	return {
-		...context,
-		plans: [
-			...context.plans,
-			{
-				id: "support-addon",
-				is_add_on: true,
-				items: [],
-				name: "Support Add-on",
-				price: { amount: 10, interval: BillingInterval.Month },
-				version: 1,
-			},
-		],
+export const complexScheduleStarts = [
+	Date.UTC(2026, 7, 24, 12),
+	Date.UTC(2027, 7, 24, 12),
+	Date.UTC(2028, 7, 24, 12),
+	Date.UTC(2029, 7, 24, 12),
+];
+
+const monthlyItem = (feature_id: string, included: number) => ({
+	feature_id,
+	included,
+	pooled: false,
+	reset: { interval: "month" },
+});
+
+const planFeatureIds: Record<string, string> = {
+	"analytics-addon": "reports",
+	core: "messages",
+	"success-addon": "sessions",
+	"support-addon": "tickets",
+};
+
+const customizedPlan = ({
+	amount,
+	included,
+	plan_id,
+	version = 1,
+}: {
+	amount: number;
+	included: number;
+	plan_id: string;
+	version?: number;
+}) => ({
+	customize: {
+		items: [monthlyItem(planFeatureIds[plan_id]!, included)],
+		price: { amount, interval: "month" },
+	},
+	plan_id,
+	version,
+});
+
+export const complexScheduleRequest = ({
+	phaseTwoVersion = 2,
+	phaseThreeSupportPrice = 275,
+	phaseFourMessages = 40_000,
+}: {
+	phaseTwoVersion?: number;
+	phaseThreeSupportPrice?: number;
+	phaseFourMessages?: number;
+} = {}): Record<string, unknown> => ({
+	billing_behavior: "none",
+	billing_cycle_anchor: "now",
+	phases: [
+		[900, 12_000, 1, 175, 5_000, 225, 25],
+		[1_100, 20_000, phaseTwoVersion, 190, 7_500, 250, 50],
+		[1_350, 30_000, 3, 200, 9_000, phaseThreeSupportPrice, 75],
+		[1_500, phaseFourMessages, 3, 225, 10_000, 300, 100],
+	].map(
+		(
+			[
+				corePrice,
+				messages,
+				version,
+				analyticsPrice,
+				reports,
+				supportPrice,
+				tickets,
+			],
+			index,
+		) => ({
+			...(index % 2 ? { billing_cycle_anchor: "phase_start" } : {}),
+			plans: [
+				customizedPlan({
+					amount: corePrice,
+					included: messages,
+					plan_id: "core",
+					version,
+				}),
+				customizedPlan({
+					amount: analyticsPrice,
+					included: reports,
+					plan_id: "analytics-addon",
+				}),
+				customizedPlan({
+					amount: supportPrice,
+					included: tickets,
+					plan_id: "support-addon",
+				}),
+			],
+			starts_at: complexScheduleStarts[index],
+		}),
+	),
+	unscheduled_plans: [
+		customizedPlan({
+			amount: 95,
+			included: 25,
+			plan_id: "success-addon",
+		}),
+	],
+});
+
+export const complexScheduleContext = (): GenerationContext => {
+	const plans = [
+		...[1, 2, 3].map((version) => ({
+			id: "core",
+			items: [monthlyItem("messages", version * 10_000)],
+			name: "Core",
+			price: { amount: version * 500, interval: "month" },
+			version,
+		})),
+		...(
+			[
+				["analytics-addon", "Analytics Add-on", 200, 5_000, "reports"],
+				["support-addon", "Support Add-on", 300, 50, "tickets"],
+				["success-addon", "Success Add-on", 100, 25, "sessions"],
+			] as const
+		).map(([id, name, amount, included, featureId]) => ({
+			id,
+			is_add_on: true,
+			items: [monthlyItem(featureId, included)],
+			name,
+			price: { amount, interval: "month" },
+			version: 1,
+		})),
+	];
+	const schedule = complexScheduleRequest() as {
+		phases: {
+			plans: ReturnType<typeof customizedPlan>[];
+			starts_at: number;
+		}[];
 	};
+	const customerProductId = (phase: number, planId: string) =>
+		`cp_${phase + 1}_${planId}`;
+
+	return {
+		customer: {
+			current_plans: schedule.phases.flatMap((phase, phaseIndex) =>
+				phase.plans.map((plan) => ({
+					customer_product_id: customerProductId(phaseIndex, plan.plan_id),
+					effective_plan: {
+						...plans.find(
+							(candidate) =>
+								candidate.id === plan.plan_id &&
+								candidate.version === plan.version,
+						),
+						...plan.customize,
+					},
+					plan_id: plan.plan_id,
+					status: phaseIndex ? "scheduled" : "active",
+				})),
+			),
+			id: "cus_complex_schedule",
+			name: "Example Company",
+			schedules: [
+				{
+					phases: schedule.phases.map((phase, phaseIndex) => ({
+						customer_product_ids: phase.plans.map((plan) =>
+							customerProductId(phaseIndex, plan.plan_id),
+						),
+						starts_at: phase.starts_at,
+					})),
+				},
+			],
+		},
+		features: [
+			{ id: "messages", name: "Messages", type: "single_use" },
+			{ id: "reports", name: "Reports", type: "single_use" },
+			{ id: "sessions", name: "Success Sessions", type: "single_use" },
+			{ id: "tickets", name: "Support Tickets", type: "single_use" },
+		],
+		now,
+		plans,
+	} as unknown as GenerationContext;
 };
 
 /** Enterprise org with a volume-tiered prepaid credits ladder — the shape that

--- a/server/tests/evals/generateBillingRequest/fixtures.ts
+++ b/server/tests/evals/generateBillingRequest/fixtures.ts
@@ -230,6 +230,7 @@ export const complexScheduleContext = (): GenerationContext => {
 	];
 	const schedule = complexScheduleRequest() as {
 		phases: {
+			billing_cycle_anchor?: string;
 			plans: ReturnType<typeof customizedPlan>[];
 			starts_at: number;
 		}[];
@@ -259,6 +260,9 @@ export const complexScheduleContext = (): GenerationContext => {
 			schedules: [
 				{
 					phases: schedule.phases.map((phase, phaseIndex) => ({
+						...(phase.billing_cycle_anchor
+							? { billing_cycle_anchor: phase.billing_cycle_anchor }
+							: {}),
 						customer_product_ids: phase.plans.map((plan) =>
 							customerProductId(phaseIndex, plan.plan_id),
 						),

--- a/server/tests/evals/generateBillingRequest/generate-billing-request.eval.ts
+++ b/server/tests/evals/generateBillingRequest/generate-billing-request.eval.ts
@@ -6,6 +6,7 @@
  * Run: bun eval:generation  (needs ANTHROPIC_API_KEY + BRAINTRUST_API_KEY)
  */
 
+import { isDeepStrictEqual } from "node:util";
 import {
 	type ApiPlanV1,
 	applyCustomizeToPlan,
@@ -21,6 +22,8 @@ import type {
 } from "@/internal/billing/v2/actions/generateRequest/generationSchemas";
 import type { GenerationContext } from "@/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext";
 import {
+	complexScheduleContext,
+	complexScheduleRequest,
 	creditLadderContext,
 	entityScaleContext,
 	rolloverCreditsBaseItems,
@@ -30,7 +33,6 @@ import {
 	tieredScaleContext,
 	variantLadderContext,
 	versionedPlanContext,
-	versionedScheduleContext,
 } from "./fixtures";
 
 type EvalInput = {
@@ -41,6 +43,7 @@ type EvalInput = {
 	forbiddenKeys?: string[];
 	applyToItems?: ApiPlanV1["items"];
 	expectedApplied?: Record<string, unknown>[];
+	exact?: boolean;
 };
 
 type EvalOutput = {
@@ -158,6 +161,29 @@ const expectedParams = ({
 	};
 };
 
+const exactParams = ({
+	input,
+	output,
+	expected,
+}: {
+	input: EvalInput;
+	output: EvalOutput;
+	expected?: Record<string, unknown>;
+}) => {
+	if (!input.exact) return null;
+	const matches = isDeepStrictEqual(output.params, expected);
+	if (!matches) {
+		console.warn(
+			`[exact_params] ${input.tool}: "${input.prompt}"\nexpected ${JSON.stringify(expected)}\nactual   ${JSON.stringify(output.params)}`,
+		);
+	}
+	return {
+		name: "exact_params",
+		score: matches ? 1 : 0,
+		...(matches ? {} : { metadata: { actual: output.params, expected } }),
+	};
+};
+
 const appliedPlan = ({
 	input,
 	output,
@@ -205,12 +231,6 @@ const appliedPlan = ({
 		...(mismatches.length ? { metadata: { mismatches } } : {}),
 	};
 };
-
-const scheduledVersionStarts = [
-	Date.UTC(2026, 7, 24, 12),
-	Date.UTC(2027, 7, 24, 12),
-	Date.UTC(2028, 7, 24, 12),
-];
 
 const cases: EvalCase[] = [
 	{
@@ -651,98 +671,46 @@ const cases: EvalCase[] = [
 			],
 		},
 	},
-	{
-		name: "schedule: existing phases survive a targeted version change",
-		input: {
-			context: versionedScheduleContext(),
-			currentRequest: {
-				phases: [1, 2, 3].map((version, index) => ({
-					...(index === 1 ? { billing_cycle_anchor: "phase_start" } : {}),
-					plans: [
-						{
-							plan_id: "generation",
-							version,
-							...(index === 1
-								? {
-										customize: {
-											price: { amount: 25, interval: "month" },
-										},
-									}
-								: {}),
-						},
-					],
-					starts_at: scheduledVersionStarts[index],
-				})),
-				unscheduled_plans: [{ plan_id: "support-addon" }],
-			},
+	...[
+		{
+			name: "schedule: changes one version without dropping complex phases",
 			prompt:
-				"In the existing schedule, move only phase 2 to version 3 but keep its custom $25 monthly price. Leave every other field unchanged.",
-			tool: "create_schedule",
+				"Change only the Core plan in phase 2 to version 3. Keep its $1,100 monthly price, its items, and every other schedule field exactly unchanged.",
+			expected: complexScheduleRequest({ phaseTwoVersion: 3 }),
 		},
-		expected: {
-			phases: [
-				{
-					plans: [{ plan_id: "generation", version: 1 }],
-					starts_at: scheduledVersionStarts[0],
-				},
-				{
-					billing_cycle_anchor: "phase_start",
-					plans: [
-						{
-							customize: {
-								price: { amount: 25, interval: "month" },
-							},
-							plan_id: "generation",
-							version: 3,
-						},
-					],
-					starts_at: scheduledVersionStarts[1],
-				},
-				{
-					plans: [{ plan_id: "generation", version: 3 }],
-					starts_at: scheduledVersionStarts[2],
-				},
-			],
-			unscheduled_plans: [{ plan_id: "support-addon" }],
-		},
-	},
-	{
-		name: "schedule: append relative phase without rewriting the schedule",
-		input: {
-			context: versionedScheduleContext(),
-			currentRequest: {
-				phases: [1, 2, 3].map((version, index) => ({
-					plans: [{ plan_id: "generation", version }],
-					starts_at: scheduledVersionStarts[index],
-				})),
-				unscheduled_plans: [{ plan_id: "support-addon" }],
-			},
+		{
+			name: "schedule: changes one add-on price without dropping sibling plans",
 			prompt:
-				"Preserve the entire existing schedule and Support Add-on, then append phase 4 two months after phase 3 on generation v1 at a custom $15 per month.",
-			tool: "create_schedule",
+				"In phase 3 only, change the Support Add-on price from $275 to $325 per month. Preserve the rest of the schedule exactly.",
+			expected: complexScheduleRequest({ phaseThreeSupportPrice: 325 }),
 		},
-		expected: {
-			phases: [
-				...scheduledVersionStarts.map((starts_at, index) => ({
-					plans: [{ plan_id: "generation", version: index + 1 }],
-					starts_at,
-				})),
-				{
-					plans: [
-						{
-							customize: {
-								price: { amount: 15, interval: "month" },
-							},
-							plan_id: "generation",
-							version: 1,
-						},
-					],
-					starting_after: { duration_count: 2, duration_type: "month" },
-				},
-			],
-			unscheduled_plans: [{ plan_id: "support-addon" }],
+		{
+			name: "schedule: changes one entitlement without dropping nested items",
+			prompt:
+				"In phase 4 only, increase the Core plan's included Messages from 40,000 to 45,000. Keep its price, version, other plans, and all other fields exactly unchanged.",
+			expected: complexScheduleRequest({ phaseFourMessages: 45_000 }),
 		},
-	},
+		{
+			name: "schedule: a follow-up edit preserves the prior generated change",
+			currentRequest: complexScheduleRequest({ phaseThreeSupportPrice: 325 }),
+			prompt:
+				"Now increase phase 4 Core Messages to 45,000. Keep the phase 3 Support Add-on at $325 and preserve everything else.",
+			expected: complexScheduleRequest({
+				phaseFourMessages: 45_000,
+				phaseThreeSupportPrice: 325,
+			}),
+		},
+	].map(({ name, prompt, expected, currentRequest }) => ({
+		name,
+		input: {
+			context: complexScheduleContext(),
+			currentRequest: currentRequest ?? complexScheduleRequest(),
+			exact: true,
+			prompt,
+			tool: "create_schedule" as const,
+		},
+		expected,
+	})),
 ];
 
 Eval("generate-billing-request", {
@@ -754,7 +722,7 @@ Eval("generate-billing-request", {
 			tags: [input.tool],
 			// biome-ignore lint/suspicious/noExplicitAny: braintrust's case type is looser than ours
 		})) as any,
-	scores: [schemaFirstTry, expectedParams, appliedPlan],
+	scores: [schemaFirstTry, expectedParams, exactParams, appliedPlan],
 	task: async (input: EvalInput): Promise<EvalOutput> => {
 		try {
 			const { params, repaired, repairReason } = await computeGeneratedParams({

--- a/server/tests/integration/billing/generateRequest/generate-create-schedule-e2e.test.ts
+++ b/server/tests/integration/billing/generateRequest/generate-create-schedule-e2e.test.ts
@@ -11,6 +11,7 @@ import {
 	CreateScheduleParamsV0Schema,
 	ms,
 	type ProductItem,
+	schedules,
 } from "@autumn/shared";
 import {
 	getCustomerProductEntitlementBalances,
@@ -18,14 +19,17 @@ import {
 	getRequiredScheduleId,
 } from "@tests/integration/billing/create-schedule/utils/createScheduleTestHelpers.js";
 import { messagesItem } from "@tests/integration/catalog-v2/plans/licenses/utils/seedLicensePlans.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import { productItemsToCustomizePlanV1 } from "@utils/productV2Utils/productItemUtils/convertProductItem/productItemsToCustomizePlanV1.js";
 import chalk from "chalk";
+import { eq } from "drizzle-orm";
 import { setupGenerationContext } from "@/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.js";
 import { CusService } from "@/internal/customers/CusService.js";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
 import { hydrateCustomerWithSchedules } from "@/internal/customers/cusUtils/getFullCustomerSchedule.js";
 import { resetCatalogPlans } from "../../../scenarios/catalog/utils/catalogScenario.js";
 
@@ -159,6 +163,11 @@ test(`${chalk.yellowBright("billing.generate schedule: generated edit previews, 
 			.flatMap(({ customer_product_ids }) => customer_product_ids)
 			.every((id) => knownCustomerProductIds.has(id)),
 	).toBe(true);
+	expect(
+		persistedSchedule?.phases.map(
+			({ billing_cycle_anchor }) => billing_cycle_anchor,
+		),
+	).toEqual([undefined, "phase_start", undefined, "phase_start"]);
 	const generated = await autumnV2_2.post(GENERATE_PATH, {
 		customer_id: customerId,
 		current_request: initialRequest,
@@ -177,6 +186,7 @@ test(`${chalk.yellowBright("billing.generate schedule: generated edit previews, 
 		plans: {
 			items: { included_usage?: number; price?: number }[];
 			plan_id: string;
+			version?: number;
 		}[];
 		starts_at: number;
 	}[];
@@ -184,6 +194,9 @@ test(`${chalk.yellowBright("billing.generate schedule: generated edit previews, 
 	expect(
 		generatedPhases.map(({ plans }) => plans.map(({ plan_id }) => plan_id)),
 	).toEqual(phaseTerms.map(() => [planId, analyticsId, supportId]));
+	expect(generatedPhases.map(({ plans }) => plans[0]?.version)).toEqual(
+		phaseTerms.map(({ version }) => version),
+	);
 	expect(
 		generatedPhases.map(({ billing_cycle_anchor }) => billing_cycle_anchor),
 	).toEqual([undefined, "phase_start", undefined, "phase_start"]);
@@ -233,6 +246,18 @@ test(`${chalk.yellowBright("billing.generate schedule: generated edit previews, 
 		),
 	);
 	expect(appliedPrices).toEqual(expectedPrices);
+	const appliedVersions = await Promise.all(
+		applied.phases.map(
+			async ({ customer_product_ids }) =>
+				(
+					await CusProductService.getFull({
+						db: ctx.db,
+						id: customer_product_ids[0]!,
+					})
+				)?.product.version,
+		),
+	);
+	expect(appliedVersions).toEqual(phaseTerms.map(({ version }) => version));
 	const coreEntitlements = await Promise.all(
 		applied.phases.map(
 			async ({ customer_product_ids }) =>
@@ -258,6 +283,59 @@ test(`${chalk.yellowBright("billing.generate schedule: generated edit previews, 
 	const hydrated = await hydrateCustomerWithSchedules({ ctx, fullCustomer });
 	expect(hydrated.schedule?.id).toBe(appliedScheduleId);
 	expect(hydrated.schedule?.phases).toHaveLength(4);
+}, 120_000);
+
+test(`${chalk.yellowBright("billing.generate schedule: loads complete legacy entity context")}`, async () => {
+	const customerId = "generate-schedule-entity-context-customer";
+	const plans = Array.from({ length: 6 }, (_, index) =>
+		products.base({
+			id: `generate-schedule-entity-context-plan-${index}`,
+			isAddOn: index > 0,
+			items: [items.monthlyPrice({ price: 20 + index })],
+		}),
+	);
+	const { autumnV1, ctx, entities } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.products({ list: plans, prefix: "" }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+		],
+		actions: [],
+	});
+	const entityId = entities[0]!.id;
+	const response = await autumnV1.billing.createSchedule({
+		customer_id: customerId,
+		entity_id: entityId,
+		phases: [
+			{
+				plans: plans.map(({ id }) => ({ plan_id: id })),
+				starts_at: Date.now(),
+			},
+			{
+				plans: plans.map(({ id }) => ({ plan_id: id })),
+				starts_at: Date.now() + ms.days(30),
+			},
+		],
+	});
+
+	await ctx.db
+		.update(schedules)
+		.set({ entity_id: null, internal_entity_id: null })
+		.where(eq(schedules.id, getRequiredScheduleId(response.schedule_id)));
+
+	const { context } = await setupGenerationContext({ ctx, customerId });
+	expect(context.customer.schedules).toMatchObject([{ entity_id: entityId }]);
+	const currentPlanIds = new Set(
+		context.customer.current_plans.map(
+			({ customer_product_id }) => customer_product_id,
+		),
+	);
+	expect(
+		response.phases
+			.flatMap(({ customer_product_ids }) => customer_product_ids)
+			.every((id) => currentPlanIds.has(id)),
+	).toBe(true);
 }, 120_000);
 
 test(`${chalk.yellowBright("billing.generate schedule: appends a relative phase and preserves an unscheduled plan")}`, async () => {

--- a/server/tests/integration/billing/generateRequest/generate-create-schedule-e2e.test.ts
+++ b/server/tests/integration/billing/generateRequest/generate-create-schedule-e2e.test.ts
@@ -13,17 +13,19 @@ import {
 	type ProductItem,
 } from "@autumn/shared";
 import {
+	getCustomerProductEntitlementBalances,
 	getCustomerProductPriceAmounts,
 	getRequiredScheduleId,
 } from "@tests/integration/billing/create-schedule/utils/createScheduleTestHelpers.js";
 import { messagesItem } from "@tests/integration/catalog-v2/plans/licenses/utils/seedLicensePlans.js";
 import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import { productItemsToCustomizePlanV1 } from "@utils/productV2Utils/productItemUtils/convertProductItem/productItemsToCustomizePlanV1.js";
 import chalk from "chalk";
+import { setupGenerationContext } from "@/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.js";
 import { CusService } from "@/internal/customers/CusService.js";
-import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
 import { hydrateCustomerWithSchedules } from "@/internal/customers/cusUtils/getFullCustomerSchedule.js";
 import { resetCatalogPlans } from "../../../scenarios/catalog/utils/catalogScenario.js";
 
@@ -63,9 +65,28 @@ const generatedRequestToApi = ({
 
 test(`${chalk.yellowBright("billing.generate schedule: generated edit previews, executes, and persists")}`, async () => {
 	const customerId = "generate-schedule-e2e-customer";
+	const analyticsId = "generate-analytics-addon";
+	const supportId = "generate-support-addon";
+	const successId = "generate-success-addon";
+	const addOn = (id: string, price: number) =>
+		products.base({
+			id,
+			isAddOn: true,
+			items: [items.monthlyPrice({ price }), items.monthlyWords()],
+		});
 	const { autumnV1, autumnV2_2, autumnV2_3, ctx } = await initScenario({
 		customerId,
-		setup: [s.customer({ paymentMethod: "success", testClock: false })],
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.products({
+				list: [
+					addOn(analyticsId, 200),
+					addOn(supportId, 300),
+					addOn(successId, 100),
+				],
+				prefix: "",
+			}),
+		],
 		actions: [],
 	});
 	await resetCatalogPlans({ ctx, planIds: [planId] });
@@ -85,76 +106,149 @@ test(`${chalk.yellowBright("billing.generate schedule: generated edit previews, 
 		});
 	}
 
-	const now = Date.now();
-	const startsAt = [now, now + ms.days(30), now + ms.days(60)];
+	const startsAt = [0, 365, 730, 1_095].map(
+		(days) => Date.now() + ms.days(days),
+	);
+	const phaseTerms = [
+		{ analytics: 175, core: 900, messages: 12_000, support: 225, version: 1 },
+		{ analytics: 190, core: 1_100, messages: 20_000, support: 250, version: 2 },
+		{ analytics: 200, core: 1_350, messages: 30_000, support: 275, version: 3 },
+		{ analytics: 225, core: 1_500, messages: 40_000, support: 300, version: 3 },
+	];
+	const pricedPlan = (plan_id: string, amount: number) => ({
+		plan_id,
+		customize: { price: { amount, interval: BillingInterval.Month } },
+	});
 	const initialRequest = CreateScheduleParamsV0Schema.parse({
+		billing_behavior: "none",
+		billing_cycle_anchor: "now",
 		customer_id: customerId,
-		phases: [
-			{ starts_at: startsAt[0], plans: [{ plan_id: planId, version: 2 }] },
-			{
-				starts_at: startsAt[1],
-				plans: [
-					{
-						plan_id: planId,
-						version: 2,
-						customize: {
-							price: { amount: 25, interval: BillingInterval.Month },
-						},
+		phases: phaseTerms.map((terms, index) => ({
+			...(index % 2 ? { billing_cycle_anchor: "phase_start" as const } : {}),
+			plans: [
+				{
+					...pricedPlan(planId, terms.core),
+					customize: {
+						items: [itemsV2.monthlyMessages({ included: terms.messages })],
+						price: { amount: terms.core, interval: BillingInterval.Month },
 					},
-				],
-			},
-			{ starts_at: startsAt[2], plans: [{ plan_id: planId, version: 3 }] },
-		],
+					version: terms.version,
+				},
+				pricedPlan(analyticsId, terms.analytics),
+				pricedPlan(supportId, terms.support),
+			],
+			starts_at: startsAt[index],
+		})),
+		unscheduled_plans: [pricedPlan(successId, 95)],
 	});
 	const initial = await autumnV1.billing.createSchedule(initialRequest);
+	const { context } = await setupGenerationContext({ ctx, customerId });
+	const [persistedSchedule] = context.customer.schedules ?? [];
+	expect(
+		persistedSchedule?.phases.map(
+			({ customer_product_ids }) => customer_product_ids.length,
+		),
+	).toEqual([3, 3, 3, 3]);
+	const knownCustomerProductIds = new Set(
+		context.customer.current_plans.map(
+			({ customer_product_id }) => customer_product_id,
+		),
+	);
+	expect(
+		persistedSchedule?.phases
+			.flatMap(({ customer_product_ids }) => customer_product_ids)
+			.every((id) => knownCustomerProductIds.has(id)),
+	).toBe(true);
 	const generated = await autumnV2_2.post(GENERATE_PATH, {
 		customer_id: customerId,
 		current_request: initialRequest,
 		prompt:
-			"Move only phase 2 to version 3 but keep its $25 monthly price. Leave phases 1 and 3 unchanged.",
+			"In phase 3 only, change the Support Add-on price from $275 to $325 per month. Preserve every phase, plan, date, billing anchor, version, item customization, and the unscheduled Success Add-on exactly.",
 		tool: "create_schedule",
 	});
 
-	expect(
-		generated.request.phases.map(
-			(phase: { starts_at: number }) => phase.starts_at,
-		),
-	).toEqual(startsAt);
-	expect(
-		generated.request.phases.map(
-			(phase: { plans: { version: number }[] }) => phase.plans[0]?.version,
-		),
-	).toEqual([2, 3, 3]);
-	const phaseTwoItems = generated.request.phases[1]?.plans[0]?.items as {
-		price?: number;
+	const expectedPrices = phaseTerms.map((terms, index) => [
+		terms.core,
+		terms.analytics,
+		index === 2 ? 325 : terms.support,
+	]);
+	const generatedPhases = generated.request.phases as {
+		billing_cycle_anchor?: string;
+		plans: {
+			items: { included_usage?: number; price?: number }[];
+			plan_id: string;
+		}[];
+		starts_at: number;
 	}[];
-	expect(phaseTwoItems.some((item) => item.price === 25)).toBe(true);
+	expect(generatedPhases.map(({ starts_at }) => starts_at)).toEqual(startsAt);
+	expect(
+		generatedPhases.map(({ plans }) => plans.map(({ plan_id }) => plan_id)),
+	).toEqual(phaseTerms.map(() => [planId, analyticsId, supportId]));
+	expect(
+		generatedPhases.map(({ billing_cycle_anchor }) => billing_cycle_anchor),
+	).toEqual([undefined, "phase_start", undefined, "phase_start"]);
+	expect(
+		generatedPhases.map(({ plans }) =>
+			plans.map(
+				({ items: planItems }) => planItems.find(({ price }) => price)?.price,
+			),
+		),
+	).toEqual(expectedPrices);
+	expect(
+		generatedPhases.map(
+			({ plans }) =>
+				plans[0]?.items.find(({ included_usage }) => included_usage)
+					?.included_usage,
+		),
+	).toEqual(phaseTerms.map(({ messages }) => messages));
+	expect(generated.request.unscheduled_plans).toMatchObject([
+		{
+			plan_id: successId,
+			items: expect.arrayContaining([expect.objectContaining({ price: 95 })]),
+		},
+	]);
 	const request = generatedRequestToApi({ ctx, request: generated.request });
-	expect(request.phases[1]?.plans[0]?.customize?.price?.amount).toBe(25);
 
-	const preview = await autumnV1.post(
-		"/billing.preview_create_schedule",
-		request,
-	);
-	expect(preview.next_cycle?.subtotal).toBe(25);
+	await autumnV1.post("/billing.preview_create_schedule", request);
 	const applied = await autumnV1.billing.createSchedule(request);
 
 	getRequiredScheduleId(initial.schedule_id);
 	const appliedScheduleId = getRequiredScheduleId(applied.schedule_id);
-	expect(applied.phases).toHaveLength(3);
-	const phaseTwoCustomerProductId = applied.phases[1]?.customer_product_ids[0];
-	if (!phaseTwoCustomerProductId)
-		throw new Error("Expected phase 2 customer product");
-	const phaseTwoProduct = await CusProductService.getFull({
-		db: ctx.db,
-		id: phaseTwoCustomerProductId,
-	});
-	expect(phaseTwoProduct?.product.version).toBe(3);
-	const phaseTwoPrices = await getCustomerProductPriceAmounts({
-		ctx,
-		customerProductId: phaseTwoCustomerProductId,
-	});
-	expect(phaseTwoPrices).toEqual([25]);
+	expect(
+		applied.phases.map(
+			({ customer_product_ids }) => customer_product_ids.length,
+		),
+	).toEqual([3, 3, 3, 3]);
+	const appliedPrices = await Promise.all(
+		applied.phases.map(
+			async ({ customer_product_ids }) =>
+				await Promise.all(
+					customer_product_ids.map(
+						async (customerProductId) =>
+							(
+								await getCustomerProductPriceAmounts({ ctx, customerProductId })
+							)[0],
+					),
+				),
+		),
+	);
+	expect(appliedPrices).toEqual(expectedPrices);
+	const coreEntitlements = await Promise.all(
+		applied.phases.map(
+			async ({ customer_product_ids }) =>
+				await getCustomerProductEntitlementBalances({
+					ctx,
+					customerProductId: customer_product_ids[0]!,
+				}),
+		),
+	);
+	expect(
+		coreEntitlements.map(
+			(entitlements) =>
+				entitlements.find(({ feature_id }) => feature_id === "messages")
+					?.balance,
+		),
+	).toEqual(phaseTerms.map(({ messages }) => messages));
 
 	const fullCustomer = await CusService.getFull({
 		ctx,
@@ -163,7 +257,7 @@ test(`${chalk.yellowBright("billing.generate schedule: generated edit previews, 
 	});
 	const hydrated = await hydrateCustomerWithSchedules({ ctx, fullCustomer });
 	expect(hydrated.schedule?.id).toBe(appliedScheduleId);
-	expect(hydrated.schedule?.phases).toHaveLength(3);
+	expect(hydrated.schedule?.phases).toHaveLength(4);
 }, 120_000);
 
 test(`${chalk.yellowBright("billing.generate schedule: appends a relative phase and preserves an unscheduled plan")}`, async () => {

--- a/server/tests/scenarios/billing/schedule-playground-scenario.test.ts
+++ b/server/tests/scenarios/billing/schedule-playground-scenario.test.ts
@@ -194,4 +194,19 @@ test("scenario: complex attached schedule playground", async () => {
 	expect(
 		persisted?.phases.map((phase) => phase.customer_product_ids.length),
 	).toEqual([3, 3, 3, 3]);
+	expect(
+		persisted?.phases.map(({ customer_product_ids, starts_at }) => ({
+			customer_product_ids,
+			starts_at,
+		})),
+	).toEqual(
+		response.phases.map(({ customer_product_ids, starts_at }) => ({
+			customer_product_ids,
+			starts_at,
+		})),
+	);
+	expect(
+		new Set(response.phases.flatMap((phase) => phase.customer_product_ids))
+			.size,
+	).toBe(12);
 });

--- a/server/tests/scenarios/billing/schedule-playground-scenario.test.ts
+++ b/server/tests/scenarios/billing/schedule-playground-scenario.test.ts
@@ -1,86 +1,140 @@
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
+import { BillingInterval, ms } from "@autumn/shared";
 import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
 import { products } from "@tests/utils/fixtures/products";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { getFullCustomerSchedule } from "@/internal/customers/cusUtils/getFullCustomerSchedule";
 
-const named = <T extends { name: string }>(name: string, plan: T) => ({
-	...plan,
+type Usage = "credits" | "messages" | "words";
+
+const usageItem = (usage: Usage, included: number) =>
+	usage === "messages"
+		? itemsV2.monthlyMessages({ included })
+		: usage === "words"
+			? itemsV2.monthlyWords({ included })
+			: itemsV2.monthlyCredits({ included });
+
+const catalogPlan = ({
+	id,
+	name,
+	price,
+	usage,
+	included,
+	isAddOn = false,
+}: {
+	id: string;
+	name: string;
+	price: number;
+	usage: Usage;
+	included: number;
+	isAddOn?: boolean;
+}) => ({
+	...products.base({
+		id,
+		group: isAddOn ? undefined : id,
+		isAddOn,
+		items: [
+			items.monthlyPrice({ price }),
+			usage === "messages"
+				? items.monthlyMessages({ includedUsage: included })
+				: usage === "words"
+					? items.monthlyWords({ includedUsage: included })
+					: items.monthlyCredits({ includedUsage: included }),
+		],
+	}),
 	name,
 });
 
-test("scenario: schedule playground", async () => {
-	const plans = [
-		named(
-			"Basic Monthly",
-			products.base({
-				id: "schedule-basic-monthly",
-				group: "schedule-playground",
-				items: [
-					items.monthlyPrice({ price: 20 }),
-					items.monthlyMessages({ includedUsage: 1_000 }),
-				],
-			}),
-		),
-		named(
-			"Standard Monthly",
-			products.base({
-				id: "schedule-standard-monthly",
-				group: "schedule-playground",
-				items: [
-					items.monthlyPrice({ price: 50 }),
-					items.monthlyMessages({ includedUsage: 5_000 }),
-					items.dashboard(),
-				],
-			}),
-		),
-		named(
-			"Advanced Monthly",
-			products.base({
-				id: "schedule-advanced-monthly",
-				group: "schedule-playground",
-				items: [
-					items.monthlyPrice({ price: 100 }),
-					items.monthlyMessages({ includedUsage: 20_000 }),
-					items.monthlyUsers({ includedUsage: 10 }),
-					items.dashboard(),
-				],
-			}),
-		),
-		named(
-			"Standard Annual",
-			products.base({
-				id: "schedule-standard-annual",
-				group: "schedule-playground",
-				items: [
-					items.annualPrice({ price: 500 }),
-					items.monthlyMessages({ includedUsage: 5_000 }),
-					items.dashboard(),
-				],
-			}),
-		),
-		named(
-			"Message Add-on",
-			products.base({
-				id: "schedule-message-addon",
-				group: "schedule-playground",
-				isAddOn: true,
-				items: [
-					items.monthlyPrice({ price: 15 }),
-					items.monthlyMessages({ includedUsage: 2_000 }),
-				],
-			}),
-		),
-		named(
-			"Credit Pack",
-			products.oneOffAddOn({
-				id: "schedule-credit-pack",
-				items: [items.oneOffMessages({ billingUnits: 1_000, price: 25 })],
-			}),
-		),
-	];
+const customizedPlan = ({
+	amount,
+	included,
+	plan_id,
+	usage,
+}: {
+	amount: number;
+	included: number;
+	plan_id: string;
+	usage: Usage;
+}) => ({
+	customize: {
+		items: [usageItem(usage, included)],
+		price: { amount, interval: BillingInterval.Month },
+	},
+	plan_id,
+});
 
-	await initScenario({
-		customerId: "schedule-playground-customer",
+test("scenario: complex attached schedule playground", async () => {
+	const plans = [
+		catalogPlan({
+			id: "schedule-core",
+			name: "Core",
+			price: 1_000,
+			usage: "messages",
+			included: 10_000,
+		}),
+		catalogPlan({
+			id: "schedule-analytics-addon",
+			name: "Analytics Add-on",
+			price: 200,
+			usage: "words",
+			included: 5_000,
+			isAddOn: true,
+		}),
+		catalogPlan({
+			id: "schedule-support-addon",
+			name: "Support Add-on",
+			price: 300,
+			usage: "credits",
+			included: 50,
+			isAddOn: true,
+		}),
+		catalogPlan({
+			id: "schedule-success-addon",
+			name: "Success Add-on",
+			price: 100,
+			usage: "credits",
+			included: 25,
+			isAddOn: true,
+		}),
+	];
+	const phaseTerms = [
+		{
+			core: 900,
+			messages: 12_000,
+			analytics: 175,
+			reports: 5_000,
+			support: 225,
+			tickets: 25,
+		},
+		{
+			core: 1_100,
+			messages: 20_000,
+			analytics: 190,
+			reports: 7_500,
+			support: 250,
+			tickets: 50,
+		},
+		{
+			core: 1_350,
+			messages: 30_000,
+			analytics: 200,
+			reports: 9_000,
+			support: 275,
+			tickets: 75,
+		},
+		{
+			core: 1_500,
+			messages: 40_000,
+			analytics: 225,
+			reports: 10_000,
+			support: 300,
+			tickets: 100,
+		},
+	];
+	const customerId = "schedule-playground-customer";
+	const { autumnV1, ctx, customer } = await initScenario({
+		customerId,
 		setup: [
 			s.customer({
 				name: "Schedule Test Customer",
@@ -89,6 +143,55 @@ test("scenario: schedule playground", async () => {
 			}),
 			s.products({ list: plans, prefix: "" }),
 		],
-		actions: [s.attach({ productId: "schedule-basic-monthly" })],
+		actions: [],
 	});
-}, 30_000);
+	const now = Date.now();
+	const response = await autumnV1.billing.createSchedule({
+		billing_behavior: "none",
+		billing_cycle_anchor: "now",
+		customer_id: customerId,
+		phases: phaseTerms.map((terms, index) => ({
+			...(index % 2 ? { billing_cycle_anchor: "phase_start" as const } : {}),
+			plans: [
+				customizedPlan({
+					amount: terms.core,
+					included: terms.messages,
+					plan_id: "schedule-core",
+					usage: "messages",
+				}),
+				customizedPlan({
+					amount: terms.analytics,
+					included: terms.reports,
+					plan_id: "schedule-analytics-addon",
+					usage: "words",
+				}),
+				customizedPlan({
+					amount: terms.support,
+					included: terms.tickets,
+					plan_id: "schedule-support-addon",
+					usage: "credits",
+				}),
+			],
+			starts_at: now + ms.days(index * 365),
+		})),
+		unscheduled_plans: [
+			customizedPlan({
+				amount: 95,
+				included: 25,
+				plan_id: "schedule-success-addon",
+				usage: "credits",
+			}),
+		],
+	});
+
+	expect(
+		response.phases.map((phase) => phase.customer_product_ids.length),
+	).toEqual([3, 3, 3, 3]);
+	const persisted = await getFullCustomerSchedule({
+		ctx,
+		internalCustomerId: customer.internal_id,
+	});
+	expect(
+		persisted?.phases.map((phase) => phase.customer_product_ids.length),
+	).toEqual([3, 3, 3, 3]);
+});

--- a/vite/src/components/forms/create-schedule/hooks/useCreateScheduleGeneration.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useCreateScheduleGeneration.ts
@@ -17,7 +17,10 @@ export function useCreateScheduleGeneration({
 }): BillingGenerationState {
 	const onGenerated = useCallback(
 		(request: Record<string, unknown>) => {
-			const next = scheduleFormFromRequestBody(request);
+			const next = scheduleFormFromRequestBody(
+				request,
+				form.store.state.values.phases,
+			);
 			if (!next) {
 				toast.error("Couldn't build a schedule from that prompt");
 				return;

--- a/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
@@ -44,9 +44,14 @@ export function buildCreateScheduleRequestBody({
 	const apiPhases = phases.map((phase, index) => {
 		let startsAt = phase.startsAt;
 		if (index === 0) {
-			startsAt = allowFirstPhaseBackdate
-				? (phase.startsAt ?? now)
-				: (phase.persistedStartsAt ?? now);
+			const hasStarted =
+				phase.persistedStartsAt != null && phase.persistedStartsAt <= now;
+			if (allowFirstPhaseBackdate) startsAt = phase.startsAt ?? now;
+			else if (phase.persistedStartsAt == null) startsAt = now;
+			else
+				startsAt = hasStarted
+					? phase.persistedStartsAt
+					: (phase.startsAt ?? phase.persistedStartsAt);
 		}
 		if (startsAt === null) return null;
 

--- a/vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.test.ts
+++ b/vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.test.ts
@@ -128,4 +128,69 @@ describe("scheduleFormFromRequestBody", () => {
 			form?.phases?.map(({ persistedStartsAt }) => persistedStartsAt),
 		).toEqual([startsAt, startsAt + 1]);
 	});
+
+	test("keeps the active phase start when generation tries to move it", () => {
+		const startsAt = Date.now() - 1_000;
+		const form = scheduleFormFromRequestBody(
+			{
+				phases: [
+					{
+						plans: [{ plan_id: "generation", version: 2 }],
+						starts_at: startsAt + 1,
+					},
+				],
+			},
+			[{ persistedStartsAt: startsAt, plans: [], startsAt }],
+		);
+
+		expect(form?.phases?.[0]).toMatchObject({
+			persistedStartsAt: startsAt,
+			startsAt,
+		});
+	});
+
+	test("keeps future phase identity without discarding its generated start", () => {
+		const now = Date.UTC(2027, 0, 1);
+		const persistedStartsAt = now + 1_000;
+		const generatedStartsAt = now + 2_000;
+		const form = scheduleFormFromRequestBody(
+			{
+				phases: [
+					{
+						plans: [{ plan_id: "generation", version: 2 }],
+						starts_at: generatedStartsAt,
+					},
+				],
+			},
+			[{ persistedStartsAt, plans: [], startsAt: persistedStartsAt }],
+		);
+		const request = buildCreateScheduleRequestBody({
+			customerId: "cus_1",
+			features: [],
+			nowMs: now,
+			phases: form?.phases ?? [],
+			products: [{ id: "generation", items: [] } as ProductV2],
+		});
+
+		expect(form?.phases?.[0]).toMatchObject({
+			persistedStartsAt,
+			startsAt: generatedStartsAt,
+		});
+		expect(request?.phases[0]?.starts_at).toBe(generatedStartsAt);
+	});
+
+	test("preserves phase-level billing cycle resets", () => {
+		const form = scheduleFormFromRequestBody({
+			phases: [
+				{ plans: [{ plan_id: "launch" }], starts_at: 1780000000000 },
+				{
+					billing_cycle_anchor: "phase_start",
+					plans: [{ plan_id: "scale" }],
+					starts_at: 1790000000000,
+				},
+			],
+		});
+
+		expect(form?.resetBillingCycle).toBe(true);
+	});
 });

--- a/vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.test.ts
+++ b/vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.test.ts
@@ -106,4 +106,26 @@ describe("scheduleFormFromRequestBody", () => {
 			version: 3,
 		});
 	});
+
+	test("preserves persisted phase identity after a generated edit", () => {
+		const startsAt = Date.UTC(2027, 0, 1);
+		const previousPhases = [0, 1].map((index) => ({
+			persistedStartsAt: startsAt + index,
+			plans: [],
+			startsAt: startsAt + index,
+		}));
+		const form = scheduleFormFromRequestBody(
+			{
+				phases: previousPhases.map((phase) => ({
+					plans: [{ plan_id: "generation", version: 2 }],
+					starts_at: phase.startsAt,
+				})),
+			},
+			previousPhases,
+		);
+
+		expect(
+			form?.phases?.map(({ persistedStartsAt }) => persistedStartsAt),
+		).toEqual([startsAt, startsAt + 1]);
+	});
 });

--- a/vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.ts
+++ b/vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.ts
@@ -79,21 +79,30 @@ export const scheduleFormFromRequestBody = (
 			persistedStartsAt == null ? [] : [persistedStartsAt],
 		),
 	);
+	const firstPersistedStartsAt = persistedPhases[0]?.persistedStartsAt;
 	let previousStartsAt: number | null = null;
-	const phases = request.phases.flatMap((value) => {
+	const phases = request.phases.flatMap((value, index) => {
 		const phase = requestRecord(value);
 		if (!phase) return [];
 		const plans = plansFrom(phase.plans);
 		if (!plans.length) return [];
-		const startsAt = startsAtFrom({ phase, previousStartsAt });
+		const generatedStartsAt = startsAtFrom({ phase, previousStartsAt });
+		const startsAt =
+			index === 0 &&
+			firstPersistedStartsAt != null &&
+			firstPersistedStartsAt <= Date.now()
+				? firstPersistedStartsAt
+				: generatedStartsAt;
+		let persistedStartsAt: number | undefined;
+		if (index === 0) persistedStartsAt = firstPersistedStartsAt;
+		else if (startsAt != null && persistedStarts.has(startsAt))
+			persistedStartsAt = startsAt;
 		previousStartsAt = startsAt ?? previousStartsAt ?? Date.now();
 		return [
 			{
 				plans,
 				startsAt,
-				...(startsAt != null && persistedStarts.has(startsAt)
-					? { persistedStartsAt: startsAt }
-					: {}),
+				...(persistedStartsAt != null ? { persistedStartsAt } : {}),
 			},
 		];
 	});
@@ -105,7 +114,11 @@ export const scheduleFormFromRequestBody = (
 				: null,
 		enablePlanImmediately: request.enable_plan_immediately === true,
 		phases,
-		resetBillingCycle: request.billing_cycle_anchor === "now",
+		resetBillingCycle:
+			request.billing_cycle_anchor === "now" ||
+			request.phases.some(
+				(value) => requestRecord(value)?.billing_cycle_anchor === "phase_start",
+			),
 		unscheduledPlans: plansFrom(request.unscheduled_plans),
 	};
 };

--- a/vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.ts
+++ b/vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.ts
@@ -11,6 +11,7 @@ import {
 } from "@/components/forms/shared/utils/requestBodyOverrideHelpers";
 import type {
 	CreateScheduleForm,
+	SchedulePhase,
 	SchedulePlan,
 } from "../createScheduleFormSchema";
 
@@ -69,9 +70,15 @@ const startsAtFrom = ({
  * request (per-plan customize already flattened to items) into form values. */
 export const scheduleFormFromRequestBody = (
 	request: RequestBody,
+	persistedPhases: SchedulePhase[] = [],
 ): Partial<CreateScheduleForm> | undefined => {
 	if (!Array.isArray(request.phases) || !request.phases.length)
 		return undefined;
+	const persistedStarts = new Set(
+		persistedPhases.flatMap(({ persistedStartsAt }) =>
+			persistedStartsAt == null ? [] : [persistedStartsAt],
+		),
+	);
 	let previousStartsAt: number | null = null;
 	const phases = request.phases.flatMap((value) => {
 		const phase = requestRecord(value);
@@ -80,7 +87,15 @@ export const scheduleFormFromRequestBody = (
 		if (!plans.length) return [];
 		const startsAt = startsAtFrom({ phase, previousStartsAt });
 		previousStartsAt = startsAt ?? previousStartsAt ?? Date.now();
-		return [{ plans, startsAt }];
+		return [
+			{
+				plans,
+				startsAt,
+				...(startsAt != null && persistedStarts.has(startsAt)
+					? { persistedStartsAt: startsAt }
+					: {}),
+			},
+		];
 	});
 	if (!phases.length) return undefined;
 	return {


### PR DESCRIPTION
## Summary
- include persisted schedule topology in billing.generate context without duplicating effective plan data
- preserve persisted phase identity across repeated generated edits
- expand complex schedule scenarios, exact evals, and end-to-end persistence coverage

## Validation
- red/green: persisted phase identity regression test
- `bun test src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.test.ts` (5 passed)
- server and Vite typechecks
- create-schedule billing.generate integration suite (2 passed)
- schedule exact-match generation evals (100%)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `billing.generate` so generated schedule edits keep the persisted schedule topology and phase identity, and no longer replace a requested first-phase start date with the current time.

**Bug Fixes**
- Loads persisted customer and entity schedule topology into the generation context, including phase-level billing cycle anchors.
- Carries persisted phase start dates into the schedule form so repeated edits keep phase identity; started first phases keep their persisted start, future ones respect the generated date.

**Refactors**
- Isolates schedule context loading in its own helper.

<sup>Written for commit 36b51e110ea28a6558511ba00518158ddaaa6d34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds persisted schedule topology to billing-generation context and carries phase identity through repeated generated edits.
- **Bug fixes:** Preserve existing schedule phase dates and identities while applying generated edits.
- **Improvements:** Include customer- and entity-scoped schedule topology, phase billing anchors, and scheduled products in generation context.
- **Improvements:** Expand exact-generation, form-mapping, and end-to-end persistence coverage for complex schedules.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because removing or reordering the first generated phase can still transfer the old phase’s persisted identity to its replacement.

Generated phase zero inherits the previous first phase’s persisted timestamp without confirming that it is the same phase, and request construction then treats an already-started inherited timestamp as authoritative.

**Files Needing Attention:** vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.ts; vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.ts | Maps generated schedules back into form state and preserves persisted timestamps, but first-phase identity remains index-based. |
| vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts | Distinguishes active and future persisted first phases when constructing the submitted schedule. |
| server/src/internal/billing/v2/actions/generateRequest/setup/loadGenerationScheduleContext.ts | Loads compact customer and entity schedule topology, scheduled products, and phase-level billing anchors for generation. |
| server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts | Adds complete scheduled-product and schedule context to billing generation. |

<sub>Reviews (4): Last reviewed commit: ["refactor(billing): extract schedule cont..."](https://github.com/useautumn/autumn/commit/36b51e110ea28a6558511ba00518158ddaaa6d34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59473029)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)
- Knowledge Base — [Customer, subject, and entitlement operations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/customer-management.md)
- Knowledge Base — [Operational web applications and UI primitives](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/operational-web-applications.md)
</details>


<!-- /greptile_comment -->