### PR TITLE
feat(catalog): validate credit dimensions at save time

### DIFF
--- a/server/src/internal/features/featureUtils.ts
+++ b/server/src/internal/features/featureUtils.ts
@@ -15,6 +15,8 @@ import {
 import { ACTIVE_STATUSES } from "@server/internal/customers/cusProducts/CusProductService";
 import RecaseError from "@server/utils/errorUtils";
 import { StatusCodes } from "http-status-codes";
+import { validateCreditDimensionRules } from "./validateCreditDimensionRules.js";
+import { validateCreditRate } from "./validateCreditRate.js";
 
 export const validateFeatureId = (featureId: string) => {
 	if (!featureId.match(/^[a-zA-Z0-9_-]+$/)) {
@@ -138,58 +140,8 @@ export const validateCreditSystem = (
 			schemaItem.feature_amount = featureAmount;
 		}
 
-		if (schemaItem.tier_behavior === "graduated") {
-			if (!Array.isArray(schemaItem.tiers) || schemaItem.tiers.length === 0) {
-				invalidCreditSystem(
-					"Graduated credit schemas require at least one tier.",
-				);
-			}
-
-			let previousBoundary = 0;
-			for (const [index, tier] of schemaItem.tiers.entries()) {
-				const creditAmount = Number(tier.credit_amount);
-				if (!Number.isFinite(creditAmount) || creditAmount < 0) {
-					invalidCreditSystem("Tier credit costs must be zero or greater.");
-				}
-				tier.credit_amount = creditAmount;
-
-				const isLastTier = index === schemaItem.tiers.length - 1;
-				if (tier.to === "inf") {
-					if (!isLastTier) {
-						invalidCreditSystem(
-							"Only the final graduated tier may use an infinity boundary.",
-						);
-					}
-					continue;
-				}
-
-				const boundary = Number(tier.to);
-				if (
-					!Number.isFinite(boundary) ||
-					boundary <= 0 ||
-					boundary <= previousBoundary
-				) {
-					invalidCreditSystem(
-						"Graduated tier boundaries must be positive and strictly increasing.",
-					);
-				}
-				if (isLastTier) {
-					invalidCreditSystem(
-						"The final graduated tier must use an infinity boundary.",
-					);
-				}
-
-				tier.to = boundary;
-				previousBoundary = boundary;
-			}
-			continue;
-		}
-
-		const creditAmount = Number(schemaItem.credit_amount);
-		if (!Number.isFinite(creditAmount) || creditAmount < 0) {
-			invalidCreditSystem("Credit cost must be zero or greater.");
-		}
-		schemaItem.credit_amount = creditAmount;
+		validateCreditRate({ rate: schemaItem, invalidCreditSystem });
+		validateCreditDimensionRules({ schemaItem, invalidCreditSystem });
 	}
 
 	return newConfig;

--- a/server/src/internal/features/validateCreditDimensionRules.ts
+++ b/server/src/internal/features/validateCreditDimensionRules.ts
@@ -1,0 +1,116 @@
+import type { CreditDimension, CreditSchemaItem } from "@autumn/shared";
+import {
+	minimumCreditRateAmount,
+	validateCreditRate,
+} from "./validateCreditRate.js";
+
+const matchesCanCoexist = (
+	left: CreditDimension["match"],
+	right: CreditDimension["match"],
+): boolean =>
+	Object.entries(left).every(
+		([key, value]) => right[key] === undefined || right[key] === value,
+	);
+
+const sameSpecificity = (
+	left: CreditDimension,
+	right: CreditDimension,
+): boolean =>
+	Object.keys(left.match).length === Object.keys(right.match).length &&
+	(left.priority ?? null) === (right.priority ?? null);
+
+const validateDimensionsAreSeparable = ({
+	dimensions,
+	invalidCreditSystem,
+}: {
+	dimensions: [string, CreditDimension][];
+	invalidCreditSystem: (message: string) => never;
+}) => {
+	for (const [leftIndex, [leftName, left]] of dimensions.entries()) {
+		for (const [rightName, right] of dimensions.slice(leftIndex + 1)) {
+			const ambiguous =
+				sameSpecificity(left, right) &&
+				matchesCanCoexist(left.match, right.match);
+			if (ambiguous) {
+				invalidCreditSystem(
+					`Dimensions "${leftName}" and "${rightName}" can both match the same event. Give one more match keys or a priority.`,
+				);
+			}
+		}
+	}
+};
+
+const validateMultipliersKeepRatesNonNegative = ({
+	schemaItem,
+	invalidCreditSystem,
+}: {
+	schemaItem: CreditSchemaItem;
+	invalidCreditSystem: (message: string) => never;
+}) => {
+	const multipliers = Object.values(schemaItem.multipliers ?? {});
+	const rates = [schemaItem, ...Object.values(schemaItem.dimensions ?? {})];
+
+	const cheapestRate = Math.min(...rates.map(minimumCreditRateAmount));
+	const discountFactor = multipliers.reduce(
+		(product, multiplier) =>
+			multiplier.factor !== undefined && multiplier.factor < 1
+				? product * multiplier.factor
+				: product,
+		1,
+	);
+	const negativeAdds = multipliers.reduce(
+		(sum, multiplier) =>
+			multiplier.add !== undefined && multiplier.add < 0
+				? sum + multiplier.add
+				: sum,
+		0,
+	);
+
+	if (cheapestRate * discountFactor + negativeAdds < 0) {
+		invalidCreditSystem(
+			`Multipliers on ${schemaItem.metered_feature_id} can take a rate below zero.`,
+		);
+	}
+};
+
+/** Rules that only exist once a rate-card row has dimensions or multipliers. */
+export const validateCreditDimensionRules = ({
+	schemaItem,
+	invalidCreditSystem,
+}: {
+	schemaItem: CreditSchemaItem;
+	invalidCreditSystem: (message: string) => never;
+}): void => {
+	const dimensions = Object.entries(schemaItem.dimensions ?? {});
+	for (const [name, dimension] of dimensions) {
+		if (
+			dimension.priority !== undefined &&
+			!Number.isInteger(dimension.priority)
+		) {
+			invalidCreditSystem(`Dimension "${name}" priority must be an integer.`);
+		}
+		validateCreditRate({ rate: dimension, invalidCreditSystem });
+	}
+
+	validateDimensionsAreSeparable({ dimensions, invalidCreditSystem });
+
+	for (const [name, multiplier] of Object.entries(
+		schemaItem.multipliers ?? {},
+	)) {
+		const hasFactor = multiplier.factor !== undefined;
+		const hasAdd = multiplier.add !== undefined;
+		if (!hasFactor && !hasAdd) {
+			invalidCreditSystem(`Multiplier "${name}" needs a factor or an add.`);
+		}
+		if (hasFactor && !(Number(multiplier.factor) > 0)) {
+			invalidCreditSystem(
+				`Multiplier "${name}" factor must be greater than zero.`,
+			);
+		}
+		if (hasAdd && !Number.isFinite(Number(multiplier.add))) {
+			invalidCreditSystem(`Multiplier "${name}" add must be a number.`);
+		}
+	}
+
+	validateMultipliersKeepRatesNonNegative({ schemaItem, invalidCreditSystem });
+};

--- a/server/src/internal/features/validateCreditRate.ts
+++ b/server/src/internal/features/validateCreditRate.ts
@@ -1,0 +1,75 @@
+import type { CreditTier } from "@autumn/shared";
+
+type CreditRate = {
+	tier_behavior?: "graduated";
+	tiers?: CreditTier[];
+	credit_amount?: number;
+};
+
+/** Checks a flat or graduated rate and coerces its numbers in place; shared by rows and dimensions. */
+export const validateCreditRate = ({
+	rate,
+	invalidCreditSystem,
+}: {
+	rate: CreditRate;
+	invalidCreditSystem: (message: string) => never;
+}): void => {
+	if (rate.tier_behavior === "graduated") {
+		if (!Array.isArray(rate.tiers) || rate.tiers.length === 0) {
+			invalidCreditSystem(
+				"Graduated credit schemas require at least one tier.",
+			);
+		}
+
+		const tiers = rate.tiers ?? [];
+		let previousBoundary = 0;
+		for (const [index, tier] of tiers.entries()) {
+			const creditAmount = Number(tier.credit_amount);
+			if (!Number.isFinite(creditAmount) || creditAmount < 0) {
+				invalidCreditSystem("Tier credit costs must be zero or greater.");
+			}
+			tier.credit_amount = creditAmount;
+
+			const isLastTier = index === tiers.length - 1;
+			if (tier.to === "inf") {
+				if (!isLastTier) {
+					invalidCreditSystem(
+						"Only the final graduated tier may use an infinity boundary.",
+					);
+				}
+				continue;
+			}
+
+			const boundary = Number(tier.to);
+			if (
+				!Number.isFinite(boundary) ||
+				boundary <= 0 ||
+				boundary <= previousBoundary
+			) {
+				invalidCreditSystem(
+					"Graduated tier boundaries must be positive and strictly increasing.",
+				);
+			}
+			if (isLastTier) {
+				invalidCreditSystem(
+					"The final graduated tier must use an infinity boundary.",
+				);
+			}
+
+			tier.to = boundary;
+			previousBoundary = boundary;
+		}
+		return;
+	}
+
+	const creditAmount = Number(rate.credit_amount);
+	if (!Number.isFinite(creditAmount) || creditAmount < 0) {
+		invalidCreditSystem("Credit cost must be zero or greater.");
+	}
+	rate.credit_amount = creditAmount;
+};
+
+export const minimumCreditRateAmount = (rate: CreditRate): number =>
+	rate.tier_behavior === "graduated"
+		? Math.min(...(rate.tiers ?? []).map((tier) => tier.credit_amount))
+		: (rate.credit_amount ?? 0);

--- a/server/tests/integration/catalog-v2/features/credit-dimensions.test.ts
+++ b/server/tests/integration/catalog-v2/features/credit-dimensions.test.ts
@@ -1,0 +1,304 @@
+/**
+ * catalogV2 — credit dimensions on a rate-card row: create, edit one
+ * dimension in place, convert back to a plain row, reject ambiguous cards
+ * through both write surfaces, and carry a dimensioned row inside a plan-item
+ * feature_override.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	ErrCode,
+	entitlements as entitlementsTable,
+	FeatureType,
+	FeatureUsageType,
+	ResetInterval,
+} from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { deleteDbPlans } from "../plans/utils/expectCatalogPlans.js";
+import {
+	deleteDbFeatures,
+	expectDbFeaturesCorrect,
+} from "../utils/expectCatalogFeatures.js";
+import { expectCatalogResultsCorrect } from "../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../utils/uniqueTestId.js";
+
+const meteredFeature = (featureId: string) => ({
+	feature_id: featureId,
+	name: featureId,
+	type: FeatureType.Metered,
+	consumable: true,
+});
+
+const dimensionedRate = (meteredFeatureId: string) => ({
+	metered_feature_id: meteredFeatureId,
+	credit_cost: 1,
+	dimensions: {
+		small: { match: { size: "small" }, credit_cost: 1 },
+		large: { match: { size: "large" }, credit_cost: 16 },
+		large_eu: {
+			match: { size: "large", region: "eu" },
+			credit_cost: 20,
+		},
+		xl: {
+			match: { size: "xl" },
+			tier_behavior: "graduated" as const,
+			tiers: [
+				{ to: 1_000, credit_cost: 30 },
+				{ to: "inf" as const, credit_cost: 25 },
+			],
+		},
+	},
+	multipliers: {
+		spot: { match: { lifecycle: "spot" }, factor: 0.3 },
+	},
+});
+
+const dimensionedDbRate = (meteredFeatureId: string) => ({
+	metered_feature_id: meteredFeatureId,
+	credit_amount: 1,
+	dimensions: {
+		small: { match: { size: "small" }, credit_amount: 1 },
+		large: { match: { size: "large" }, credit_amount: 16 },
+		large_eu: {
+			match: { size: "large", region: "eu" },
+			credit_amount: 20,
+		},
+		xl: {
+			match: { size: "xl" },
+			tier_behavior: "graduated" as const,
+			tiers: [
+				{ to: 1_000, credit_amount: 30 },
+				{ to: "inf" as const, credit_amount: 25 },
+			],
+		},
+	},
+	multipliers: {
+		spot: { match: { lifecycle: "spot" }, factor: 0.3 },
+	},
+});
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 credit dimensions: creates, edits one dimension, and converts back to a plain row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const meteredFeatureId = uniqueTestId("dim_metered");
+		const creditSystemId = uniqueTestId("dim_credits");
+		const featureIds = [meteredFeatureId, creditSystemId];
+		const creditSystem = {
+			feature_id: creditSystemId,
+			name: "Compute credits",
+			type: FeatureType.CreditSystem,
+			credit_schema: [dimensionedRate(meteredFeatureId)],
+		};
+
+		await deleteDbFeatures({ ctx, featureIds });
+
+		try {
+			const createResponse = await autumnV2_3.catalogV2.update({
+				features: [meteredFeature(meteredFeatureId), creditSystem],
+			});
+			expectCatalogResultsCorrect({
+				response: createResponse,
+				features: featureIds.map((id) => ({ id, action: "create" })),
+			});
+			expect(
+				createResponse.features.find(({ id }) => id === creditSystemId),
+			).toMatchObject({ credit_schema: [dimensionedRate(meteredFeatureId)] });
+			await expectDbFeaturesCorrect({
+				ctx,
+				expected: [
+					{
+						id: creditSystemId,
+						type: FeatureType.CreditSystem,
+						usageType: FeatureUsageType.Single,
+						creditSchema: [dimensionedDbRate(meteredFeatureId)],
+					},
+				],
+			});
+
+			const repricedLarge = {
+				...dimensionedRate(meteredFeatureId),
+				dimensions: {
+					...dimensionedRate(meteredFeatureId).dimensions,
+					large: { match: { size: "large" }, credit_cost: 18 },
+				},
+			};
+			const updateResponse = await autumnV2_3.catalogV2.update({
+				features: [{ ...creditSystem, credit_schema: [repricedLarge] }],
+			});
+			expectCatalogResultsCorrect({
+				response: updateResponse,
+				features: [{ id: creditSystemId, action: "update" }],
+			});
+			expect(updateResponse.features[0]).toMatchObject({
+				credit_schema: [repricedLarge],
+			});
+
+			const plainRow = { metered_feature_id: meteredFeatureId, credit_cost: 2 };
+			const flattenResponse = await autumnV2_3.catalogV2.update({
+				features: [{ ...creditSystem, credit_schema: [plainRow] }],
+			});
+			expect(flattenResponse.features[0]).toMatchObject({
+				credit_schema: [plainRow],
+			});
+			await expectDbFeaturesCorrect({
+				ctx,
+				expected: [
+					{
+						id: creditSystemId,
+						type: FeatureType.CreditSystem,
+						creditSchema: [
+							{ metered_feature_id: meteredFeatureId, credit_amount: 2 },
+						],
+					},
+				],
+			});
+		} finally {
+			await deleteDbFeatures({ ctx, featureIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 credit dimensions: rejects an ambiguous card through both write surfaces")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const meteredFeatureId = uniqueTestId("dim_amb_metered");
+		const creditSystemId = uniqueTestId("dim_amb_credits");
+		const featureIds = [meteredFeatureId, creditSystemId];
+		const ambiguousSchema = [
+			{
+				metered_feature_id: meteredFeatureId,
+				credit_cost: 1,
+				dimensions: {
+					large: { match: { size: "large" }, credit_cost: 16 },
+					eu: { match: { region: "eu" }, credit_cost: 12 },
+				},
+			},
+		];
+
+		await deleteDbFeatures({ ctx, featureIds });
+
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					meteredFeature(meteredFeatureId),
+					{
+						feature_id: creditSystemId,
+						name: creditSystemId,
+						type: FeatureType.CreditSystem,
+						credit_schema: [
+							{ metered_feature_id: meteredFeatureId, credit_cost: 1 },
+						],
+					},
+				],
+			});
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidFeature,
+				errMessage: "can both match the same event",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						features: [
+							{
+								feature_id: creditSystemId,
+								name: creditSystemId,
+								type: FeatureType.CreditSystem,
+								credit_schema: ambiguousSchema,
+							},
+						],
+					}),
+			});
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidFeature,
+				errMessage: "can both match the same event",
+				func: () =>
+					autumnV2_3.post("/features.update", {
+						feature_id: creditSystemId,
+						credit_schema: ambiguousSchema,
+					}),
+			});
+
+			const prioritised = [
+				{
+					...ambiguousSchema[0],
+					dimensions: {
+						large: { match: { size: "large" }, credit_cost: 16 },
+						eu: { match: { region: "eu" }, priority: 1, credit_cost: 12 },
+					},
+				},
+			];
+			const response = await autumnV2_3.post("/features.update", {
+				feature_id: creditSystemId,
+				credit_schema: prioritised,
+			});
+			expect(response).toMatchObject({ credit_schema: prioritised });
+		} finally {
+			await deleteDbFeatures({ ctx, featureIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 credit dimensions: a plan-item feature_override carries a dimensioned row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const meteredFeatureId = uniqueTestId("dim_ovr_metered");
+		const creditSystemId = uniqueTestId("dim_ovr_credits");
+		const planId = uniqueTestId("dim_ovr_plan");
+		const featureIds = [meteredFeatureId, creditSystemId];
+		const override = { credit_schema: [dimensionedRate(meteredFeatureId)] };
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		await deleteDbFeatures({ ctx, featureIds });
+
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					meteredFeature(meteredFeatureId),
+					{
+						feature_id: creditSystemId,
+						name: creditSystemId,
+						type: FeatureType.CreditSystem,
+						credit_schema: [
+							{ metered_feature_id: meteredFeatureId, credit_cost: 1 },
+						],
+					},
+				],
+				plans: [
+					{
+						plan_id: planId,
+						name: planId,
+						items: [
+							{
+								feature_id: creditSystemId,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+								feature_override: override,
+							},
+						],
+					},
+				],
+			});
+
+			const rows = await ctx.db
+				.select({
+					feature_id: entitlementsTable.feature_id,
+					feature_override: entitlementsTable.feature_override,
+				})
+				.from(entitlementsTable)
+				.where(eq(entitlementsTable.org_id, ctx.org.id));
+			const overrideRow = rows.find((row) => row.feature_id === creditSystemId);
+			expect(overrideRow?.feature_override?.schema).toEqual([
+				dimensionedDbRate(meteredFeatureId),
+			]);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({ ctx, featureIds });
+		}
+	},
+);

--- a/server/tests/unit/features/credit-dimensions-validation.test.ts
+++ b/server/tests/unit/features/credit-dimensions-validation.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Save-time rules for credit dimensions, applied through validateCreditSystem
+ * so feature-level and plan-item overrides get the same bar:
+ * - every dimension is a well-formed flat or graduated rate;
+ * - two dimensions that could both win the same event must be separable by
+ *   key count or priority;
+ * - multipliers cannot push any rate below zero.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	type CreditMultiplier,
+	type CreditSchemaItem,
+	type CreditSystemConfig,
+	FeatureUsageType,
+} from "@autumn/shared";
+import { validateCreditSystem } from "@/internal/features/featureUtils.js";
+
+const validate = (item: Partial<CreditSchemaItem>) =>
+	validateCreditSystem({
+		usage_type: FeatureUsageType.Single,
+		schema: [{ metered_feature_id: "cpu_minutes", credit_amount: 1, ...item }],
+	} as CreditSystemConfig);
+
+const expectRejected = (item: Partial<CreditSchemaItem>, message: RegExp) =>
+	expect(() => validate(item)).toThrow(message);
+
+describe("credit dimension validation", () => {
+	test("accepts a card with specific and general dimensions and stacked multipliers", () => {
+		const config = validate({
+			dimensions: {
+				large: { match: { size: "large" }, credit_amount: 16 },
+				large_eu: {
+					match: { size: "large", region: "eu" },
+					credit_amount: 20,
+				},
+				xl: {
+					match: { size: "xl" },
+					tier_behavior: "graduated",
+					tiers: [
+						{ to: 1_000, credit_amount: 30 },
+						{ to: "inf", credit_amount: 25 },
+					],
+				},
+			},
+			multipliers: {
+				spot: { match: { lifecycle: "spot" }, factor: 0.3 },
+				promo: { match: { cohort: "2024" }, add: -0.2 },
+			},
+		});
+
+		expect(config.schema[0]?.dimensions?.large_eu).toEqual({
+			match: { size: "large", region: "eu" },
+			credit_amount: 20,
+		});
+	});
+
+	test("coerces numeric strings inside dimension rates like the row", () => {
+		const config = validate({
+			dimensions: {
+				small: {
+					match: { size: "small" },
+					credit_amount: "2" as unknown as number,
+				},
+			},
+		});
+
+		expect(config.schema[0]?.dimensions?.small).toEqual({
+			match: { size: "small" },
+			credit_amount: 2,
+		});
+	});
+
+	test("rejects a dimension with a negative rate", () => {
+		expectRejected(
+			{
+				dimensions: { small: { match: { size: "small" }, credit_amount: -1 } },
+			},
+			/zero or greater/,
+		);
+	});
+
+	test("rejects a graduated dimension without a terminal infinity tier", () => {
+		expectRejected(
+			{
+				dimensions: {
+					xl: {
+						match: { size: "xl" },
+						tier_behavior: "graduated",
+						tiers: [{ to: 1_000, credit_amount: 30 }],
+					},
+				},
+			},
+			/infinity boundary/,
+		);
+	});
+
+	test("rejects two same-specificity dimensions that could both match one event", () => {
+		expectRejected(
+			{
+				dimensions: {
+					large: { match: { size: "large" }, credit_amount: 16 },
+					eu: { match: { region: "eu" }, credit_amount: 12 },
+				},
+			},
+			/large.*eu|eu.*large/,
+		);
+	});
+
+	test("accepts the same pair once a priority separates them", () => {
+		expect(() =>
+			validate({
+				dimensions: {
+					large: { match: { size: "large" }, credit_amount: 16 },
+					eu: { match: { region: "eu" }, priority: 1, credit_amount: 12 },
+				},
+			}),
+		).not.toThrow();
+	});
+
+	test("same-specificity dimensions with conflicting values never overlap", () => {
+		expect(() =>
+			validate({
+				dimensions: {
+					small: { match: { size: "small" }, credit_amount: 1 },
+					large: { match: { size: "large" }, credit_amount: 16 },
+				},
+			}),
+		).not.toThrow();
+	});
+
+	test("rejects a multiplier that can push the cheapest rate below zero", () => {
+		expectRejected(
+			{
+				dimensions: {
+					small: { match: { size: "small" }, credit_amount: 0.5 },
+				},
+				multipliers: {
+					spot: { match: { lifecycle: "spot" }, factor: 0.5 },
+					promo: { match: { cohort: "2024" }, add: -0.3 },
+				},
+			},
+			/below zero/,
+		);
+	});
+
+	test("rejects a multiplier with a non-positive factor or nothing to apply", () => {
+		expectRejected(
+			{ multipliers: { spot: { match: { lifecycle: "spot" }, factor: 0 } } },
+			/factor/,
+		);
+		expectRejected(
+			{
+				multipliers: {
+					spot: { match: { lifecycle: "spot" } } as unknown as CreditMultiplier,
+				},
+			},
+			/factor or an add/,
+		);
+	});
+});


### PR DESCRIPTION
The row's rate check moves into validateCreditRate so dimensions get the
same bar. validateCreditDimensionRules rejects two same-specificity
dimensions that could both match one event (unless a priority separates
them) and multipliers that can take the cheapest rate below zero. Plan-item
overrides inherit both through validateCreditSystem.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates credit rates, dimensions, and multipliers when credit systems are saved, so invalid dimensioned rate cards are rejected before they can produce incorrect prices. Existing cards are not revalidated until they are saved again.

**Validation rules**
- Applies flat and graduated rate checks to base rows, dimensions, and plan-item overrides.
- Rejects same-specificity dimensions that can match the same event unless a priority separates them.
- Rejects multipliers that can push the cheapest rate below zero.

**Known limitation**
- The multiplier check stacks all multipliers together, so mutually exclusive adjustments (e.g., spot vs on-demand) can incorrectly reject a valid card.

<sup>Written for commit 670bde9059ddd86356a2c6e0bd2b5335833fa08b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves rate validation into shared helpers and applies save-time validation to dimensioned credit rates and plan-item overrides.
- **[Improvements, API changes]** Validates flat and graduated rates consistently across base rows, dimensions, and overrides.
- **[Improvements]** Rejects ambiguous dimensions and multiplier configurations that could produce negative rates.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because valid rate cards with mutually exclusive multipliers can still be rejected during saving.

The non-negative-rate validator combines every discount and negative addition without checking whether their match conditions can occur on the same event; for example, separate adjustments for “spot” and “on_demand” lifecycle values are treated as simultaneous.

**Files Needing Attention:** server/src/internal/features/validateCreditDimensionRules.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/features/featureUtils.ts | Delegates base-row, dimension, and multiplier validation to the new shared validators. |
| server/src/internal/features/validateCreditRate.ts | Centralizes validation and numeric normalization for flat and graduated credit rates. |
| server/src/internal/features/validateCreditDimensionRules.ts | Adds dimension and multiplier validation, but the previously reported over-rejection of mutually exclusive multipliers remains. |
| server/tests/unit/features/credit-dimensions-validation.test.ts | Covers dimension-rate validation, ambiguity, priorities, and stackable multipliers. |
| server/tests/integration/catalog-v2/features/credit-dimensions.test.ts | Exercises creation, updates, flattening, ambiguity rejection, and plan-item overrides through catalog APIs. |

<sub>Reviews (2): Last reviewed commit: ["feat(catalog): validate credit dimension..."](https://github.com/useautumn/autumn/commit/a934f97bca8e5372f05c24e9c7df2009600da4df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60356150)</sub>

<!-- /greptile_comment -->