### PR TITLE
fix: flush Redis balances before Stripe webhook cache refresh

### DIFF
--- a/server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts
@@ -104,6 +104,9 @@ export const stripeWebhookRefreshMiddleware = async (
 				customerId: customer.id!,
 				ctx,
 				source: `stripeWebhookRefreshMiddleware: ${eventType}`,
+				// Attach-echo invoices are balance-neutral. Cycle handlers bump
+				// cache_version or already invalidate, so a conflict is a no-op.
+				flushBalances: true,
 			});
 		}
 	} catch (error) {

--- a/server/src/external/stripe/webhookReplay/runStripeWebhookReplay.ts
+++ b/server/src/external/stripe/webhookReplay/runStripeWebhookReplay.ts
@@ -92,6 +92,7 @@ export const runStripeWebhookReplay = async ({
 				customerId: routedCtx.fullCustomer.id,
 				ctx: routedCtx,
 				source: `stripeWebhookReplay: ${stripeEvent.type}`,
+				flushBalances: true,
 			}),
 		);
 	}

--- a/server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts
+++ b/server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts
@@ -104,8 +104,7 @@ describe(`${chalk.yellowBright("invalidation-flush: invalidation must not lose u
 			await autumnV2.customers.get<ApiCustomer>(customerId);
 		expect(getMessagesRemaining(cachedBeforeInvalidation)).toBe(95);
 
-		// flushBalances opt-in mirrors the customers.update route config — the
-		// only invalidation source where cached balances are the source of truth.
+		// flushBalances opt-in mirrors customers.update and Stripe webhook refresh.
 		await invalidateCachedFullSubject({
 			ctx,
 			customerId,

--- a/server/tests/balances/track/race-condition/webhook-refresh-flush-unsynced-balances.test.ts
+++ b/server/tests/balances/track/race-condition/webhook-refresh-flush-unsynced-balances.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Remy race: /track immediately after a paid attach, then invoice.created
+ * webhook refresh. Without flushBalances the deduction lives only in Redis
+ * and skip_cache reverts; with flush it lands in Postgres first.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { type ApiCustomer, ApiVersion, type FullCustomer } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { Hono } from "hono";
+import type Stripe from "stripe";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { waitForRedisReady } from "@/external/redis/initRedis.js";
+import { stripeWebhookRefreshMiddleware } from "@/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.js";
+import type {
+	StripeWebhookContext,
+	StripeWebhookHonoEnv,
+} from "@/external/stripe/webhookMiddlewares/stripeWebhookContext.js";
+import { executeRedisDeductionV2 } from "@/internal/balances/utils/deductionV2/executeRedisDeductionV2.js";
+import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+
+const pro = constructProduct({
+	type: "pro",
+	items: [
+		constructFeatureItem({
+			featureId: TestFeature.Messages,
+			includedUsage: 100,
+		}),
+	],
+});
+
+const testCase = "webhook-refresh-flush-unsynced-balances";
+
+const getMessagesRemaining = (customer: ApiCustomer) => {
+	const balance = customer.balances[TestFeature.Messages] as {
+		current_balance?: number;
+		remaining?: number;
+	};
+	return balance.remaining ?? balance.current_balance;
+};
+
+const runInvoiceCreatedCacheRefresh = async ({
+	customerId,
+}: {
+	customerId: string;
+}) => {
+	const app = new Hono<StripeWebhookHonoEnv>();
+	app.use("*", async (c, next) => {
+		c.set("ctx", {
+			...ctx,
+			fullCustomer: { id: customerId } as FullCustomer,
+			stripeEvent: {
+				id: "evt_remy_invoice_created",
+				type: "invoice.created",
+				data: {
+					object: {
+						customer: "cus_stripe_test",
+						billing_reason: "subscription_create",
+					},
+				},
+			} as Stripe.Event,
+		} as StripeWebhookContext);
+		await next();
+	});
+	app.use("*", stripeWebhookRefreshMiddleware);
+	app.post("/", (c) => c.json({ received: true }));
+
+	const response = await app.request("http://localhost/", { method: "POST" });
+	expect(response.status).toBe(200);
+};
+
+describe(`${chalk.yellowBright("webhook-refresh-flush: invoice.created must not lose unsynced deductions")}`, () => {
+	const customerId = testCase;
+	const autumnV2 = new AutumnInt({ version: ApiVersion.V2_1 });
+
+	beforeAll(async () => {
+		await waitForRedisReady(ctx.redisV2, "customer-redis", 5000);
+
+		await initCustomerV3({
+			ctx,
+			customerId,
+			withTestClock: true,
+			attachPm: "success",
+		});
+
+		await initProductsV0({
+			ctx,
+			products: [pro],
+			prefix: testCase,
+		});
+
+		await autumnV2.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+		});
+	});
+
+	test("invoice.created webhook refresh flushes an unsynced Redis track", async () => {
+		const fullSubject = await getOrSetCachedFullSubject({
+			ctx,
+			customerId,
+			source: "test-setup",
+		});
+
+		const messagesFeature = ctx.features.find(
+			(feature) => feature.id === TestFeature.Messages,
+		)!;
+
+		await executeRedisDeductionV2({
+			ctx,
+			deductions: [{ feature: messagesFeature, deduction: 5 }],
+			fullSubject,
+			deductionOptions: { overageBehaviour: "cap" },
+		});
+
+		const cachedBeforeRefresh =
+			await autumnV2.customers.get<ApiCustomer>(customerId);
+		expect(getMessagesRemaining(cachedBeforeRefresh)).toBe(95);
+
+		await runInvoiceCreatedCacheRefresh({ customerId });
+
+		const dbCustomer = await autumnV2.customers.get<ApiCustomer>(customerId, {
+			skip_cache: "true",
+		});
+		expect(getMessagesRemaining(dbCustomer)).toBe(95);
+
+		const rebuiltCustomer =
+			await autumnV2.customers.get<ApiCustomer>(customerId);
+		expect(getMessagesRemaining(rebuiltCustomer)).toBe(95);
+	});
+});

--- a/server/tests/unit/webhooks/stripe-webhook-refresh-flush.test.ts
+++ b/server/tests/unit/webhooks/stripe-webhook-refresh-flush.test.ts
@@ -1,0 +1,93 @@
+/** Webhook cache refresh must flush Redis balances before wiping the subject. */
+
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type {
+	StripeWebhookContext,
+	StripeWebhookHonoEnv,
+} from "@/external/stripe/webhookMiddlewares/stripeWebhookContext.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const deleteCalls: Record<string, unknown>[] = [];
+
+await mockModuleWithRestore(
+	"@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js",
+	() => ({
+		deleteCachedFullCustomer: async (args: Record<string, unknown>) => {
+			deleteCalls.push(args);
+		},
+	}),
+);
+
+const { stripeWebhookRefreshMiddleware } = await import(
+	"@/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.js"
+);
+
+const postWebhook = async ({
+	eventType,
+	billingReason,
+}: {
+	eventType: string;
+	billingReason?: string;
+}) => {
+	deleteCalls.length = 0;
+
+	const app = new Hono<StripeWebhookHonoEnv>();
+	app.use("*", async (c, next) => {
+		c.set("ctx", {
+			fullCustomer: { id: "cus_remy" },
+			stripeEvent: {
+				type: eventType,
+				data: {
+					object: {
+						customer: "cus_stripe",
+						billing_reason: billingReason,
+					},
+				},
+			},
+			logger: {
+				warn: () => {},
+				error: () => {},
+				info: () => {},
+			},
+		} as unknown as StripeWebhookContext);
+		await next();
+	});
+	app.use("*", stripeWebhookRefreshMiddleware);
+	app.post("/", (c) => c.json({ received: true }));
+
+	return app.request("http://localhost/", { method: "POST" });
+};
+
+describe("stripe webhook cache refresh flush", () => {
+	test("flushes cached balances before invalidating invoice.created", async () => {
+		const response = await postWebhook({
+			eventType: "invoice.created",
+			billingReason: "subscription_create",
+		});
+
+		expect(response.status).toBe(200);
+		expect(deleteCalls).toEqual([
+			{
+				customerId: "cus_remy",
+				ctx: expect.anything(),
+				source: "stripeWebhookRefreshMiddleware: invoice.created",
+				flushBalances: true,
+			},
+		]);
+	});
+
+	test("skips refresh for manual invoices", async () => {
+		const response = await postWebhook({
+			eventType: "invoice.paid",
+			billingReason: "manual",
+		});
+
+		expect(response.status).toBe(200);
+		expect(deleteCalls).toHaveLength(0);
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});

--- a/server/tests/unit/webhooks/stripe-webhook-replay-cache-preservation.test.ts
+++ b/server/tests/unit/webhooks/stripe-webhook-replay-cache-preservation.test.ts
@@ -8,6 +8,7 @@ import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
 
 const state = {
 	cacheDeletions: 0,
+	flushBalances: undefined as boolean | undefined,
 	handlerRuns: 0,
 	preservePublishedSubject: false,
 };
@@ -19,8 +20,9 @@ await mockModuleWithRestore("@/external/connect/createStripeCli.js", () => ({
 await mockModuleWithRestore(
 	"@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js",
 	() => ({
-		deleteCachedFullCustomer: async () => {
+		deleteCachedFullCustomer: async (args: { flushBalances?: boolean }) => {
 			state.cacheDeletions++;
+			state.flushBalances = args.flushBalances;
 		},
 	}),
 );
@@ -67,6 +69,7 @@ const { runStripeWebhookReplay } = await import(
 
 beforeEach(() => {
 	state.cacheDeletions = 0;
+	state.flushBalances = undefined;
 	state.handlerRuns = 0;
 	state.preservePublishedSubject = false;
 });
@@ -132,4 +135,5 @@ test("keeps the normal replay cleanup when nothing published a subject", async (
 
 	expect(state.handlerRuns).toBe(1);
 	expect(state.cacheDeletions).toBe(1);
+	expect(state.flushBalances).toBe(true);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Stripe webhook cache refresh now flushes Redis balances to Postgres before wiping the subject view — the same `flushBalances` path `customers.update` already uses.

Call sites:
- `stripeWebhookRefreshMiddleware` after invoice/subscription/checkout events
- `runStripeWebhookReplay` cleanup (same contract as the live route)

## Why

On remy-devhydrogen `remy3534_c02c_a` (2026-09-02):

```
07:42:19.119  balances.track 650  →  remaining 150
07:42:19.126  invoice.created cache wipe (no flush)
07:42:19.246  customers.get        →  remaining 800
07:42:19.435  skip_cache=true      →  remaining 800
```

The event row survived. Tracks ≥15s later persisted because `syncItemV4` had already landed.

First-invoice handlers (`billing_reason=subscription_create`) do not write entitlements. Cycle handlers either bump `cache_version` (flush conflicts, Postgres wins) or already invalidate (flush no-ops). Manual invoices still skip refresh.

## Tests

Verified locally after loading SQL functions (`sync_balances_v2` is not a Drizzle migration):

- Unit: webhook middleware and replay pass `flushBalances: true`; manual invoices still skip — 4 pass
- Integration: unsynced Redis deduction + `invoice.created` refresh → skip_cache stays at 95 — 2 pass
  - `invalidation-flush-unsynced-balances.test.ts`
  - `webhook-refresh-flush-unsynced-balances.test.ts`

## Out of scope

`pooled` on atmn compose/push/pull already landed in #3213.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f944616-e598-4551-9449-874f9b5439de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f944616-e598-4551-9449-874f9b5439de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where Stripe `invoice.created` webhook cache refresh discarded unsynced Redis balance deductions, causing `skip_cache` to revert to stale values. The refresh and replay paths now pass `flushBalances: true` to sync Redis balances to Postgres before invalidating the subject view, matching the existing `customers.update` behavior.

<sup>Written for commit 3b40eadfb39a39122df2d30868bf78022456510c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves unsynced Redis deductions by flushing balances to Postgres before Stripe webhook cache invalidation.
- **Bug fixes:** Enables balance flushing for live Stripe webhook refreshes.
- **Bug fixes:** Applies the same flushing behavior to webhook replay cleanup.
- **Improvements:** Adds unit and integration coverage for cache preservation and manual-invoice behavior.
</details>


<h3>Confidence Score: 4/5</h3>

The concurrent deduction window should be fixed before merging because a track accepted during webhook cleanup can still be lost.

The new webhook and replay call sites invoke a flush whose destructive Redis snapshot occurs before the subject epoch changes, allowing a concurrent deduction to be accepted outside that snapshot and later replaced by a Postgres-backed cache rebuild.

**Files Needing Attention:** server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts; server/src/external/stripe/webhookReplay/runStripeWebhookReplay.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts | Enables pre-invalidation balance flushing for live webhook refreshes, but exposes a deduction window before the epoch increment. |
| server/src/external/stripe/webhookReplay/runStripeWebhookReplay.ts | Enables the same balance flush during replay cleanup and therefore shares the concurrent-deduction risk. |
| server/tests/balances/track/race-condition/webhook-refresh-flush-unsynced-balances.test.ts | Covers a deduction completed before refresh, but not a deduction concurrent with the flush and epoch transition. |
| server/tests/unit/webhooks/stripe-webhook-refresh-flush.test.ts | Verifies live refresh opts into flushing while manual invoices remain excluded. |
| server/tests/unit/webhooks/stripe-webhook-replay-cache-preservation.test.ts | Verifies replay cleanup opts into balance flushing when cache deletion is not suppressed. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Webhook
  participant Redis
  participant Track
  participant Postgres
  Webhook->>Redis: GETDEL cached balance fields
  Webhook->>Postgres: Await balance flush
  Track->>Redis: Check unchanged subject epoch
  Track->>Redis: Write concurrent deduction
  Webhook->>Redis: Unlink subject and increment epoch
  Note over Redis,Postgres: A rebuild before deferred sync can replace the concurrent deduction
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts:109
**Concurrent deduction escapes flush**

If a track request overlaps this webhook cleanup, it can pass the old epoch check after the balance snapshot has been removed but before the epoch is incremented. That deduction is excluded from the flush and can be overwritten by a Postgres-backed cache rebuild before deferred synchronization runs, causing the customer's remaining balance to increase again; the replay call site has the same ordering.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: flush Redis balances before Stripe ..."](https://github.com/useautumn/autumn/commit/3b40eadfb39a39122df2d30868bf78022456510c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59612482)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->