### PR TITLE
test(balances): check converts required_balance at the selected dimension

### DIFF
--- a/server/tests/integration/balances/check/check-credit-dimensions.test.ts
+++ b/server/tests/integration/balances/check/check-credit-dimensions.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Contract: check on a feature whose credit rate is dimensioned converts
+ * required_balance at the dimension the properties select, falls back to the
+ * row's rate without them, and send_event deducts at the same rate.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3, FeatureConfigOverride } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const dimensionedAction1: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				large: { match: { size: "large" }, credit_amount: 16 },
+				large_eu: {
+					match: { size: "large", region: "eu" },
+					credit_amount: 20,
+				},
+			},
+			multipliers: {
+				spot: { match: { lifecycle: "spot" }, factor: 0.5 },
+			},
+		},
+	],
+};
+
+const setupDimensionedCredits = async ({
+	customerId,
+	includedUsage,
+}: {
+	customerId: string;
+	includedUsage: number;
+}) => {
+	const creditsItem = {
+		...items.free({ featureId: TestFeature.Credits, includedUsage }),
+		config: { feature_override: dimensionedAction1 },
+	};
+	const product = products.base({ id: customerId, items: [creditsItem] });
+
+	return initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [product] })],
+		actions: [s.attach({ productId: product.id })],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("check-credit-dimensions: required_balance converts at the dimension the properties select")}`,
+	async () => {
+		const customerId = "check-credit-dimensions-convert";
+		const { autumnV2_3 } = await setupDimensionedCredits({
+			customerId,
+			includedUsage: 150,
+		});
+
+		const largeEu = await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			required_balance: 10,
+			properties: { size: "large", region: "eu" },
+		});
+		expect(largeEu).toMatchObject({
+			allowed: false,
+			required_balance: 200,
+			balance: { feature_id: TestFeature.Credits, remaining: 150 },
+		});
+
+		const largeSpot = await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			required_balance: 10,
+			properties: { size: "large", lifecycle: "spot" },
+		});
+		expect(largeSpot).toMatchObject({ allowed: true, required_balance: 80 });
+
+		const plain = await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			required_balance: 10,
+		});
+		expect(plain).toMatchObject({ allowed: true, required_balance: 10 });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("check-credit-dimensions: send_event deducts at the selected dimension")}`,
+	async () => {
+		const customerId = "check-credit-dimensions-send-event";
+		const { autumnV1, autumnV2_3 } = await setupDimensionedCredits({
+			customerId,
+			includedUsage: 1_000,
+		});
+
+		const response = await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			required_balance: 10,
+			properties: { size: "large" },
+			send_event: true,
+		});
+		expect(response).toMatchObject({ allowed: true, required_balance: 160 });
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(customer.features[TestFeature.Credits]).toMatchObject({
+			balance: 1_000 - 160,
+			usage: 160,
+		});
+	},
+);


### PR DESCRIPTION
Layer 6 of the credit dimensions stack — check.

**Goal** — no runtime change; the properties threading in #3220 already projects the check fast path. This layer pins the check contract.

**Verify** — `bun t server/tests/integration/balances/check/check-credit-dimensions.test.ts`
- `required_balance: 10` with `{ size: large, region: eu }` → `required_balance: 200`, not allowed against 150 credits
- with `{ size: large, lifecycle: spot }` → `required_balance: 80`, allowed
- with no properties → `required_balance: 10` at the row's rate
- `send_event: true` with `{ size: large }` → allowed at 160 and the pool drops by 160

Existing `credit-systems1` / `credit-systems3` check suites still green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds integration tests pinning the check contract for dimensioned credit rates, with no runtime changes.

- Verifies `required_balance` converts at the dimension selected by properties, falls back to the row's rate without properties, and `send_event` deducts at the same rate.
- Runs via `bun t server/tests/integration/balances/check/check-credit-dimensions.test.ts`; existing `credit-systems1` / `credit-systems3` check suites stay green.

<sup>Written for commit da306f48c2deef019f7a9c5ab1b145cc036eb72c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds integration coverage for dimension-based credit balance checks without changing runtime behavior.

- **Improvements** — Tests that checks convert the required balance using selected dimensions and multipliers.
- **Improvements** — Tests fallback behavior when no properties are supplied.
- **Improvements** — Tests that `send_event` deducts credits using the same selected rate.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/tests/integration/balances/check/check-credit-dimensions.test.ts | Adds isolated integration tests covering dimension selection, multiplier application, default rates, and event-driven credit deductions. |

<sub>Reviews (2): Last reviewed commit: ["test(balances): check converts required\_..."](https://github.com/useautumn/autumn/commit/134a313bd96019a38537679edba49f4b0b6e357f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60356164)</sub>

<!-- /greptile_comment -->