### PR TITLE
fix: license_entitlements FK violation on in-place license plan item edits

### DIFF
--- a/server/src/internal/licenses/actions/customize/rebaseCatalogPlanLicenses.ts
+++ b/server/src/internal/licenses/actions/customize/rebaseCatalogPlanLicenses.ts
@@ -76,22 +76,35 @@ const pinCatalogRefsForCustomizedLink = async ({
 export const materializeCustomerPlanLicenseSnapshots = async ({
 	db,
 	baseProduct,
+	alsoPinPlanLicenses = [],
 }: {
 	db: DrizzleCli;
 	baseProduct: FullProduct;
+	/** Links that keep the old shape after the base rewrite (non-propagated),
+	 * pinned so the rewrite relabels their rows instead of deleting them. */
+	alsoPinPlanLicenses?: DbPlanLicense[];
 }) => {
 	const referenced =
 		await planLicenseRepo.listCustomerReferencedByLicenseInternalProductIds({
 			db,
 			licenseInternalProductIds: [baseProduct.internal_id],
 		});
+	const referencedIds = new Set(
+		referenced.map((planLicense) => planLicense.id),
+	);
+	const toPin = [
+		...referenced,
+		...alsoPinPlanLicenses.filter(
+			(planLicense) => !referencedIds.has(planLicense.id),
+		),
+	];
 	const items = derivePlanLicenseItemRefs(baseProduct);
 	const existingRows = await licenseItemRepo.listByPlanLicenseIds({
 		db,
-		planLicenseIds: referenced.map((planLicense) => planLicense.id),
+		planLicenseIds: toPin.map((planLicense) => planLicense.id),
 	});
 	let materialized = false;
-	for (const planLicense of referenced) {
+	for (const planLicense of toPin) {
 		if (planLicense.customized) {
 			await pinCatalogRefsForCustomizedLink({
 				db,

--- a/server/src/internal/product/actions/updateProduct/updateProductItems.ts
+++ b/server/src/internal/product/actions/updateProduct/updateProductItems.ts
@@ -63,6 +63,9 @@ export const updateProductItems = async ({
 		await materializeCustomerPlanLicenseSnapshots({
 			db: tx,
 			baseProduct: currentFullProduct,
+			alsoPinPlanLicenses: preparedLicenseRebases
+				.filter((rebase) => !rebase.propagate)
+				.map((rebase) => rebase.link),
 		});
 		const shouldUseInPlaceEdit =
 			useInPlaceEdit ||

--- a/server/tests/integration/licenses/catalog-update/license-inplace-edit-pins-links.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-inplace-edit-pins-links.test.ts
@@ -16,6 +16,7 @@ import { expect, test } from "bun:test";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
 
 test.concurrent(
 	`${chalk.yellowBright("licenses: in-place item edit pins non-propagated catalog links")}`,
@@ -31,7 +32,7 @@ test.concurrent(
 			reset: { interval: "month" },
 		});
 
-		const { autumnV2_2 } = await initScenario({
+		const { autumnV2_2, ctx } = await initScenario({
 			customerId: `license-pin-${suffix}`,
 			setup: [s.customer({ testClock: false })],
 			actions: [],
@@ -80,5 +81,20 @@ test.concurrent(
 			included: 0,
 			prepaid_only: true,
 		});
+
+		// The non-propagated link keeps the OLD item shape (pinned, not adopted).
+		const parentFull = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: parentId,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		const link = parentFull.licenses?.[0];
+		expect(link?.customized).toBe(true);
+		const linkedItem = link?.product.entitlements.find(
+			(entitlement) => entitlement.feature.id === TestFeature.Messages,
+		);
+		expect(linkedItem?.pooled).toBe(false);
+		expect(linkedItem?.allowance).toBe(25);
 	},
 );

--- a/server/tests/integration/licenses/catalog-update/license-inplace-edit-pins-links.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-inplace-edit-pins-links.test.ts
@@ -1,0 +1,84 @@
+/**
+ * TDD test: in-place item edit on a license plan whose parent link is
+ * non-customized, non-propagated, and has no customer references.
+ *
+ * Red-failure mode (pre-fix): the item rewrite deleted the old entitlement
+ * (nothing referenced it), then the license rebase pinned the old shape by
+ * inserting license_entitlements pointing at the deleted row —
+ * "license_entitlements_entitlement_fkey" FK violation, catalog.update 500s.
+ *
+ * Green-success criteria (post-fix): the old rows are pinned before the
+ * rewrite, the update succeeds, and the non-propagated link keeps the old
+ * item shape while the base plan carries the new one.
+ */
+
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: in-place item edit pins non-propagated catalog links")}`,
+	async () => {
+		const suffix = Math.random().toString(36).slice(2, 9);
+		const seatId = `license_pin_seat_${suffix}`;
+		const parentId = `license_pin_parent_${suffix}`;
+
+		const seatItem = (pooled: boolean) => ({
+			feature_id: TestFeature.Messages,
+			included: 25,
+			...(pooled ? { pooled: true } : {}),
+			reset: { interval: "month" },
+		});
+
+		const { autumnV2_2 } = await initScenario({
+			customerId: `license-pin-${suffix}`,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2_2.post("/catalog.update", {
+			plans: [
+				{
+					plan_id: seatId,
+					name: "Pin Seat",
+					items: [seatItem(false)],
+					price: { amount: 70, interval: "month" },
+					licenses: [],
+				},
+				{
+					plan_id: parentId,
+					name: "Pin Parent",
+					licenses: [{ license_plan_id: seatId, included: 0 }],
+				},
+			],
+		});
+
+		// Pre-fix: 500 "license_entitlements_entitlement_fkey" FK violation.
+		await autumnV2_2.post("/catalog.update", {
+			plans: [
+				{
+					plan_id: seatId,
+					name: "Pin Seat",
+					items: [seatItem(true)],
+					price: { amount: 70, interval: "month" },
+					licenses: [],
+				},
+			],
+		});
+
+		const seat = await autumnV2_2.post("/plans.get", { plan_id: seatId });
+		expect(seat.items.some((item: { pooled?: boolean }) => item.pooled)).toBe(
+			true,
+		);
+
+		const parent = await autumnV2_2.post("/plans.get", { plan_id: parentId });
+		expect(parent.licenses).toHaveLength(1);
+		expect(parent.licenses[0]).toMatchObject({
+			license_plan_id: seatId,
+			version: 1,
+			included: 0,
+			prepaid_only: true,
+		});
+	},
+);


### PR DESCRIPTION
## Summary

Hotfix for `catalog.update` 500ing with `insert or update on table "license_entitlements" violates foreign key constraint "license_entitlements_entitlement_fkey"` when a license plan's items are edited in place.

**Root cause** — inside `updateProductItems`' transaction:

1. Rebase prepare snapshots each parent link's old item shape.
2. The materialize step pins old rows into `license_entitlements` — but only for **customer-referenced** links.
3. `handleNewProductItems` replaces the changed item: the old entitlement has no references, so it's **deleted**.
4. Rebase apply keeps the old shape for **non-propagated** links by inserting `license_entitlements` rows pointing at the entitlement deleted in step 3 → FK violation, whole update rolls back.

Any in-place item change on a license plan whose parent catalog link is non-customized, non-propagated, and customer-free hits this.

**Fix** — pass the non-propagated prepared links into the materialize step so their rows are pinned too. The rewrite's existing delete-protection (`deleteEntsKeepingReferenced`) then relabels those rows `is_custom` instead of deleting them, which is exactly the path that already works for customer-referenced links. Propagated links are unchanged: their pin is cleared by rebase apply and the existing sweep removes leftovers.

## Test

`server/tests/integration/licenses/catalog-update/license-inplace-edit-pins-links.test.ts` — parent plan linking a seat plan (no customers), then an in-place `pooled` edit on the seat plan. Red on the unfixed code with the exact FK violation; green with the fix, asserting the update succeeds, the base plan carries the new item, and the parent link survives.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `catalog.update` 500ing with a `license_entitlements_entitlement_fkey` violation when a license plan item is edited in place and its parent catalog link is non-customized, non-propagated, and has no customer references. The materialize step now pins non-propagated prepared links so the rewrite relabels them `is_custom` instead of deleting the old entitlement; propagated links keep the existing sweep behavior. Adds an integration test that reproduces the failure and asserts the parent link keeps the old item shape.

<sup>Written for commit a4946ed39570b45fb427914506a4ab681f0c318b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents catalog updates from deleting entitlement rows still needed by non-propagated parent license links. It also completes the regression test by verifying that the parent retains its previous effective item configuration.

- **[Bug fixes]** Pin non-propagated parent license links before rewriting a base plan’s items, preventing the foreign-key failure.
- **[Improvements]** Deduplicate links that are already pinned because customers reference them.
- **[Improvements]** Verify that the updated base plan adopts the new pooled setting while its non-propagated parent keeps the old setting.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/licenses/actions/customize/rebaseCatalogPlanLicenses.ts | Extends snapshot materialization to deduplicated non-propagated license links so their old entitlement references survive the base rewrite. |
| server/src/internal/product/actions/updateProduct/updateProductItems.ts | Passes prepared non-propagated parent links into materialization before product items are rewritten. |
| server/tests/integration/licenses/catalog-update/license-inplace-edit-pins-links.test.ts | Reproduces the foreign-key regression and now verifies both the updated base item and the parent link’s preserved effective item shape. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant API as catalog.update
    participant Rebase as License rebase
    participant DB as Database
    API->>Rebase: Prepare parent-link rebases
    Rebase->>DB: Pin non-propagated links to old items
    API->>DB: Rewrite base plan items
    API->>Rebase: Apply prepared rebases
    Rebase->>DB: Preserve old parent shape and sweep propagated pins
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: assert non-propagated link keeps o..."](https://github.com/useautumn/autumn/commit/a4946ed39570b45fb427914506a4ab681f0c318b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59639960)</sub>

<!-- /greptile_comment -->