### PR TITLE
fix: flush Redis balances before Stripe webhook cache refresh

### DIFF
--- a/server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts
@@ -104,6 +104,9 @@ export const stripeWebhookRefreshMiddleware = async (
 				customerId: customer.id!,
 				ctx,
 				source: `stripeWebhookRefreshMiddleware: ${eventType}`,
+				// Attach-echo invoices are balance-neutral. Cycle handlers bump
+				// cache_version or already invalidate, so a conflict is a no-op.
+				flushBalances: true,
 			});
 		}
 	} catch (error) {

--- a/server/src/external/stripe/webhookReplay/runStripeWebhookReplay.ts
+++ b/server/src/external/stripe/webhookReplay/runStripeWebhookReplay.ts
@@ -92,6 +92,7 @@ export const runStripeWebhookReplay = async ({
 				customerId: routedCtx.fullCustomer.id,
 				ctx: routedCtx,
 				source: `stripeWebhookReplay: ${stripeEvent.type}`,
+				flushBalances: true,
 			}),
 		);
 	}

--- a/server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts
+++ b/server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts
@@ -104,8 +104,7 @@ describe(`${chalk.yellowBright("invalidation-flush: invalidation must not lose u
 			await autumnV2.customers.get<ApiCustomer>(customerId);
 		expect(getMessagesRemaining(cachedBeforeInvalidation)).toBe(95);
 
-		// flushBalances opt-in mirrors the customers.update route config — the
-		// only invalidation source where cached balances are the source of truth.
+		// flushBalances opt-in mirrors customers.update and Stripe webhook refresh.
 		await invalidateCachedFullSubject({
 			ctx,
 			customerId,

--- a/server/tests/balances/track/race-condition/webhook-refresh-flush-unsynced-balances.test.ts
+++ b/server/tests/balances/track/race-condition/webhook-refresh-flush-unsynced-balances.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Remy race: /track immediately after a paid attach, then invoice.created
+ * webhook refresh. Without flushBalances the deduction lives only in Redis
+ * and skip_cache reverts; with flush it lands in Postgres first.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { type ApiCustomer, ApiVersion, type FullCustomer } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { Hono } from "hono";
+import type Stripe from "stripe";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { waitForRedisReady } from "@/external/redis/initRedis.js";
+import { stripeWebhookRefreshMiddleware } from "@/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.js";
+import type {
+	StripeWebhookContext,
+	StripeWebhookHonoEnv,
+} from "@/external/stripe/webhookMiddlewares/stripeWebhookContext.js";
+import { executeRedisDeductionV2 } from "@/internal/balances/utils/deductionV2/executeRedisDeductionV2.js";
+import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+
+const pro = constructProduct({
+	type: "pro",
+	items: [
+		constructFeatureItem({
+			featureId: TestFeature.Messages,
+			includedUsage: 100,
+		}),
+	],
+});
+
+const testCase = "webhook-refresh-flush-unsynced-balances";
+
+const getMessagesRemaining = (customer: ApiCustomer) => {
+	const balance = customer.balances[TestFeature.Messages] as {
+		current_balance?: number;
+		remaining?: number;
+	};
+	return balance.remaining ?? balance.current_balance;
+};
+
+const runInvoiceCreatedCacheRefresh = async ({
+	customerId,
+}: {
+	customerId: string;
+}) => {
+	const app = new Hono<StripeWebhookHonoEnv>();
+	app.use("*", async (c, next) => {
+		c.set("ctx", {
+			...ctx,
+			fullCustomer: { id: customerId } as FullCustomer,
+			stripeEvent: {
+				id: "evt_remy_invoice_created",
+				type: "invoice.created",
+				data: {
+					object: {
+						customer: "cus_stripe_test",
+						billing_reason: "subscription_create",
+					},
+				},
+			} as Stripe.Event,
+		} as StripeWebhookContext);
+		await next();
+	});
+	app.use("*", stripeWebhookRefreshMiddleware);
+	app.post("/", (c) => c.json({ received: true }));
+
+	const response = await app.request("http://localhost/", { method: "POST" });
+	expect(response.status).toBe(200);
+};
+
+describe(`${chalk.yellowBright("webhook-refresh-flush: invoice.created must not lose unsynced deductions")}`, () => {
+	const customerId = testCase;
+	const autumnV2 = new AutumnInt({ version: ApiVersion.V2_1 });
+
+	beforeAll(async () => {
+		await waitForRedisReady(ctx.redisV2, "customer-redis", 5000);
+
+		await initCustomerV3({
+			ctx,
+			customerId,
+			withTestClock: true,
+			attachPm: "success",
+		});
+
+		await initProductsV0({
+			ctx,
+			products: [pro],
+			prefix: testCase,
+		});
+
+		await autumnV2.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+		});
+	});
+
+	test("invoice.created webhook refresh flushes an unsynced Redis track", async () => {
+		const fullSubject = await getOrSetCachedFullSubject({
+			ctx,
+			customerId,
+			source: "test-setup",
+		});
+
+		const messagesFeature = ctx.features.find(
+			(feature) => feature.id === TestFeature.Messages,
+		)!;
+
+		await executeRedisDeductionV2({
+			ctx,
+			deductions: [{ feature: messagesFeature, deduction: 5 }],
+			fullSubject,
+			deductionOptions: { overageBehaviour: "cap" },
+		});
+
+		const cachedBeforeRefresh =
+			await autumnV2.customers.get<ApiCustomer>(customerId);
+		expect(getMessagesRemaining(cachedBeforeRefresh)).toBe(95);
+
+		await runInvoiceCreatedCacheRefresh({ customerId });
+
+		const dbCustomer = await autumnV2.customers.get<ApiCustomer>(customerId, {
+			skip_cache: "true",
+		});
+		expect(getMessagesRemaining(dbCustomer)).toBe(95);
+
+		const rebuiltCustomer =
+			await autumnV2.customers.get<ApiCustomer>(customerId);
+		expect(getMessagesRemaining(rebuiltCustomer)).toBe(95);
+	});
+});

--- a/server/tests/unit/webhooks/stripe-webhook-refresh-flush.test.ts
+++ b/server/tests/unit/webhooks/stripe-webhook-refresh-flush.test.ts
@@ -1,0 +1,93 @@
+/** Webhook cache refresh must flush Redis balances before wiping the subject. */
+
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type {
+	StripeWebhookContext,
+	StripeWebhookHonoEnv,
+} from "@/external/stripe/webhookMiddlewares/stripeWebhookContext.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const deleteCalls: Record<string, unknown>[] = [];
+
+await mockModuleWithRestore(
+	"@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js",
+	() => ({
+		deleteCachedFullCustomer: async (args: Record<string, unknown>) => {
+			deleteCalls.push(args);
+		},
+	}),
+);
+
+const { stripeWebhookRefreshMiddleware } = await import(
+	"@/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.js"
+);
+
+const postWebhook = async ({
+	eventType,
+	billingReason,
+}: {
+	eventType: string;
+	billingReason?: string;
+}) => {
+	deleteCalls.length = 0;
+
+	const app = new Hono<StripeWebhookHonoEnv>();
+	app.use("*", async (c, next) => {
+		c.set("ctx", {
+			fullCustomer: { id: "cus_remy" },
+			stripeEvent: {
+				type: eventType,
+				data: {
+					object: {
+						customer: "cus_stripe",
+						billing_reason: billingReason,
+					},
+				},
+			},
+			logger: {
+				warn: () => {},
+				error: () => {},
+				info: () => {},
+			},
+		} as unknown as StripeWebhookContext);
+		await next();
+	});
+	app.use("*", stripeWebhookRefreshMiddleware);
+	app.post("/", (c) => c.json({ received: true }));
+
+	return app.request("http://localhost/", { method: "POST" });
+};
+
+describe("stripe webhook cache refresh flush", () => {
+	test("flushes cached balances before invalidating invoice.created", async () => {
+		const response = await postWebhook({
+			eventType: "invoice.created",
+			billingReason: "subscription_create",
+		});
+
+		expect(response.status).toBe(200);
+		expect(deleteCalls).toEqual([
+			{
+				customerId: "cus_remy",
+				ctx: expect.anything(),
+				source: "stripeWebhookRefreshMiddleware: invoice.created",
+				flushBalances: true,
+			},
+		]);
+	});
+
+	test("skips refresh for manual invoices", async () => {
+		const response = await postWebhook({
+			eventType: "invoice.paid",
+			billingReason: "manual",
+		});
+
+		expect(response.status).toBe(200);
+		expect(deleteCalls).toHaveLength(0);
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});

--- a/server/tests/unit/webhooks/stripe-webhook-replay-cache-preservation.test.ts
+++ b/server/tests/unit/webhooks/stripe-webhook-replay-cache-preservation.test.ts
@@ -8,6 +8,7 @@ import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
 
 const state = {
 	cacheDeletions: 0,
+	flushBalances: undefined as boolean | undefined,
 	handlerRuns: 0,
 	preservePublishedSubject: false,
 };
@@ -19,8 +20,9 @@ await mockModuleWithRestore("@/external/connect/createStripeCli.js", () => ({
 await mockModuleWithRestore(
 	"@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js",
 	() => ({
-		deleteCachedFullCustomer: async () => {
+		deleteCachedFullCustomer: async (args: { flushBalances?: boolean }) => {
 			state.cacheDeletions++;
+			state.flushBalances = args.flushBalances;
 		},
 	}),
 );
@@ -67,6 +69,7 @@ const { runStripeWebhookReplay } = await import(
 
 beforeEach(() => {
 	state.cacheDeletions = 0;
+	state.flushBalances = undefined;
 	state.handlerRuns = 0;
 	state.preservePublishedSubject = false;
 });
@@ -132,4 +135,5 @@ test("keeps the normal replay cleanup when nothing published a subject", async (
 
 	expect(state.handlerRuns).toBe(1);
 	expect(state.cacheDeletions).toBe(1);
+	expect(state.flushBalances).toBe(true);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Stripe webhook cache refresh now flushes Redis balances to Postgres before wiping the subject view — the same `flushBalances` path `customers.update` already uses.

Call sites:
- `stripeWebhookRefreshMiddleware` after invoice/subscription/checkout events
- `runStripeWebhookReplay` cleanup (same contract as the live route)

## Why

On remy-devhydrogen `remy3534_c02c_a` (2026-09-02):

```
07:42:19.119  balances.track 650  →  remaining 150
07:42:19.126  invoice.created cache wipe (no flush)
07:42:19.246  customers.get        →  remaining 800
07:42:19.435  skip_cache=true      →  remaining 800
```

`sync_balances_v2` refuses the write when `cache_version` or `next_reset_at` changed (cycle reset / in-place update). New attach rows are not in the Redis manifest, so the new grant is never a flush target.

## Tests

- Unit: webhook middleware and replay pass `flushBalances: true`; manual invoices still skip
- Integration: unsynced Redis deduction + `invoice.created` refresh → skip_cache stays at 95
- `bun tw core` running against this branch

## Out of scope

`pooled` on atmn compose/push/pull already landed in #3213.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f944616-e598-4551-9449-874f9b5439de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f944616-e598-4551-9449-874f9b5439de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stripe webhook cache refresh now flushes Redis balances to Postgres before wiping the subject view, so `skip_cache` no longer reverts to a stale value after `invoice.created`.

- Applies `flushBalances: true` to the webhook refresh middleware and webhook replay cleanup, matching the `customers.update` path.
- Manual invoices still skip the refresh.
- Adds integration and unit tests covering the unsynced deduction race and replay cleanup.

<sup>Written for commit e5e5d104333e13858c6c6ff58dbf26f4bfec503f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves pending Redis usage before Stripe webhook cache refreshes and replay cleanup, preventing a refreshed customer balance from reverting to an older Postgres value.

- **[Bug fixes]** Flushes cached balances before live Stripe webhook refreshes delete the customer view.
- **[Bug fixes]** Applies the same balance-preserving cleanup to replayed Stripe webhooks.
- **[Improvements]** Adds unit and integration coverage for unsynced deductions, manual-invoice exclusions, and replay cleanup options.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the new flush-before-invalidation behavior covered for both live and replayed webhooks.

The changed call sites use the existing balance-flush path before deleting cached customer views, and the reviewed handler ordering and invalidation behavior revealed no concrete regression.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts | Live webhook cleanup now flushes pending Redis balances before invalidating the customer cache. |
| server/src/external/stripe/webhookReplay/runStripeWebhookReplay.ts | Replay cleanup now follows the same flush-before-invalidate contract as live webhook processing. |
| server/tests/balances/track/race-condition/webhook-refresh-flush-unsynced-balances.test.ts | Adds an integration regression test proving an unsynced deduction survives invoice-created cache refresh. |
| server/tests/unit/webhooks/stripe-webhook-refresh-flush.test.ts | Verifies refresh-eligible events request balance flushing while manual invoices remain excluded. |
| server/tests/unit/webhooks/stripe-webhook-replay-cache-preservation.test.ts | Extends replay cleanup coverage to assert that balance flushing is enabled. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Handler as Webhook handler
    participant Cache as Redis balance cache
    participant DB as Postgres
    Stripe->>Handler: Deliver or replay event
    Handler->>Handler: Process event
    Handler->>Cache: Flush pending balance fields
    Cache->>DB: Persist unsynced deductions
    Handler->>Cache: Delete cached customer view
    Note over Cache,DB: The next customer read rebuilds from persisted balances
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: flush Redis balances before Stripe ..."](https://github.com/useautumn/autumn/commit/e5e5d104333e13858c6c6ff58dbf26f4bfec503f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59623428)</sub>

<!-- /greptile_comment -->