### PR TITLE
feat(balances): price tracks by credit dimensions

### DIFF
--- a/server/src/internal/analytics/actions/aggregateDeductions.ts
+++ b/server/src/internal/analytics/actions/aggregateDeductions.ts
@@ -8,7 +8,13 @@ import type {
 	FullCustomer,
 	RangeEnum,
 } from "@autumn/shared";
-import { findFeatureById, isAnyCreditSystem, notNullish } from "@autumn/shared";
+import {
+	type CreditSchemaItem,
+	findFeatureById,
+	hasCreditDimensionRules,
+	isAnyCreditSystem,
+	notNullish,
+} from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
 import type { AggregateDeductionsPipeRow } from "@/external/tinybird/initTinybird.js";
 import { getTinybirdPipes } from "@/external/tinybird/initTinybird.js";
@@ -145,6 +151,10 @@ export const resolveCreditCost = ({
 		errorOnNotFound: false,
 	});
 	if (!sourceFeature) return null;
+	const schemaItem = creditSystem.config?.schema?.find(
+		(item: CreditSchemaItem) => item.metered_feature_id === sourceFeatureId,
+	);
+	if (schemaItem && hasCreditDimensionRules(schemaItem)) return null;
 	const rateCard = getCreditRateCard({ sourceFeature, creditSystem });
 	if (rateCard?.tier_behavior === "graduated") return null;
 

--- a/server/src/internal/balances/check/getCheckResponseV2.ts
+++ b/server/src/internal/balances/check/getCheckResponseV2.ts
@@ -42,6 +42,7 @@ export const getCheckResponseV2 = async ({
 			amount: requiredBalance,
 			reverseOrder: ctx.org.config?.reverse_deduction_order,
 			inStatuses: orgToInStatuses({ org: ctx.org }),
+			eventProperties: properties ?? undefined,
 		});
 	}
 

--- a/server/src/internal/balances/check/runCheckWithTrackV2.ts
+++ b/server/src/internal/balances/check/runCheckWithTrackV2.ts
@@ -109,6 +109,7 @@ export const runCheckWithTrackV2 = async ({
 					amount: requiredBalance,
 					reverseOrder: ctx.org.config?.reverse_deduction_order,
 					inStatuses: orgToInStatuses({ org: ctx.org }),
+					eventProperties: body.properties,
 				})
 			: requiredBalance;
 

--- a/server/src/internal/balances/utils/deduction/computeCreditCosts.ts
+++ b/server/src/internal/balances/utils/deduction/computeCreditCosts.ts
@@ -2,11 +2,12 @@ import {
 	AllowanceType,
 	type CreditSchemaItem,
 	creditSystemContainsFeature,
-	entitlementToCreditSystem,
 	ErrCode,
+	entitlementToCreditSystem,
 	type Feature,
 	FeatureType,
 	type FullCusEntWithFullCusProduct,
+	hasCreditDimensionRules,
 	RecaseError,
 } from "@autumn/shared";
 import { logger } from "@/external/logtail/logtailUtils.js";
@@ -31,10 +32,12 @@ export const computeCreditCosts = ({
 	cusEnts,
 	deduction,
 	catalogFeatures,
+	eventProperties,
 }: {
 	cusEnts: FullCusEntWithFullCusProduct[];
 	deduction: FeatureDeduction;
 	catalogFeatures?: Feature[];
+	eventProperties?: Record<string, unknown>;
 }): CreditCostLookup => {
 	const costMap = new Map<string, ComputedCreditCost>();
 
@@ -59,6 +62,7 @@ export const computeCreditCosts = ({
 				? getCreditRateCard({
 						sourceFeature: deduction.feature,
 						creditSystem,
+						eventProperties,
 					})
 				: undefined;
 			if (
@@ -93,6 +97,7 @@ export const computeCreditCosts = ({
 					featureId: deduction.feature.id,
 					creditSystem,
 					amount: deduction.tokens?.cost,
+					eventProperties,
 				}),
 				...(rateCard ? { rateCard } : {}),
 			});
@@ -127,7 +132,8 @@ export const computeCreditCosts = ({
 				currentCreditSystem &&
 				currentSchemaItem &&
 				(currentCreditSystem.config.invoice_credit ||
-					currentSchemaItem.tier_behavior === "graduated")
+					currentSchemaItem.tier_behavior === "graduated" ||
+					hasCreditDimensionRules(currentSchemaItem))
 			) {
 				throw new RecaseError({
 					message:

--- a/server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts
@@ -97,6 +97,7 @@ export const prepareFeatureDeduction = ({
 		cusEnts,
 		deduction,
 		catalogFeatures: ctx.features,
+		eventProperties: options?.eventProperties ?? undefined,
 	});
 
 	// Build input for each customer entitlement

--- a/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
@@ -141,6 +141,7 @@ export const prepareFeatureDeductionV2 = ({
 		cusEnts: customerEntitlements,
 		deduction,
 		catalogFeatures: ctx.features,
+		eventProperties: options.eventProperties ?? undefined,
 	});
 
 	const customerEntitlementDeductions: CustomerEntitlementDeduction[] =

--- a/server/src/internal/balances/utils/lockV2/buildFinalizeLockContextV2.ts
+++ b/server/src/internal/balances/utils/lockV2/buildFinalizeLockContextV2.ts
@@ -23,7 +23,10 @@ export type FinalizeLockContextV2 = {
 	additionalValue: number;
 	properties?: Record<string, unknown>;
 	deduction: FeatureDeduction;
-	deductionOptions: { triggerAutoTopUp: boolean };
+	deductionOptions: {
+		triggerAutoTopUp: boolean;
+		eventProperties?: Record<string, unknown>;
+	};
 };
 
 export const buildFinalizeLockContextV2 = async ({
@@ -88,6 +91,6 @@ export const buildFinalizeLockContextV2 = async ({
 			unwindValue,
 			lockReceiptKey,
 		},
-		deductionOptions: { triggerAutoTopUp: true },
+		deductionOptions: { triggerAutoTopUp: true, eventProperties },
 	};
 };

--- a/server/src/internal/features/creditDimensions/resolveCreditDimensionRate.ts
+++ b/server/src/internal/features/creditDimensions/resolveCreditDimensionRate.ts
@@ -1,0 +1,144 @@
+import {
+	type CreditDimension,
+	type CreditMultiplier,
+	type CreditSchemaItem,
+	usageLimitFilterMatchesProperties,
+} from "@autumn/shared";
+import { Decimal } from "decimal.js";
+import { invalidCreditRateCard } from "../creditSystemUtils.js";
+
+export type EventProperties = Record<string, unknown> | undefined;
+
+/** A rate-card row with its dimension rules applied: a plain flat or graduated rate, plus which dimension won. */
+export type ResolvedCreditSchemaItem = CreditSchemaItem & {
+	dimension_name?: string;
+};
+
+// An empty match applies to every event, so a missing property bag still matches it.
+const matchesEvent = ({
+	match,
+	eventProperties,
+}: {
+	match: CreditDimension["match"];
+	eventProperties: EventProperties;
+}): boolean =>
+	usageLimitFilterMatchesProperties({
+		filterProperties: match,
+		eventProperties: eventProperties ?? {},
+	});
+
+const specificity = (dimension: CreditDimension) =>
+	Object.keys(dimension.match).length;
+
+const pickWinningDimension = ({
+	dimensions,
+	eventProperties,
+}: {
+	dimensions: Record<string, CreditDimension>;
+	eventProperties: EventProperties;
+}): [string, CreditDimension] | undefined =>
+	Object.entries(dimensions)
+		.filter(([, dimension]) =>
+			matchesEvent({ match: dimension.match, eventProperties }),
+		)
+		.sort(
+			([leftName, left], [rightName, right]) =>
+				specificity(right) - specificity(left) ||
+				(right.priority ?? 0) - (left.priority ?? 0) ||
+				leftName.localeCompare(rightName),
+		)[0];
+
+const combineMultipliers = ({
+	multipliers,
+	eventProperties,
+}: {
+	multipliers: Record<string, CreditMultiplier>;
+	eventProperties: EventProperties;
+}) => {
+	const matching = Object.values(multipliers).filter((multiplier) =>
+		matchesEvent({ match: multiplier.match, eventProperties }),
+	);
+	const factor = matching.reduce(
+		(product, multiplier) => product.mul(multiplier.factor ?? 1),
+		new Decimal(1),
+	);
+	const add = matching.reduce(
+		(sum, multiplier) => sum.add(multiplier.add ?? 0),
+		new Decimal(0),
+	);
+	return { factor, add };
+};
+
+const scaleAmount = ({
+	amount,
+	factor,
+	add,
+	invalidRate,
+}: {
+	amount: number;
+	factor: Decimal;
+	add: Decimal;
+	invalidRate: (message: string) => never;
+}): number => {
+	const scaled = new Decimal(amount).mul(factor).add(add);
+	if (scaled.lt(0)) {
+		invalidRate("Credit multipliers took the rate below zero");
+	}
+	return scaled.toNumber();
+};
+
+/**
+ * The most specific matching dimension sets the rate (else the row's own);
+ * every matching multiplier scales it, factors first, then adds.
+ */
+export const resolveCreditDimensionRate = ({
+	schemaItem,
+	eventProperties,
+	creditSystemId,
+}: {
+	schemaItem: CreditSchemaItem;
+	eventProperties: EventProperties;
+	creditSystemId: string;
+}): ResolvedCreditSchemaItem => {
+	const invalidRate = (message: string): never => {
+		throw invalidCreditRateCard({
+			featureId: schemaItem.metered_feature_id,
+			creditSystemId,
+			message,
+		});
+	};
+
+	const { dimensions, multipliers, ...row } = schemaItem;
+	const winner = pickWinningDimension({
+		dimensions: dimensions ?? {},
+		eventProperties,
+	});
+	const [dimensionName, rate] = winner ?? [undefined, row];
+	const { factor, add } = combineMultipliers({
+		multipliers: multipliers ?? {},
+		eventProperties,
+	});
+	const scale = (amount: number) =>
+		scaleAmount({ amount, factor, add, invalidRate });
+
+	const base = {
+		metered_feature_id: row.metered_feature_id,
+		...(row.feature_amount === undefined
+			? {}
+			: { feature_amount: row.feature_amount }),
+		...(dimensionName === undefined ? {} : { dimension_name: dimensionName }),
+	};
+
+	if (rate.tier_behavior === "graduated") {
+		return {
+			...base,
+			tier_behavior: "graduated",
+			tiers: rate.tiers.map((tier) => ({
+				to: tier.to,
+				credit_amount: scale(tier.credit_amount),
+			})),
+		};
+	}
+
+	return { ...base, credit_amount: scale(rate.credit_amount) };
+};

--- a/server/src/internal/features/creditSystemUtils.ts
+++ b/server/src/internal/features/creditSystemUtils.ts
@@ -1,19 +1,26 @@
 import {
+	buildUsageAttributionKey,
 	type CreditSchemaItem,
 	type CreditTier,
 	type CusProductStatus,
 	cusEntToCurrentBalance,
-	entitlementToCreditSystem,
 	ErrCode,
+	entitlementToCreditSystem,
 	type Feature,
 	FeatureType,
 	type FullSubject,
 	fullSubjectToCustomerEntitlements,
+	hasCreditDimensionRules,
 	isAiCreditSystem,
 	isAnyCreditSystem,
 	RecaseError,
 } from "@autumn/shared";
 import { Decimal } from "decimal.js";
+import {
+	type EventProperties,
+	type ResolvedCreditSchemaItem,
+	resolveCreditDimensionRate,
+} from "./creditDimensions/resolveCreditDimensionRate.js";
 
 export type CreditRateCard = {
 	source_internal_feature_id: string;
@@ -49,7 +56,7 @@ export const isEnablingInvoiceCreditFeature = ({
 	!isInvoiceCreditFeature({ feature: currentFeature }) &&
 	isInvoiceCreditFeature({ feature: nextFeature });
 
-const invalidCreditRateCard = ({
+export const invalidCreditRateCard = ({
 	featureId,
 	creditSystemId,
 	message,
@@ -193,25 +200,37 @@ const getSchemaItemCreditCost = ({
 		.toNumber();
 };
 
+/** The row for a feature, with its dimension rules applied to the event — always a plain flat or graduated rate. */
 const getCreditSchemaItem = ({
 	featureId,
 	creditSystem,
+	eventProperties,
 }: {
 	featureId: string;
 	creditSystem: Feature;
-}) => {
+	eventProperties?: EventProperties;
+}): ResolvedCreditSchemaItem | undefined => {
 	const schema: CreditSchemaItem[] = creditSystem.config.schema;
-	return schema.find(
+	const schemaItem = schema.find(
 		(schemaItem) => schemaItem.metered_feature_id === featureId,
 	);
+	if (!schemaItem || !hasCreditDimensionRules(schemaItem)) return schemaItem;
+
+	return resolveCreditDimensionRate({
+		schemaItem,
+		eventProperties,
+		creditSystemId: creditSystem.id,
+	});
 };
 
 export const getCreditRateCard = ({
 	sourceFeature,
 	creditSystem,
+	eventProperties,
 }: {
 	sourceFeature: Feature;
 	creditSystem: Feature;
+	eventProperties?: EventProperties;
 }): CreditRateCard | undefined => {
 	if (creditSystem.type !== FeatureType.CreditSystem) {
 		return undefined;
@@ -230,11 +249,15 @@ export const getCreditRateCard = ({
 	const schemaItem = getCreditSchemaItem({
 		featureId: sourceFeature.id,
 		creditSystem,
+		eventProperties,
 	});
 	if (!schemaItem) return undefined;
 
 	const base = {
-		source_internal_feature_id: sourceFeature.internal_id,
+		source_internal_feature_id: buildUsageAttributionKey({
+			internalFeatureId: sourceFeature.internal_id,
+			dimensionName: schemaItem.dimension_name,
+		}),
 		feature_amount: schemaItem.feature_amount ?? 1,
 	};
 	if (schemaItem.tier_behavior === "graduated") {
@@ -317,12 +340,14 @@ const getCreditRateFundedUnits = ({
 	currentUsage,
 	requestedUnits,
 	availableCredits,
+	eventProperties,
 }: {
 	featureId: string;
 	creditSystem: Feature;
 	currentUsage: number;
 	requestedUnits: number;
 	availableCredits: number;
+	eventProperties?: EventProperties;
 }): number => {
 	if (requestedUnits <= 0) return 0;
 	const requestedCredits = featureToCreditSystem({
@@ -330,6 +355,7 @@ const getCreditRateFundedUnits = ({
 		creditSystem,
 		amount: requestedUnits,
 		currentUsage,
+		eventProperties,
 	});
 	if (requestedCredits <= availableCredits) return requestedUnits;
 	if (availableCredits <= 0) return 0;
@@ -346,6 +372,7 @@ const getCreditRateFundedUnits = ({
 			creditSystem,
 			amount: candidateUnits,
 			currentUsage,
+			eventProperties,
 		});
 		if (candidateCredits <= availableCredits) {
 			lowerBound = candidateUnits;
@@ -364,6 +391,7 @@ export const getCreditRateRequiredBalance = ({
 	amount,
 	reverseOrder = false,
 	inStatuses,
+	eventProperties,
 }: {
 	fullSubject: FullSubject;
 	sourceFeature: Feature;
@@ -371,6 +399,7 @@ export const getCreditRateRequiredBalance = ({
 	amount: number;
 	reverseOrder?: boolean;
 	inStatuses?: CusProductStatus[];
+	eventProperties?: EventProperties;
 }): number => {
 	// Only this credit system's entitlements that actually fund the source
 	// feature under their effective schema (an override may have removed it).
@@ -388,6 +417,7 @@ export const getCreditRateRequiredBalance = ({
 	const schemaItem = getCreditSchemaItem({
 		featureId: sourceFeature.id,
 		creditSystem,
+		eventProperties,
 	});
 	const hasOverriddenEntitlement = customerEntitlements.some(
 		(customerEntitlement) => customerEntitlement.entitlement.feature_override,
@@ -400,6 +430,7 @@ export const getCreditRateRequiredBalance = ({
 			featureId: sourceFeature.id,
 			creditSystem,
 			amount,
+			eventProperties,
 		});
 	}
 
@@ -413,9 +444,17 @@ export const getCreditRateRequiredBalance = ({
 		const entitlementCreditSystem = entitlementToCreditSystem({
 			entitlement: customerEntitlement.entitlement,
 		});
+		const entitlementSchemaItem = getCreditSchemaItem({
+			featureId: sourceFeature.id,
+			creditSystem: entitlementCreditSystem,
+			eventProperties,
+		});
+		const attributionKey = buildUsageAttributionKey({
+			internalFeatureId: sourceFeature.internal_id,
+			dimensionName: entitlementSchemaItem?.dimension_name,
+		});
 		const currentUsage =
-			customerEntitlement.usage_attribution?.[sourceFeature.internal_id]
-				?.units ?? 0;
+			customerEntitlement.usage_attribution?.[attributionKey]?.units ?? 0;
 		const availableCredits = cusEntToCurrentBalance({
 			cusEnt: customerEntitlement,
 			entityId: fullSubject.entity?.id ?? undefined,
@@ -427,12 +466,14 @@ export const getCreditRateRequiredBalance = ({
 			currentUsage,
 			requestedUnits: remainingUnits.toNumber(),
 			availableCredits,
+			eventProperties,
 		});
 		const fundedCredits = featureToCreditSystem({
 			featureId: sourceFeature.id,
 			creditSystem: entitlementCreditSystem,
 			amount: fundedUnits,
 			currentUsage,
+			eventProperties,
 		});
 		requiredCredits = requiredCredits.add(fundedCredits);
 		remainingUnits = remainingUnits.sub(fundedUnits);
@@ -449,6 +490,7 @@ export const getCreditRateRequiredBalance = ({
 				creditSystem: finalCreditSystem,
 				amount: remainingUnits.toNumber(),
 				currentUsage: finalUsage,
+				eventProperties,
 			}),
 		)
 		.toNumber();
@@ -459,13 +501,19 @@ export const featureToCreditSystem = ({
 	creditSystem,
 	amount,
 	currentUsage = 0,
+	eventProperties,
 }: {
 	featureId: string;
 	creditSystem: Feature;
 	amount: number;
 	currentUsage?: number;
+	eventProperties?: EventProperties;
 }) => {
-	const schemaItem = getCreditSchemaItem({ featureId, creditSystem });
+	const schemaItem = getCreditSchemaItem({
+		featureId,
+		creditSystem,
+		eventProperties,
+	});
 	if (schemaItem)
 		return getSchemaItemCreditCost({
 			featureId,
@@ -484,11 +532,13 @@ export const getCreditCost = ({
 	creditSystem,
 	amount = 1,
 	currentUsage = 0,
+	eventProperties,
 }: {
 	featureId: string;
 	creditSystem: Feature;
 	amount?: number;
 	currentUsage?: number;
+	eventProperties?: EventProperties;
 }) => {
 	if (!isAnyCreditSystem(creditSystem.type)) {
 		return amount;
@@ -505,7 +555,11 @@ export const getCreditCost = ({
 			data: { featureId, creditSystemId: creditSystem.id },
 		});
 	}
-	const schemaItem = getCreditSchemaItem({ featureId, creditSystem });
+	const schemaItem = getCreditSchemaItem({
+		featureId,
+		creditSystem,
+		eventProperties,
+	});
 	if (schemaItem)
 		return getSchemaItemCreditCost({
 			featureId,

--- a/server/tests/integration/balances/track/basic/track-credit-dimensions.test.ts
+++ b/server/tests/integration/balances/track/basic/track-credit-dimensions.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Contract: a dimensioned rate-card row prices a track by its properties —
+ * the most specific matching dimension sets the rate, multipliers scale it,
+ * no match falls back to the row's rate — on both the cached and persisted
+ * paths, with per-dimension attribution and per-dimension tier progress, and
+ * a finalize repricing at the properties the check locked with.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	customerEntitlements,
+	type FeatureConfigOverride,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
+
+const dimensionedAction1: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				large: { match: { size: "large" }, credit_amount: 16 },
+				large_eu: {
+					match: { size: "large", region: "eu" },
+					credit_amount: 20,
+				},
+				xl: {
+					match: { size: "xl" },
+					tier_behavior: "graduated",
+					tiers: [
+						{ to: 5, credit_amount: 2 },
+						{ to: "inf", credit_amount: 1 },
+					],
+				},
+			},
+			multipliers: {
+				spot: { match: { lifecycle: "spot" }, factor: 0.3 },
+			},
+		},
+	],
+};
+
+const withFeatureOverride = (
+	item: ReturnType<typeof items.consumable>,
+	featureOverride: FeatureConfigOverride,
+) => ({
+	...item,
+	config: { ...item.config, feature_override: featureOverride },
+});
+
+const expectCreditsBalance = async ({
+	autumnV1,
+	customerId,
+	balance,
+}: {
+	autumnV1: Awaited<ReturnType<typeof initScenario>>["autumnV1"];
+	customerId: string;
+	balance: number;
+}) => {
+	const cached = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	expect(cached.features[TestFeature.InvoiceCredits]?.balance).toBeCloseTo(
+		balance,
+		8,
+	);
+	await timeout(2_000);
+	const persisted = await autumnV1.customers.get<ApiCustomerV3>(customerId, {
+		skip_cache: "true",
+	});
+	expect(persisted.features[TestFeature.InvoiceCredits]?.balance).toBeCloseTo(
+		balance,
+		8,
+	);
+};
+
+const setupDimensionedCredits = async ({
+	customerId,
+}: {
+	customerId: string;
+}) => {
+	const creditsItem = withFeatureOverride(
+		items.consumable({
+			featureId: TestFeature.InvoiceCredits,
+			includedUsage: 1_000,
+			price: 1,
+			billingUnits: 1,
+		}),
+		dimensionedAction1,
+	);
+	const product = products.base({ id: customerId, items: [creditsItem] });
+
+	return initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.products({ list: [product] }),
+		],
+		actions: [s.billing.attach({ productId: product.id })],
+	});
+};
+
+const readAttribution = async ({
+	ctx,
+	internalCustomerId,
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+	internalCustomerId: string;
+}) => {
+	const [row] = await ctx.db
+		.select({ usageAttribution: customerEntitlements.usage_attribution })
+		.from(customerEntitlements)
+		.where(
+			and(
+				eq(customerEntitlements.internal_customer_id, internalCustomerId),
+				eq(customerEntitlements.feature_id, TestFeature.InvoiceCredits),
+			),
+		)
+		.limit(1);
+	return row?.usageAttribution ?? {};
+};
+
+test.concurrent(
+	`${chalk.yellowBright("track-credit-dimensions: the matching dimension and multipliers price the track")}`,
+	async () => {
+		const customerId = "track-credit-dimensions-match";
+		const { autumnV1, autumnV2_3, ctx, customer } =
+			await setupDimensionedCredits({ customerId });
+		const action1InternalId = ctx.features.find(
+			(feature) => feature.id === TestFeature.Action1,
+		)?.internal_id;
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 10,
+			properties: { size: "large", region: "eu", lifecycle: "spot" },
+		});
+		await expectCreditsBalance({ autumnV1, customerId, balance: 1_000 - 60 });
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 10,
+			properties: { size: "large" },
+		});
+		await expectCreditsBalance({
+			autumnV1,
+			customerId,
+			balance: 1_000 - 60 - 160,
+		});
+
+		await timeout(3_000);
+		expect(
+			await readAttribution({ ctx, internalCustomerId: customer.internal_id }),
+		).toEqual({
+			[`${action1InternalId}::large_eu`]: { units: 10, credits: 60 },
+			[`${action1InternalId}::large`]: { units: 10, credits: 160 },
+		});
+	},
+	{ timeout: 120_000 },
+);
+
+test.concurrent(
+	`${chalk.yellowBright("track-credit-dimensions: no match and no properties price at the row's rate")}`,
+	async () => {
+		const customerId = "track-credit-dimensions-fallback";
+		const { autumnV1, autumnV2_3 } = await setupDimensionedCredits({
+			customerId,
+		});
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 10,
+			properties: { size: "xxl" },
+		});
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 10,
+		});
+		await expectCreditsBalance({ autumnV1, customerId, balance: 1_000 - 20 });
+	},
+	{ timeout: 120_000 },
+);
+
+test.concurrent(
+	`${chalk.yellowBright("track-credit-dimensions: a graduated dimension climbs its own ladder")}`,
+	async () => {
+		const customerId = "track-credit-dimensions-graduated";
+		const { autumnV1, autumnV2_3, ctx, customer } =
+			await setupDimensionedCredits({ customerId });
+		const action1InternalId = ctx.features.find(
+			(feature) => feature.id === TestFeature.Action1,
+		)?.internal_id;
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 3,
+			properties: { size: "xl" },
+		});
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 4,
+			properties: { size: "xl" },
+		});
+		// 3 @ 2 = 6, then 2 @ 2 + 2 @ 1 = 6 — the second track crosses the tier.
+		await expectCreditsBalance({ autumnV1, customerId, balance: 1_000 - 12 });
+
+		await timeout(3_000);
+		expect(
+			await readAttribution({ ctx, internalCustomerId: customer.internal_id }),
+		).toEqual({ [`${action1InternalId}::xl`]: { units: 7, credits: 12 } });
+	},
+	{ timeout: 120_000 },
+);
+
+test.concurrent(
+	`${chalk.yellowBright("track-credit-dimensions: finalize reprices at the properties the check locked with")}`,
+	async () => {
+		const customerId = "track-credit-dimensions-finalize";
+		const { autumnV1, autumnV2_3 } = await setupDimensionedCredits({
+			customerId,
+		});
+		const lockId = `${customerId}-lock`;
+
+		const check = await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			required_balance: 10,
+			properties: { size: "large", region: "eu" },
+			lock: { enabled: true, lock_id: lockId },
+		});
+		expect(check.allowed).toBe(true);
+		await expectCreditsBalance({ autumnV1, customerId, balance: 1_000 - 200 });
+
+		await autumnV2_3.balances.finalize({
+			lock_id: lockId,
+			action: "confirm",
+			override_value: 5,
+		});
+		await expectCreditsBalance({ autumnV1, customerId, balance: 1_000 - 100 });
+	},
+	{ timeout: 120_000 },
+);

--- a/server/tests/unit/features/resolve-credit-dimension-rate.test.ts
+++ b/server/tests/unit/features/resolve-credit-dimension-rate.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Runtime contract for credit dimensions: the most specific matching dimension
+ * sets the rate (else the row's), every matching multiplier scales it, and the
+ * result is an ordinary flat or graduated item the existing cost math consumes.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	type CreditSchemaItem,
+	type Feature,
+	FeatureType,
+	FeatureUsageType,
+	type FullCusEntWithFullCusProduct,
+} from "@autumn/shared";
+import { computeCreditCosts } from "@/internal/balances/utils/deduction/computeCreditCosts.js";
+import { resolveCreditDimensionRate } from "@/internal/features/creditDimensions/resolveCreditDimensionRate.js";
+import {
+	getCreditCost,
+	getCreditRateCard,
+} from "@/internal/features/creditSystemUtils.js";
+
+const row: CreditSchemaItem = {
+	metered_feature_id: "cpu_minutes",
+	credit_amount: 1,
+	dimensions: {
+		small: { match: { size: "small" }, credit_amount: 1 },
+		large: { match: { size: "large" }, credit_amount: 16 },
+		large_eu: {
+			match: { size: "large", region: "eu" },
+			credit_amount: 20,
+		},
+		eu: { match: { region: "eu" }, priority: 1, credit_amount: 12 },
+		xl: {
+			match: { size: "xl" },
+			tier_behavior: "graduated",
+			tiers: [
+				{ to: 1_000, credit_amount: 30 },
+				{ to: "inf", credit_amount: 25 },
+			],
+		},
+	},
+	multipliers: {
+		spot: { match: { lifecycle: "spot" }, factor: 0.3 },
+		promo: { match: { cohort: "2024" }, add: -0.2 },
+		everyone: { match: {}, factor: 1 },
+	},
+};
+
+const resolve = (eventProperties?: Record<string, unknown>) =>
+	resolveCreditDimensionRate({
+		schemaItem: row,
+		eventProperties,
+		creditSystemId: "credits",
+	});
+
+describe("resolveCreditDimensionRate", () => {
+	test("the most specific dimension wins and names the attribution", () => {
+		expect(resolve({ size: "large", region: "eu" })).toEqual({
+			metered_feature_id: "cpu_minutes",
+			dimension_name: "large_eu",
+			credit_amount: 20,
+		});
+	});
+
+	test("priority breaks a tie between equally specific dimensions", () => {
+		expect(resolve({ size: "small", region: "eu" })).toMatchObject({
+			dimension_name: "eu",
+			credit_amount: 12,
+		});
+	});
+
+	test("no match falls back to the row's rate with no dimension name", () => {
+		expect(resolve({ size: "xxl" })).toEqual({
+			metered_feature_id: "cpu_minutes",
+			credit_amount: 1,
+		});
+		expect(resolve(undefined)).toEqual({
+			metered_feature_id: "cpu_minutes",
+			credit_amount: 1,
+		});
+	});
+
+	test("multipliers stack: factors multiply, then adds are summed", () => {
+		expect(
+			resolve({ size: "large", lifecycle: "spot", cohort: "2024" }),
+		).toMatchObject({ dimension_name: "large", credit_amount: 16 * 0.3 - 0.2 });
+	});
+
+	test("a graduated dimension scales every tier and keeps its boundaries", () => {
+		expect(resolve({ size: "xl", lifecycle: "spot" })).toEqual({
+			metered_feature_id: "cpu_minutes",
+			dimension_name: "xl",
+			tier_behavior: "graduated",
+			tiers: [
+				{ to: 1_000, credit_amount: 9 },
+				{ to: "inf", credit_amount: 7.5 },
+			],
+		});
+	});
+
+	test("property values are compared as strings", () => {
+		const numericRow: CreditSchemaItem = {
+			metered_feature_id: "cpu_minutes",
+			credit_amount: 1,
+			dimensions: { eight: { match: { size: "8" }, credit_amount: 8 } },
+		};
+		expect(
+			resolveCreditDimensionRate({
+				schemaItem: numericRow,
+				eventProperties: { size: 8 },
+				creditSystemId: "credits",
+			}),
+		).toMatchObject({ dimension_name: "eight" });
+	});
+
+	test("a rate that would go below zero is rejected, never clamped", () => {
+		const cheapRow: CreditSchemaItem = {
+			metered_feature_id: "cpu_minutes",
+			credit_amount: 0.1,
+			multipliers: { promo: { match: {}, add: -0.5 } },
+		};
+		expect(() =>
+			resolveCreditDimensionRate({
+				schemaItem: cheapRow,
+				eventProperties: {},
+				creditSystemId: "credits",
+			}),
+		).toThrow(/below zero/);
+	});
+});
+
+const makeFeature = (
+	id: string,
+	type: FeatureType,
+	schema: CreditSchemaItem[] = [],
+): Feature => ({
+	internal_id: `fe_${id}`,
+	org_id: "org_test",
+	created_at: 0,
+	env: "sandbox" as Feature["env"],
+	id,
+	name: id,
+	type,
+	config: { schema, usage_type: FeatureUsageType.Single, invoice_credit: true },
+	archived: false,
+	event_names: [],
+	model_markups: null,
+});
+
+const cpuMinutes = makeFeature("cpu_minutes", FeatureType.Metered);
+const credits = makeFeature("credits", FeatureType.CreditSystem, [row]);
+
+describe("credit cost through dimensions", () => {
+	test("getCreditCost rates by the event's properties", () => {
+		expect(
+			getCreditCost({
+				featureId: "cpu_minutes",
+				creditSystem: credits,
+				amount: 10,
+				eventProperties: { size: "large", region: "eu", lifecycle: "spot" },
+			}),
+		).toBe(60);
+		expect(
+			getCreditCost({
+				featureId: "cpu_minutes",
+				creditSystem: credits,
+				amount: 10,
+			}),
+		).toBe(10);
+	});
+
+	test("getCreditRateCard keys attribution by the winning dimension", () => {
+		expect(
+			getCreditRateCard({
+				sourceFeature: cpuMinutes,
+				creditSystem: credits,
+				eventProperties: { size: "large", region: "eu" },
+			}),
+		).toEqual({
+			source_internal_feature_id: "fe_cpu_minutes::large_eu",
+			feature_amount: 1,
+			credit_amount: 20,
+		});
+		expect(
+			getCreditRateCard({ sourceFeature: cpuMinutes, creditSystem: credits }),
+		).toMatchObject({ source_internal_feature_id: "fe_cpu_minutes" });
+	});
+
+	test("computeCreditCosts threads the event's properties to every entitlement", () => {
+		const lookup = computeCreditCosts({
+			cusEnts: [
+				{ id: "ce_credits", entitlement: { feature: credits } },
+			] as FullCusEntWithFullCusProduct[],
+			deduction: { feature: cpuMinutes, deduction: 10 },
+			eventProperties: { size: "xl", lifecycle: "spot" },
+		});
+
+		expect(lookup("ce_credits")).toEqual({
+			creditCost: 9,
+			rateCard: {
+				source_internal_feature_id: "fe_cpu_minutes::xl",
+				feature_amount: 1,
+				tier_behavior: "graduated",
+				tiers: [
+					{ to: 1_000, credit_amount: 9 },
+					{ to: "inf", credit_amount: 7.5 },
+				],
+			},
+		});
+	});
+});


### PR DESCRIPTION
getCreditSchemaItem is the one place dimensions enter: a row with rules is
projected through resolveCreditDimensionRate into an ordinary flat or
graduated item (most specific match sets the rate, every matching
multiplier scales it, no match keeps the row's rate), so the cost math,
rate cards, Lua and SQL stay unchanged. The winning dimension names the
attribution key. Event properties are threaded from the deduction options
through computeCreditCosts and the creditSystemUtils entry points, the
check conversion, and finalize — which previously dropped the receipt's
properties. Dimensioned rows join the fail-closed set and report no single
rate to analytics.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rate-card rows with dimension rules now price tracks by the event's properties: the most specific matching dimension sets the rate, multipliers scale it, and no match falls back to the row's rate. The winning dimension names the usage attribution key. Dimensioned catalog rows are fail-closed and report no single rate to analytics; dimensioned rows from a customer entitlement override still report one.

- Threads event properties from deduction options through cost computation, check conversion, and finalize (finalize previously dropped the receipt's properties).

**Migration**
- Event properties must be provided at check and finalize time for dimensioned pricing to apply.

<sup>Written for commit 3b52a79746d4de1b10920f8373eb0374fe045895. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds property-based credit pricing and carries event properties through check, track, deduction, and finalize flows. The analytics safeguard remains incomplete for customer-specific pricing overrides.

- **Improvements, API changes:** Resolves the most specific matching credit dimension, applies matching multipliers, and attributes usage to the selected dimension.
- **Bug fixes, Improvements:** Preserves event properties through balance checks and lock finalization so reserved usage is repriced consistently.
- **Bug fixes:** Suppresses a single analytics conversion rate for dimensioned catalog rows, but not when dimensions come from an entitlement override.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because customer-specific dimension overrides can still produce incorrect credit costs in deduction analytics.

The analytics fix checks only the catalog credit schema, while deduction-time pricing can use a customer entitlement override; consequently, analytics can report a flat catalog rate that differs from the credits actually charged.

**Files Needing Attention:** server/src/internal/analytics/actions/aggregateDeductions.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/features/creditDimensions/resolveCreditDimensionRate.ts | Adds deterministic dimension selection and multiplier application for flat and graduated credit rates. |
| server/src/internal/features/creditSystemUtils.ts | Applies resolved dimensions throughout credit conversion and keys usage attribution by the winning dimension. |
| server/src/internal/balances/utils/lockV2/buildFinalizeLockContextV2.ts | Preserves checked event properties in finalize deduction options. |
| server/src/internal/analytics/actions/aggregateDeductions.ts | Suppresses rates for dimensioned catalog rows but still reports a flat rate when dimensions are introduced by an entitlement override. |
| server/tests/integration/balances/track/basic/track-credit-dimensions.test.ts | Covers property-based pricing, fallback pricing, per-dimension graduated progress, attribution, and finalize repricing. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Event properties] --> B[Check or track]
  B --> C[Resolve effective credit schema]
  C --> D[Select dimension and multipliers]
  D --> E[Deduct credits]
  D --> F[Dimension usage attribution]
  B --> G[Lock receipt]
  G --> H[Finalize with original properties]
  E --> I[Deduction analytics]
  J[Catalog schema only] --> I
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/analytics/actions/aggregateDeductions.ts:154-157
**Override dimensions still report rates**

When a customer entitlement replaces a flat catalog rate with dimension-based pricing, this guard inspects only the catalog schema and then reports the catalog rate. For example, an EU event charged 20 credits by the override is still reported in deduction analytics with a credit cost of 1.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(balances): price tracks by credit d..."](https://github.com/useautumn/autumn/commit/412254df0e5776396cf77b14e5249b0482b0f6dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60356156)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Event metering, balances, and insights](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/event-metering-and-insights.md)
- Knowledge Base — [Analytics stores and data exports](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/analytics-and-data-exports.md)

<!-- /greptile_comment -->