### PR TITLE
feat(api): credit dimensions on the credit_schema API shape

### DIFF
--- a/packages/atmn/src/commands/push/push.ts
+++ b/packages/atmn/src/commands/push/push.ts
@@ -436,6 +436,12 @@ function normalizeFeatureForCompare(f: Feature): Record<string, unknown> {
 						creditSchemaItem.billingUnits !== 1 && {
 							billingUnits: creditSchemaItem.billingUnits,
 						}),
+					...(creditSchemaItem.dimensions !== undefined && {
+						dimensions: creditSchemaItem.dimensions,
+					}),
+					...(creditSchemaItem.multipliers !== undefined && {
+						multipliers: creditSchemaItem.multipliers,
+					}),
 				};
 
 				return creditSchemaItem.tierBehavior === "graduated"

--- a/packages/atmn/src/commands/test-diff/command.ts
+++ b/packages/atmn/src/commands/test-diff/command.ts
@@ -46,6 +46,12 @@ function normalizeFeatureForCompare(f: Feature): Rec {
 						creditSchemaItem.billingUnits !== 1 && {
 							billingUnits: creditSchemaItem.billingUnits,
 						}),
+					...(creditSchemaItem.dimensions !== undefined && {
+						dimensions: creditSchemaItem.dimensions,
+					}),
+					...(creditSchemaItem.multipliers !== undefined && {
+						multipliers: creditSchemaItem.multipliers,
+					}),
 				};
 
 				return creditSchemaItem.tierBehavior === "graduated"

--- a/packages/atmn/src/compose/models/featureModels.ts
+++ b/packages/atmn/src/compose/models/featureModels.ts
@@ -9,9 +9,40 @@ export const CreditTierSchema = z.object({
 	creditCost: z.number(),
 });
 
+const CreditMatchSchema = z.record(
+	z.string(),
+	z.union([z.string(), z.number(), z.boolean()]),
+);
+
+const CreditDimensionBaseSchema = z.object({
+	match: CreditMatchSchema,
+	priority: z.number().int().optional(),
+});
+
+export const CreditDimensionSchema = z.union([
+	CreditDimensionBaseSchema.extend({
+		creditCost: z.number(),
+		tierBehavior: z.never().optional(),
+		tiers: z.never().optional(),
+	}),
+	CreditDimensionBaseSchema.extend({
+		creditCost: z.never().optional(),
+		tierBehavior: z.literal("graduated"),
+		tiers: z.array(CreditTierSchema),
+	}),
+]);
+
+export const CreditMultiplierSchema = z.object({
+	match: CreditMatchSchema,
+	factor: z.number().optional(),
+	add: z.number().optional(),
+});
+
 const CreditSchemaItemBaseSchema = z.object({
 	meteredFeatureId: z.string(),
 	billingUnits: z.number().optional(),
+	dimensions: z.record(z.string(), CreditDimensionSchema).optional(),
+	multipliers: z.record(z.string(), CreditMultiplierSchema).optional(),
 });
 
 export const FlatCreditSchemaItemSchema = CreditSchemaItemBaseSchema.extend({
@@ -33,6 +64,8 @@ export const CreditSchemaItemSchema = z.union([
 ]);
 
 export type CreditSchemaItem = z.infer<typeof CreditSchemaItemSchema>;
+export type CreditDimension = z.infer<typeof CreditDimensionSchema>;
+export type CreditMultiplier = z.infer<typeof CreditMultiplierSchema>;
 
 export const FeatureSchema = z.object({
 	id: z.string().meta({

--- a/packages/atmn/src/lib/transforms/apiToSdk/Transformer.test.ts
+++ b/packages/atmn/src/lib/transforms/apiToSdk/Transformer.test.ts
@@ -110,6 +110,65 @@ describe("Transformer", () => {
 			);
 		});
 
+		test("dimensioned credit system round trip", () => {
+			const apiFeature = {
+				id: "credits",
+				name: "Credits",
+				type: "credit_system",
+				consumable: true,
+				archived: false,
+				credit_schema: [
+					{
+						metered_feature_id: "cpu_minutes",
+						credit_cost: 1,
+						dimensions: {
+							large_eu: {
+								match: { size: "large", region: "eu" },
+								priority: 1,
+								credit_cost: 20,
+							},
+							xl: {
+								match: { size: "xl" },
+								tier_behavior: "graduated" as const,
+								tiers: [{ to: "inf" as const, credit_cost: 25 }],
+							},
+						},
+						multipliers: {
+							spot: { match: { lifecycle: "spot" }, factor: 0.3 },
+						},
+					},
+				],
+			};
+
+			const feature = transformApiFeature(apiFeature);
+
+			expect(feature.type).toBe("credit_system");
+			if (feature.type === "credit_system") {
+				expect(feature.creditSchema[0]).toEqual({
+					meteredFeatureId: "cpu_minutes",
+					creditCost: 1,
+					dimensions: {
+						large_eu: {
+							match: { size: "large", region: "eu" },
+							priority: 1,
+							creditCost: 20,
+						},
+						xl: {
+							match: { size: "xl" },
+							tierBehavior: "graduated",
+							tiers: [{ to: "inf", creditCost: 25 }],
+						},
+					},
+					multipliers: {
+						spot: { match: { lifecycle: "spot" }, factor: 0.3 },
+					},
+				});
+			}
+			expect(transformFeatureToApi(feature).credit_schema).toEqual(
+				apiFeature.credit_schema,
+			);
+		});
+
 		test("ai_credit_system", () => {
 			const result = transformApiFeature({
 				id: "ai_credits",
@@ -125,7 +184,9 @@ describe("Transformer", () => {
 			expect(result.type).toBe("ai_credit_system");
 			if (result.type === "ai_credit_system") {
 				expect(result.modelMarkups).toBeDefined();
-				expect(result.modelMarkups!["anthropic/claude-opus-4-5"].markup).toBe(20);
+				expect(result.modelMarkups!["anthropic/claude-opus-4-5"].markup).toBe(
+					20,
+				);
 			}
 		});
 	});

--- a/packages/atmn/src/lib/transforms/apiToSdk/feature.ts
+++ b/packages/atmn/src/lib/transforms/apiToSdk/feature.ts
@@ -1,4 +1,4 @@
-import { isGraduatedCreditSchemaItem } from "@autumn/shared";
+import { isGraduatedCreditSchemaItem, mapRecordValues } from "@autumn/shared";
 import type {
 	CreditDimension,
 	CreditSchemaItem,
@@ -35,20 +35,14 @@ function mapCreditDimension(dimension: ApiCreditDimension): CreditDimension {
 	return { ...base, creditCost: dimension.credit_cost };
 }
 
-function mapRecord<T, U>(
-	record: Record<string, T> | undefined,
-	map: (value: T) => U,
-): Record<string, U> | undefined {
-	if (record === undefined) return undefined;
-	return Object.fromEntries(
-		Object.entries(record).map(([name, value]) => [name, map(value)]),
-	);
-}
-
 function mapCreditDimensionRules(creditSchemaItem: ApiCreditSchemaItem) {
-	const dimensions = mapRecord(creditSchemaItem.dimensions, mapCreditDimension);
 	return {
-		...(dimensions !== undefined && { dimensions }),
+		...(creditSchemaItem.dimensions !== undefined && {
+			dimensions: mapRecordValues({
+				record: creditSchemaItem.dimensions,
+				mapValue: mapCreditDimension,
+			}),
+		}),
 		...(creditSchemaItem.multipliers !== undefined && {
 			multipliers: creditSchemaItem.multipliers,
 		}),

--- a/packages/atmn/src/lib/transforms/apiToSdk/feature.ts
+++ b/packages/atmn/src/lib/transforms/apiToSdk/feature.ts
@@ -1,5 +1,6 @@
 import { isGraduatedCreditSchemaItem } from "@autumn/shared";
 import type {
+	CreditDimension,
 	CreditSchemaItem,
 	Feature,
 	ModelMarkupEntry,
@@ -9,6 +10,51 @@ import { createTransformer } from "./Transformer.js";
 
 type RawApiFeature = Omit<ApiFeature, "type"> & { type: string };
 
+type ApiCreditSchemaItem = NonNullable<RawApiFeature["credit_schema"]>[number];
+type ApiCreditDimension = NonNullable<
+	ApiCreditSchemaItem["dimensions"]
+>[string];
+
+function mapCreditDimension(dimension: ApiCreditDimension): CreditDimension {
+	const base = {
+		match: dimension.match,
+		...(dimension.priority !== undefined && { priority: dimension.priority }),
+	};
+
+	if ("tier_behavior" in dimension) {
+		return {
+			...base,
+			tierBehavior: "graduated",
+			tiers: dimension.tiers.map((tier) => ({
+				to: tier.to,
+				creditCost: tier.credit_cost,
+			})),
+		};
+	}
+
+	return { ...base, creditCost: dimension.credit_cost };
+}
+
+function mapRecord<T, U>(
+	record: Record<string, T> | undefined,
+	map: (value: T) => U,
+): Record<string, U> | undefined {
+	if (record === undefined) return undefined;
+	return Object.fromEntries(
+		Object.entries(record).map(([name, value]) => [name, map(value)]),
+	);
+}
+
+function mapCreditDimensionRules(creditSchemaItem: ApiCreditSchemaItem) {
+	const dimensions = mapRecord(creditSchemaItem.dimensions, mapCreditDimension);
+	return {
+		...(dimensions !== undefined && { dimensions }),
+		...(creditSchemaItem.multipliers !== undefined && {
+			multipliers: creditSchemaItem.multipliers,
+		}),
+	};
+}
+
 function mapCreditSchema(api: RawApiFeature): CreditSchemaItem[] {
 	return (api.credit_schema ?? []).map((creditSchemaItem) => {
 		const base = {
@@ -16,6 +62,7 @@ function mapCreditSchema(api: RawApiFeature): CreditSchemaItem[] {
 			...(creditSchemaItem.billing_units !== undefined && {
 				billingUnits: creditSchemaItem.billing_units,
 			}),
+			...mapCreditDimensionRules(creditSchemaItem),
 		};
 
 		if (isGraduatedCreditSchemaItem(creditSchemaItem)) {
@@ -36,7 +83,9 @@ function mapCreditSchema(api: RawApiFeature): CreditSchemaItem[] {
 	});
 }
 
-function mapModelMarkups(api: RawApiFeature): Record<string, ModelMarkupEntry> | undefined {
+function mapModelMarkups(
+	api: RawApiFeature,
+): Record<string, ModelMarkupEntry> | undefined {
 	if (!api.model_markups) return undefined;
 	return Object.fromEntries(
 		Object.entries(api.model_markups).map(([modelId, entry]) => [
@@ -46,7 +95,7 @@ function mapModelMarkups(api: RawApiFeature): Record<string, ModelMarkupEntry> |
 				inputCost: entry.input_cost,
 				outputCost: entry.output_cost,
 			},
-		])
+		]),
 	);
 }
 

--- a/packages/atmn/src/lib/transforms/apiToSdk/feature.ts
+++ b/packages/atmn/src/lib/transforms/apiToSdk/feature.ts
@@ -1,4 +1,4 @@
-import { isGraduatedCreditSchemaItem, mapRecordValues } from "@autumn/shared";
+import { mapRecordValues } from "@autumn/shared";
 import type {
 	CreditDimension,
 	CreditSchemaItem,
@@ -14,25 +14,33 @@ type ApiCreditSchemaItem = NonNullable<RawApiFeature["credit_schema"]>[number];
 type ApiCreditDimension = NonNullable<
 	ApiCreditSchemaItem["dimensions"]
 >[string];
+type ApiCreditRate =
+	| {
+			tier_behavior: "graduated";
+			tiers: { to: number | "inf"; credit_cost: number }[];
+	  }
+	| { credit_cost: number };
 
-function mapCreditDimension(dimension: ApiCreditDimension): CreditDimension {
-	const base = {
-		match: dimension.match,
-		...(dimension.priority !== undefined && { priority: dimension.priority }),
-	};
-
-	if ("tier_behavior" in dimension) {
+/** The flat-or-graduated part of a rate, API → SDK naming. Rows and dimensions share it. */
+function mapCreditRate(rate: ApiCreditRate) {
+	if ("tier_behavior" in rate) {
 		return {
-			...base,
-			tierBehavior: "graduated",
-			tiers: dimension.tiers.map((tier) => ({
+			tierBehavior: "graduated" as const,
+			tiers: rate.tiers.map((tier) => ({
 				to: tier.to,
 				creditCost: tier.credit_cost,
 			})),
 		};
 	}
+	return { creditCost: rate.credit_cost };
+}
 
-	return { ...base, creditCost: dimension.credit_cost };
+function mapCreditDimension(dimension: ApiCreditDimension): CreditDimension {
+	return {
+		match: dimension.match,
+		...(dimension.priority !== undefined && { priority: dimension.priority }),
+		...mapCreditRate(dimension),
+	};
 }
 
 function mapCreditDimensionRules(creditSchemaItem: ApiCreditSchemaItem) {
@@ -50,31 +58,14 @@ function mapCreditDimensionRules(creditSchemaItem: ApiCreditSchemaItem) {
 }
 
 function mapCreditSchema(api: RawApiFeature): CreditSchemaItem[] {
-	return (api.credit_schema ?? []).map((creditSchemaItem) => {
-		const base = {
-			meteredFeatureId: creditSchemaItem.metered_feature_id,
-			...(creditSchemaItem.billing_units !== undefined && {
-				billingUnits: creditSchemaItem.billing_units,
-			}),
-			...mapCreditDimensionRules(creditSchemaItem),
-		};
-
-		if (isGraduatedCreditSchemaItem(creditSchemaItem)) {
-			return {
-				...base,
-				tierBehavior: "graduated",
-				tiers: creditSchemaItem.tiers.map((tier) => ({
-					to: tier.to,
-					creditCost: tier.credit_cost,
-				})),
-			};
-		}
-
-		return {
-			...base,
-			creditCost: creditSchemaItem.credit_cost,
-		};
-	});
+	return (api.credit_schema ?? []).map((creditSchemaItem) => ({
+		meteredFeatureId: creditSchemaItem.metered_feature_id,
+		...(creditSchemaItem.billing_units !== undefined && {
+			billingUnits: creditSchemaItem.billing_units,
+		}),
+		...mapCreditDimensionRules(creditSchemaItem),
+		...mapCreditRate(creditSchemaItem),
+	}));
 }
 
 function mapModelMarkups(

--- a/packages/atmn/src/lib/transforms/sdkToApi/feature.ts
+++ b/packages/atmn/src/lib/transforms/sdkToApi/feature.ts
@@ -1,5 +1,70 @@
-import type { Feature } from "../../../compose/models/index.js";
+import type {
+	CreditDimension,
+	CreditMultiplier,
+	CreditSchemaItem,
+	Feature,
+} from "../../../compose/models/index.js";
 import type { ApiFeature } from "../../api/types/feature.js";
+
+type ApiCreditSchemaItem = NonNullable<ApiFeature["credit_schema"]>[number];
+type ApiCreditDimension = NonNullable<
+	ApiCreditSchemaItem["dimensions"]
+>[string];
+
+const matchToApi = (
+	match: CreditDimension["match"],
+): ApiCreditDimension["match"] =>
+	Object.fromEntries(
+		Object.entries(match).map(([key, value]) => [key, String(value)]),
+	);
+
+function creditDimensionToApi(dimension: CreditDimension): ApiCreditDimension {
+	const base = {
+		match: matchToApi(dimension.match),
+		...(dimension.priority !== undefined && { priority: dimension.priority }),
+	};
+
+	if (dimension.tierBehavior === "graduated") {
+		return {
+			...base,
+			tier_behavior: "graduated" as const,
+			tiers: dimension.tiers.map((tier) => ({
+				to: tier.to,
+				credit_cost: tier.creditCost,
+			})),
+		};
+	}
+
+	return { ...base, credit_cost: dimension.creditCost };
+}
+
+function creditMultiplierToApi(
+	multiplier: CreditMultiplier,
+): NonNullable<ApiCreditSchemaItem["multipliers"]>[string] {
+	return { ...multiplier, match: matchToApi(multiplier.match) };
+}
+
+function creditDimensionRulesToApi(
+	creditSchemaItem: Pick<CreditSchemaItem, "dimensions" | "multipliers">,
+) {
+	return {
+		...(creditSchemaItem.dimensions !== undefined && {
+			dimensions: Object.fromEntries(
+				Object.entries(creditSchemaItem.dimensions).map(([name, dimension]) => [
+					name,
+					creditDimensionToApi(dimension),
+				]),
+			),
+		}),
+		...(creditSchemaItem.multipliers !== undefined && {
+			multipliers: Object.fromEntries(
+				Object.entries(creditSchemaItem.multipliers).map(
+					([name, multiplier]) => [name, creditMultiplierToApi(multiplier)],
+				),
+			),
+		}),
+	};
+}
 
 export interface ApiFeatureParams {
 	id: string;
@@ -9,11 +74,14 @@ export interface ApiFeatureParams {
 	archived?: boolean;
 	event_names?: string[];
 	credit_schema?: ApiFeature["credit_schema"];
-	model_markups?: Record<string, {
-		markup?: number;
-		input_cost?: number;
-		output_cost?: number;
-	}>;
+	model_markups?: Record<
+		string,
+		{
+			markup?: number;
+			input_cost?: number;
+			output_cost?: number;
+		}
+	>;
 	default_markup?: number;
 	provider_markups?: Record<string, { markup: number }>;
 }
@@ -44,6 +112,7 @@ export function transformFeatureToApi(feature: Feature): ApiFeatureParams {
 				...(creditSchemaItem.billingUnits !== undefined && {
 					billing_units: creditSchemaItem.billingUnits,
 				}),
+				...creditDimensionRulesToApi(creditSchemaItem),
 			};
 
 			if (creditSchemaItem.tierBehavior === "graduated") {
@@ -74,7 +143,7 @@ export function transformFeatureToApi(feature: Feature): ApiFeatureParams {
 						input_cost: entry.inputCost,
 						output_cost: entry.outputCost,
 					},
-				])
+				]),
 			);
 		}
 		if (feature.defaultMarkup !== undefined) {

--- a/packages/atmn/src/lib/transforms/sdkToApi/feature.ts
+++ b/packages/atmn/src/lib/transforms/sdkToApi/feature.ts
@@ -19,24 +19,40 @@ const matchToApi = (
 		Object.entries(match).map(([key, value]) => [key, String(value)]),
 	);
 
-function creditDimensionToApi(dimension: CreditDimension): ApiCreditDimension {
-	const base = {
-		match: matchToApi(dimension.match),
-		...(dimension.priority !== undefined && { priority: dimension.priority }),
-	};
+type SdkCreditRate =
+	| {
+			tierBehavior: "graduated";
+			tiers: { to: number | "inf"; creditCost: number }[];
+	  }
+	| { tierBehavior?: undefined; creditCost: number };
 
-	if (dimension.tierBehavior === "graduated") {
+type ApiCreditRate =
+	| {
+			tier_behavior: "graduated";
+			tiers: { to: number | "inf"; credit_cost: number }[];
+	  }
+	| { credit_cost: number };
+
+/** The flat-or-graduated part of a rate, SDK → API naming. Rows and dimensions share it. */
+function creditRateToApi(rate: SdkCreditRate): ApiCreditRate {
+	if (rate.tierBehavior === "graduated") {
 		return {
-			...base,
-			tier_behavior: "graduated" as const,
-			tiers: dimension.tiers.map((tier) => ({
+			tier_behavior: "graduated",
+			tiers: rate.tiers.map((tier) => ({
 				to: tier.to,
 				credit_cost: tier.creditCost,
 			})),
 		};
 	}
+	return { credit_cost: rate.creditCost };
+}
 
-	return { ...base, credit_cost: dimension.creditCost };
+function creditDimensionToApi(dimension: CreditDimension): ApiCreditDimension {
+	return {
+		match: matchToApi(dimension.match),
+		...(dimension.priority !== undefined && { priority: dimension.priority }),
+		...creditRateToApi(dimension),
+	};
 }
 
 function creditMultiplierToApi(
@@ -104,31 +120,14 @@ export function transformFeatureToApi(feature: Feature): ApiFeatureParams {
 	}
 
 	if (feature.type === "credit_system" && feature.creditSchema) {
-		base.credit_schema = feature.creditSchema.map((creditSchemaItem) => {
-			const baseItem = {
-				metered_feature_id: creditSchemaItem.meteredFeatureId,
-				...(creditSchemaItem.billingUnits !== undefined && {
-					billing_units: creditSchemaItem.billingUnits,
-				}),
-				...creditDimensionRulesToApi(creditSchemaItem),
-			};
-
-			if (creditSchemaItem.tierBehavior === "graduated") {
-				return {
-					...baseItem,
-					tier_behavior: "graduated" as const,
-					tiers: creditSchemaItem.tiers.map((tier) => ({
-						to: tier.to,
-						credit_cost: tier.creditCost,
-					})),
-				};
-			}
-
-			return {
-				...baseItem,
-				credit_cost: creditSchemaItem.creditCost,
-			};
-		});
+		base.credit_schema = feature.creditSchema.map((creditSchemaItem) => ({
+			metered_feature_id: creditSchemaItem.meteredFeatureId,
+			...(creditSchemaItem.billingUnits !== undefined && {
+				billing_units: creditSchemaItem.billingUnits,
+			}),
+			...creditDimensionRulesToApi(creditSchemaItem),
+			...creditRateToApi(creditSchemaItem),
+		}));
 	}
 
 	if (feature.type === "ai_credit_system") {

--- a/packages/atmn/src/lib/transforms/sdkToApi/feature.ts
+++ b/packages/atmn/src/lib/transforms/sdkToApi/feature.ts
@@ -1,3 +1,4 @@
+import { mapRecordValues } from "@autumn/shared";
 import type {
 	CreditDimension,
 	CreditMultiplier,
@@ -49,19 +50,16 @@ function creditDimensionRulesToApi(
 ) {
 	return {
 		...(creditSchemaItem.dimensions !== undefined && {
-			dimensions: Object.fromEntries(
-				Object.entries(creditSchemaItem.dimensions).map(([name, dimension]) => [
-					name,
-					creditDimensionToApi(dimension),
-				]),
-			),
+			dimensions: mapRecordValues({
+				record: creditSchemaItem.dimensions,
+				mapValue: creditDimensionToApi,
+			}),
 		}),
 		...(creditSchemaItem.multipliers !== undefined && {
-			multipliers: Object.fromEntries(
-				Object.entries(creditSchemaItem.multipliers).map(
-					([name, multiplier]) => [name, creditMultiplierToApi(multiplier)],
-				),
-			),
+			multipliers: mapRecordValues({
+				record: creditSchemaItem.multipliers,
+				mapValue: creditMultiplierToApi,
+			}),
 		}),
 	};
 }

--- a/server/src/internal/features/featureActions/hasCreditRateCardChanged.ts
+++ b/server/src/internal/features/featureActions/hasCreditRateCardChanged.ts
@@ -1,4 +1,8 @@
-import type { CreditSchemaItem, CreditSystemConfig } from "@autumn/shared";
+import {
+	type CreditSchemaItem,
+	type CreditSystemConfig,
+	creditDimensionRulesEqual,
+} from "@autumn/shared";
 
 const creditSchemaItemsEqual = ({
 	left,
@@ -9,6 +13,7 @@ const creditSchemaItemsEqual = ({
 }): boolean => {
 	if ((left.feature_amount ?? 1) !== (right.feature_amount ?? 1)) return false;
 	if (left.tier_behavior !== right.tier_behavior) return false;
+	if (!creditDimensionRulesEqual({ left, right })) return false;
 
 	if (
 		left.tier_behavior !== "graduated" ||

--- a/server/src/utils/hash/hashJson.ts
+++ b/server/src/utils/hash/hashJson.ts
@@ -1,27 +1,5 @@
 import { createHash } from "node:crypto";
-
-/**
- * Recursively sort object keys, strip undefined values, and produce a stable string.
- * Array element order is preserved; object key order is not.
- */
-const deterministicStringify = (value: unknown): string => {
-	if (value === null || value === undefined) return "null";
-	if (typeof value !== "object") return JSON.stringify(value);
-
-	if (Array.isArray(value))
-		return `[${value.map(deterministicStringify).join(",")}]`;
-
-	const obj = value as Record<string, unknown>;
-
-	if (typeof obj.toJSON === "function")
-		return deterministicStringify(obj.toJSON());
-
-	const sortedKeys = Object.keys(obj)
-		.filter((k) => obj[k] !== undefined)
-		.sort();
-
-	return `{${sortedKeys.map((k) => `${JSON.stringify(k)}:${deterministicStringify(obj[k])}`).join(",")}}`;
-};
+import { deterministicStringify } from "@autumn/shared";
 
 /** Produce a SHA-256 hex digest from any JSON-serialisable value, key-order independent. */
 export const hashJson = ({ value }: { value: unknown }): string => {

--- a/server/tests/unit/features/credit-dimensions-api.test.ts
+++ b/server/tests/unit/features/credit-dimensions-api.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Contract for credit dimensions on the API surface:
+ * - `credit_schema` items accept `dimensions` / `multipliers` with API naming
+ *   (`credit_cost`), strict like the rest of the item;
+ * - API ↔ DB converters round-trip them (credit_cost ↔ credit_amount);
+ * - legacy V0 shapes cannot represent them and bail rather than emit garbage;
+ * - every schema comparator notices a dimension or multiplier edit.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	type ApiFeatureV1,
+	apiCreditSchemaItemToDb,
+	CreateFeatureV2ParamsSchema,
+	type CreditSchemaItem,
+	dbCreditSchemaItemToApi,
+	diffFeatureV1,
+	type Entitlement,
+	entsAreSame,
+	type Feature,
+	FeatureType,
+	FeatureUsageType,
+	toApiFeature,
+} from "@autumn/shared";
+import { apiCreditSchemaToV0 } from "@shared/api/features/changes/V1.2_FeatureChange";
+import { entitlements } from "@tests/utils/fixtures/db/entitlements";
+import { hasCreditRateCardChanged } from "@/internal/features/featureActions/hasCreditRateCardChanged.js";
+
+const apiRow = {
+	metered_feature_id: "cpu_minutes",
+	credit_cost: 1,
+	dimensions: {
+		small: { match: { size: "small" }, credit_cost: 1 },
+		large_eu: {
+			match: { size: "large", region: "eu" },
+			priority: 1,
+			credit_cost: 20,
+		},
+		xl: {
+			match: { size: "xl" },
+			tier_behavior: "graduated" as const,
+			tiers: [
+				{ to: 1_000, credit_cost: 30 },
+				{ to: "inf" as const, credit_cost: 25 },
+			],
+		},
+	},
+	multipliers: {
+		spot: { match: { lifecycle: "spot" }, factor: 0.3 },
+		promo: { match: { cohort: "2024" }, add: -0.2 },
+	},
+};
+
+const dbRow: CreditSchemaItem = {
+	metered_feature_id: "cpu_minutes",
+	credit_amount: 1,
+	dimensions: {
+		small: { match: { size: "small" }, credit_amount: 1 },
+		large_eu: {
+			match: { size: "large", region: "eu" },
+			priority: 1,
+			credit_amount: 20,
+		},
+		xl: {
+			match: { size: "xl" },
+			tier_behavior: "graduated",
+			tiers: [
+				{ to: 1_000, credit_amount: 30 },
+				{ to: "inf", credit_amount: 25 },
+			],
+		},
+	},
+	multipliers: {
+		spot: { match: { lifecycle: "spot" }, factor: 0.3 },
+		promo: { match: { cohort: "2024" }, add: -0.2 },
+	},
+};
+
+const createParams = (creditSchema: unknown) =>
+	CreateFeatureV2ParamsSchema.safeParse({
+		feature_id: "credits",
+		name: "Credits",
+		type: FeatureType.CreditSystem,
+		credit_schema: [creditSchema],
+	});
+
+describe("credit dimensions API schema", () => {
+	test("accepts dimensions and multipliers on a credit_schema item", () => {
+		const result = createParams(apiRow);
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+
+		expect(result.data.credit_schema?.[0]).toEqual(apiRow);
+	});
+
+	test("rejects unknown keys inside a dimension", () => {
+		const result = createParams({
+			...apiRow,
+			dimensions: {
+				small: { match: { size: "small" }, credit_cost: 1, colour: "red" },
+			},
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects a graduated dimension whose final tier is not inf", () => {
+		const result = createParams({
+			...apiRow,
+			dimensions: {
+				xl: {
+					match: { size: "xl" },
+					tier_behavior: "graduated",
+					tiers: [{ to: 1_000, credit_cost: 30 }],
+				},
+			},
+		});
+
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("credit dimensions converters", () => {
+	test("API to DB renames credit_cost to credit_amount inside dimensions", () => {
+		expect(apiCreditSchemaItemToDb(apiRow)).toEqual(dbRow);
+	});
+
+	test("DB to API is the inverse", () => {
+		expect(dbCreditSchemaItemToApi(dbRow)).toEqual(apiRow);
+	});
+
+	test("plain items still convert without dimension keys", () => {
+		expect(
+			apiCreditSchemaItemToDb({ metered_feature_id: "a", credit_cost: 2 }),
+		).toEqual({ metered_feature_id: "a", credit_amount: 2 });
+	});
+});
+
+describe("credit dimensions on legacy shapes", () => {
+	const creditFeature: Feature = {
+		internal_id: "fe_credits",
+		org_id: "org",
+		env: "sandbox",
+		id: "credits",
+		name: "Credits",
+		type: FeatureType.CreditSystem,
+		config: { usage_type: FeatureUsageType.Single, schema: [dbRow] },
+		archived: false,
+		event_names: [],
+		created_at: 1,
+	} as unknown as Feature;
+
+	test("V0 credit_schema bails to null for a dimensioned item", () => {
+		expect(apiCreditSchemaToV0({ creditSchema: [apiRow] })).toBeNull();
+	});
+
+	test("V0 feature response omits credit_schema for a dimensioned item", () => {
+		expect(
+			toApiFeature({ feature: creditFeature }).credit_schema,
+		).toBeUndefined();
+	});
+});
+
+describe("credit dimensions comparators", () => {
+	const withMultiplierFactor = (factor: number): CreditSchemaItem => ({
+		...dbRow,
+		multipliers: {
+			...dbRow.multipliers,
+			spot: { match: { lifecycle: "spot" }, factor },
+		},
+	});
+
+	const withReorderedRecords = (): CreditSchemaItem => ({
+		...dbRow,
+		dimensions: {
+			xl: dbRow.dimensions?.xl!,
+			large_eu: dbRow.dimensions?.large_eu!,
+			small: dbRow.dimensions?.small!,
+		},
+	});
+
+	const config = (item: CreditSchemaItem) => ({
+		usage_type: FeatureUsageType.Single,
+		provider_markups: undefined,
+		schema: [item],
+	});
+
+	test("hasCreditRateCardChanged sees a multiplier edit and ignores record order", () => {
+		expect(
+			hasCreditRateCardChanged({
+				oldConfig: config(dbRow),
+				newConfig: config(withMultiplierFactor(0.5)),
+			}),
+		).toBe(true);
+		expect(
+			hasCreditRateCardChanged({
+				oldConfig: config(dbRow),
+				newConfig: config(withReorderedRecords()),
+			}),
+		).toBe(false);
+	});
+
+	test("entsAreSame sees a dimension edit inside feature_override", () => {
+		const build = (item: CreditSchemaItem) =>
+			entitlements.build({
+				feature_override: { schema: [item] },
+			} as Partial<Entitlement>);
+
+		expect(entsAreSame(build(dbRow), build(withReorderedRecords()))).toBe(true);
+		expect(entsAreSame(build(dbRow), build(withMultiplierFactor(0.5)))).toBe(
+			false,
+		);
+	});
+
+	test("diffFeatureV1 reports a dimension rate change", () => {
+		const feature = (creditSchema: ApiFeatureV1["credit_schema"]) =>
+			({
+				id: "credits",
+				name: "Credits",
+				type: FeatureType.CreditSystem,
+				consumable: true,
+				archived: false,
+				credit_schema: creditSchema,
+			}) as ApiFeatureV1;
+
+		const changed = {
+			...apiRow,
+			dimensions: {
+				...apiRow.dimensions,
+				small: { match: { size: "small" }, credit_cost: 2 },
+			},
+		};
+
+		expect(
+			diffFeatureV1({ from: feature([apiRow]), to: feature([apiRow]) })
+				.previous_attributes,
+		).toBeNull();
+		expect(
+			diffFeatureV1({ from: feature([apiRow]), to: feature([changed]) })
+				.previous_attributes,
+		).toEqual({ credit_schema: [apiRow] });
+	});
+});

--- a/shared/api/features/changes/V1.2_FeatureChange.ts
+++ b/shared/api/features/changes/V1.2_FeatureChange.ts
@@ -6,6 +6,7 @@ import {
 import { FeatureType } from "@models/featureModels/featureEnums.js";
 import { isAiCreditSystem } from "@utils/featureUtils/classifyFeature/isAiCreditSystem";
 import type { z } from "zod/v4";
+import { hasCreditDimensionRules } from "../../../utils/featureUtils/classifyFeature/hasCreditDimensionRules.js";
 import { ApiFeatureV1Schema } from "../apiFeatureV1.js";
 import { isGraduatedCreditSchemaItem } from "../creditRateCard.js";
 import {
@@ -26,6 +27,7 @@ export const apiCreditSchemaToV0 = ({
 	for (const item of creditSchema) {
 		if (
 			isGraduatedCreditSchemaItem(item) ||
+			hasCreditDimensionRules(item) ||
 			(item.billing_units ?? 1) !== 1
 		) {
 			return null;

--- a/shared/api/features/creditRateCard.ts
+++ b/shared/api/features/creditRateCard.ts
@@ -1,7 +1,7 @@
 import { z } from "zod/v4";
 import {
-	CREDIT_DIMENSION_NAME_MAX_LENGTH,
-	USAGE_ATTRIBUTION_DIMENSION_SEPARATOR,
+	CreditDimensionNameSchema,
+	CreditMatchSchema,
 } from "../../models/featureModels/featureConfig/creditConfig.js";
 
 export const ApiCreditTierSchema = z.object({
@@ -53,15 +53,10 @@ const refineGraduatedTiers = (
 	}
 };
 
-const ApiCreditMatchSchema = z
-	.record(
-		z.string(),
-		z.union([z.string(), z.number(), z.boolean()]).transform(String),
-	)
-	.meta({
-		description:
-			"Event properties this entry applies to. Every key must equal the tracked property, compared as strings.",
-	});
+const ApiCreditMatchSchema = CreditMatchSchema.meta({
+	description:
+		"Event properties this entry applies to. Every key must equal the tracked property, compared as strings.",
+});
 
 const ApiCreditDimensionBaseSchema = z.object({
 	match: ApiCreditMatchSchema,
@@ -105,14 +100,6 @@ export const ApiCreditMultiplierSchema = z
 		{ message: "A multiplier needs a factor or an add." },
 	);
 
-const ApiCreditDimensionNameSchema = z
-	.string()
-	.min(1)
-	.max(CREDIT_DIMENSION_NAME_MAX_LENGTH)
-	.refine((name) => !name.includes(USAGE_ATTRIBUTION_DIMENSION_SEPARATOR), {
-		message: `Dimension names cannot contain "${USAGE_ATTRIBUTION_DIMENSION_SEPARATOR}".`,
-	});
-
 const ApiCreditSchemaItemBaseSchema = z.object({
 	metered_feature_id: z.string().nonempty().meta({
 		description:
@@ -123,14 +110,14 @@ const ApiCreditSchemaItemBaseSchema = z.object({
 			"Number of metered-feature units priced together. Defaults to one when omitted.",
 	}),
 	dimensions: z
-		.record(ApiCreditDimensionNameSchema, ApiCreditDimensionSchema)
+		.record(CreditDimensionNameSchema, ApiCreditDimensionSchema)
 		.optional()
 		.meta({
 			description:
 				"Named rates chosen by event properties. The most specific match sets the rate; with no match the item's own rate applies.",
 		}),
 	multipliers: z
-		.record(ApiCreditDimensionNameSchema, ApiCreditMultiplierSchema)
+		.record(CreditDimensionNameSchema, ApiCreditMultiplierSchema)
 		.optional()
 		.meta({
 			description:

--- a/shared/api/features/creditRateCard.ts
+++ b/shared/api/features/creditRateCard.ts
@@ -1,4 +1,117 @@
 import { z } from "zod/v4";
+import {
+	CREDIT_DIMENSION_NAME_MAX_LENGTH,
+	USAGE_ATTRIBUTION_DIMENSION_SEPARATOR,
+} from "../../models/featureModels/featureConfig/creditConfig.js";
+
+export const ApiCreditTierSchema = z.object({
+	to: z.union([z.number().positive(), z.enum(["inf"])]).meta({
+		description:
+			"Inclusive upper usage boundary for this graduated tier. The final tier must be 'inf'.",
+	}),
+	credit_cost: z.number().min(0).meta({
+		description: "Credits consumed per billing-unit group within this tier.",
+	}),
+});
+
+const refineGraduatedTiers = (
+	item: { tiers: z.infer<typeof ApiCreditTierSchema>[] },
+	ctx: z.RefinementCtx,
+) => {
+	let previousBoundary = 0;
+
+	for (const [index, tier] of item.tiers.entries()) {
+		const isLastTier = index === item.tiers.length - 1;
+
+		if (tier.to === "inf") {
+			if (!isLastTier) {
+				ctx.addIssue({
+					code: "custom",
+					message: "Only the final tier may use an 'inf' boundary.",
+					path: ["tiers", index, "to"],
+				});
+			}
+			continue;
+		}
+
+		if (tier.to <= previousBoundary) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Tier boundaries must be strictly increasing.",
+				path: ["tiers", index, "to"],
+			});
+		}
+		previousBoundary = tier.to;
+
+		if (isLastTier) {
+			ctx.addIssue({
+				code: "custom",
+				message: "The final tier must use an 'inf' boundary.",
+				path: ["tiers", index, "to"],
+			});
+		}
+	}
+};
+
+const ApiCreditMatchSchema = z
+	.record(
+		z.string(),
+		z.union([z.string(), z.number(), z.boolean()]).transform(String),
+	)
+	.meta({
+		description:
+			"Event properties this entry applies to. Every key must equal the tracked property, compared as strings.",
+	});
+
+const ApiCreditDimensionBaseSchema = z.object({
+	match: ApiCreditMatchSchema,
+	priority: z.number().int().optional().meta({
+		description:
+			"Breaks ties between dimensions that match the same number of keys. Higher wins.",
+	}),
+});
+
+export const ApiCreditDimensionSchema = z.union([
+	ApiCreditDimensionBaseSchema.extend({
+		tier_behavior: z.literal("graduated"),
+		tiers: z.array(ApiCreditTierSchema).min(1),
+	})
+		.strict()
+		.superRefine(refineGraduatedTiers),
+	ApiCreditDimensionBaseSchema.extend({
+		credit_cost: z.number().min(0).meta({
+			description:
+				"Credits consumed per billing-unit group when this dimension matches.",
+		}),
+	}).strict(),
+]);
+
+export const ApiCreditMultiplierSchema = z
+	.object({
+		match: ApiCreditMatchSchema,
+		factor: z.number().positive().optional().meta({
+			description:
+				"Multiplies the matched rate. All matching multipliers stack.",
+		}),
+		add: z.number().optional().meta({
+			description:
+				"Added to the rate after every factor is applied, in credits per billing-unit group.",
+		}),
+	})
+	.strict()
+	.refine(
+		(multiplier) =>
+			multiplier.factor !== undefined || multiplier.add !== undefined,
+		{ message: "A multiplier needs a factor or an add." },
+	);
+
+const ApiCreditDimensionNameSchema = z
+	.string()
+	.min(1)
+	.max(CREDIT_DIMENSION_NAME_MAX_LENGTH)
+	.refine((name) => !name.includes(USAGE_ATTRIBUTION_DIMENSION_SEPARATOR), {
+		message: `Dimension names cannot contain "${USAGE_ATTRIBUTION_DIMENSION_SEPARATOR}".`,
+	});
 
 const ApiCreditSchemaItemBaseSchema = z.object({
 	metered_feature_id: z.string().nonempty().meta({
@@ -9,16 +122,20 @@ const ApiCreditSchemaItemBaseSchema = z.object({
 		description:
 			"Number of metered-feature units priced together. Defaults to one when omitted.",
 	}),
-});
-
-export const ApiCreditTierSchema = z.object({
-	to: z.union([z.number().positive(), z.enum(["inf"])]).meta({
-		description:
-			"Inclusive upper usage boundary for this graduated tier. The final tier must be 'inf'.",
-	}),
-	credit_cost: z.number().min(0).meta({
-		description: "Credits consumed per billing-unit group within this tier.",
-	}),
+	dimensions: z
+		.record(ApiCreditDimensionNameSchema, ApiCreditDimensionSchema)
+		.optional()
+		.meta({
+			description:
+				"Named rates chosen by event properties. The most specific match sets the rate; with no match the item's own rate applies.",
+		}),
+	multipliers: z
+		.record(ApiCreditDimensionNameSchema, ApiCreditMultiplierSchema)
+		.optional()
+		.meta({
+			description:
+				"Named adjustments chosen by event properties. Every match applies: factors multiply, then adds are summed.",
+		}),
 });
 
 export const ApiFlatCreditSchemaItemSchema =
@@ -34,41 +151,7 @@ export const ApiGraduatedCreditSchemaItemSchema =
 		tiers: z.array(ApiCreditTierSchema).min(1),
 	})
 		.strict()
-		.superRefine((item, ctx) => {
-		let previousBoundary = 0;
-
-		for (const [index, tier] of item.tiers.entries()) {
-			const isLastTier = index === item.tiers.length - 1;
-
-			if (tier.to === "inf") {
-				if (!isLastTier) {
-					ctx.addIssue({
-						code: "custom",
-						message: "Only the final tier may use an 'inf' boundary.",
-						path: ["tiers", index, "to"],
-					});
-				}
-				continue;
-			}
-
-			if (tier.to <= previousBoundary) {
-				ctx.addIssue({
-					code: "custom",
-					message: "Tier boundaries must be strictly increasing.",
-					path: ["tiers", index, "to"],
-				});
-			}
-			previousBoundary = tier.to;
-
-			if (isLastTier) {
-				ctx.addIssue({
-					code: "custom",
-					message: "The final tier must use an 'inf' boundary.",
-					path: ["tiers", index, "to"],
-				});
-			}
-		}
-	});
+		.superRefine(refineGraduatedTiers);
 
 export const ApiCreditSchemaItemSchema = z.union([
 	ApiGraduatedCreditSchemaItemSchema,
@@ -97,3 +180,6 @@ export const isGraduatedCreditSchemaItem = (
 	ApiCreditSchemaItem | ApiCreditSchemaResponseItem,
 	{ tier_behavior: "graduated" }
 > => "tier_behavior" in item && item.tier_behavior === "graduated";
+
+export type ApiCreditDimension = z.infer<typeof ApiCreditDimensionSchema>;
+export type ApiCreditMultiplier = z.infer<typeof ApiCreditMultiplierSchema>;

--- a/shared/utils/common/deterministicStringify.ts
+++ b/shared/utils/common/deterministicStringify.ts
@@ -1,0 +1,22 @@
+/**
+ * Recursively sort object keys, strip undefined values, and produce a stable string.
+ * Array element order is preserved; object key order is not.
+ */
+export const deterministicStringify = (value: unknown): string => {
+	if (value === null || value === undefined) return "null";
+	if (typeof value !== "object") return JSON.stringify(value);
+
+	if (Array.isArray(value))
+		return `[${value.map(deterministicStringify).join(",")}]`;
+
+	const obj = value as Record<string, unknown>;
+
+	if (typeof obj.toJSON === "function")
+		return deterministicStringify(obj.toJSON());
+
+	const sortedKeys = Object.keys(obj)
+		.filter((k) => obj[k] !== undefined)
+		.sort();
+
+	return `{${sortedKeys.map((k) => `${JSON.stringify(k)}:${deterministicStringify(obj[k])}`).join(",")}}`;
+};

--- a/shared/utils/common/index.ts
+++ b/shared/utils/common/index.ts
@@ -1,3 +1,4 @@
+export * from "./deterministicStringify";
 export * from "./enrichCtxWithFeatures";
 export * from "./formatUtils/index";
 export * from "./mathUtils";

--- a/shared/utils/common/objectUtils.ts
+++ b/shared/utils/common/objectUtils.ts
@@ -1,2 +1,13 @@
 export const isEmptyObject = (value: object): boolean =>
 	Object.keys(value).length === 0;
+
+export const mapRecordValues = <T, U>({
+	record,
+	mapValue,
+}: {
+	record: Record<string, T>;
+	mapValue: (value: T) => U;
+}): Record<string, U> =>
+	Object.fromEntries(
+		Object.entries(record).map(([key, value]) => [key, mapValue(value)]),
+	);

--- a/shared/utils/featureUtils.ts
+++ b/shared/utils/featureUtils.ts
@@ -2,6 +2,7 @@ import { ApiFeatureV0Schema } from "@api/features/prevVersions/apiFeatureV0.js";
 import type { CreditSchemaItem } from "../models/featureModels/featureConfig/creditConfig.js";
 import { FeatureType } from "../models/featureModels/featureEnums.js";
 import type { Feature } from "../models/featureModels/featureModels.js";
+import { hasCreditDimensionRules } from "./featureUtils/classifyFeature/hasCreditDimensionRules.js";
 import { creditSystemContainsFeature } from "./featureUtils/creditSystemUtils.js";
 // import {
 // 	constructBooleanFeature,
@@ -24,6 +25,7 @@ export const toApiFeature = ({ feature }: { feature: Feature }) => {
 		const canRepresentSchema = feature.config.schema.every(
 			(item: CreditSchemaItem) =>
 				item.tier_behavior !== "graduated" &&
+				!hasCreditDimensionRules(item) &&
 				(item.feature_amount === undefined || item.feature_amount === 1),
 		);
 		if (canRepresentSchema) {

--- a/shared/utils/featureUtils/apiFeatureToDbFeature.ts
+++ b/shared/utils/featureUtils/apiFeatureToDbFeature.ts
@@ -15,6 +15,7 @@ import type { ApiFeatureOverride } from "../../api/features/apiFeatureOverride.j
 import type { ApiFeatureV1 } from "../../api/features/apiFeatureV1.js";
 import type { ApiFeatureProcessors } from "../../api/features/components/processors.js";
 import {
+	type ApiCreditDimension,
 	type ApiCreditSchemaItem,
 	isGraduatedCreditSchemaItem,
 } from "../../api/features/creditRateCard.js";
@@ -29,6 +30,7 @@ import {
 	LATEST_VERSION,
 } from "../../api/versionUtils/versionUtils.js";
 import type {
+	CreditDimension,
 	CreditSchemaItem,
 	FeatureConfigOverride,
 } from "../../models/featureModels/featureConfig/creditConfig.js";
@@ -81,6 +83,84 @@ export const featureToApiProcessors = (
 	};
 };
 
+const apiCreditDimensionToDb = (
+	dimension: ApiCreditDimension,
+): CreditDimension => {
+	const base = {
+		match: dimension.match,
+		...(dimension.priority === undefined
+			? {}
+			: { priority: dimension.priority }),
+	};
+
+	if ("tier_behavior" in dimension) {
+		return {
+			...base,
+			tier_behavior: "graduated",
+			tiers: dimension.tiers.map((tier) => ({
+				to: tier.to,
+				credit_amount: tier.credit_cost,
+			})),
+		};
+	}
+
+	return { ...base, credit_amount: dimension.credit_cost };
+};
+
+const dbCreditDimensionToApi = (
+	dimension: CreditDimension,
+): ApiCreditDimension => {
+	const base = {
+		match: dimension.match,
+		...(dimension.priority === undefined
+			? {}
+			: { priority: dimension.priority }),
+	};
+
+	if (dimension.tier_behavior === "graduated") {
+		return {
+			...base,
+			tier_behavior: "graduated",
+			tiers: dimension.tiers.map((tier) => ({
+				to: tier.to,
+				credit_cost: tier.credit_amount,
+			})),
+		};
+	}
+
+	return { ...base, credit_cost: dimension.credit_amount };
+};
+
+const mapRecord = <T, U>(
+	record: Record<string, T> | undefined,
+	map: (value: T) => U,
+): Record<string, U> | undefined =>
+	record === undefined
+		? undefined
+		: Object.fromEntries(
+				Object.entries(record).map(([name, value]) => [name, map(value)]),
+			);
+
+const apiCreditDimensionRulesToDb = (credit: ApiCreditSchemaItem) => {
+	const dimensions = mapRecord(credit.dimensions, apiCreditDimensionToDb);
+	return {
+		...(dimensions === undefined ? {} : { dimensions }),
+		...(credit.multipliers === undefined
+			? {}
+			: { multipliers: credit.multipliers }),
+	};
+};
+
+const dbCreditDimensionRulesToApi = (credit: CreditSchemaItem) => {
+	const dimensions = mapRecord(credit.dimensions, dbCreditDimensionToApi);
+	return {
+		...(dimensions === undefined ? {} : { dimensions }),
+		...(credit.multipliers === undefined
+			? {}
+			: { multipliers: credit.multipliers }),
+	};
+};
+
 export const apiCreditSchemaItemToDb = (
 	credit: ApiCreditSchemaItem,
 ): CreditSchemaItem => {
@@ -89,6 +169,7 @@ export const apiCreditSchemaItemToDb = (
 		...(credit.billing_units === undefined
 			? {}
 			: { feature_amount: credit.billing_units }),
+		...apiCreditDimensionRulesToDb(credit),
 	};
 
 	if (isGraduatedCreditSchemaItem(credit)) {
@@ -129,6 +210,7 @@ export const dbCreditSchemaItemToApi = (
 		...(credit.feature_amount === undefined
 			? {}
 			: { billing_units: credit.feature_amount }),
+		...dbCreditDimensionRulesToApi(credit),
 	};
 
 	if (credit.tier_behavior === "graduated") {

--- a/shared/utils/featureUtils/apiFeatureToDbFeature.ts
+++ b/shared/utils/featureUtils/apiFeatureToDbFeature.ts
@@ -14,10 +14,9 @@ import { isAiCreditSystem } from "@utils/featureUtils/classifyFeature/isAiCredit
 import type { ApiFeatureOverride } from "../../api/features/apiFeatureOverride.js";
 import type { ApiFeatureV1 } from "../../api/features/apiFeatureV1.js";
 import type { ApiFeatureProcessors } from "../../api/features/components/processors.js";
-import {
-	type ApiCreditDimension,
-	type ApiCreditSchemaItem,
-	isGraduatedCreditSchemaItem,
+import type {
+	ApiCreditDimension,
+	ApiCreditSchemaItem,
 } from "../../api/features/creditRateCard.js";
 import type {
 	CreateFeatureV1Params,
@@ -32,6 +31,7 @@ import {
 import type {
 	CreditDimension,
 	CreditSchemaItem,
+	CreditTier,
 	FeatureConfigOverride,
 } from "../../models/featureModels/featureConfig/creditConfig.js";
 import type { SharedContext } from "../../types/sharedContext.js";
@@ -84,53 +84,55 @@ export const featureToApiProcessors = (
 	};
 };
 
+type ApiCreditRate =
+	| {
+			tier_behavior: "graduated";
+			tiers: { to: number | "inf"; credit_cost: number }[];
+	  }
+	| { credit_cost: number };
+
+type DbCreditRate =
+	| { tier_behavior: "graduated"; tiers: CreditTier[] }
+	| { credit_amount: number };
+
+/** The flat-or-graduated part of a rate, API → DB naming. Rows and dimensions share it. */
+const apiCreditRateToDb = (rate: ApiCreditRate): DbCreditRate =>
+	"tier_behavior" in rate
+		? {
+				tier_behavior: "graduated",
+				tiers: rate.tiers.map((tier) => ({
+					to: tier.to,
+					credit_amount: tier.credit_cost,
+				})),
+			}
+		: { credit_amount: rate.credit_cost };
+
+const dbCreditRateToApi = (rate: DbCreditRate): ApiCreditRate =>
+	"tier_behavior" in rate
+		? {
+				tier_behavior: "graduated",
+				tiers: rate.tiers.map((tier) => ({
+					to: tier.to,
+					credit_cost: tier.credit_amount,
+				})),
+			}
+		: { credit_cost: rate.credit_amount };
+
 const apiCreditDimensionToDb = (
 	dimension: ApiCreditDimension,
-): CreditDimension => {
-	const base = {
-		match: dimension.match,
-		...(dimension.priority === undefined
-			? {}
-			: { priority: dimension.priority }),
-	};
-
-	if ("tier_behavior" in dimension) {
-		return {
-			...base,
-			tier_behavior: "graduated",
-			tiers: dimension.tiers.map((tier) => ({
-				to: tier.to,
-				credit_amount: tier.credit_cost,
-			})),
-		};
-	}
-
-	return { ...base, credit_amount: dimension.credit_cost };
-};
+): CreditDimension => ({
+	match: dimension.match,
+	...(dimension.priority === undefined ? {} : { priority: dimension.priority }),
+	...apiCreditRateToDb(dimension),
+});
 
 const dbCreditDimensionToApi = (
 	dimension: CreditDimension,
-): ApiCreditDimension => {
-	const base = {
-		match: dimension.match,
-		...(dimension.priority === undefined
-			? {}
-			: { priority: dimension.priority }),
-	};
-
-	if (dimension.tier_behavior === "graduated") {
-		return {
-			...base,
-			tier_behavior: "graduated",
-			tiers: dimension.tiers.map((tier) => ({
-				to: tier.to,
-				credit_cost: tier.credit_amount,
-			})),
-		};
-	}
-
-	return { ...base, credit_cost: dimension.credit_amount };
-};
+): ApiCreditDimension => ({
+	match: dimension.match,
+	...(dimension.priority === undefined ? {} : { priority: dimension.priority }),
+	...dbCreditRateToApi(dimension),
+});
 
 const apiCreditDimensionRulesToDb = (credit: ApiCreditSchemaItem) => ({
 	...(credit.dimensions === undefined
@@ -162,28 +164,14 @@ const dbCreditDimensionRulesToApi = (credit: CreditSchemaItem) => ({
 
 export const apiCreditSchemaItemToDb = (
 	credit: ApiCreditSchemaItem,
-): CreditSchemaItem => {
-	const base = {
-		metered_feature_id: credit.metered_feature_id,
-		...(credit.billing_units === undefined
-			? {}
-			: { feature_amount: credit.billing_units }),
-		...apiCreditDimensionRulesToDb(credit),
-	};
-
-	if (isGraduatedCreditSchemaItem(credit)) {
-		return {
-			...base,
-			tier_behavior: "graduated",
-			tiers: credit.tiers.map((tier) => ({
-				to: tier.to,
-				credit_amount: tier.credit_cost,
-			})),
-		};
-	}
-
-	return { ...base, credit_amount: credit.credit_cost };
-};
+): CreditSchemaItem => ({
+	metered_feature_id: credit.metered_feature_id,
+	...(credit.billing_units === undefined
+		? {}
+		: { feature_amount: credit.billing_units }),
+	...apiCreditDimensionRulesToDb(credit),
+	...apiCreditRateToDb(credit),
+});
 
 export const apiFeatureOverrideToDb = (
 	override: ApiFeatureOverride,
@@ -203,28 +191,14 @@ export const dbFeatureOverrideToApi = (
 
 export const dbCreditSchemaItemToApi = (
 	credit: CreditSchemaItem,
-): ApiCreditSchemaItem => {
-	const base = {
-		metered_feature_id: credit.metered_feature_id,
-		...(credit.feature_amount === undefined
-			? {}
-			: { billing_units: credit.feature_amount }),
-		...dbCreditDimensionRulesToApi(credit),
-	};
-
-	if (credit.tier_behavior === "graduated") {
-		return {
-			...base,
-			tier_behavior: "graduated",
-			tiers: credit.tiers.map((tier) => ({
-				to: tier.to,
-				credit_cost: tier.credit_amount,
-			})),
-		};
-	}
-
-	return { ...base, credit_cost: credit.credit_amount };
-};
+): ApiCreditSchemaItem => ({
+	metered_feature_id: credit.metered_feature_id,
+	...(credit.feature_amount === undefined
+		? {}
+		: { billing_units: credit.feature_amount }),
+	...dbCreditDimensionRulesToApi(credit),
+	...dbCreditRateToApi(credit),
+});
 
 export const apiFeatureToDbFeature = ({
 	apiFeature,

--- a/shared/utils/featureUtils/apiFeatureToDbFeature.ts
+++ b/shared/utils/featureUtils/apiFeatureToDbFeature.ts
@@ -35,6 +35,7 @@ import type {
 	FeatureConfigOverride,
 } from "../../models/featureModels/featureConfig/creditConfig.js";
 import type { SharedContext } from "../../types/sharedContext.js";
+import { mapRecordValues } from "../common/objectUtils.js";
 import { notNullish, nullish } from "../utils.js";
 import { buildAiCreditSystemConfig } from "./buildAiCreditSystemConfig.js";
 import { isAnyCreditSystem } from "./classifyFeature/isAnyCreditSystem.js";
@@ -131,35 +132,33 @@ const dbCreditDimensionToApi = (
 	return { ...base, credit_cost: dimension.credit_amount };
 };
 
-const mapRecord = <T, U>(
-	record: Record<string, T> | undefined,
-	map: (value: T) => U,
-): Record<string, U> | undefined =>
-	record === undefined
-		? undefined
-		: Object.fromEntries(
-				Object.entries(record).map(([name, value]) => [name, map(value)]),
-			);
+const apiCreditDimensionRulesToDb = (credit: ApiCreditSchemaItem) => ({
+	...(credit.dimensions === undefined
+		? {}
+		: {
+				dimensions: mapRecordValues({
+					record: credit.dimensions,
+					mapValue: apiCreditDimensionToDb,
+				}),
+			}),
+	...(credit.multipliers === undefined
+		? {}
+		: { multipliers: credit.multipliers }),
+});
 
-const apiCreditDimensionRulesToDb = (credit: ApiCreditSchemaItem) => {
-	const dimensions = mapRecord(credit.dimensions, apiCreditDimensionToDb);
-	return {
-		...(dimensions === undefined ? {} : { dimensions }),
-		...(credit.multipliers === undefined
-			? {}
-			: { multipliers: credit.multipliers }),
-	};
-};
-
-const dbCreditDimensionRulesToApi = (credit: CreditSchemaItem) => {
-	const dimensions = mapRecord(credit.dimensions, dbCreditDimensionToApi);
-	return {
-		...(dimensions === undefined ? {} : { dimensions }),
-		...(credit.multipliers === undefined
-			? {}
-			: { multipliers: credit.multipliers }),
-	};
-};
+const dbCreditDimensionRulesToApi = (credit: CreditSchemaItem) => ({
+	...(credit.dimensions === undefined
+		? {}
+		: {
+				dimensions: mapRecordValues({
+					record: credit.dimensions,
+					mapValue: dbCreditDimensionToApi,
+				}),
+			}),
+	...(credit.multipliers === undefined
+		? {}
+		: { multipliers: credit.multipliers }),
+});
 
 export const apiCreditSchemaItemToDb = (
 	credit: ApiCreditSchemaItem,

--- a/shared/utils/featureUtils/classifyFeature/hasCreditDimensionRules.ts
+++ b/shared/utils/featureUtils/classifyFeature/hasCreditDimensionRules.ts
@@ -1,0 +1,7 @@
+/** True when a rate-card item carries dimensions or multipliers, in API or DB shape. */
+export const hasCreditDimensionRules = (item: {
+	dimensions?: Record<string, unknown> | null;
+	multipliers?: Record<string, unknown> | null;
+}): boolean =>
+	Object.keys(item.dimensions ?? {}).length > 0 ||
+	Object.keys(item.multipliers ?? {}).length > 0;

--- a/shared/utils/featureUtils/creditDimensions/creditDimensionRulesEqual.ts
+++ b/shared/utils/featureUtils/creditDimensions/creditDimensionRulesEqual.ts
@@ -1,0 +1,24 @@
+const sortKeysDeep = (value: unknown): unknown => {
+	if (Array.isArray(value)) return value.map(sortKeysDeep);
+	if (value === null || typeof value !== "object") return value;
+
+	const sortedEntries = Object.entries(value as Record<string, unknown>)
+		.filter(([, entry]) => entry !== undefined)
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([key, entry]) => [key, sortKeysDeep(entry)]);
+	return Object.fromEntries(sortedEntries);
+};
+
+const stableJson = (value: unknown): string =>
+	JSON.stringify(sortKeysDeep(value ?? {}));
+
+/** Structural equality of an item's dimension and multiplier rules; record order is not semantic. */
+export const creditDimensionRulesEqual = ({
+	left,
+	right,
+}: {
+	left: { dimensions?: unknown; multipliers?: unknown };
+	right: { dimensions?: unknown; multipliers?: unknown };
+}): boolean =>
+	stableJson(left.dimensions) === stableJson(right.dimensions) &&
+	stableJson(left.multipliers) === stableJson(right.multipliers);

--- a/shared/utils/featureUtils/creditDimensions/creditDimensionRulesEqual.ts
+++ b/shared/utils/featureUtils/creditDimensions/creditDimensionRulesEqual.ts
@@ -1,16 +1,4 @@
-const sortKeysDeep = (value: unknown): unknown => {
-	if (Array.isArray(value)) return value.map(sortKeysDeep);
-	if (value === null || typeof value !== "object") return value;
-
-	const sortedEntries = Object.entries(value as Record<string, unknown>)
-		.filter(([, entry]) => entry !== undefined)
-		.sort(([left], [right]) => left.localeCompare(right))
-		.map(([key, entry]) => [key, sortKeysDeep(entry)]);
-	return Object.fromEntries(sortedEntries);
-};
-
-const stableJson = (value: unknown): string =>
-	JSON.stringify(sortKeysDeep(value ?? {}));
+import { deterministicStringify } from "../../common/deterministicStringify.js";
 
 /** Structural equality of an item's dimension and multiplier rules; record order is not semantic. */
 export const creditDimensionRulesEqual = ({
@@ -20,5 +8,7 @@ export const creditDimensionRulesEqual = ({
 	left: { dimensions?: unknown; multipliers?: unknown };
 	right: { dimensions?: unknown; multipliers?: unknown };
 }): boolean =>
-	stableJson(left.dimensions) === stableJson(right.dimensions) &&
-	stableJson(left.multipliers) === stableJson(right.multipliers);
+	deterministicStringify(left.dimensions ?? {}) ===
+		deterministicStringify(right.dimensions ?? {}) &&
+	deterministicStringify(left.multipliers ?? {}) ===
+		deterministicStringify(right.multipliers ?? {});

--- a/shared/utils/featureUtils/diffFeature/diffFeatureV1.ts
+++ b/shared/utils/featureUtils/diffFeature/diffFeatureV1.ts
@@ -1,5 +1,6 @@
 import type { ApiFeatureV1 } from "@api/features/apiFeatureV1.js";
 import { isGraduatedCreditSchemaItem } from "@api/features/creditRateCard.js";
+import { creditDimensionRulesEqual } from "../creditDimensions/creditDimensionRulesEqual.js";
 
 type FeatureDisplay = ApiFeatureV1["display"];
 type CreditSchema = ApiFeatureV1["credit_schema"];
@@ -36,11 +37,9 @@ const creditSchemaItemsEqual = ({
 	right: NonNullable<CreditSchema>[number];
 }) => {
 	if ((left.billing_units ?? 1) !== (right.billing_units ?? 1)) return false;
+	if (!creditDimensionRulesEqual({ left, right })) return false;
 
-	if (
-		isGraduatedCreditSchemaItem(left) &&
-		isGraduatedCreditSchemaItem(right)
-	) {
+	if (isGraduatedCreditSchemaItem(left) && isGraduatedCreditSchemaItem(right)) {
 		return (
 			left.tiers.length === right.tiers.length &&
 			left.tiers.every(
@@ -51,10 +50,7 @@ const creditSchemaItemsEqual = ({
 		);
 	}
 
-	if (
-		isGraduatedCreditSchemaItem(left) ||
-		isGraduatedCreditSchemaItem(right)
-	) {
+	if (isGraduatedCreditSchemaItem(left) || isGraduatedCreditSchemaItem(right)) {
 		return false;
 	}
 

--- a/shared/utils/featureUtils/index.ts
+++ b/shared/utils/featureUtils/index.ts
@@ -4,15 +4,15 @@ import { isAnyCreditSystem } from "@utils/featureUtils/classifyFeature/isAnyCred
 import { isConsumableFeature } from "@utils/featureUtils/classifyFeature/isConsumableFeature";
 import { findFeatureById } from "@utils/featureUtils/findFeatureUtils";
 
+export { hasCreditDimensionRules } from "@utils/featureUtils/classifyFeature/hasCreditDimensionRules";
+export { isAiCreditSystem } from "@utils/featureUtils/classifyFeature/isAiCreditSystem";
+export { isAnyCreditSystem } from "@utils/featureUtils/classifyFeature/isAnyCreditSystem";
 export * from "./apiFeatureToDbFeature";
-
 export * from "./convertFeatureUtils";
+export * from "./creditDimensions/creditDimensionRulesEqual";
 export * from "./creditSystemUtils";
 export * from "./findFeatureUtils";
 export * from "./sortFeatures";
-
-export { isAiCreditSystem } from "@utils/featureUtils/classifyFeature/isAiCreditSystem";
-export { isAnyCreditSystem } from "@utils/featureUtils/classifyFeature/isAnyCreditSystem";
 
 export const featureUtils = {
 	isConsumable: isConsumableFeature,

--- a/shared/utils/productUtils/entUtils/compareEnt/entsAreSame.ts
+++ b/shared/utils/productUtils/entUtils/compareEnt/entsAreSame.ts
@@ -3,6 +3,7 @@
 import {
 	AllowanceType,
 	type CreditSchemaItem,
+	creditDimensionRulesEqual,
 	EntInterval,
 	type Entitlement,
 	type FeatureConfigOverride,
@@ -51,6 +52,7 @@ const creditSchemasAreSame = ({
 		if (!item2) return false;
 		return (
 			(item1.feature_amount ?? 1) == (item2.feature_amount ?? 1) &&
+			creditDimensionRulesEqual({ left: item1, right: item2 }) &&
 			item1.credit_amount == item2.credit_amount &&
 			(item1.tier_behavior ?? null) === (item2.tier_behavior ?? null) &&
 			(item1.tiers ?? []).length === (item2.tiers ?? []).length &&


### PR DESCRIPTION
Layer 2 of the credit dimensions stack — the API surface.

**Goal** — `credit_schema` items accept `dimensions` / `multipliers` with API naming (`credit_cost`), strict like the rest of the item, and everything that copies or compares a schema item carries them.

**What's here**
- `creditRateCard.ts`: `ApiCreditDimensionSchema`, `ApiCreditMultiplierSchema` on the `.strict()` item base; tier refinement shared with rows.
- Converters: one arm each in `apiCreditSchemaItemToDb` / `dbCreditSchemaItemToApi` (feature overrides, plan items and agent types inherit).
- Legacy V0 shapes bail rather than emit `credit_cost: undefined`: `apiCreditSchemaToV0`, `toApiFeature`.
- Comparators compare the rules structurally (record order is not semantic): `diffFeatureV1` and `hasCreditRateCardChanged` are the two separate cache-clear lanes (catalogV2 vs features.update); `entsAreSame` is customize.
- `atmn` CLI: compose model + both transforms + compare normalizers, so pull/push round-trips dimensions instead of wiping them.

**Verify**
- `cd server && bun ts`
- unit: `tests/unit/features/credit-dimensions-api.test.ts` + `credit-rate-card-cache`, `shared/diffFeatureV1`, `catalogV2/comparators/entsAreSame`
- `cd packages/atmn && bun test src/lib/transforms`

OpenAPI derives from the zod schemas, so the contract picks the fields up without edits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds named dimensions and multipliers to `credit_schema` items with API `credit_cost` naming, so credit pricing rules round-trip through API, DB, SDK, and `atmn`. Legacy V0 shapes bail instead of emitting unsupported dimension data.

- Strict validation covers flat and graduated dimension rates, match values, and multiplier adjustments.
- `diffFeatureV1`, `hasCreditRateCardChanged`, and `entsAreSame` detect rule changes while ignoring record order.
- `atmn` pull, push, and diff normalization preserve dimensions and multipliers instead of dropping them.
- Deduction still prices from base rates only, and `atmn` stringifies match values, so numeric or boolean matches report as changed every diff.

<sup>Written for commit b3ef649ef5fc6aba118b3bb179efb6d9c469bf4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds credit dimensions and multipliers to the public credit-schema shape and carries them through API, database, CLI, and comparison boundaries.

- **[API changes]** Adds strict schemas for flat and graduated dimension rates and multiplier adjustments.
- **[Improvements]** Preserves dimension rules across API/DB and API/CLI transformations.
- **[Bug fixes]** Updates schema comparisons and legacy compatibility handling so rule changes are detected or omitted where unsupported.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because configured dimension rates are not applied during deduction and non-string CLI match values remain permanently out of sync.

Credit-schema rules reach storage but the deduction path still calculates from the base rate, so a matching dimension such as `size=large` does not change the credits charged. Separately, the CLI sends numeric and boolean matches as strings while comparing them to the original primitive values, causing repeated false changes after push.

**Files Needing Attention:** shared/api/features/creditRateCard.ts, server/src/internal/features/creditSystemUtils.ts, packages/atmn/src/lib/transforms/sdkToApi/feature.ts, packages/atmn/src/commands/push/push.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/features/creditRateCard.ts | Adds strict public schemas for named dimensions, graduated dimension rates, and multiplier adjustments. |
| shared/utils/featureUtils/apiFeatureToDbFeature.ts | Extends bidirectional API/DB conversion to retain dimension and multiplier rules. |
| packages/atmn/src/lib/transforms/sdkToApi/feature.ts | Adds SDK-to-API mappings for dimension rates, multipliers, and match properties. |
| packages/atmn/src/lib/transforms/apiToSdk/feature.ts | Adds inverse API-to-SDK mappings and shares rate conversion between rows and dimensions. |
| shared/utils/featureUtils/creditDimensions/creditDimensionRulesEqual.ts | Introduces order-independent structural comparison for dimension and multiplier records. |
| server/src/internal/features/featureActions/hasCreditRateCardChanged.ts | Includes dimension and multiplier changes in credit-rate-card cache invalidation. |
| server/tests/unit/features/credit-dimensions-api.test.ts | Covers validation, conversion, legacy compatibility, and comparator behavior for the new API fields. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Config[atmn configuration] -->|SDK to API transform| API[Credit schema API]
    API -->|API to DB conversion| DB[(Stored feature configuration)]
    DB --> Compare[Catalog and entitlement comparisons]
    API -->|API to SDK transform| Config
    DB --> Legacy[Legacy response compatibility]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: share the credit rate converte..."](https://github.com/useautumn/autumn/commit/6d4b6b11831d7feeacc062b1dab3944b7efdbdb3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60356143)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Usage and billing API platform](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/api-platform.md)
- Knowledge Base — [SDKs and API contract delivery](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/sdk-and-api-contract-delivery.md)
</details>


<!-- /greptile_comment -->