### PR TITLE
feat(billing): one invoice-credit line per dimension

### DIFF
--- a/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-credit-dimensions.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-credit-dimensions.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Contract: invoice credits drawn through dimensions bill one line per
+ * (feature, dimension). Action1 is dimensioned by size inside the plan item's
+ * feature_override; the renewal invoice carries a charge line per dimension
+ * naming it, a single "Credits applied" refund, an unchanged total, and
+ * attribution resets after billing.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5, FeatureConfigOverride } from "@autumn/shared";
+import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement.js";
+import { expectInvoiceLineItemsCorrect } from "@tests/integration/billing/utils/expectInvoiceLineItemsCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const withFeatureOverride = (
+	item: ReturnType<typeof items.consumable>,
+	featureOverride: FeatureConfigOverride,
+) => ({
+	...item,
+	config: { ...item.config, feature_override: featureOverride },
+});
+
+test.concurrent(
+	`${chalk.yellowBright("invoice.created credit dimensions: one charge line per dimension of the same feature")}`,
+	async () => {
+		const invoiceCreditItem = withFeatureOverride(
+			items.consumable({
+				featureId: TestFeature.InvoiceCredits,
+				includedUsage: 100,
+				price: 1,
+			}),
+			{
+				schema: [
+					{
+						metered_feature_id: TestFeature.Action1,
+						credit_amount: 0.2,
+						dimensions: {
+							large: { match: { size: "large" }, credit_amount: 1 },
+						},
+						multipliers: {
+							spot: { match: { lifecycle: "spot" }, factor: 0.5 },
+						},
+					},
+				],
+			},
+		);
+		const product = products.pro({
+			id: "dimension-invoice-credit",
+			items: [invoiceCreditItem],
+		});
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "dimension-invoice-credit",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [product] }),
+			],
+			actions: [
+				s.billing.attach({ productId: product.id }),
+				// 20 large @ 1 = 20 · 20 large spot @ 0.5 = 10 · 50 plain @ 0.2 = 10.
+				// 40 credits < 100 included, so the total stays the $20 base price.
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 20,
+					properties: { size: "large" },
+				}),
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 20,
+					properties: { size: "large", lifecycle: "spot" },
+				}),
+				s.track({ featureId: TestFeature.Action1, value: 50 }),
+				s.advanceToNextInvoice({ withPause: true }),
+			],
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		const renewalInvoice = customer.invoices?.[0];
+		expect(renewalInvoice?.stripe_id).toBeDefined();
+		expect(renewalInvoice?.total).toBe(20);
+
+		const storedLineItems = await expectInvoiceLineItemsCorrect({
+			stripeInvoiceId: renewalInvoice!.stripe_id,
+			expectedCount: 4,
+			expectedTotal: 20,
+			expectedLineItems: [
+				{ isBasePrice: true, direction: "charge", amount: 20 },
+				{
+					featureId: TestFeature.Action1,
+					direction: "charge",
+					billingTiming: "in_arrear",
+					count: 2,
+					totalAmount: 40,
+				},
+				{
+					featureId: TestFeature.InvoiceCredits,
+					direction: "refund",
+					billingTiming: "in_arrear",
+					amount: -40,
+				},
+			],
+		});
+		const action1Lines = storedLineItems
+			.filter((lineItem) => lineItem.feature_id === TestFeature.Action1)
+			.map((lineItem) => ({
+				description: lineItem.description,
+				amount: lineItem.amount,
+			}))
+			.sort((left, right) => left.amount - right.amount);
+		expect(action1Lines).toEqual([
+			{ description: "Action1, 50 units", amount: 10 },
+			{ description: "Action1 — large, 40 units", amount: 30 },
+		]);
+
+		expect(customer.balances[TestFeature.InvoiceCredits].remaining).toBe(100);
+		const resetCustomerEntitlement = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.InvoiceCredits,
+		});
+		expect(resetCustomerEntitlement?.usage_attribution).toEqual({});
+	},
+	{ timeout: 180_000 },
+);

--- a/server/tests/unit/billing/invoice-credit-dimension-line-items.test.ts
+++ b/server/tests/unit/billing/invoice-credit-dimension-line-items.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Invoice credits with dimensions: attribution keyed per dimension renders one
+ * line per (feature, dimension) without collapsing lines that share a feature,
+ * names the dimension in the description, and still says "Removed feature"
+ * only when the feature itself is gone.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	BillingVersion,
+	EntInterval,
+	FeatureType,
+	type UsageAttribution,
+} from "@autumn/shared";
+import { contexts } from "@tests/utils/fixtures/db/contexts.js";
+import { customerEntitlements } from "@tests/utils/fixtures/db/customerEntitlements.js";
+import { customerProducts } from "@tests/utils/fixtures/db/customerProducts.js";
+import { features } from "@tests/utils/fixtures/db/features.js";
+import { prices } from "@tests/utils/fixtures/db/prices.js";
+import { products } from "@tests/utils/fixtures/db/products.js";
+import { customerProductToArrearLineItems } from "@/internal/billing/v2/utils/lineItems/customerProductToArrearLineItems.js";
+
+const CPU_INTERNAL_ID = "internal_cpu_minutes";
+const PERIOD_START = Date.UTC(2026, 0, 1);
+const PERIOD_END = Date.UTC(2026, 1, 1);
+
+const cpuMinutes = features.create({
+	id: "cpu_minutes",
+	internalId: CPU_INTERNAL_ID,
+	name: "CPU minutes",
+});
+
+const lineItemsFor = ({
+	usageAttribution,
+	catalogFeatures = [cpuMinutes],
+}: {
+	usageAttribution: UsageAttribution;
+	catalogFeatures?: (typeof cpuMinutes)[];
+}) => {
+	const customerEntitlement = customerEntitlements.create({
+		id: "customer_entitlement_invoice_credits",
+		featureId: "invoice_credits",
+		internalFeatureId: "internal_invoice_credits",
+		featureName: "Invoice credits",
+		featureType: FeatureType.CreditSystem,
+		featureConfig: { invoice_credit: true, schema: [] },
+		allowance: 1_000,
+		balance: 1_000 - 260,
+		interval: EntInterval.Month,
+		nextResetAt: PERIOD_END,
+	});
+	customerEntitlement.usage_attribution = usageAttribution;
+
+	const invoiceCreditPrice = prices.createConsumable({
+		id: "price_invoice_credits",
+		featureId: "invoice_credits",
+		internalFeatureId: "internal_invoice_credits",
+		entitlementId: customerEntitlement.entitlement.id,
+	});
+	const fullProduct = products.createFull({
+		id: "enterprise",
+		name: "Enterprise",
+		prices: [invoiceCreditPrice],
+		entitlements: [customerEntitlement.entitlement],
+		stripeProductId: "stripe_product_enterprise",
+	});
+	const customerProduct = customerProducts.create({
+		id: "customer_product_enterprise",
+		productId: fullProduct.id,
+		product: fullProduct,
+		customerEntitlements: [customerEntitlement],
+		customerPrices: [prices.createCustomer({ price: invoiceCreditPrice })],
+	});
+	const ctx = contexts.create({
+		features: catalogFeatures,
+		org: {
+			...contexts.createOrg(),
+			config: { disable_overage_billing: false },
+		} as never,
+	});
+	const billingContext = contexts.createBilling({
+		customerProducts: [customerProduct],
+		currentEpochMs: PERIOD_END - 1,
+		billingCycleAnchorMs: PERIOD_START,
+		resetCycleAnchorMs: PERIOD_START,
+		billingVersion: BillingVersion.V2,
+	});
+
+	return customerProductToArrearLineItems({
+		ctx,
+		customerProduct,
+		billingContext,
+		options: { invoiceCredits: { idempotencyScope: "invoice_1" } },
+	}).invoiceCreditLineItems.map((lineItem) => ({
+		id: lineItem.id,
+		amount: lineItem.amount,
+		description: lineItem.description,
+		featureId: lineItem.context.feature?.id,
+	}));
+};
+
+describe("invoice credit dimension line items", () => {
+	test("renders one line per dimension of the same feature, then the offset", () => {
+		expect(
+			lineItemsFor({
+				usageAttribution: {
+					[`${CPU_INTERNAL_ID}::large_eu`]: { units: 10, credits: 60 },
+					[`${CPU_INTERNAL_ID}::large`]: { units: 10, credits: 160 },
+					[CPU_INTERNAL_ID]: { units: 40, credits: 40 },
+				},
+			}),
+		).toEqual([
+			{
+				id: `invoice_li_credit_invoice_1_customer_entitlement_invoice_credits_${CPU_INTERNAL_ID}`,
+				amount: 40,
+				description: "CPU minutes, 40 units",
+				featureId: "cpu_minutes",
+			},
+			{
+				id: `invoice_li_credit_invoice_1_customer_entitlement_invoice_credits_${CPU_INTERNAL_ID}::large`,
+				amount: 160,
+				description: "CPU minutes — large, 10 units",
+				featureId: "cpu_minutes",
+			},
+			{
+				id: `invoice_li_credit_invoice_1_customer_entitlement_invoice_credits_${CPU_INTERNAL_ID}::large_eu`,
+				amount: 60,
+				description: "CPU minutes — large_eu, 10 units",
+				featureId: "cpu_minutes",
+			},
+			{
+				id: "invoice_li_credit_invoice_1_customer_entitlement_invoice_credits_applied",
+				amount: -260,
+				description: "Credits applied",
+				featureId: "invoice_credits",
+			},
+		]);
+	});
+
+	test("a dimension on a removed feature still says Removed feature, never the credit feature", () => {
+		const [line] = lineItemsFor({
+			usageAttribution: {
+				[`${CPU_INTERNAL_ID}::large`]: { units: 10, credits: 160 },
+			},
+			catalogFeatures: [],
+		});
+
+		expect(line).toMatchObject({
+			description: "Removed feature — large, 10 units",
+			featureId: "invoice_credits",
+		});
+	});
+});

--- a/server/tests/utils/testInitUtils/initScenario.ts
+++ b/server/tests/utils/testInitUtils/initScenario.ts
@@ -145,6 +145,7 @@ type TrackAction = {
 	type: "track";
 	featureId: string;
 	value: number;
+	properties?: Record<string, unknown>;
 	entityIndex?: number;
 	timeout?: number;
 };
@@ -595,11 +596,13 @@ const removePaymentMethod = (): ConfigFn => {
 const track = ({
 	featureId,
 	value,
+	properties,
 	entityIndex,
 	timeout,
 }: {
 	featureId: string;
 	value: number;
+	properties?: Record<string, unknown>;
 	entityIndex?: number;
 	timeout?: number;
 }): ConfigFn => {
@@ -611,6 +614,7 @@ const track = ({
 				type: "track" as const,
 				featureId,
 				value,
+				properties,
 				entityIndex,
 				timeout,
 			},
@@ -1621,6 +1625,7 @@ export async function initScenario({
 				customer_id: customerId,
 				feature_id: action.featureId,
 				value: action.value,
+				properties: action.properties,
 				entity_id: entityId,
 			});
 			if (action.timeout) {

--- a/shared/utils/billingUtils/invoicingUtils/lineItemBuilders/invoiceCreditCustomerEntitlementToLineItems.ts
+++ b/shared/utils/billingUtils/invoicingUtils/lineItemBuilders/invoiceCreditCustomerEntitlementToLineItems.ts
@@ -4,6 +4,7 @@ import type { LineItemContext } from "../../../../models/billingModels/lineItem/
 import type { FullCusEntWithFullCusProduct } from "../../../../models/cusProductModels/cusEntModels/cusEntWithProduct.js";
 import type { Feature } from "../../../../models/featureModels/featureModels.js";
 import { cusEntToInvoiceOverage } from "../../../cusEntUtils/overageUtils/cusEntToInvoiceOverage.js";
+import { parseUsageAttributionKey } from "../../../cusEntUtils/usageAttribution/parseUsageAttributionKey.js";
 import { findFeatureByInternalId } from "../../../featureUtils/findFeatureUtils.js";
 import {
 	atmnToStripeAmount,
@@ -69,12 +70,19 @@ export const invoiceCreditCustomerEntitlementToLineItems = ({
 
 	let totalCredits = new Decimal(0);
 	let totalRoundedCredits = new Decimal(0);
-	for (const [sourceInternalFeatureId, sourceAttribution] of attribution) {
+	for (const [attributionKey, sourceAttribution] of attribution) {
+		const { internalFeatureId, dimensionName } = parseUsageAttributionKey({
+			key: attributionKey,
+		});
 		const sourceFeature = findFeatureByInternalId({
 			features,
-			internalId: sourceInternalFeatureId,
+			internalId: internalFeatureId,
 			errorOnNotFound: false,
 		});
+		const sourceName = sourceFeature?.name ?? "Removed feature";
+		const sourceLabel = dimensionName
+			? `${sourceName} — ${dimensionName}`
+			: sourceName;
 		totalCredits = totalCredits.add(sourceAttribution.credits);
 		const roundedCredits = roundToCurrency({
 			amount: sourceAttribution.credits,
@@ -88,7 +96,7 @@ export const invoiceCreditCustomerEntitlementToLineItems = ({
 				direction: "charge",
 			},
 			amount: roundedCredits,
-			description: `${sourceFeature?.name ?? "Removed feature"}, ${creditQuantityFormatter.format(sourceAttribution.units)} units`,
+			description: `${sourceLabel}, ${creditQuantityFormatter.format(sourceAttribution.units)} units`,
 			shouldProrate: false,
 			usage: sourceAttribution.units,
 		});
@@ -96,7 +104,7 @@ export const invoiceCreditCustomerEntitlementToLineItems = ({
 			withStableInvoiceCreditId({
 				lineItem: sourceLineItem,
 				idempotencyScope,
-				position: `${customerEntitlement.id}_${sourceInternalFeatureId}`,
+				position: `${customerEntitlement.id}_${attributionKey}`,
 			}),
 		);
 	}


### PR DESCRIPTION
Layer 5 of the credit dimensions stack — invoice lines.

**Goal** — invoice credits drawn through dimensions bill one line per (feature, dimension); carry-over, reset and sync are untouched because they never parse the attribution key.

**What's here**
- `invoiceCreditCustomerEntitlementToLineItems`: parses the key (`fe_action1::large`), resolves the feature from its prefix, and names the dimension in the description — `"Action1 — large, 40 units"`. The line id keeps the raw key, so two dimensions of one feature never collide; the "Credits applied" offset is unchanged.
- `s.track` in the scenario harness accepts `properties`.

**Verify**
- unit: `tests/unit/billing/invoice-credit-dimension-line-items.test.ts` — two lines sharing a `feature_id` render separately with stable ids, and a dimension on a removed feature still says "Removed feature" (attributed to the credit feature, as today); plus existing `invoice-credit-line-items` and `credit-rate-card-attribution-carry`
- integration: `bun t server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-credit-dimensions.test.ts` — Stripe test clock through a renewal: `action1 $30` (large) + `action1 $10` (plain) + `invoice_credits −$40` + base `$20`, total unchanged, attribution reset; existing `invoice-created-feature-override` and `invoice-created-invoice-credits` still green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders one invoice-credit line per (feature, dimension) instead of collapsing all dimensions of a feature into a single line. Each line's description now names the dimension, and the line ID uses the full attribution key so two dimensions of the same feature never collide.

**Migration**
- Invoice-credit line item IDs now include the dimension suffix; any invoices re-generated after this change will carry different IDs than those produced before it.

<sup>Written for commit 2628ba74e8f6a11f77aa3fa0473b7beff32f68d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR separates dimension-attributed invoice credits into distinct invoice lines while preserving the existing total credit offset.
- **[Improvements]** Parse attribution keys to resolve the source feature and include the dimension in invoice-line descriptions.
- **[Bug fixes]** Use each complete attribution key as the line identity so dimensions of the same feature no longer collapse together.
- **[API changes]** Extend the scenario test helper’s tracking action to accept event properties.
- **[Improvements]** Add unit and Stripe renewal coverage for dimension-specific credit lines, removed features, totals, and attribution reset behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/billingUtils/invoicingUtils/lineItemBuilders/invoiceCreditCustomerEntitlementToLineItems.ts | Parses dimension-aware attribution keys and creates separately identified, clearly labeled invoice-credit charge lines. |
| server/tests/utils/testInitUtils/initScenario.ts | Passes optional event properties through the scenario tracking helper. |
| server/tests/unit/billing/invoice-credit-dimension-line-items.test.ts | Covers distinct dimension lines, stable identifiers, descriptions, and removed-feature fallback behavior. |
| server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-credit-dimensions.test.ts | Exercises dimension-attributed credits through a Stripe renewal and verifies invoice totals and attribution reset. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  U[Tracked usage with properties] --> A[Usage attribution key]
  A --> P[Parse feature and dimension]
  P --> L[Create one charge line per attribution key]
  L --> O[Create aggregate Credits applied offset]
  O --> I[Renewal invoice]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(billing): one invoice-credit line p..."](https://github.com/useautumn/autumn/commit/7b6157a830c0901b23ab3582a272238d09e1de94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60356159)</sub>

<!-- /greptile_comment -->