### PR TITLE
fix: avoid reinserting pending custom catalog rows

### DIFF
--- a/server/src/internal/billing/v2/execute/promotePendingCustomerProducts.ts
+++ b/server/src/internal/billing/v2/execute/promotePendingCustomerProducts.ts
@@ -61,6 +61,9 @@ export const promotePendingCustomerProducts = async ({
 
 	return {
 		...autumnBillingPlan,
+		customPrices: undefined,
+		customEntitlements: undefined,
+		customFreeTrial: undefined,
 		insertCustomerProducts:
 			autumnBillingPlan.insertCustomerProducts?.filter(
 				(planned) => !promotedIds.has(planned.id),

--- a/server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-attach.test.ts
+++ b/server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-attach.test.ts
@@ -26,6 +26,7 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import type {
 	AttachParamsV0Input,
+	AttachParamsV1Input,
 	BillingChangeResponse,
 	CustomerPlanChange,
 	PlanChangeAction,
@@ -40,6 +41,7 @@ import { TestFeature } from "@tests/setup/v2Features.js";
 import { completeInvoiceConfirmationV2 as completeInvoiceConfirmation } from "@tests/utils/browserPool/completeInvoiceConfirmationV2";
 import { completeStripeCheckoutFormV2 as completeStripeCheckoutForm } from "@tests/utils/browserPool/completeStripeCheckoutFormV2";
 import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
@@ -453,14 +455,14 @@ test.concurrent(
 // CHECKOUT: ATTACH VIA STRIPE CHECKOUT (no payment method on file)
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// Red: pending promotion erased the paid plan before billing and product webhooks.
-// Green: checkout emits both events with the activated paid plan.
-test(`${chalk.yellowBright("billing.updated: stripe checkout completion → activated")}`, async () => {
+// Red: promotion reinserts the pending custom price and crashes before webhooks.
+// Green: checkout emits both events with the activated custom-price plan.
+test(`${chalk.yellowBright("billing.updated: custom-price checkout completion → activated")}`, async () => {
 	const customerId = "billing-updated-stripe-checkout";
 	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
 	const pro = products.pro({ id: "pro-checkout", items: [messagesItem] });
 
-	const { autumnV1 } = await initScenario({
+	const { autumnV2_2 } = await initScenario({
 		customerId,
 		setup: [
 			s.customer({ testClock: true, skipWebhooks: true }), // no payment method
@@ -470,9 +472,10 @@ test(`${chalk.yellowBright("billing.updated: stripe checkout completion → acti
 	});
 
 	// Attach returns a payment_url because there's no PM on file
-	const attachResult = await autumnV1.billing.attach({
+	const attachResult = await autumnV2_2.billing.attach<AttachParamsV1Input>({
 		customer_id: customerId,
-		product_id: pro.id,
+		plan_id: pro.id,
+		customize: { price: itemsV2.monthlyPrice({ amount: 42 }) },
 	});
 	expect(attachResult.payment_url).toContain("checkout.stripe.com");
 


### PR DESCRIPTION
## Summary
- omit custom prices, entitlements, and free trials already persisted by the pending path before executing the promoted plan
- cover a custom-price Stripe Checkout through both Autumn webhook deliveries

## Red / green
- RED on main: checkout completed, but customer.products.updated was null after 30s because prices_id_key crashed the handler
- GREEN with fix: checkout completed and both billing.updated and customer.products.updated arrived; 1 test passed, 0 failed
- bunx tsgo --build --noEmit
- biome check on both changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom-price Stripe Checkouts crashing on completion by omitting pending custom catalog rows when promoting a pending plan.

- Previously the promoted plan reinserted custom prices, entitlements, and free trials already persisted by the pending path, causing a `prices_id_key` constraint crash before webhooks fired.
- Updates the integration test to cover a custom-price checkout and verify both `billing.updated` and `customer.products.updated` webhook deliveries.

<sup>Written for commit ca0d86322d704b7cadad1693f3f46899b6f5be33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents checkout completion from attempting to insert custom catalog rows that were already stored when the purchase became pending.

- **Bug fixes:** Removes persisted custom prices, entitlements, and free-trial definitions from the promoted execution plan, preventing duplicate insertion failures.
- **Improvements:** Extends the checkout integration scenario to verify that a custom-price purchase emits both billing and customer-product webhooks.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the custom-row suppression matching the pending-plan persistence lifecycle.

Pending creation stores the complete set of custom catalog rows before checkout, and the promotion path now avoids inserting those same rows again while preserving all remaining customer-product actions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/execute/promotePendingCustomerProducts.ts | Prevents promoted pending plans from reinserting custom catalog records that were persisted during pending-plan creation. |
| server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-attach.test.ts | Updates checkout coverage to exercise a custom price and require both billing and customer-product webhook deliveries. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Checkout
    participant DB
    participant Stripe
    participant Webhook
    Client->>Checkout: Attach custom-price plan
    Checkout->>DB: Persist custom rows and pending product
    Checkout->>Stripe: Create checkout session
    Stripe-->>Checkout: Checkout completed
    Checkout->>DB: Promote pending product
    Note over Checkout,DB: Omit already-persisted custom rows
    Checkout->>DB: Execute remaining billing actions
    Checkout->>Webhook: Send billing.updated
    Checkout->>Webhook: Send customer.products.updated
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: avoid reinserting pending custom ca..."](https://github.com/useautumn/autumn/commit/ca0d86322d704b7cadad1693f3f46899b6f5be33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59582780)</sub>

<!-- /greptile_comment -->