### PR TITLE
feat: atmn support for pooled plan items in CLI push/pull

### DIFF
--- a/packages/atmn/src/commands/push/push.ts
+++ b/packages/atmn/src/commands/push/push.ts
@@ -487,8 +487,11 @@ function normalizePlanFeatureForCompare(pf: PlanItem): Record<string, unknown> {
 		featureId: pf.featureId,
 	};
 
+	if (f.entityFeatureId != null) result.entityFeatureId = f.entityFeatureId;
+
 	if (f.included != null && f.included !== 0) result.included = f.included;
 	if (f.unlimited === true) result.unlimited = true;
+	if (f.pooled === true) result.pooled = true;
 
 	const reset = f.reset as Record<string, unknown> | undefined;
 	if (reset != null) {

--- a/packages/atmn/src/commands/push/push.ts
+++ b/packages/atmn/src/commands/push/push.ts
@@ -582,7 +582,11 @@ function normalizePlanForCompare(
 
 	if (plan.items != null && plan.items.length > 0) {
 		result.items = [...plan.items]
-			.sort((a, b) => a.featureId.localeCompare(b.featureId))
+			.sort(
+				(a, b) =>
+					a.featureId.localeCompare(b.featureId) ||
+					(a.entityFeatureId ?? "").localeCompare(b.entityFeatureId ?? ""),
+			)
 			.map(normalizePlanFeatureForCompare);
 	}
 	result.licenses = [...(plan.licenses ?? [])]

--- a/packages/atmn/src/compose/models/planModels.ts
+++ b/packages/atmn/src/compose/models/planModels.ts
@@ -117,6 +117,10 @@ export const PlanItemSchema = z.object({
 	unlimited: z.boolean().optional().meta({
 		description: "If true, customer has unlimited access to this feature.",
 	}),
+	pooled: z.boolean().optional().meta({
+		description:
+			"Whether entity-level grants contribute to a shared customer balance.",
+	}),
 	reset: z
 		.object({
 			interval: z
@@ -404,6 +408,8 @@ type PlanItemBaseFields = {
 	included?: number;
 	/** Whether usage is unlimited */
 	unlimited?: boolean;
+	/** Whether entity-level grants contribute to a shared customer balance */
+	pooled?: boolean;
 	/** Proration rules for quantity changes */
 	proration?: ProrationConfig;
 	/** Rollover policy for unused usage */

--- a/packages/atmn/src/lib/transforms/apiToSdk/planItem.ts
+++ b/packages/atmn/src/lib/transforms/apiToSdk/planItem.ts
@@ -3,19 +3,16 @@ import type { ApiPlanItem } from "../../api/types/index.js";
 import { createTransformer } from "./Transformer.js";
 
 /** Maps API plan items to SDK config while omitting redundant reset cycles. */
-export const planItemTransformer = createTransformer<
-	ApiPlanItem,
-	PlanItem
->({
+export const planItemTransformer = createTransformer<ApiPlanItem, PlanItem>({
 	// rename: maps api snake_case field -> sdk camelCase field (shallow copy)
 	rename: {
 		feature_id: "featureId",
 		entity_feature_id: "entityFeatureId",
 	},
 
-	// Only persist unlimited when true (false is implicit default)
-	copy: ["unlimited"],
-	swapFalse: ["unlimited"],
+	// Only persist unlimited/pooled when true (false is implicit default)
+	copy: ["unlimited", "pooled"],
+	swapFalse: ["unlimited", "pooled"],
 
 	// Computed fields
 	compute: {
@@ -26,8 +23,7 @@ export const planItemTransformer = createTransformer<
 			if (!api.reset) return undefined;
 			const matchesPrice =
 				String(api.reset.interval) === String(api.price?.interval) &&
-				(api.reset.interval_count ?? 1) ===
-					(api.price?.interval_count ?? 1);
+				(api.reset.interval_count ?? 1) === (api.price?.interval_count ?? 1);
 			if (matchesPrice) return undefined;
 			return {
 				interval: api.reset.interval,
@@ -112,8 +108,6 @@ export const planItemTransformer = createTransformer<
 	},
 });
 
-export function transformApiPlanItem(
-	apiPlanItem: ApiPlanItem,
-): PlanItem {
+export function transformApiPlanItem(apiPlanItem: ApiPlanItem): PlanItem {
 	return planItemTransformer.transform(apiPlanItem);
 }

--- a/packages/atmn/src/lib/transforms/sdkToApi/plan.ts
+++ b/packages/atmn/src/lib/transforms/sdkToApi/plan.ts
@@ -45,8 +45,10 @@ export interface ApiPlanParams {
 
 export interface ApiPlanItemParams {
 	feature_id: string;
+	entity_feature_id?: string;
 	included?: number;
 	unlimited?: boolean;
+	pooled?: boolean;
 	reset?: {
 		interval: string;
 		interval_count?: number;
@@ -85,12 +87,20 @@ export function transformPlanItem(planItem: PlanItem): ApiPlanItemParams {
 		feature_id: planItem.featureId,
 	};
 
+	if (planItem.entityFeatureId != null) {
+		result.entity_feature_id = planItem.entityFeatureId;
+	}
+
 	if (planItem.included !== undefined) {
 		result.included = planItem.included;
 	}
 
 	if (planItem.unlimited !== undefined) {
 		result.unlimited = planItem.unlimited;
+	}
+
+	if (planItem.pooled === true) {
+		result.pooled = true;
 	}
 
 	if (planItem.reset) {

--- a/packages/atmn/src/lib/transforms/sdkToCode/planItem.ts
+++ b/packages/atmn/src/lib/transforms/sdkToCode/planItem.ts
@@ -32,6 +32,8 @@ const isSimpleItem = ({
 }) =>
 	!shouldEmitIncluded({ planItem, features }) &&
 	planItem.unlimited !== true &&
+	planItem.pooled !== true &&
+	planItem.entityFeatureId == null &&
 	!planItem.reset &&
 	!planItem.price &&
 	!planItem.proration &&
@@ -72,6 +74,11 @@ export function buildPlanItemCode({
 	lines.push(`${itemIndent}item({`);
 	lines.push(`${fieldIndent}featureId: ${featureIdCode},`);
 
+	// Add entityFeatureId
+	if (planItem.entityFeatureId != null) {
+		lines.push(`${fieldIndent}entityFeatureId: '${planItem.entityFeatureId}',`);
+	}
+
 	// Add included (granted_balance)
 	if (shouldEmitIncluded({ planItem, features })) {
 		lines.push(`${fieldIndent}included: ${planItem.included},`);
@@ -80,6 +87,11 @@ export function buildPlanItemCode({
 	// Add unlimited
 	if (planItem.unlimited === true) {
 		lines.push(`${fieldIndent}unlimited: true,`);
+	}
+
+	// Add pooled
+	if (planItem.pooled === true) {
+		lines.push(`${fieldIndent}pooled: true,`);
 	}
 
 	// Add reset object (nested)

--- a/packages/atmn/src/lib/transforms/sdkToCode/planItem.ts
+++ b/packages/atmn/src/lib/transforms/sdkToCode/planItem.ts
@@ -1,5 +1,5 @@
 import type { Feature, PlanItem } from "../../../compose/models/index.js";
-import { formatValue } from "./helpers.js";
+import { escapeString, formatValue } from "./helpers.js";
 
 const isBooleanFeatureItem = ({
 	planItem,
@@ -76,7 +76,9 @@ export function buildPlanItemCode({
 
 	// Add entityFeatureId
 	if (planItem.entityFeatureId != null) {
-		lines.push(`${fieldIndent}entityFeatureId: '${planItem.entityFeatureId}',`);
+		lines.push(
+			`${fieldIndent}entityFeatureId: '${escapeString(planItem.entityFeatureId)}',`,
+		);
 	}
 
 	// Add included (granted_balance)

--- a/packages/atmn/test/codegen/pooled-items.test.ts
+++ b/packages/atmn/test/codegen/pooled-items.test.ts
@@ -1,0 +1,58 @@
+/** Pooled items: pull emits pooled/entityFeatureId and push sends them back. */
+import { describe, expect, test } from "bun:test";
+import type { Plan } from "../../src/compose/models/index.js";
+import { transformApiPlan } from "../../src/lib/transforms/apiToSdk/plan.js";
+import { transformPlanToApi } from "../../src/lib/transforms/sdkToApi/plan.js";
+import { buildPlanCode } from "../../src/lib/transforms/sdkToCode/plan.js";
+
+const apiPlan = {
+	id: "team",
+	name: "Team",
+	version: 1,
+	items: [
+		{
+			feature_id: "credits",
+			entity_feature_id: "seats",
+			included: 500,
+			unlimited: false,
+			pooled: true,
+			reset: { interval: "month" as const },
+		},
+		{
+			feature_id: "messages",
+			included: 100,
+			unlimited: false,
+			pooled: false,
+			reset: { interval: "month" as const },
+		},
+	],
+};
+
+describe("pooled plan items", () => {
+	test("pull generates config with pooled and entityFeatureId", () => {
+		const pulled = transformApiPlan(apiPlan as never);
+		const code = buildPlanCode(pulled, []);
+
+		expect(code).toContain("pooled: true");
+		expect(code).toContain("entityFeatureId: 'seats'");
+	});
+
+	test("pull omits pooled when false", () => {
+		const pulled = transformApiPlan(apiPlan as never);
+
+		expect(pulled.items?.[0]?.pooled).toBe(true);
+		expect(pulled.items?.[1]?.pooled).toBeUndefined();
+	});
+
+	test("pull and push preserve pooled and entityFeatureId", () => {
+		const pulled = transformApiPlan(apiPlan as never);
+		const pushed = transformPlanToApi(pulled as Plan);
+
+		expect(pushed.items?.[0]).toMatchObject({
+			feature_id: "credits",
+			entity_feature_id: "seats",
+			pooled: true,
+		});
+		expect(pushed.items?.[1]).not.toHaveProperty("pooled");
+	});
+});

--- a/packages/atmn/test/integration/catalog/pooled-config.test.ts
+++ b/packages/atmn/test/integration/catalog/pooled-config.test.ts
@@ -1,0 +1,95 @@
+/// <reference types="bun" />
+
+import { expect, test } from "bun:test";
+import { readFile, writeFile } from "node:fs/promises";
+import { ProductService } from "../../../../../server/src/internal/products/ProductService.js";
+import {
+	createCleanAtmnIntegrationContext,
+	prepareAtmnIntegrationWorkspace,
+	runAtmnWorkspaceCli,
+} from "../utils/atmnTestWorkspace.js";
+
+const config = (pooled: boolean) => `import { feature, item, plan } from 'atmn';
+
+export const poolSeats = feature({
+	id: 'atmn_pool_seats',
+	name: 'Pool Seats',
+	type: 'metered',
+	consumable: false,
+});
+
+export const poolCredits = feature({
+	id: 'atmn_pool_credits',
+	name: 'Pool Credits',
+	type: 'metered',
+	consumable: true,
+});
+
+export const team = plan({
+	id: 'atmn_pooled_team',
+	name: 'Pooled Team',
+	items: [
+		item({
+			featureId: poolCredits.id,
+			entityFeatureId: poolSeats.id,
+			${pooled ? "pooled: true," : ""}
+			included: 500,
+			reset: { interval: 'month' },
+		}),
+	],
+});
+`;
+
+test.concurrent(
+	"atmn pooled items push, pull round-trip, and unset in place",
+	async () => {
+		const ctx = await createCleanAtmnIntegrationContext();
+		const workspace = await prepareAtmnIntegrationWorkspace({
+			secretKey: ctx.orgSecretKey,
+		});
+		const push = () =>
+			runAtmnWorkspaceCli({
+				args: ["--yes"],
+				command: "push",
+				headless: true,
+				workspace,
+			});
+		const getEntitlement = async () => {
+			const product = await ProductService.getFull({
+				db: ctx.db,
+				env: ctx.env,
+				idOrInternalId: "atmn_pooled_team",
+				orgId: ctx.org.id,
+			});
+			return product.entitlements.find(
+				(entitlement) => entitlement.feature.id === "atmn_pool_credits",
+			);
+		};
+
+		await writeFile(workspace.configPath, config(true));
+		await push();
+
+		let entitlement = await getEntitlement();
+		expect(entitlement?.pooled).toBe(true);
+		expect(entitlement?.entity_feature_id).toBe("atmn_pool_seats");
+
+		await runAtmnWorkspaceCli({
+			args: ["--force", "--no-declaration-file"],
+			command: "pull",
+			headless: true,
+			workspace,
+		});
+		const pulled = await readFile(workspace.configPath, "utf8");
+		expect(pulled).toContain("pooled: true");
+		expect(pulled).toContain("entityFeatureId: 'atmn_pool_seats'");
+		await push();
+
+		entitlement = await getEntitlement();
+		expect(entitlement?.pooled).toBe(true);
+
+		await writeFile(workspace.configPath, config(false));
+		await push();
+		entitlement = await getEntitlement();
+		expect(entitlement?.pooled).toBe(false);
+	},
+);

--- a/packages/atmn/test/integration/catalog/pooled-config.test.ts
+++ b/packages/atmn/test/integration/catalog/pooled-config.test.ts
@@ -91,5 +91,6 @@ test.concurrent(
 		await push();
 		entitlement = await getEntitlement();
 		expect(entitlement?.pooled).toBe(false);
+		expect(entitlement?.entity_feature_id).toBe("atmn_pool_seats");
 	},
 );


### PR DESCRIPTION
## Summary

Lets `pooled` be defined on plan items in `autumn.config.ts` and pushed/pulled via the CLI. The server already supports `pooled` end to end on `catalog.update` (params schema, validation, diff, item→entitlement mapping) — the CLI was the only gap: the compose `item()` type didn't have the field and the transforms dropped it.

- `compose/models/planModels.ts` — add `pooled` to `PlanItemSchema` and the `PlanItem` type
- `sdkToApi/plan.ts` — send `pooled` (only when true) and `entity_feature_id` on push; `entityFeatureId` was previously pulled but silently dropped on push, and pooled per-entity grants need it
- `apiToSdk/planItem.ts` — carry `pooled` through pull (omitted when false)
- `sdkToCode/planItem.ts` — emit `pooled: true` / `entityFeatureId` (escaped) in generated config
- `push.ts` — include both fields in the local change-compare, with `entityFeatureId` as an item sort tiebreaker so plans with multiple items on one feature compare order-independently

## Review follow-ups

All cubic/greptile findings addressed in 33f8105: `escapeString` around the generated `entityFeatureId` literal, the sort tiebreaker above, and an assertion that `entity_feature_id` is retained when `pooled` is unset.

## Tests

- `test/codegen/pooled-items.test.ts` (offline): pull emits `pooled`/`entityFeatureId` in generated code, omits `pooled: false`, and pull→push preserves both
- `test/integration/catalog/pooled-config.test.ts`: push a pooled item → entitlement has `pooled: true` + `entity_feature_id` in DB → pull round-trips the config → re-push is a no-op → removing `pooled` updates the plan in place and keeps `entity_feature_id`

Ran against the local stack: integration test green, atmn offline suite green, `tsgo --build --noEmit` clean.

## Publishing

Commit message uses the unscoped `feat:` prefix so `atmn-publish` auto-publishes a patch once this lands on `main` via squash-merge (the workflow's bump detector doesn't match scoped prefixes like `feat(atmn):`).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The CLI now preserves pooled plan-item configuration and entity feature IDs across push, pull, comparison, and generated configuration.
- **[API changes]** Adds `pooled` to the plan-item schema and sends pooled and entity-feature fields to the catalog API.
- **[Improvements]** Preserves these fields during pull and includes them when deciding whether a plan changed.
- **[Bug fixes]** Escapes entity feature IDs before embedding them in generated TypeScript.
- **[Improvements]** Adds offline and integration coverage for pooled-item round trips and updates.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/atmn/src/compose/models/planModels.ts | Adds the optional pooled field to the public plan-item schema and type. |
| packages/atmn/src/lib/transforms/sdkToApi/plan.ts | Sends entity feature IDs and enabled pooled state in catalog plan requests. |
| packages/atmn/src/lib/transforms/apiToSdk/planItem.ts | Preserves enabled pooled state when converting API plan items into SDK configuration. |
| packages/atmn/src/lib/transforms/sdkToCode/planItem.ts | Generates pooled and entity-feature configuration while safely escaping entity feature IDs. |
| packages/atmn/src/commands/push/push.ts | Includes pooled and entity-feature values in normalized plan comparisons. |
| packages/atmn/test/codegen/pooled-items.test.ts | Covers pooled-item code generation and transform round trips. |
| packages/atmn/test/integration/catalog/pooled-config.test.ts | Covers pooled catalog persistence, pull/push stability, and disabling pooled state. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Config[autumn.config.ts] -->|pooled and entityFeatureId| Push[CLI push transform]
  Push --> API[Catalog API]
  API --> Pull[CLI pull transform]
  Pull --> Codegen[Generated autumn.config.ts]
  Codegen -->|escaped entityFeatureId| Config
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: address cubic review — escape entit..."](https://github.com/useautumn/autumn/commit/33f8105fd4eee7d85cc5a5848eac5fc4ec973529) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59493637)</sub>

<!-- /greptile_comment -->