### PR TITLE
Hotfix: preserve promoted products in billing webhooks

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
@@ -166,7 +166,7 @@ const executeCheckoutSessionMetadataV2 = async ({
 		billingContext: updatedDeferredData.billingContext,
 	});
 
-	await promotePendingCustomerProducts({
+	const autumnBillingPlanToExecute = await promotePendingCustomerProducts({
 		ctx,
 		autumnBillingPlan: updatedDeferredData.billingPlan.autumn,
 		fullCustomer: updatedDeferredData.billingContext.fullCustomer,
@@ -176,7 +176,7 @@ const executeCheckoutSessionMetadataV2 = async ({
 	// Execute autumn billing plan (includes customer products, upsertSubscription, upsertInvoice)
 	await executeAutumnBillingPlan({
 		ctx,
-		autumnBillingPlan: updatedDeferredData.billingPlan.autumn,
+		autumnBillingPlan: autumnBillingPlanToExecute,
 		stripeInvoice: checkoutContext.stripeInvoice,
 	});
 

--- a/server/src/internal/billing/v2/execute/executeDeferredBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeDeferredBillingPlan.ts
@@ -58,7 +58,7 @@ export const executeDeferredBillingPlan = async ({
 		});
 	}
 
-	await promotePendingCustomerProducts({
+	const autumnBillingPlanToExecute = await promotePendingCustomerProducts({
 		ctx,
 		autumnBillingPlan: billingPlan.autumn,
 		fullCustomer: billingContext.fullCustomer,
@@ -67,7 +67,7 @@ export const executeDeferredBillingPlan = async ({
 
 	await executeAutumnBillingPlan({
 		ctx,
-		autumnBillingPlan: billingPlan.autumn,
+		autumnBillingPlan: autumnBillingPlanToExecute,
 		stripeInvoice: stripeBillingResult.stripeInvoice ?? stripeInvoice,
 		stripeInvoiceItems: stripeBillingResult.stripeInvoiceItems,
 		autumnInvoice: stripeBillingResult.autumnInvoice,

--- a/server/src/internal/billing/v2/execute/promotePendingCustomerProducts.ts
+++ b/server/src/internal/billing/v2/execute/promotePendingCustomerProducts.ts
@@ -26,7 +26,7 @@ export const promotePendingCustomerProducts = async ({
 		inStatuses: [CusProductStatus.Pending],
 	});
 
-	if (!pendingCustomerProducts.length) return;
+	if (!pendingCustomerProducts.length) return autumnBillingPlan;
 
 	const promotedIds = new Set<string>();
 
@@ -59,8 +59,11 @@ export const promotePendingCustomerProducts = async ({
 		promotedIds.add(customerProduct.id);
 	}
 
-	autumnBillingPlan.insertCustomerProducts =
-		autumnBillingPlan.insertCustomerProducts?.filter(
-			(planned) => !promotedIds.has(planned.id),
-		) ?? [];
+	return {
+		...autumnBillingPlan,
+		insertCustomerProducts:
+			autumnBillingPlan.insertCustomerProducts?.filter(
+				(planned) => !promotedIds.has(planned.id),
+			) ?? [],
+	};
 };

--- a/server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-attach.test.ts
+++ b/server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-attach.test.ts
@@ -453,6 +453,8 @@ test.concurrent(
 // CHECKOUT: ATTACH VIA STRIPE CHECKOUT (no payment method on file)
 // ═══════════════════════════════════════════════════════════════════════════════
 
+// Red: pending promotion erased the paid plan before billing and product webhooks.
+// Green: checkout emits both events with the activated paid plan.
 test(`${chalk.yellowBright("billing.updated: stripe checkout completion → activated")}`, async () => {
 	const customerId = "billing-updated-stripe-checkout";
 	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
@@ -478,18 +480,30 @@ test(`${chalk.yellowBright("billing.updated: stripe checkout completion → acti
 	// handleCheckoutSessionMetadataV2 → executeBillingPlan → webhook fires
 	await completeStripeCheckoutForm({ url: attachResult.payment_url });
 
-	const result = await waitForWebhook<BillingUpdatedPayload>({
-		token: playToken,
-		predicate: (payload) =>
-			payload.type === "billing.updated" &&
-			payload.data?.customer_id === customerId &&
-			findChange(payload.data.plan_changes, {
-				action: "activated",
-				planId: pro.id,
-			}) !== undefined,
-		timeoutMs: 30000,
-	});
+	const [productsResult, result] = await Promise.all([
+		waitForWebhook<CustomerProductsUpdatedPayload>({
+			token: playToken,
+			predicate: (payload) =>
+				payload.type === "customer.products.updated" &&
+				payload.data?.customer?.id === customerId &&
+				payload.data?.updated_product?.id === pro.id &&
+				payload.data?.scenario === "new",
+			timeoutMs: 30000,
+		}),
+		waitForWebhook<BillingUpdatedPayload>({
+			token: playToken,
+			predicate: (payload) =>
+				payload.type === "billing.updated" &&
+				payload.data?.customer_id === customerId &&
+				findChange(payload.data.plan_changes, {
+					action: "activated",
+					planId: pro.id,
+				}) !== undefined,
+			timeoutMs: 30000,
+		}),
+	]);
 
+	expect(productsResult).not.toBeNull();
 	expect(result).not.toBeNull();
 	const activated = findChange(result!.payload.data.plan_changes, {
 		action: "activated",


### PR DESCRIPTION
## Summary
- keep the original semantic billing plan after pending products are promoted
- execute DB writes with a filtered copy so promoted rows are not inserted twice
- restore paid-plan transitions for `customer.products.updated` and `billing.updated`

## Verification
- `bunx tsgo --build --noEmit`
- Stripe checkout → Autumn webhook handler → Svix: paid plan delivered as `activated` and `active`
- confirmed the pre-fix test times out because the activated paid plan is absent, then passes with this patch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves promoted products when pending customer products are promoted, so `customer.products.updated` and `billing.updated` webhooks again include the activated paid plan and promoted rows are no longer inserted twice. `promotePendingCustomerProducts` now returns a filtered copy of the plan instead of mutating it; checkout and deferred billing execution use that copy for DB writes while the original plan is kept for webhook payloads. Adds integration coverage for checkout completion emitting both webhooks with the activated paid plan.

<sup>Written for commit 6b144c808d71798b628e3c70a7d9a829ec039b29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The hotfix preserves the semantic billing plan for webhook generation while executing database writes with a filtered copy.
- **Bug fixes:** Promoted pending products remain present when generating `customer.products.updated` and `billing.updated`.
- **Improvements:** Billing execution receives a filtered plan so already-promoted customer products are not inserted again.
- **Improvements:** Integration coverage now verifies both product and billing webhooks after Stripe checkout completion.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/execute/promotePendingCustomerProducts.ts | Returns a filtered billing-plan copy rather than removing promoted products from the original semantic plan. |
| server/src/internal/billing/v2/execute/executeDeferredBillingPlan.ts | Uses the filtered copy for persistence while retaining the original plan for downstream webhook generation. |
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts | Separates the checkout plan used for database execution from the plan used to describe completed transitions. |
| server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-attach.test.ts | Verifies that checkout completion emits both the activated product event and the activated billing-plan transition. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Stripe
  participant Checkout as Checkout handler
  participant Promote as Pending-product promotion
  participant DB as Billing execution
  participant Hooks as Customer webhooks
  Stripe->>Checkout: Checkout completed
  Checkout->>Promote: Original semantic billing plan
  Promote->>Promote: Promote matching pending rows
  Promote-->>Checkout: Filtered execution copy
  Checkout->>DB: Execute filtered plan
  Checkout->>Hooks: Emit events from original plan
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: cover promoted product checkout we..."](https://github.com/useautumn/autumn/commit/6b144c808d71798b628e3c70a7d9a829ec039b29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59553582)</sub>

**Context used:**

- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)
- Knowledge Base — [Webhook contracts and delivery events](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/webhook-contracts.md)

<!-- /greptile_comment -->