### PR TITLE
feat(shared): credit dimensions and multipliers on rate-card rows

### DIFF
--- a/server/tests/unit/features/credit-dimensions-models.test.ts
+++ b/server/tests/unit/features/credit-dimensions-models.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Contract for credit-system dimensions on a rate-card row:
+ * - a row keeps its own rate and optionally carries named `dimensions`
+ *   (match → rate) and `multipliers` (match → factor / add);
+ * - dimension entries are full rates, flat or graduated, like the row;
+ * - entry names become usage-attribution keys, so they are bounded and
+ *   cannot contain the key separator.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	buildUsageAttributionKey,
+	CreditDimensionSchema,
+	CreditMultiplierSchema,
+	type CreditSchemaItem,
+	CreditSchemaItemSchema,
+	parseUsageAttributionKey,
+} from "@autumn/shared";
+
+const dimensionedRow: CreditSchemaItem = {
+	metered_feature_id: "cpu_minutes",
+	credit_amount: 1,
+	dimensions: {
+		small: { match: { size: "small" }, credit_amount: 1 },
+		large_eu: {
+			match: { size: "large", region: "eu" },
+			priority: 1,
+			credit_amount: 20,
+		},
+		xl: {
+			match: { size: "xl" },
+			tier_behavior: "graduated",
+			tiers: [
+				{ to: 1_000, credit_amount: 30 },
+				{ to: "inf", credit_amount: 25 },
+			],
+		},
+	},
+	multipliers: {
+		spot: { match: { lifecycle: "spot" }, factor: 0.3 },
+		promo: { match: { cohort: "2024" }, add: -0.2 },
+	},
+};
+
+describe("credit dimension models", () => {
+	test("a row carries named dimensions and multipliers alongside its own rate", () => {
+		const result = CreditSchemaItemSchema.safeParse(dimensionedRow);
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+
+		expect(result.data).toEqual(dimensionedRow);
+	});
+
+	test("a graduated row can carry dimensions too", () => {
+		const result = CreditSchemaItemSchema.safeParse({
+			metered_feature_id: "cpu_minutes",
+			tier_behavior: "graduated",
+			tiers: [{ to: "inf", credit_amount: 1 }],
+			dimensions: dimensionedRow.dimensions,
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	test("plain rows are unchanged", () => {
+		const result = CreditSchemaItemSchema.safeParse({
+			metered_feature_id: "feature_a",
+			credit_amount: 1,
+		});
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+
+		expect(result.data).toEqual({
+			metered_feature_id: "feature_a",
+			credit_amount: 1,
+		});
+	});
+
+	test("match values are stored as strings", () => {
+		const result = CreditDimensionSchema.safeParse({
+			match: { size: 8, gpu: true },
+			credit_amount: 2,
+		});
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+
+		expect(result.data.match).toEqual({ size: "8", gpu: "true" });
+	});
+
+	test("rejects a dimension that mixes a flat rate with graduated tiers", () => {
+		const result = CreditDimensionSchema.safeParse({
+			match: { size: "small" },
+			credit_amount: 1,
+			tier_behavior: "graduated",
+			tiers: [{ to: "inf", credit_amount: 0.5 }],
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects a multiplier with neither factor nor add", () => {
+		const result = CreditMultiplierSchema.safeParse({
+			match: { lifecycle: "spot" },
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects a non-positive multiplier factor", () => {
+		for (const factor of [0, -1]) {
+			const result = CreditMultiplierSchema.safeParse({
+				match: { lifecycle: "spot" },
+				factor,
+			});
+
+			expect(result.success).toBe(false);
+		}
+	});
+
+	test("rejects dimension names that cannot become attribution keys", () => {
+		for (const name of ["large::eu", "x".repeat(65), ""]) {
+			const result = CreditSchemaItemSchema.safeParse({
+				metered_feature_id: "cpu_minutes",
+				credit_amount: 1,
+				dimensions: {
+					[name]: { match: { size: "large" }, credit_amount: 20 },
+				},
+			});
+
+			expect(result.success).toBe(false);
+		}
+	});
+});
+
+describe("usage attribution keys", () => {
+	test("a plain source keys by its internal feature id", () => {
+		const key = buildUsageAttributionKey({
+			internalFeatureId: "fe_cpu",
+		});
+
+		expect(key).toBe("fe_cpu");
+		expect(parseUsageAttributionKey({ key })).toEqual({
+			internalFeatureId: "fe_cpu",
+		});
+	});
+
+	test("a dimensioned source round-trips its entry name", () => {
+		const key = buildUsageAttributionKey({
+			internalFeatureId: "fe_cpu",
+			dimensionName: "large_eu",
+		});
+
+		expect(key).toBe("fe_cpu::large_eu");
+		expect(parseUsageAttributionKey({ key })).toEqual({
+			internalFeatureId: "fe_cpu",
+			dimensionName: "large_eu",
+		});
+	});
+});

--- a/shared/models/featureModels/featureConfig/creditConfig.ts
+++ b/shared/models/featureModels/featureConfig/creditConfig.ts
@@ -19,7 +19,7 @@ const graduatedCreditRateShape = {
 };
 
 // Event property values are compared as strings at track time.
-const CreditMatchSchema = z.record(
+export const CreditMatchSchema = z.record(
 	z.string(),
 	z.union([z.string(), z.number(), z.boolean()]).transform(String),
 );
@@ -52,7 +52,7 @@ export const USAGE_ATTRIBUTION_DIMENSION_SEPARATOR = "::";
 export const CREDIT_DIMENSION_NAME_MAX_LENGTH = 64;
 
 // Dimension names become usage-attribution keys, so they must stay parseable.
-const CreditDimensionNameSchema = z
+export const CreditDimensionNameSchema = z
 	.string()
 	.min(1)
 	.max(CREDIT_DIMENSION_NAME_MAX_LENGTH)

--- a/shared/models/featureModels/featureConfig/creditConfig.ts
+++ b/shared/models/featureModels/featureConfig/creditConfig.ts
@@ -1,28 +1,81 @@
 import { z } from "zod/v4";
 import { FeatureUsageType } from "../featureEnums.js";
 
-const CreditSchemaItemBaseSchema = z.object({
-	metered_feature_id: z.string(),
-	feature_amount: z.number().optional(),
-});
-
 export const CreditTierSchema = z.object({
 	to: z.union([z.number(), z.literal("inf")]),
 	credit_amount: z.number(),
 });
 
-export const FlatCreditSchemaItemSchema = CreditSchemaItemBaseSchema.extend({
+const flatCreditRateShape = {
 	credit_amount: z.number(),
 	tier_behavior: z.never().optional(),
 	tiers: z.never().optional(),
+};
+
+const graduatedCreditRateShape = {
+	credit_amount: z.never().optional(),
+	tier_behavior: z.literal("graduated"),
+	tiers: z.array(CreditTierSchema),
+};
+
+// Event property values are compared as strings at track time.
+const CreditMatchSchema = z.record(
+	z.string(),
+	z.union([z.string(), z.number(), z.boolean()]).transform(String),
+);
+
+const CreditDimensionBaseSchema = z.object({
+	match: CreditMatchSchema,
+	priority: z.number().int().optional(),
 });
 
-export const GraduatedCreditSchemaItemSchema =
-	CreditSchemaItemBaseSchema.extend({
-		credit_amount: z.never().optional(),
-		tier_behavior: z.literal("graduated"),
-		tiers: z.array(CreditTierSchema),
+export const CreditDimensionSchema = z.union([
+	CreditDimensionBaseSchema.extend(flatCreditRateShape),
+	CreditDimensionBaseSchema.extend(graduatedCreditRateShape),
+]);
+
+export const CreditMultiplierSchema = z
+	.object({
+		match: CreditMatchSchema,
+		factor: z.number().positive().optional(),
+		add: z.number().optional(),
+	})
+	.refine(
+		(multiplier) =>
+			multiplier.factor !== undefined || multiplier.add !== undefined,
+		{
+			message: "A multiplier needs a factor or an add",
+		},
+	);
+
+export const USAGE_ATTRIBUTION_DIMENSION_SEPARATOR = "::";
+export const CREDIT_DIMENSION_NAME_MAX_LENGTH = 64;
+
+// Dimension names become usage-attribution keys, so they must stay parseable.
+const CreditDimensionNameSchema = z
+	.string()
+	.min(1)
+	.max(CREDIT_DIMENSION_NAME_MAX_LENGTH)
+	.refine((name) => !name.includes(USAGE_ATTRIBUTION_DIMENSION_SEPARATOR), {
+		message: `Dimension names cannot contain "${USAGE_ATTRIBUTION_DIMENSION_SEPARATOR}"`,
 	});
+
+const CreditSchemaItemBaseSchema = z.object({
+	metered_feature_id: z.string(),
+	feature_amount: z.number().optional(),
+	dimensions: z
+		.record(CreditDimensionNameSchema, CreditDimensionSchema)
+		.optional(),
+	multipliers: z
+		.record(CreditDimensionNameSchema, CreditMultiplierSchema)
+		.optional(),
+});
+
+export const FlatCreditSchemaItemSchema =
+	CreditSchemaItemBaseSchema.extend(flatCreditRateShape);
+
+export const GraduatedCreditSchemaItemSchema =
+	CreditSchemaItemBaseSchema.extend(graduatedCreditRateShape);
 
 export const CreditSchemaItemSchema = z.union([
 	FlatCreditSchemaItemSchema,
@@ -73,6 +126,8 @@ export const ModelMarkupsSchema = z
 export type CreditSystemConfig = z.infer<typeof CreditSystemConfigSchema>;
 export type FeatureConfigOverride = z.infer<typeof FeatureConfigOverrideSchema>;
 export type CreditSchemaItem = z.infer<typeof CreditSchemaItemSchema>;
+export type CreditDimension = z.infer<typeof CreditDimensionSchema>;
+export type CreditMultiplier = z.infer<typeof CreditMultiplierSchema>;
 export type CreditTier = z.infer<typeof CreditTierSchema>;
 export type ModelMarkups = z.infer<typeof ModelMarkupsSchema>;
 export type ProviderMarkups = z.infer<typeof ProviderMarkupsSchema>;

--- a/shared/utils/cusEntUtils/index.ts
+++ b/shared/utils/cusEntUtils/index.ts
@@ -62,3 +62,5 @@ export * from "./overageUtils/cusEntToInvoiceOverage";
 export * from "./overageUtils/cusEntToInvoiceUsage";
 export * from "./overageUtils/cusEntToOptions";
 export * from "./sortCusEntsForDeduction";
+export * from "./usageAttribution/buildUsageAttributionKey";
+export * from "./usageAttribution/parseUsageAttributionKey";

--- a/shared/utils/cusEntUtils/usageAttribution/buildUsageAttributionKey.ts
+++ b/shared/utils/cusEntUtils/usageAttribution/buildUsageAttributionKey.ts
@@ -1,0 +1,12 @@
+import { USAGE_ATTRIBUTION_DIMENSION_SEPARATOR } from "../../../models/featureModels/featureConfig/creditConfig.js";
+
+export const buildUsageAttributionKey = ({
+	internalFeatureId,
+	dimensionName,
+}: {
+	internalFeatureId: string;
+	dimensionName?: string;
+}): string =>
+	dimensionName
+		? `${internalFeatureId}${USAGE_ATTRIBUTION_DIMENSION_SEPARATOR}${dimensionName}`
+		: internalFeatureId;

--- a/shared/utils/cusEntUtils/usageAttribution/parseUsageAttributionKey.ts
+++ b/shared/utils/cusEntUtils/usageAttribution/parseUsageAttributionKey.ts
@@ -1,0 +1,22 @@
+import { USAGE_ATTRIBUTION_DIMENSION_SEPARATOR } from "../../../models/featureModels/featureConfig/creditConfig.js";
+
+export type ParsedUsageAttributionKey = {
+	internalFeatureId: string;
+	dimensionName?: string;
+};
+
+export const parseUsageAttributionKey = ({
+	key,
+}: {
+	key: string;
+}): ParsedUsageAttributionKey => {
+	const separatorIndex = key.indexOf(USAGE_ATTRIBUTION_DIMENSION_SEPARATOR);
+	if (separatorIndex === -1) return { internalFeatureId: key };
+
+	return {
+		internalFeatureId: key.slice(0, separatorIndex),
+		dimensionName: key.slice(
+			separatorIndex + USAGE_ATTRIBUTION_DIMENSION_SEPARATOR.length,
+		),
+	};
+};


### PR DESCRIPTION
A rate-card row can now carry named dimensions (property match → its own
flat or graduated rate, with optional priority) and multipliers (property
match → factor and/or add). Dimension names become usage-attribution keys
via buildUsageAttributionKey / parseUsageAttributionKey, so they are
bounded and cannot contain the separator.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rate-card rows can now carry named dimensions and multipliers in addition to their own flat or graduated rate, enabling property-based rates and adjustments without changing plain rows.

- Dimensions support flat or graduated rates with optional priority; multipliers apply a factor and/or additive adjustment.
- Match values normalize to strings; the exported schemas cap dimension names at 64 characters and reject `::`.
- Adds `buildUsageAttributionKey` and `parseUsageAttributionKey`, which split on the first `::` and don't validate inputs, so callers should pass schema-validated names.

<sup>Written for commit 44d1884f444745048c911f4cf2a06fbfae8a61cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds property-based credit dimensions and multipliers to shared rate-card schemas, plus helpers for encoding dimension names into usage-attribution keys.

- **[API changes, Improvements]** Adds validated dimension and multiplier models supporting flat or graduated rates, priorities, factors, and additive adjustments.
- **[API changes]** Exports shared attribution-key build and parse helpers.
- **[Improvements]** Adds unit coverage for model validation, value normalization, plain-row compatibility, and normal attribution-key round trips.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking recommendation to make the exported attribution-key builder reject inputs that cannot round-trip.

The new schemas enforce the documented dimension-name constraints, and no blocking runtime failure was established; the remaining concern is that direct users of the exported codec can bypass those constraints and create ambiguous keys.

**Files Needing Attention:** shared/utils/cusEntUtils/usageAttribution/buildUsageAttributionKey.ts, shared/utils/cusEntUtils/usageAttribution/parseUsageAttributionKey.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/models/featureModels/featureConfig/creditConfig.ts | Adds dimension, multiplier, matching, naming, and reusable rate schemas while preserving plain and graduated rate-card rows. |
| shared/utils/cusEntUtils/usageAttribution/buildUsageAttributionKey.ts | Adds the shared key builder, but its unrestricted string inputs do not enforce the codec constraints defined by the model schema. |
| shared/utils/cusEntUtils/usageAttribution/parseUsageAttributionKey.ts | Adds first-separator parsing that round-trips valid schema-backed names but cannot disambiguate unrestricted builder inputs. |
| server/tests/unit/features/credit-dimensions-models.test.ts | Covers the principal schema contracts and valid key round trips, but not direct malformed inputs to the exported key helpers. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Internal feature ID] --> C[Build attribution key]
  B[Optional dimension name] --> C
  C --> D[feature ID::dimension name]
  D --> E[Parse at first separator]
  E --> F[Internal feature ID]
  E --> G[Optional dimension name]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
shared/utils/cusEntUtils/usageAttribution/buildUsageAttributionKey.ts:10-12
**Attribution keys accept ambiguous inputs**

The exported builder accepts raw strings without enforcing the codec constraints. For example, feature `fe_cpu::legacy` with dimension `large` is parsed back as feature `fe_cpu` and dimension `legacy::large`, while an empty dimension is silently discarded, so direct callers cannot rely on lossless round trips.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(shared): export the credit matc..."](https://github.com/useautumn/autumn/commit/8249fa07f2405d259db9760761438f0f1b788df5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60356139)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->