### PR TITLE
feat(atmn): push a config file to the catalog, end to end

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -334,9 +334,11 @@
         "atmn-nightly": "dist/cli.js",
       },
       "dependencies": {
+        "arctic": "3.7.0",
         "chalk": "5.6.2",
         "commander": "14.0.3",
         "dotenv": "16.6.1",
+        "open": "10.2.0",
         "yaml": "2.9.0",
       },
       "devDependencies": {

--- a/packages/atmn-nightly/.gitignore
+++ b/packages/atmn-nightly/.gitignore
@@ -1,0 +1,2 @@
+test/.tmp/
+dist/

--- a/packages/atmn-nightly/example/autumn.config.ts
+++ b/packages/atmn-nightly/example/autumn.config.ts
@@ -1,18 +1,5 @@
-import { feature } from "../src/generated/features";
 import { atmn } from "../src/generated/wire";
 
-/**
- * A config you can push. Every feature you want to exist goes here — the
- * payload is the complete desired catalog, so a feature you delete from this
- * file is a feature you are asking the server to remove.
- */
-export default atmn({
-	features: [
-		feature({
-			featureId: "atmn_demo_messages",
-			name: "Demo Messages",
-			type: "metered",
-			consumable: true,
-		}),
-	],
-});
+export default atmn({ features: [
+	// ai
+] });

--- a/packages/atmn-nightly/example/autumn.config.ts
+++ b/packages/atmn-nightly/example/autumn.config.ts
@@ -1,5 +1,18 @@
+import { feature } from "../src/generated/features";
 import { atmn } from "../src/generated/wire";
 
-export default atmn({ features: [
-	// ai
-] });
+/**
+ * A config you can push. Every feature you want to exist goes here — the
+ * payload is the complete desired catalog, so a feature you delete from this
+ * file is a feature you are asking the server to remove.
+ */
+export default atmn({
+	features: [
+		feature({
+			featureId: "atmn_demo_messages",
+			name: "Demo Messages",
+			type: "metered",
+			consumable: true,
+		}),
+	],
+});

--- a/packages/atmn-nightly/example/autumn.config.ts
+++ b/packages/atmn-nightly/example/autumn.config.ts
@@ -1,0 +1,18 @@
+import { feature } from "../src/generated/features";
+import { atmn } from "../src/generated/wire";
+
+/**
+ * A config you can push. Every feature you want to exist goes here — the
+ * payload is the complete desired catalog, so a feature you delete from this
+ * file is a feature you are asking the server to remove.
+ */
+export default atmn({
+	features: [
+		feature({
+			featureId: "atmn_demo_messages",
+			name: "Demo Messages",
+			type: "metered",
+			consumable: true,
+		}),
+	],
+});

--- a/packages/atmn-nightly/example/features/ai.ts
+++ b/packages/atmn-nightly/example/features/ai.ts
@@ -1,8 +1,0 @@
-import { feature } from "../../src/generated/features";
-
-export const ai = feature({
-    featureId: "atmn_demo_messages",
-    name: "Demo Messages",
-    type: "metered",
-    consumable: true,
-})

--- a/packages/atmn-nightly/example/features/ai.ts
+++ b/packages/atmn-nightly/example/features/ai.ts
@@ -1,0 +1,8 @@
+import { feature } from "../../src/generated/features";
+
+export const ai = feature({
+    featureId: "atmn_demo_messages",
+    name: "Demo Messages",
+    type: "metered",
+    consumable: true,
+})

--- a/packages/atmn-nightly/package.json
+++ b/packages/atmn-nightly/package.json
@@ -27,9 +27,11 @@
 		"README.md"
 	],
 	"dependencies": {
+		"arctic": "3.7.0",
 		"chalk": "5.6.2",
 		"commander": "14.0.3",
 		"dotenv": "16.6.1",
+		"open": "10.2.0",
 		"yaml": "2.9.0"
 	},
 	"devDependencies": {

--- a/packages/atmn-nightly/src/actions/login.ts
+++ b/packages/atmn-nightly/src/actions/login.ts
@@ -1,0 +1,100 @@
+import { announceAuthorizationUrl } from "../auth/announceAuthorizationUrl";
+import { openSystemBrowser } from "../auth/browser/openSystemBrowser";
+import { createOrgApiKeys } from "../auth/createOrgApiKeys";
+import {
+	CLI_OAUTH_SCOPES,
+	getBackendUrl,
+	getCliClientId,
+} from "../auth/oauthConfig";
+import {
+	type AuthorizationUrlListener,
+	runOAuthFlow,
+} from "../auth/runOAuthFlow";
+import type { BrowserOpener } from "../auth/types/browserOpener";
+import type { OAuthTokens } from "../auth/types/oauthTokens";
+import type { OrgApiKeys } from "../auth/types/orgApiKeys";
+import { loadEnvFiles, writeEnvValues } from "../env/loadEnv";
+import { configSearchDirs } from "./push";
+
+export type Authorize = ({
+	onAuthorizationUrl,
+}: {
+	onAuthorizationUrl: AuthorizationUrlListener;
+}) => Promise<OAuthTokens>;
+
+export type CreateApiKeys = ({
+	accessToken,
+}: {
+	accessToken: string;
+}) => Promise<OrgApiKeys>;
+
+export type LoginOptions = {
+	cwd?: string;
+	/** Where to write progress. Injected so tests can capture it. */
+	write?: (text: string) => void;
+	openBrowser?: BrowserOpener;
+	authorize?: Authorize;
+	createApiKeys?: CreateApiKeys;
+};
+
+export type LoginResult = {
+	envPath: string;
+	orgId?: string;
+	writtenKeys: string[];
+};
+
+const authorizeWithAutumn: Authorize = ({ onAuthorizationUrl }) =>
+	runOAuthFlow({
+		clientId: getCliClientId(),
+		backendUrl: getBackendUrl(),
+		scopes: CLI_OAUTH_SCOPES,
+		onAuthorizationUrl,
+	});
+
+const createAutumnApiKeys: CreateApiKeys = ({ accessToken }) =>
+	createOrgApiKeys({ accessToken, backendUrl: getBackendUrl() });
+
+const keysToEnvValues = ({
+	keys,
+}: {
+	keys: OrgApiKeys;
+}): Record<string, string> => {
+	const values: Record<string, string> = {};
+	if (keys.sandboxKey) values.AUTUMN_SECRET_KEY = keys.sandboxKey;
+	if (keys.prodKey) values.AUTUMN_PROD_SECRET_KEY = keys.prodKey;
+	return values;
+};
+
+/**
+ * Authorize in a browser — or on any other machine — then mint the org's keys
+ * and put them where `loadEnvFiles` will find them again.
+ */
+export const runLogin = async ({
+	cwd = process.cwd(),
+	write = (text) => process.stdout.write(text),
+	openBrowser = openSystemBrowser,
+	authorize = authorizeWithAutumn,
+	createApiKeys = createAutumnApiKeys,
+}: LoginOptions = {}): Promise<LoginResult> => {
+	const dirs = configSearchDirs({ cwd });
+	loadEnvFiles({ dirs });
+
+	const tokens = await authorize({
+		onAuthorizationUrl: ({ url }) =>
+			announceAuthorizationUrl({ url, write, openBrowser }),
+	});
+
+	const keys = await createApiKeys({ accessToken: tokens.accessToken });
+	const values = keysToEnvValues({ keys });
+
+	if (Object.keys(values).length === 0) {
+		throw new Error("Authorization succeeded but no API keys were returned.");
+	}
+
+	const envPath = writeEnvValues({ dirs, values });
+	const writtenKeys = Object.keys(values);
+
+	write(`\nWrote ${writtenKeys.join(" and ")} to ${envPath}\n`);
+
+	return { envPath, orgId: keys.orgId, writtenKeys };
+};

--- a/packages/atmn-nightly/src/actions/push.ts
+++ b/packages/atmn-nightly/src/actions/push.ts
@@ -1,0 +1,77 @@
+import { join } from "node:path";
+import { loadConfig } from "../config/loadConfig";
+import { loadEnvFiles } from "../env/loadEnv";
+import type { AutumnClient } from "../generated/client";
+import {
+	type CatalogPreview,
+	previewIsEmpty,
+	renderPreview,
+} from "../render/renderPreview";
+import { findRepoLayout } from "../repo/findRepoRoot";
+
+export type PushResult = {
+	configPath: string;
+	preview: CatalogPreview;
+	/** Absent on a dry run, or when the preview showed nothing to do. */
+	applied?: unknown;
+	migrationIds: string[];
+};
+
+export type PushOptions = {
+	client: AutumnClient;
+	cwd?: string;
+	dryRun?: boolean;
+	/** Where to write progress. Injected so tests can capture it. */
+	write?: (text: string) => void;
+	migrationLinkBase?: string;
+};
+
+/** The directories a config may live in, nearest first. */
+export const configSearchDirs = ({ cwd }: { cwd: string }): string[] => {
+	const { packageRoot, repoRoot } = findRepoLayout({ cwd });
+	return [...new Set([cwd, join(cwd, "atmn"), packageRoot, repoRoot])];
+};
+
+/**
+ * Preview, then apply. The CLI decides nothing here — it sends the same
+ * document twice and renders what comes back, which is why a clean preview is
+ * a real guarantee rather than a guess.
+ */
+export const runPush = async ({
+	client,
+	cwd = process.cwd(),
+	dryRun = false,
+	write = (text) => process.stdout.write(text),
+	migrationLinkBase,
+}: PushOptions): Promise<PushResult> => {
+	const dirs = configSearchDirs({ cwd });
+	loadEnvFiles({ dirs });
+
+	const { path: configPath, wire } = await loadConfig({ dirs });
+
+	const preview = (await client.previewUpdate(
+		wire as Record<string, unknown>,
+	)) as CatalogPreview;
+
+	write(`${renderPreview({ preview, migrationLinkBase })}\n`);
+
+	if (previewIsEmpty({ preview })) {
+		return { configPath, preview, migrationIds: [] };
+	}
+	if (dryRun) {
+		write("\nDry run — nothing applied.\n");
+		return { configPath, preview, migrationIds: [] };
+	}
+
+	const applied = (await client.update(wire as Record<string, unknown>)) as {
+		migrations?: { id?: string }[];
+	};
+
+	const migrationIds = (applied.migrations ?? [])
+		.map((migration) => migration.id)
+		.filter((id): id is string => typeof id === "string");
+
+	write("\nApplied.\n");
+
+	return { configPath, preview, applied, migrationIds };
+};

--- a/packages/atmn-nightly/src/auth/announceAuthorizationUrl.ts
+++ b/packages/atmn-nightly/src/auth/announceAuthorizationUrl.ts
@@ -1,0 +1,26 @@
+import { tryOpenBrowser } from "./browser/tryOpenBrowser";
+import type { BrowserOpener } from "./types/browserOpener";
+
+/**
+ * The URL is printed whether or not a browser opened, so it can be finished on
+ * a phone or a laptop when the CLI is running over SSH or in a container.
+ */
+export const announceAuthorizationUrl = async ({
+	url,
+	write,
+	openBrowser,
+}: {
+	url: string;
+	write: (text: string) => void;
+	openBrowser: BrowserOpener;
+}): Promise<void> => {
+	write(`\nVisit this URL to authenticate:\n\n  ${url}\n\n`);
+
+	const opened = await tryOpenBrowser({ url, openBrowser });
+
+	write(
+		opened
+			? "Opened your browser. Waiting for authorization...\n"
+			: "No browser could be opened here — open the URL above on any machine.\nWaiting for authorization...\n",
+	);
+};

--- a/packages/atmn-nightly/src/auth/browser/openSystemBrowser.ts
+++ b/packages/atmn-nightly/src/auth/browser/openSystemBrowser.ts
@@ -1,0 +1,7 @@
+import open from "open";
+import type { BrowserOpener } from "../types/browserOpener";
+import { watchLauncher } from "./watchLauncher";
+
+export const openSystemBrowser: BrowserOpener = async ({ url }) => {
+	await watchLauncher({ launcher: await open(url) });
+};

--- a/packages/atmn-nightly/src/auth/browser/tryOpenBrowser.ts
+++ b/packages/atmn-nightly/src/auth/browser/tryOpenBrowser.ts
@@ -1,0 +1,17 @@
+import type { BrowserOpener } from "../types/browserOpener";
+
+/** Never throws: a machine with no browser is a supported way to log in. */
+export const tryOpenBrowser = async ({
+	url,
+	openBrowser,
+}: {
+	url: string;
+	openBrowser: BrowserOpener;
+}): Promise<boolean> => {
+	try {
+		await openBrowser({ url });
+		return true;
+	} catch {
+		return false;
+	}
+};

--- a/packages/atmn-nightly/src/auth/browser/watchLauncher.ts
+++ b/packages/atmn-nightly/src/auth/browser/watchLauncher.ts
@@ -1,0 +1,46 @@
+/** Anything with node's `once`; a spawned `ChildProcess` satisfies it. */
+export type Launcher = {
+	once(event: string, listener: (...args: unknown[]) => void): unknown;
+};
+
+/**
+ * How long to keep watching before treating a still-running launcher as a
+ * success — some openers stay resident for the life of the browser.
+ */
+export const LAUNCHER_SETTLE_MS = 1500;
+
+/**
+ * A launcher that never spawned (no xdg-open) or exited non-zero (no display,
+ * no default browser) opened nothing. This, not a TTY check, is what tells us
+ * the environment is headless.
+ */
+export const watchLauncher = ({
+	launcher,
+	settleMs = LAUNCHER_SETTLE_MS,
+}: {
+	launcher: Launcher;
+	settleMs?: number;
+}): Promise<void> =>
+	new Promise((resolve, reject) => {
+		const settled = setTimeout(resolve, settleMs);
+
+		launcher.once("error", (...args: unknown[]) => {
+			clearTimeout(settled);
+			const [cause] = args;
+			reject(
+				cause instanceof Error
+					? cause
+					: new Error("Browser launcher failed to start"),
+			);
+		});
+
+		launcher.once("close", (...args: unknown[]) => {
+			clearTimeout(settled);
+			const [code] = args;
+			if (typeof code === "number" && code !== 0) {
+				reject(new Error(`Browser launcher exited with code ${code}`));
+				return;
+			}
+			resolve();
+		});
+	});

--- a/packages/atmn-nightly/src/auth/buildAuthorizationUrl.ts
+++ b/packages/atmn-nightly/src/auth/buildAuthorizationUrl.ts
@@ -1,0 +1,36 @@
+import { CodeChallengeMethod, OAuth2Client } from "arctic";
+import { getAuthorizationEndpoint, getOAuthRedirectUri } from "./oauthConfig";
+
+export const createOAuthClient = ({
+	clientId,
+	port,
+}: {
+	clientId: string;
+	port: number;
+}): OAuth2Client =>
+	new OAuth2Client(clientId, null, getOAuthRedirectUri({ port }));
+
+export const buildAuthorizationUrl = ({
+	client,
+	backendUrl,
+	scopes,
+	state,
+	codeVerifier,
+}: {
+	client: OAuth2Client;
+	backendUrl: string;
+	scopes: readonly string[];
+	state: string;
+	codeVerifier: string;
+}): URL => {
+	const url = client.createAuthorizationURLWithPKCE(
+		getAuthorizationEndpoint({ backendUrl }),
+		state,
+		CodeChallengeMethod.S256,
+		codeVerifier,
+		[...scopes],
+	);
+	// Always show the org picker; a silent grant would pin the wrong org.
+	url.searchParams.set("prompt", "consent");
+	return url;
+};

--- a/packages/atmn-nightly/src/auth/callbackPages.ts
+++ b/packages/atmn-nightly/src/auth/callbackPages.ts
@@ -1,0 +1,126 @@
+/** Ported from v2 so the browser half of login looks unchanged. */
+const BASE_STYLES = `
+	@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+	* { box-sizing: border-box; margin: 0; padding: 0; }
+
+	body {
+		font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+		min-height: 100vh;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: #fafaf9;
+		color: #121212;
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+	}
+
+	.container { text-align: center; padding: 3rem 2rem; max-width: 400px; }
+
+	.icon {
+		width: 64px;
+		height: 64px;
+		border-radius: 16px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		margin: 0 auto 1.5rem;
+	}
+
+	.icon-success {
+		background: linear-gradient(135deg, #f3e8ff 0%, #ede1ff 100%);
+		border: 2px solid #c4b5fd;
+		color: #8838ff;
+	}
+
+	.icon-error {
+		background: linear-gradient(135deg, #fee2e2 0%, #fecaca 100%);
+		border: 2px solid #fca5a5;
+		color: #dc2626;
+	}
+
+	h1 { font-size: 20px; font-weight: 600; margin-bottom: 0.5rem; letter-spacing: -0.02em; }
+	.error h1 { color: #dc2626; }
+
+	.description { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 1.5rem; }
+
+	.hint {
+		font-size: 13px;
+		color: #888;
+		padding: 0.75rem 1rem;
+		background: #f5f5f4;
+		border-radius: 8px;
+		border: 1px solid #e5e5e5;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		body { background: #161616; color: #ddd; }
+		.icon-success { background: linear-gradient(135deg, #2d1f4e 0%, #3d2a5e 100%); border-color: #6b46c1; color: #a855f7; }
+		.icon-error { background: linear-gradient(135deg, #4a1a1a 0%, #5c2020 100%); border-color: #dc2626; color: #f87171; }
+		.error h1 { color: #f87171; }
+		.description { color: #999; }
+		.hint { background: #1d1d1d; border-color: #2c2c2c; }
+	}
+`;
+
+const SUCCESS_ICON = `<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
+
+const ERROR_ICON = `<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`;
+
+const renderPage = ({
+	variant,
+	icon,
+	title,
+	description,
+	hint,
+}: {
+	variant: "success" | "error";
+	icon: string;
+	title: string;
+	description: string;
+	hint: string;
+}): string => `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>${title} - Autumn</title>
+	<style>${BASE_STYLES}</style>
+</head>
+<body>
+	<div class="container ${variant}">
+		<div class="icon icon-${variant}">${icon}</div>
+		<h1>${title}</h1>
+		<p class="description">${description}</p>
+		<p class="hint">${hint}</p>
+	</div>
+</body>
+</html>`;
+
+/** The error text comes from the authorization server, so it must be escaped. */
+const escapeHtml = ({ text }: { text: string }): string =>
+	text
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#039;");
+
+export const renderSuccessPage = (): string =>
+	renderPage({
+		variant: "success",
+		icon: SUCCESS_ICON,
+		title: "Authorization Successful",
+		description: "Your CLI has been authenticated successfully.",
+		hint: "You can close this window and return to your terminal.",
+	});
+
+export const renderErrorPage = ({ message }: { message: string }): string =>
+	renderPage({
+		variant: "error",
+		icon: ERROR_ICON,
+		title: "Authorization Failed",
+		description: escapeHtml({ text: message }),
+		hint: "Please close this window and try again in your terminal.",
+	});

--- a/packages/atmn-nightly/src/auth/createOrgApiKeys.ts
+++ b/packages/atmn-nightly/src/auth/createOrgApiKeys.ts
@@ -1,0 +1,45 @@
+import { getApiKeysEndpoint } from "./oauthConfig";
+import type { OrgApiKeys } from "./types/orgApiKeys";
+
+type ApiKeysResponse = {
+	sandbox_key?: string;
+	prod_key?: string;
+	org_id?: string;
+	message?: string;
+	error?: string;
+};
+
+/** Mint the org's sandbox and production keys from the OAuth access token. */
+export const createOrgApiKeys = async ({
+	accessToken,
+	backendUrl,
+	fetch = globalThis.fetch,
+}: {
+	accessToken: string;
+	backendUrl: string;
+	fetch?: typeof globalThis.fetch;
+}): Promise<OrgApiKeys> => {
+	const response = await fetch(getApiKeysEndpoint({ backendUrl }), {
+		method: "POST",
+		headers: {
+			authorization: `Bearer ${accessToken}`,
+			"content-type": "application/json",
+		},
+	});
+
+	const body = (await response.json().catch(() => ({}))) as ApiKeysResponse;
+
+	if (!response.ok) {
+		throw new Error(
+			body.message ??
+				body.error ??
+				`Failed to create API keys (${response.status})`,
+		);
+	}
+
+	return {
+		sandboxKey: body.sandbox_key,
+		prodKey: body.prod_key,
+		orgId: body.org_id,
+	};
+};

--- a/packages/atmn-nightly/src/auth/oauthConfig.ts
+++ b/packages/atmn-nightly/src/auth/oauthConfig.ts
@@ -1,0 +1,61 @@
+const DEFAULT_BACKEND_URL = "https://api.useautumn.com";
+
+/**
+ * The registered Better Auth client for the atmn CLI, carried over from v2 so
+ * existing consent records keep working.
+ */
+const CLI_CLIENT_ID = "hAWUopQqLnsSwuRgeRzIBzKslwXmQUSr";
+
+const OAUTH_PORT_BASE = 31448;
+const OAUTH_PORT_RANGE = 5;
+
+/** Callback ports tried in order; every one is registered as a redirect URI. */
+export const OAUTH_PORTS = Array.from(
+	{ length: OAUTH_PORT_RANGE },
+	(_, offset) => OAUTH_PORT_BASE + offset,
+);
+
+/**
+ * Modern read/write scopes covering everything the CLI reads and everything the
+ * minted keys are used for. The server rewrites v2's CRUDL scopes to these.
+ */
+export const CLI_OAUTH_SCOPES = [
+	"organisation:read",
+	"customers:read",
+	"customers:write",
+	"features:read",
+	"features:write",
+	"plans:read",
+	"plans:write",
+	"rewards:read",
+	"rewards:write",
+	"apiKeys:read",
+	"apiKeys:write",
+] as const;
+
+export const getBackendUrl = (): string =>
+	process.env.ATMN_BACKEND_URL ?? DEFAULT_BACKEND_URL;
+
+export const getCliClientId = (): string =>
+	process.env.ATMN_CLI_CLIENT_ID ?? CLI_CLIENT_ID;
+
+export const getOAuthRedirectUri = ({ port }: { port: number }): string =>
+	`http://localhost:${port}/`;
+
+export const getAuthorizationEndpoint = ({
+	backendUrl,
+}: {
+	backendUrl: string;
+}): string => `${backendUrl}/api/auth/oauth2/authorize`;
+
+export const getTokenEndpoint = ({
+	backendUrl,
+}: {
+	backendUrl: string;
+}): string => `${backendUrl}/api/auth/oauth2/token`;
+
+export const getApiKeysEndpoint = ({
+	backendUrl,
+}: {
+	backendUrl: string;
+}): string => `${backendUrl}/cli/api-keys`;

--- a/packages/atmn-nightly/src/auth/runOAuthFlow.ts
+++ b/packages/atmn-nightly/src/auth/runOAuthFlow.ts
@@ -1,0 +1,213 @@
+import { createServer } from "node:http";
+import {
+	generateCodeVerifier,
+	generateState,
+	type OAuth2Client,
+	OAuth2RequestError,
+} from "arctic";
+import {
+	buildAuthorizationUrl,
+	createOAuthClient,
+} from "./buildAuthorizationUrl";
+import { renderErrorPage, renderSuccessPage } from "./callbackPages";
+import { getTokenEndpoint, OAUTH_PORTS } from "./oauthConfig";
+import type { OAuthTokens } from "./types/oauthTokens";
+
+const AUTHORIZATION_TIMEOUT_MS = 5 * 60 * 1000;
+
+export type AuthorizationUrlListener = ({
+	url,
+}: {
+	url: string;
+}) => Promise<void> | void;
+
+export type RunOAuthFlowOptions = {
+	clientId: string;
+	backendUrl: string;
+	scopes: readonly string[];
+	onAuthorizationUrl: AuthorizationUrlListener;
+};
+
+type CallbackOutcome = { page: string; tokens?: OAuthTokens; error?: Error };
+
+const failedCallback = ({ message }: { message: string }): CallbackOutcome => ({
+	page: renderErrorPage({ message }),
+	error: new Error(message),
+});
+
+const exchangeAuthorizationCode = async ({
+	client,
+	backendUrl,
+	code,
+	codeVerifier,
+}: {
+	client: OAuth2Client;
+	backendUrl: string;
+	code: string;
+	codeVerifier: string;
+}): Promise<CallbackOutcome> => {
+	try {
+		const tokens = await client.validateAuthorizationCode(
+			getTokenEndpoint({ backendUrl }),
+			code,
+			codeVerifier,
+		);
+		return {
+			page: renderSuccessPage(),
+			tokens: {
+				accessToken: tokens.accessToken(),
+				tokenType: "Bearer",
+				expiresInSeconds: tokens.accessTokenExpiresInSeconds(),
+				refreshToken: tokens.hasRefreshToken()
+					? tokens.refreshToken()
+					: undefined,
+			},
+		};
+	} catch (error) {
+		const message =
+			error instanceof OAuth2RequestError
+				? `OAuth error: ${error.code}`
+				: "Token exchange failed";
+		return failedCallback({ message });
+	}
+};
+
+const readCallback = async ({
+	callbackUrl,
+	client,
+	backendUrl,
+	state,
+	codeVerifier,
+}: {
+	callbackUrl: URL;
+	client: OAuth2Client;
+	backendUrl: string;
+	state: string;
+	codeVerifier: string;
+}): Promise<CallbackOutcome> => {
+	const denial = callbackUrl.searchParams.get("error");
+	if (denial) {
+		return failedCallback({
+			message: callbackUrl.searchParams.get("error_description") ?? denial,
+		});
+	}
+	if (callbackUrl.searchParams.get("state") !== state) {
+		return failedCallback({ message: "Invalid state — possible CSRF" });
+	}
+
+	const code = callbackUrl.searchParams.get("code");
+	if (!code) return failedCallback({ message: "Missing authorization code" });
+
+	return await exchangeAuthorizationCode({
+		client,
+		backendUrl,
+		code,
+		codeVerifier,
+	});
+};
+
+/** Resolves null when the port is taken, so the caller can try the next one. */
+const listenForCallback = ({
+	port,
+	onCallback,
+	onListening,
+}: {
+	port: number;
+	onCallback: ({
+		callbackUrl,
+	}: {
+		callbackUrl: URL;
+	}) => Promise<CallbackOutcome>;
+	onListening: () => void;
+}): Promise<OAuthTokens | null> =>
+	new Promise((resolve, reject) => {
+		const server = createServer(async (request, response) => {
+			const callbackUrl = new URL(
+				request.url ?? "/",
+				`http://localhost:${port}`,
+			);
+			if (callbackUrl.pathname !== "/") {
+				response.writeHead(404).end("Not found");
+				return;
+			}
+
+			const { page, tokens, error } = await onCallback({ callbackUrl });
+			clearTimeout(timeout);
+
+			// Settle only once the page is flushed — the browser's keep-alive socket
+			// would otherwise outlive the command and hang the CLI.
+			response.writeHead(200, { "Content-Type": "text/html" }).end(page, () => {
+				shutDown();
+				if (tokens) resolve(tokens);
+				else reject(error ?? new Error("Authorization returned no tokens"));
+			});
+		});
+
+		const shutDown = () => {
+			server.close();
+			server.closeAllConnections();
+		};
+
+		const timeout = setTimeout(() => {
+			shutDown();
+			reject(new Error("Authorization timed out. Please try again."));
+		}, AUTHORIZATION_TIMEOUT_MS);
+
+		server.once("error", (error: NodeJS.ErrnoException) => {
+			clearTimeout(timeout);
+			if (error.code === "EADDRINUSE") resolve(null);
+			else reject(error);
+		});
+
+		server.listen(port, onListening);
+	});
+
+/**
+ * PKCE authorization against a loopback callback. The URL is handed to the
+ * caller the moment the server is listening, so it can be shown and opened.
+ */
+export const runOAuthFlow = async ({
+	clientId,
+	backendUrl,
+	scopes,
+	onAuthorizationUrl,
+}: RunOAuthFlowOptions): Promise<OAuthTokens> => {
+	const codeVerifier = generateCodeVerifier();
+	const state = generateState();
+
+	for (const port of OAUTH_PORTS) {
+		const client = createOAuthClient({ clientId, port });
+		const authorizationUrl = buildAuthorizationUrl({
+			client,
+			backendUrl,
+			scopes,
+			state,
+			codeVerifier,
+		});
+
+		const tokens = await listenForCallback({
+			port,
+			onCallback: ({ callbackUrl }) =>
+				readCallback({
+					callbackUrl,
+					client,
+					backendUrl,
+					state,
+					codeVerifier,
+				}),
+			onListening: () => {
+				void Promise.resolve(
+					onAuthorizationUrl({ url: authorizationUrl.toString() }),
+				).catch(() => {
+					// Announcing is best-effort; the flow still works if it fails.
+				});
+			},
+		});
+
+		if (tokens) return tokens;
+	}
+
+	throw new Error(
+		`All OAuth callback ports (${OAUTH_PORTS.at(0)}-${OAUTH_PORTS.at(-1)}) are in use.`,
+	);
+};

--- a/packages/atmn-nightly/src/auth/types/browserOpener.ts
+++ b/packages/atmn-nightly/src/auth/types/browserOpener.ts
@@ -1,0 +1,5 @@
+/**
+ * Resolves once a browser was actually launched, and rejects otherwise — the
+ * rejection is the only honest headless signal, since a TTY proves nothing.
+ */
+export type BrowserOpener = ({ url }: { url: string }) => Promise<void>;

--- a/packages/atmn-nightly/src/auth/types/oauthTokens.ts
+++ b/packages/atmn-nightly/src/auth/types/oauthTokens.ts
@@ -1,0 +1,6 @@
+export type OAuthTokens = {
+	accessToken: string;
+	tokenType: "Bearer";
+	expiresInSeconds?: number;
+	refreshToken?: string;
+};

--- a/packages/atmn-nightly/src/auth/types/orgApiKeys.ts
+++ b/packages/atmn-nightly/src/auth/types/orgApiKeys.ts
@@ -1,0 +1,6 @@
+/** Either key can be absent when the org's OAuth client is bound to one env. */
+export type OrgApiKeys = {
+	sandboxKey?: string;
+	prodKey?: string;
+	orgId?: string;
+};

--- a/packages/atmn-nightly/src/cli.ts
+++ b/packages/atmn-nightly/src/cli.ts
@@ -1,26 +1,17 @@
 #!/usr/bin/env node
 import { Command } from "commander";
+import { runLogin } from "./actions/login";
 import { runPush } from "./actions/push";
+import {
+	requireSecretKey,
+	resolveTarget,
+	type TargetFlags,
+} from "./env/resolveTarget";
 import { createClient } from "./generated/client";
 import { version } from "./version";
 
 const NOT_IMPLEMENTED = (step: string) => () => {
 	throw new Error(`Not implemented yet — lands in ${step}.`);
-};
-
-/**
- * Sandbox unless --prod, matching the two keys people already have. Multi
- * sandbox selection is still to be designed.
- */
-const requireSecretKey = ({ prod }: { prod?: boolean }): string => {
-	const name = prod ? "AUTUMN_PROD_SECRET_KEY" : "AUTUMN_SECRET_KEY";
-	const key = process.env[name];
-	if (!key) {
-		throw new Error(
-			`${name} is not set. Put it in your .env, or export it before running.`,
-		);
-	}
-	return key;
 };
 
 /**
@@ -32,8 +23,12 @@ const normalizeVersionFlag = ({ argv }: { argv: string[] }): string[] =>
 
 const withEnvironmentFlags = (command: Command): Command =>
 	command
-		.option("--prod", "target production instead of sandbox")
-		.option("--sandbox <sandboxId>", "target a specific sandbox");
+		.option("-p, --prod", "target production instead of sandbox")
+		.option("--sandbox <sandboxId>", "target a specific sandbox")
+		.option("-l, --local", "target a local server (default port 8080)")
+		// Long-only: -p is prod.
+		.option("--port <port>", "port for --local")
+		.option("-b, --base-url <url>", "send to this URL instead");
 
 export const buildProgram = (): Command => {
 	const program = new Command();
@@ -47,7 +42,9 @@ export const buildProgram = (): Command => {
 	program
 		.command("login")
 		.description("authenticate and write org keys to your .env")
-		.action(NOT_IMPLEMENTED("3.0"));
+		.action(async () => {
+			await runLogin();
+		});
 
 	withEnvironmentFlags(
 		program
@@ -55,9 +52,13 @@ export const buildProgram = (): Command => {
 			.description("apply autumn.config.ts to your catalog")
 			.option("-y, --yes", "skip confirmation prompts")
 			.option("-d, --dry-run", "preview without applying"),
-	).action(async (options: { prod?: boolean; dryRun?: boolean }) => {
+	).action(async (options: TargetFlags & { dryRun?: boolean }) => {
+		const target = resolveTarget(options);
 		await runPush({
-			client: createClient({ secretKey: requireSecretKey(options) }),
+			client: createClient({
+				secretKey: requireSecretKey({ target }),
+				...(target.baseUrl ? { baseUrl: target.baseUrl } : {}),
+			}),
 			dryRun: options.dryRun === true,
 		});
 	});

--- a/packages/atmn-nightly/src/cli.ts
+++ b/packages/atmn-nightly/src/cli.ts
@@ -28,7 +28,7 @@ const withEnvironmentFlags = (command: Command): Command =>
 		.option("--sandbox <sandboxId>", "target a specific sandbox")
 		.option("-l, --local", "target a local server (default port 8080)")
 		// Long-only: -p is prod.
-		.option("--port <port>", "port for --local")
+		.option("--port <port>", "port of a local server (implies --local)")
 		.option("-b, --base-url <url>", "send to this URL instead");
 
 export const buildProgram = (): Command => {

--- a/packages/atmn-nightly/src/cli.ts
+++ b/packages/atmn-nightly/src/cli.ts
@@ -1,13 +1,26 @@
 #!/usr/bin/env node
-import { join } from "node:path";
 import { Command } from "commander";
-import { loadConfig } from "./config/loadConfig";
-import { loadEnvFiles } from "./env/loadEnv";
-import { findRepoLayout } from "./repo/findRepoRoot";
+import { runPush } from "./actions/push";
+import { createClient } from "./generated/client";
 import { version } from "./version";
 
 const NOT_IMPLEMENTED = (step: string) => () => {
 	throw new Error(`Not implemented yet — lands in ${step}.`);
+};
+
+/**
+ * Sandbox unless --prod, matching the two keys people already have. Multi
+ * sandbox selection is still to be designed.
+ */
+const requireSecretKey = ({ prod }: { prod?: boolean }): string => {
+	const name = prod ? "AUTUMN_PROD_SECRET_KEY" : "AUTUMN_SECRET_KEY";
+	const key = process.env[name];
+	if (!key) {
+		throw new Error(
+			`${name} is not set. Put it in your .env, or export it before running.`,
+		);
+	}
+	return key;
 };
 
 /**
@@ -42,14 +55,11 @@ export const buildProgram = (): Command => {
 			.description("apply autumn.config.ts to your catalog")
 			.option("-y, --yes", "skip confirmation prompts")
 			.option("-d, --dry-run", "preview without applying"),
-	).action(async () => {
-		const { packageRoot, repoRoot } = findRepoLayout();
-		const dirs = [
-			...new Set([packageRoot, join(packageRoot, "atmn"), repoRoot]),
-		];
-		loadEnvFiles({ dirs });
-		const { path } = await loadConfig({ dirs });
-		throw new Error(`Loaded ${path}. Push lands in 3.2.`);
+	).action(async (options: { prod?: boolean; dryRun?: boolean }) => {
+		await runPush({
+			client: createClient({ secretKey: requireSecretKey(options) }),
+			dryRun: options.dryRun === true,
+		});
 	});
 
 	withEnvironmentFlags(

--- a/packages/atmn-nightly/src/cli.ts
+++ b/packages/atmn-nightly/src/cli.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { runLogin } from "./actions/login";
-import { runPush } from "./actions/push";
+import { configSearchDirs, runPush } from "./actions/push";
+import { loadEnvFiles } from "./env/loadEnv";
 import {
 	requireSecretKey,
 	resolveTarget,
@@ -53,6 +54,11 @@ export const buildProgram = (): Command => {
 			.option("-y, --yes", "skip confirmation prompts")
 			.option("-d, --dry-run", "preview without applying"),
 	).action(async (options: TargetFlags & { dryRun?: boolean }) => {
+		// Env first: the key and AUTUMN_BASE_URL usually live in a .env beside
+		// the config, so reading them after building the client would never see
+		// them — which is what the "put it in your .env" error message promises.
+		loadEnvFiles({ dirs: configSearchDirs({ cwd: process.cwd() }) });
+
 		const target = resolveTarget(options);
 		await runPush({
 			client: createClient({

--- a/packages/atmn-nightly/src/config/loadConfig.ts
+++ b/packages/atmn-nightly/src/config/loadConfig.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
 
 const CONFIG_FILENAMES = ["autumn.config.ts", "autumn.config.js"] as const;
 
@@ -42,7 +41,12 @@ export const loadConfig = async ({
 	const path = findConfigPath({ dirs });
 	if (!path) throw new ConfigNotFoundError(dirs);
 
-	const module = await import(pathToFileURL(path).href);
+	// Cache-busted because the module cache would otherwise pin the first read
+	// for the life of the process — irrelevant for a single `atmn push`, wrong
+	// for anything that pushes twice (tests today, a watch mode later).
+	// The query goes on the plain path: appended to a file:// href Bun
+	// normalises it away and serves the cached module.
+	const module = await import(`${path}?v=${Date.now()}`);
 	const wire = module.default;
 
 	if (wire === undefined) {

--- a/packages/atmn-nightly/src/env/loadEnv.ts
+++ b/packages/atmn-nightly/src/env/loadEnv.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { parse } from "dotenv";
 
@@ -44,3 +44,60 @@ export const readAutumnKeys = (): AutumnKeys => ({
 	sandboxKey: process.env.AUTUMN_SECRET_KEY,
 	prodKey: process.env.AUTUMN_PROD_SECRET_KEY,
 });
+
+/** The file `loadEnvFiles` reads first, so writes land where reads look. */
+export const findEnvFile = ({
+	dirs,
+}: {
+	dirs: string[];
+}): string | undefined => {
+	for (const dir of dirs) {
+		for (const file of FILES_IN_PRECEDENCE_ORDER) {
+			const path = join(dir, file);
+			if (existsSync(path)) return path;
+		}
+	}
+	return undefined;
+};
+
+const isAssignmentFor = ({
+	line,
+	key,
+}: {
+	line: string;
+	key: string;
+}): boolean => line.trimStart().startsWith(`${key}=`);
+
+/** Rewrites keys in place and appends the rest; every other line survives. */
+export const upsertEnvContent = ({
+	content,
+	values,
+}: {
+	content: string;
+	values: Record<string, string>;
+}): string => {
+	const trimmed = content.endsWith("\n") ? content.slice(0, -1) : content;
+	const lines = trimmed === "" ? [] : trimmed.split("\n");
+
+	for (const [key, value] of Object.entries(values)) {
+		const index = lines.findIndex((line) => isAssignmentFor({ line, key }));
+		if (index === -1) lines.push(`${key}=${value}`);
+		else lines[index] = `${key}=${value}`;
+	}
+
+	return `${lines.join("\n")}\n`;
+};
+
+export const writeEnvValues = ({
+	dirs,
+	values,
+}: {
+	dirs: string[];
+	values: Record<string, string>;
+}): string => {
+	const path = findEnvFile({ dirs }) ?? join(dirs[0] ?? process.cwd(), ".env");
+	const content = existsSync(path) ? readFileSync(path, "utf8") : "";
+
+	writeFileSync(path, upsertEnvContent({ content, values }));
+	return path;
+};

--- a/packages/atmn-nightly/src/env/resolveTarget.ts
+++ b/packages/atmn-nightly/src/env/resolveTarget.ts
@@ -17,10 +17,11 @@ export type Target = {
 /**
  * Where to send, and which key to send it with.
  *
- * Precedence is flags, then `AUTUMN_BASE_URL`, then the spec's server. The env
- * var exists so a directory can pin itself to a local server through its own
- * `.env` — otherwise the safe target is the one you have to remember, and the
- * default is production.
+ * The most specific target wins: `--base-url`, then `--local`/`--port`, then
+ * `AUTUMN_BASE_URL`, then the spec's server. Ranking rather than refusing
+ * means a scripted `-l` can be overridden by an ad-hoc `-b` without editing
+ * the script. The env var exists so a directory can pin itself to a local
+ * server through its own `.env` — the default is production.
  */
 export const resolveTarget = ({
 	prod,
@@ -28,17 +29,11 @@ export const resolveTarget = ({
 	port,
 	baseUrl,
 }: TargetFlags): Target => {
-	if (baseUrl && local) {
-		throw new Error("Pass either --base-url or --local, not both.");
-	}
-	if (port && !local) {
-		throw new Error("--port only applies with --local.");
-	}
-
 	const secretKeyName = prod ? "AUTUMN_PROD_SECRET_KEY" : "AUTUMN_SECRET_KEY";
 
 	if (baseUrl) return { baseUrl, secretKeyName };
-	if (local) {
+	// A port implies the host: `--port 3001` alone is a local target.
+	if (local || port) {
 		return {
 			baseUrl: `${LOCAL_HOST}:${port ?? DEFAULT_LOCAL_PORT}`,
 			secretKeyName,

--- a/packages/atmn-nightly/src/env/resolveTarget.ts
+++ b/packages/atmn-nightly/src/env/resolveTarget.ts
@@ -15,9 +15,12 @@ export type Target = {
 };
 
 /**
- * Where to send, and which key to send it with. `--base-url` wins outright;
- * `--local` is the shorthand everyone actually types, with `--port` for a
- * non-default local server. Long-only for port, since `-p` belongs to prod.
+ * Where to send, and which key to send it with.
+ *
+ * Precedence is flags, then `AUTUMN_BASE_URL`, then the spec's server. The env
+ * var exists so a directory can pin itself to a local server through its own
+ * `.env` — otherwise the safe target is the one you have to remember, and the
+ * default is production.
  */
 export const resolveTarget = ({
 	prod,
@@ -41,7 +44,9 @@ export const resolveTarget = ({
 			secretKeyName,
 		};
 	}
-	return { secretKeyName };
+
+	const fromEnv = process.env.AUTUMN_BASE_URL;
+	return fromEnv ? { baseUrl: fromEnv, secretKeyName } : { secretKeyName };
 };
 
 export const requireSecretKey = ({ target }: { target: Target }): string => {

--- a/packages/atmn-nightly/src/env/resolveTarget.ts
+++ b/packages/atmn-nightly/src/env/resolveTarget.ts
@@ -1,0 +1,55 @@
+const LOCAL_HOST = "http://localhost";
+const DEFAULT_LOCAL_PORT = 8080;
+
+export type TargetFlags = {
+	prod?: boolean;
+	local?: boolean;
+	port?: string;
+	baseUrl?: string;
+};
+
+export type Target = {
+	/** Undefined means the generated client's default (the spec's server). */
+	baseUrl?: string;
+	secretKeyName: "AUTUMN_SECRET_KEY" | "AUTUMN_PROD_SECRET_KEY";
+};
+
+/**
+ * Where to send, and which key to send it with. `--base-url` wins outright;
+ * `--local` is the shorthand everyone actually types, with `--port` for a
+ * non-default local server. Long-only for port, since `-p` belongs to prod.
+ */
+export const resolveTarget = ({
+	prod,
+	local,
+	port,
+	baseUrl,
+}: TargetFlags): Target => {
+	if (baseUrl && local) {
+		throw new Error("Pass either --base-url or --local, not both.");
+	}
+	if (port && !local) {
+		throw new Error("--port only applies with --local.");
+	}
+
+	const secretKeyName = prod ? "AUTUMN_PROD_SECRET_KEY" : "AUTUMN_SECRET_KEY";
+
+	if (baseUrl) return { baseUrl, secretKeyName };
+	if (local) {
+		return {
+			baseUrl: `${LOCAL_HOST}:${port ?? DEFAULT_LOCAL_PORT}`,
+			secretKeyName,
+		};
+	}
+	return { secretKeyName };
+};
+
+export const requireSecretKey = ({ target }: { target: Target }): string => {
+	const key = process.env[target.secretKeyName];
+	if (!key) {
+		throw new Error(
+			`${target.secretKeyName} is not set. Put it in your .env, or export it before running.`,
+		);
+	}
+	return key;
+};

--- a/packages/atmn-nightly/src/render/renderPreview.ts
+++ b/packages/atmn-nightly/src/render/renderPreview.ts
@@ -13,8 +13,10 @@ type PreviewChange = {
 	name?: string;
 };
 
-type FeatureChange = PreviewChange & { feature_id?: string };
-type PlanChange = PreviewChange & { plan_id?: string; version?: number };
+// Fixture casing, not wire: the client recases every response on the way in,
+// so this renders `featureId`, never `feature_id`.
+type FeatureChange = PreviewChange & { featureId?: string };
+type PlanChange = PreviewChange & { planId?: string; version?: number };
 
 export type CatalogPreview = {
 	features?: FeatureChange[];
@@ -29,11 +31,13 @@ const MARKERS: Record<
 	create: { symbol: "+", paint: chalk.green },
 	update: { symbol: "~", paint: chalk.yellow },
 	delete: { symbol: "-", paint: chalk.red },
-	skip: { symbol: "=", paint: chalk.dim },
 };
 
+/** The spec's enum is create | update | delete | skip | none. */
+const APPLIED_ACTIONS = new Set(["create", "update", "delete"]);
+
 const marker = (action: ChangeAction | undefined) =>
-	MARKERS[action ?? "skip"] ?? { symbol: "?", paint: chalk.dim };
+	MARKERS[action ?? ""] ?? { symbol: "?", paint: chalk.dim };
 
 const line = ({
 	action,
@@ -49,9 +53,13 @@ const line = ({
 	return `  ${paint(`${symbol} ${id}`)}${suffix}`;
 };
 
-/** Anything that is not a no-op — what the user is actually being told. */
+/**
+ * Positive on purpose: listing what counts as a change means a no-op value
+ * added to the enum later reads as "nothing to do" rather than leaking into
+ * the output as an unknown marker.
+ */
 const isChange = (change: PreviewChange): boolean =>
-	change.action !== undefined && change.action !== "skip";
+	change.action !== undefined && APPLIED_ACTIONS.has(change.action);
 
 export const renderPreview = ({
 	preview,
@@ -78,7 +86,7 @@ export const renderPreview = ({
 				...features.map((feature) =>
 					line({
 						action: feature.action,
-						id: feature.feature_id ?? "?",
+						id: feature.featureId ?? "?",
 						label: feature.name,
 					}),
 				),
@@ -95,8 +103,8 @@ export const renderPreview = ({
 						action: plan.action,
 						id:
 							plan.version === undefined
-								? (plan.plan_id ?? "?")
-								: `${plan.plan_id}@v${plan.version}`,
+								? (plan.planId ?? "?")
+								: `${plan.planId}@v${plan.version}`,
 						label: plan.name,
 					}),
 				),

--- a/packages/atmn-nightly/src/render/renderPreview.ts
+++ b/packages/atmn-nightly/src/render/renderPreview.ts
@@ -1,0 +1,132 @@
+import chalk from "chalk";
+
+/**
+ * Headless rendering only, for now — the shape a CI log or a piped terminal
+ * wants. The interactive view comes later and reads the same fields; nothing
+ * here computes anything, it only reports what preview returned.
+ */
+
+type ChangeAction = "create" | "update" | "delete" | "skip" | string;
+
+type PreviewChange = {
+	action?: ChangeAction;
+	name?: string;
+};
+
+type FeatureChange = PreviewChange & { feature_id?: string };
+type PlanChange = PreviewChange & { plan_id?: string; version?: number };
+
+export type CatalogPreview = {
+	features?: FeatureChange[];
+	plans?: PlanChange[];
+	migrations?: { id?: string }[];
+};
+
+const MARKERS: Record<
+	string,
+	{ symbol: string; paint: (s: string) => string }
+> = {
+	create: { symbol: "+", paint: chalk.green },
+	update: { symbol: "~", paint: chalk.yellow },
+	delete: { symbol: "-", paint: chalk.red },
+	skip: { symbol: "=", paint: chalk.dim },
+};
+
+const marker = (action: ChangeAction | undefined) =>
+	MARKERS[action ?? "skip"] ?? { symbol: "?", paint: chalk.dim };
+
+const line = ({
+	action,
+	id,
+	label,
+}: {
+	action: ChangeAction | undefined;
+	id: string;
+	label?: string;
+}): string => {
+	const { symbol, paint } = marker(action);
+	const suffix = label && label !== id ? chalk.dim(`  ${label}`) : "";
+	return `  ${paint(`${symbol} ${id}`)}${suffix}`;
+};
+
+/** Anything that is not a no-op — what the user is actually being told. */
+const isChange = (change: PreviewChange): boolean =>
+	change.action !== undefined && change.action !== "skip";
+
+export const renderPreview = ({
+	preview,
+	migrationLinkBase,
+}: {
+	preview: CatalogPreview;
+	/** Omitted in tests; the dashboard origin in real runs. */
+	migrationLinkBase?: string;
+}): string => {
+	const features = (preview.features ?? []).filter(isChange);
+	const plans = (preview.plans ?? []).filter(isChange);
+	const migrations = preview.migrations ?? [];
+
+	if (features.length === 0 && plans.length === 0) {
+		return chalk.dim("No changes. Your catalog matches your config.");
+	}
+
+	const sections: string[] = [];
+
+	if (features.length > 0) {
+		sections.push(
+			[
+				chalk.bold(`Features (${features.length})`),
+				...features.map((feature) =>
+					line({
+						action: feature.action,
+						id: feature.feature_id ?? "?",
+						label: feature.name,
+					}),
+				),
+			].join("\n"),
+		);
+	}
+
+	if (plans.length > 0) {
+		sections.push(
+			[
+				chalk.bold(`Plans (${plans.length})`),
+				...plans.map((plan) =>
+					line({
+						action: plan.action,
+						id:
+							plan.version === undefined
+								? (plan.plan_id ?? "?")
+								: `${plan.plan_id}@v${plan.version}`,
+						label: plan.name,
+					}),
+				),
+			].join("\n"),
+		);
+	}
+
+	if (migrations.length > 0) {
+		// Draft migrations are the server telling you customers need moving. The
+		// push still applies; these are run later, deliberately.
+		sections.push(
+			[
+				chalk.bold(`Draft migrations (${migrations.length})`),
+				...migrations.map((migration) =>
+					migrationLinkBase
+						? `  ${chalk.cyan(`${migrationLinkBase}/migrations/${migration.id}`)}`
+						: `  ${chalk.cyan(migration.id ?? "?")}`,
+				),
+			].join("\n"),
+		);
+	}
+
+	return sections.join("\n\n");
+};
+
+/** True when there is nothing to apply — lets push skip the write entirely. */
+export const previewIsEmpty = ({
+	preview,
+}: {
+	preview: CatalogPreview;
+}): boolean =>
+	(preview.features ?? []).filter(isChange).length === 0 &&
+	(preview.plans ?? []).filter(isChange).length === 0;

--- a/packages/atmn-nightly/test/authorizationUrl.test.ts
+++ b/packages/atmn-nightly/test/authorizationUrl.test.ts
@@ -1,0 +1,45 @@
+/** The URL is the whole contract with the authorization server. */
+
+import { expect, test } from "bun:test";
+import {
+	buildAuthorizationUrl,
+	createOAuthClient,
+} from "../src/auth/buildAuthorizationUrl";
+import { CLI_OAUTH_SCOPES, OAUTH_PORTS } from "../src/auth/oauthConfig";
+
+const buildUrl = ({ port }: { port: number }): URL =>
+	buildAuthorizationUrl({
+		client: createOAuthClient({ clientId: "cli_client", port }),
+		backendUrl: "http://localhost:8080",
+		scopes: CLI_OAUTH_SCOPES,
+		state: "state_value",
+		codeVerifier: "verifier_value",
+	});
+
+test("asks for PKCE against the backend's authorize endpoint", () => {
+	const url = buildUrl({ port: OAUTH_PORTS[0] });
+
+	expect(url.origin + url.pathname).toBe(
+		"http://localhost:8080/api/auth/oauth2/authorize",
+	);
+	expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+	expect(url.searchParams.get("code_challenge")).toBeTruthy();
+	expect(url.searchParams.get("state")).toBe("state_value");
+	// The verifier is the secret half — it must never leave the process.
+	expect(url.search).not.toContain("verifier_value");
+});
+
+test("redirects to the loopback port the callback server is on", () => {
+	expect(buildUrl({ port: 31450 }).searchParams.get("redirect_uri")).toBe(
+		"http://localhost:31450/",
+	);
+});
+
+test("requests modern read/write scopes and forces the org picker", () => {
+	const url = buildUrl({ port: OAUTH_PORTS[0] });
+
+	expect(url.searchParams.get("scope")?.split(" ")).toEqual([
+		...CLI_OAUTH_SCOPES,
+	]);
+	expect(url.searchParams.get("prompt")).toBe("consent");
+});

--- a/packages/atmn-nightly/test/envWriter.test.ts
+++ b/packages/atmn-nightly/test/envWriter.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The writer has to agree with `loadEnvFiles` about where keys live, and it has
+ * to leave every line it did not put there alone.
+ */
+
+import { afterEach, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { upsertEnvContent, writeEnvValues } from "../src/env/loadEnv";
+
+const temporaryDirs: string[] = [];
+
+const makeDir = (): string => {
+	const dir = mkdtempSync(join(tmpdir(), "atmn-env-"));
+	temporaryDirs.push(dir);
+	return dir;
+};
+
+afterEach(() => {
+	for (const dir of temporaryDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("an existing key is updated in place, keeping its position", () => {
+	const content = upsertEnvContent({
+		content: "A=1\nAUTUMN_SECRET_KEY=old\nB=2\n",
+		values: { AUTUMN_SECRET_KEY: "new" },
+	});
+
+	expect(content).toBe("A=1\nAUTUMN_SECRET_KEY=new\nB=2\n");
+});
+
+test("unrelated lines survive, comments and blanks included", () => {
+	const content = upsertEnvContent({
+		content:
+			"# billing\nDATABASE_URL=postgres://x\n\n#AUTUMN_SECRET_KEY=commented\n",
+		values: { AUTUMN_SECRET_KEY: "new" },
+	});
+
+	expect(content).toBe(
+		"# billing\nDATABASE_URL=postgres://x\n\n#AUTUMN_SECRET_KEY=commented\nAUTUMN_SECRET_KEY=new\n",
+	);
+});
+
+test("a key that only shares a prefix is not mistaken for the key", () => {
+	const content = upsertEnvContent({
+		content: "AUTUMN_SECRET_KEY_OLD=keep\n",
+		values: { AUTUMN_SECRET_KEY: "new" },
+	});
+
+	expect(content).toBe("AUTUMN_SECRET_KEY_OLD=keep\nAUTUMN_SECRET_KEY=new\n");
+});
+
+test("an empty file gets the keys without a leading blank line", () => {
+	expect(upsertEnvContent({ content: "", values: { A: "1", B: "2" } })).toBe(
+		"A=1\nB=2\n",
+	);
+});
+
+test(".env.local wins when both files exist", () => {
+	const dir = makeDir();
+	writeFileSync(join(dir, ".env"), "AUTUMN_SECRET_KEY=from_env\n");
+	writeFileSync(join(dir, ".env.local"), "AUTUMN_SECRET_KEY=from_env_local\n");
+
+	const path = writeEnvValues({
+		dirs: [dir],
+		values: { AUTUMN_SECRET_KEY: "new" },
+	});
+
+	expect(path).toBe(join(dir, ".env.local"));
+	expect(readFileSync(join(dir, ".env.local"), "utf8")).toBe(
+		"AUTUMN_SECRET_KEY=new\n",
+	);
+	// The lower-precedence file is left exactly as it was.
+	expect(readFileSync(join(dir, ".env"), "utf8")).toBe(
+		"AUTUMN_SECRET_KEY=from_env\n",
+	);
+});
+
+test("an env file further up the search path is preferred over a new one", () => {
+	const repoRoot = makeDir();
+	const packageDir = join(repoRoot, "package");
+	writeFileSync(join(repoRoot, ".env"), "A=1\n");
+
+	const path = writeEnvValues({
+		dirs: [packageDir, repoRoot],
+		values: { AUTUMN_SECRET_KEY: "new" },
+	});
+
+	expect(path).toBe(join(repoRoot, ".env"));
+});
+
+test("with no env file anywhere, .env is created in the first directory", () => {
+	const dir = makeDir();
+
+	const path = writeEnvValues({
+		dirs: [dir],
+		values: { AUTUMN_SECRET_KEY: "new" },
+	});
+
+	expect(path).toBe(join(dir, ".env"));
+	expect(readFileSync(path, "utf8")).toBe("AUTUMN_SECRET_KEY=new\n");
+});

--- a/packages/atmn-nightly/test/login.test.ts
+++ b/packages/atmn-nightly/test/login.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Login never touches the network here: the OAuth flow and the key-minting call
+ * are injected. What is under test is the part v2 got wrong — deciding whether
+ * a browser exists by trying to open one, not by looking at `isTTY`.
+ */
+
+import { afterEach, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	type Authorize,
+	type CreateApiKeys,
+	type LoginOptions,
+	runLogin,
+} from "../src/actions/login";
+import type { BrowserOpener } from "../src/auth/types/browserOpener";
+
+const AUTHORIZATION_URL =
+	"https://api.useautumn.com/api/auth/oauth2/authorize?client_id=cli&state=abc";
+
+const temporaryDirs: string[] = [];
+
+const makeProjectDir = (): string => {
+	const dir = mkdtempSync(join(tmpdir(), "atmn-login-"));
+	temporaryDirs.push(dir);
+	return dir;
+};
+
+afterEach(() => {
+	for (const dir of temporaryDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+const authorizeWithFakeTokens: Authorize = async ({ onAuthorizationUrl }) => {
+	await onAuthorizationUrl({ url: AUTHORIZATION_URL });
+	return { accessToken: "oauth_access_token", tokenType: "Bearer" };
+};
+
+const createFakeApiKeys: CreateApiKeys = async () => ({
+	sandboxKey: "am_sk_test_new",
+	prodKey: "am_sk_live_new",
+	orgId: "org_123",
+});
+
+const openerThatWorks: BrowserOpener = async () => {
+	// Resolving is what "a browser opened" means.
+};
+
+const openerThatThrows: BrowserOpener = async () => {
+	throw new Error("spawn xdg-open ENOENT");
+};
+
+const loginInto = ({
+	cwd,
+	openBrowser,
+}: {
+	cwd: string;
+	openBrowser: BrowserOpener;
+}): Promise<{ output: string; envPath: string }> => {
+	let output = "";
+	const options: LoginOptions = {
+		cwd,
+		openBrowser,
+		write: (text) => {
+			output += text;
+		},
+		authorize: authorizeWithFakeTokens,
+		createApiKeys: createFakeApiKeys,
+	};
+	return runLogin(options).then((result) => ({
+		output,
+		envPath: result.envPath,
+	}));
+};
+
+test("prints the authorization URL even when the browser opens", async () => {
+	// Copyable on a machine that is not the one running the CLI.
+	const { output } = await loginInto({
+		cwd: makeProjectDir(),
+		openBrowser: openerThatWorks,
+	});
+
+	expect(output).toContain(AUTHORIZATION_URL);
+	expect(output).toContain("Opened your browser");
+});
+
+test("a throwing opener means headless: the flow prints the URL and continues", async () => {
+	const cwd = makeProjectDir();
+
+	const { output, envPath } = await loginInto({
+		cwd,
+		openBrowser: openerThatThrows,
+	});
+
+	expect(output).toContain(AUTHORIZATION_URL);
+	expect(output).toContain("No browser could be opened here");
+	// Continuing is the point: a failed open is not a failed login.
+	expect(envPath).toBe(join(cwd, ".env"));
+	expect(readFileSync(envPath, "utf8")).toContain(
+		"AUTUMN_SECRET_KEY=am_sk_test_new",
+	);
+});
+
+test("a TTY does not make the CLI claim a browser opened", async () => {
+	const originalIsTTY = process.stdout.isTTY;
+	process.stdout.isTTY = true;
+
+	try {
+		const { output } = await loginInto({
+			cwd: makeProjectDir(),
+			openBrowser: openerThatThrows,
+		});
+		expect(output).toContain("No browser could be opened here");
+	} finally {
+		process.stdout.isTTY = originalIsTTY;
+	}
+});
+
+test("no TTY does not make the CLI skip a browser that works", async () => {
+	const originalIsTTY = process.stdout.isTTY;
+	process.stdout.isTTY = false;
+
+	try {
+		const { output } = await loginInto({
+			cwd: makeProjectDir(),
+			openBrowser: openerThatWorks,
+		});
+		expect(output).toContain("Opened your browser");
+	} finally {
+		process.stdout.isTTY = originalIsTTY;
+	}
+});
+
+test("keys go into the existing env file, leaving the rest of it alone", async () => {
+	const cwd = makeProjectDir();
+	writeFileSync(join(cwd, ".env"), "DATABASE_URL=postgres://local\n");
+
+	const { envPath } = await loginInto({ cwd, openBrowser: openerThatWorks });
+
+	expect(readFileSync(envPath, "utf8")).toBe(
+		[
+			"DATABASE_URL=postgres://local",
+			"AUTUMN_SECRET_KEY=am_sk_test_new",
+			"AUTUMN_PROD_SECRET_KEY=am_sk_live_new",
+			"",
+		].join("\n"),
+	);
+});
+
+test("a login that mints no keys fails loudly rather than writing nothing", async () => {
+	const attempt = runLogin({
+		cwd: makeProjectDir(),
+		openBrowser: openerThatWorks,
+		write: () => {},
+		authorize: authorizeWithFakeTokens,
+		createApiKeys: async () => ({ orgId: "org_123" }),
+	});
+
+	await expect(attempt).rejects.toThrow(/no API keys/);
+});

--- a/packages/atmn-nightly/test/resolveTarget.test.ts
+++ b/packages/atmn-nightly/test/resolveTarget.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Which server, and which key. Small enough to be obvious, and worth pinning
+ * because getting it wrong means pushing a sandbox config at production.
+ */
+
+import { expect, test } from "bun:test";
+import { requireSecretKey, resolveTarget } from "../src/env/resolveTarget";
+
+test("defaults to sandbox and the spec's server", () => {
+	expect(resolveTarget({})).toEqual({ secretKeyName: "AUTUMN_SECRET_KEY" });
+});
+
+test("--prod only swaps the key, never the URL", () => {
+	// The spec's server is production; --prod is about which key authenticates.
+	expect(resolveTarget({ prod: true })).toEqual({
+		secretKeyName: "AUTUMN_PROD_SECRET_KEY",
+	});
+});
+
+test("--local targets 8080, --port overrides it", () => {
+	expect(resolveTarget({ local: true }).baseUrl).toBe("http://localhost:8080");
+	expect(resolveTarget({ local: true, port: "3001" }).baseUrl).toBe(
+		"http://localhost:3001",
+	);
+});
+
+test("--base-url wins outright", () => {
+	expect(
+		resolveTarget({ baseUrl: "https://staging.example.com" }).baseUrl,
+	).toBe("https://staging.example.com");
+});
+
+test("--local and --prod compose: local server, prod key", () => {
+	expect(resolveTarget({ local: true, prod: true })).toEqual({
+		baseUrl: "http://localhost:8080",
+		secretKeyName: "AUTUMN_PROD_SECRET_KEY",
+	});
+});
+
+test("contradictory targets are refused, not silently ranked", () => {
+	expect(() =>
+		resolveTarget({ local: true, baseUrl: "https://example.com" }),
+	).toThrow(/either --base-url or --local/);
+	expect(() => resolveTarget({ port: "3001" })).toThrow(/only applies with/);
+});
+
+test("a missing key names the variable it wants", () => {
+	const previous = process.env.AUTUMN_SECRET_KEY;
+	delete process.env.AUTUMN_SECRET_KEY;
+	try {
+		expect(() => requireSecretKey({ target: resolveTarget({}) })).toThrow(
+			/AUTUMN_SECRET_KEY is not set/,
+		);
+	} finally {
+		if (previous !== undefined) process.env.AUTUMN_SECRET_KEY = previous;
+	}
+});

--- a/packages/atmn-nightly/test/resolveTarget.test.ts
+++ b/packages/atmn-nightly/test/resolveTarget.test.ts
@@ -37,11 +37,32 @@ test("--local and --prod compose: local server, prod key", () => {
 	});
 });
 
-test("contradictory targets are refused, not silently ranked", () => {
-	expect(() =>
-		resolveTarget({ local: true, baseUrl: "https://example.com" }),
-	).toThrow(/either --base-url or --local/);
-	expect(() => resolveTarget({ port: "3001" })).toThrow(/only applies with/);
+test("the most specific target wins: base-url over local over port", () => {
+	// A URL is more specific than a host, which is more specific than a port;
+	// refusing the combination made a scripted `-l` plus an ad-hoc `-b` a
+	// two-step edit instead of an override.
+	expect(
+		resolveTarget({ local: true, baseUrl: "https://example.com" }).baseUrl,
+	).toBe("https://example.com");
+	expect(
+		resolveTarget({ port: "3001", baseUrl: "https://example.com" }).baseUrl,
+	).toBe("https://example.com");
+	// --port alone is a local target: the port implies the host.
+	expect(resolveTarget({ port: "3001" }).baseUrl).toBe("http://localhost:3001");
+});
+
+test("flags beat AUTUMN_BASE_URL, which beats the spec's server", () => {
+	const previous = process.env.AUTUMN_BASE_URL;
+	process.env.AUTUMN_BASE_URL = "http://localhost:11380";
+	try {
+		expect(resolveTarget({}).baseUrl).toBe("http://localhost:11380");
+		expect(resolveTarget({ local: true }).baseUrl).toBe(
+			"http://localhost:8080",
+		);
+	} finally {
+		if (previous === undefined) delete process.env.AUTUMN_BASE_URL;
+		else process.env.AUTUMN_BASE_URL = previous;
+	}
 });
 
 test("a missing key names the variable it wants", () => {

--- a/packages/atmn-nightly/test/watchLauncher.test.ts
+++ b/packages/atmn-nightly/test/watchLauncher.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The behavioural half of headless detection. Every case here is one a TTY
+ * check gets wrong: a container, an SSH session and CI all have terminals.
+ */
+
+import { expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { watchLauncher } from "../src/auth/browser/watchLauncher";
+
+const SETTLE_MS = 20;
+
+const launcherThat = ({
+	emit,
+}: {
+	emit: (launcher: EventEmitter) => void;
+}): EventEmitter => {
+	const launcher = new EventEmitter();
+	setTimeout(() => emit(launcher), 1);
+	return launcher;
+};
+
+test("a launcher that exits cleanly opened a browser", async () => {
+	const launcher = launcherThat({
+		emit: (emitter) => emitter.emit("close", 0),
+	});
+
+	await expect(
+		watchLauncher({ launcher, settleMs: SETTLE_MS }),
+	).resolves.toBeUndefined();
+});
+
+test("a launcher that exits non-zero opened nothing", async () => {
+	// xdg-open with no display exits 3, whatever the terminal looks like.
+	const launcher = launcherThat({
+		emit: (emitter) => emitter.emit("close", 3),
+	});
+
+	await expect(
+		watchLauncher({ launcher, settleMs: SETTLE_MS }),
+	).rejects.toThrow(/exited with code 3/);
+});
+
+test("a launcher that never spawned opened nothing", async () => {
+	const launcher = launcherThat({
+		emit: (emitter) =>
+			emitter.emit("error", new Error("spawn xdg-open ENOENT")),
+	});
+
+	await expect(
+		watchLauncher({ launcher, settleMs: SETTLE_MS }),
+	).rejects.toThrow(/ENOENT/);
+});
+
+test("a launcher still running after the settle window counts as opened", async () => {
+	// Some openers stay resident for the life of the browser they launched.
+	const launcher = new EventEmitter();
+
+	await expect(
+		watchLauncher({ launcher, settleMs: SETTLE_MS }),
+	).resolves.toBeUndefined();
+});

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveFeaturesPlan/resolveAbsenteeFeatureIds.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveFeaturesPlan/resolveAbsenteeFeatureIds.ts
@@ -14,30 +14,16 @@ const statedFeatureIds = ({
 	]);
 
 /**
- * Refuses to read an empty payload as "delete every feature", for the same
- * reason the plan side does: a config that failed to load looks identical to
- * one that means it.
- */
-const assertNotAWipe = ({
-	params,
-	absentFeatureIds,
-}: {
-	params: UpdateCatalogParams;
-	absentFeatureIds: string[];
-}): void => {
-	if ((params.features ?? []).length > 0 || absentFeatureIds.length === 0)
-		return;
-	throw new RecaseError({
-		code: ErrCode.InvalidRequest,
-		message: `skip_deletions: false with no features would remove all ${absentFeatureIds.length} features. State the features you want, or pass them in skip_feature_ids.`,
-		statusCode: 400,
-	});
-};
-
-/**
  * Under full state a feature the org holds but the config never mentions is a
  * removal asked for by omission — the same rule plans follow. Archived
  * features are already off the config's surface, so they are not re-proposed.
+ *
+ * `features: []` is a removal of everything, and is allowed. It used to be
+ * refused as a suspected truncated payload, but that guard predates absent
+ * meaning "not mine": a payload that failed to state features now returns above
+ * this line, so the only thing left to block was the one case where the caller
+ * plainly said it. Refusing it also came out of `preview_update`, which meant
+ * you could not preview your way to seeing the deletions.
  */
 export const resolveAbsenteeFeatureIds = ({
 	ctx,
@@ -52,10 +38,7 @@ export const resolveAbsenteeFeatureIds = ({
 	if (params.features === undefined) return [];
 
 	const stated = statedFeatureIds({ params });
-	const absent = ctx.features
+	return ctx.features
 		.filter((feature) => !stated.has(feature.id) && !feature.archived)
 		.map((feature) => feature.id);
-
-	assertNotAWipe({ params, absentFeatureIds: absent });
-	return absent;
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveProductsPlan/resolveAbsenteePlanTargets.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveProductsPlan/resolveAbsenteePlanTargets.ts
@@ -23,32 +23,14 @@ const statedPlanIds = ({
 	]);
 
 /**
- * Refuses to read an empty payload as "delete everything".
- *
- * A config that failed to load, or a first run pointed at the wrong
- * environment, both arrive as zero plans. Wiping a live catalog is not a
- * recoverable mistake, so this is the one place full state declines to act on
- * what it was literally told.
- */
-const assertNotAWipe = ({
-	params,
-	absentPlanIds,
-}: {
-	params: UpdateCatalogParams;
-	absentPlanIds: string[];
-}): void => {
-	if ((params.plans ?? []).length > 0 || absentPlanIds.length === 0) return;
-	throw new RecaseError({
-		code: ErrCode.InvalidRequest,
-		message: `skip_deletions: false with no plans would remove all ${absentPlanIds.length} plans in the catalog. State the plans you want, or pass them in skip_plan_ids.`,
-		statusCode: 400,
-	});
-};
-
-/**
  * Under full state, a plan the catalog holds but the payload never mentions is
  * a removal the caller is asking for by omission. Archived rows are already
  * out of the catalog's live surface, so they are not re-proposed.
+ *
+ * `plans: []` removes everything, and is allowed — see the note on the feature
+ * side. The guard that used to refuse it predates absent meaning "not mine",
+ * and it fired from `preview_update`, so it blocked seeing the deletions as
+ * well as doing them.
  */
 export const resolveAbsenteePlanTargets = ({
 	params,
@@ -69,8 +51,6 @@ export const resolveAbsenteePlanTargets = ({
 		([planId, versions]) =>
 			!stated.has(planId) && versions.some((product) => !product.archived),
 	);
-
-	assertNotAWipe({ params, absentPlanIds: absent.map(([planId]) => planId) });
 
 	return absent.flatMap(([planId, versions]) =>
 		versions

--- a/server/tests/integration/atmn/push-features.test.ts
+++ b/server/tests/integration/atmn/push-features.test.ts
@@ -1,0 +1,134 @@
+/**
+ * atmn push — a config file becomes a catalog.
+ *
+ * This is the first test of the whole thesis: a TypeScript config with
+ * camelCase fixtures, executed in process, recased to the wire, previewed, then
+ * applied — with the CLI deciding nothing along the way.
+ *
+ * It asserts the config that went in and the catalog that came out. Nothing
+ * about rendering, because the rendering is a report rather than a decision.
+ *
+ * Contract:
+ *   P1  a config with features creates them
+ *   P2  preview reports the same changes update then applies
+ *   P3  --dry-run previews and writes nothing
+ *   P4  re-pushing an unchanged config is a no-op
+ *   P5  removing a feature from the config removes it from the catalog
+ */
+
+import { expect, test } from "bun:test";
+import {
+	atmnConfigSource,
+	initAtmnScenario,
+} from "@tests/utils/atmnUtils/initAtmnScenario.js";
+import { s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import { uniqueTestId } from "../catalog-v2/utils/uniqueTestId.js";
+
+const liveFeatureIds = async ({
+	ctx,
+}: {
+	ctx: AutumnContext;
+}): Promise<string[]> => {
+	const features = await FeatureService.list({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+	return features
+		.filter((feature) => !feature.archived)
+		.map((feature) => feature.id)
+		.sort();
+};
+
+test.concurrent(
+	`${chalk.yellowBright("atmn push: a config file becomes a catalog")}`,
+	async () => {
+		const messages = uniqueTestId("atmn_messages");
+		const seats = uniqueTestId("atmn_seats");
+
+		const scenario = await initAtmnScenario({
+			setup: [
+				s.platform.create({ userEmail: `${uniqueTestId("atmn")}@autumn.test` }),
+			],
+			config: `{ features: [
+				feature({ featureId: "${messages}", name: "Messages", type: "metered", consumable: true }),
+				feature({ featureId: "${seats}", name: "Seats", type: "metered" }),
+			] }`,
+		});
+
+		try {
+			// P3: a dry run reports, then stops.
+			const dry = await scenario.push({ dryRun: true });
+			expect(dry.output).toContain(messages);
+			expect(dry.output).toContain("Dry run");
+			expect(await liveFeatureIds({ ctx: scenario.ctx })).toEqual([]);
+
+			// P1 + P2: the same document previews and applies.
+			const applied = await scenario.push();
+			expect(applied.output).toContain("Applied.");
+			expect(await liveFeatureIds({ ctx: scenario.ctx })).toEqual(
+				[messages, seats].sort(),
+			);
+
+			// P4: nothing left to do, so preview reports nothing and update is skipped.
+			const again = await scenario.push();
+			expect(again.output).toContain("No changes");
+
+			// P5: omission is a removal — the payload is the whole catalog.
+			scenario.writeConfig(
+				atmnConfigSource({
+					body: `{ features: [
+						feature({ featureId: "${messages}", name: "Messages", type: "metered", consumable: true }),
+					] }`,
+				}),
+			);
+			await scenario.push();
+			expect(await liveFeatureIds({ ctx: scenario.ctx })).toEqual([messages]);
+		} finally {
+			scenario.cleanup();
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("atmn push: the config's wire document is what reaches the server")}`,
+	async () => {
+		const featureId = uniqueTestId("atmn_wire");
+
+		const scenario = await initAtmnScenario({
+			setup: [
+				s.platform.create({ userEmail: `${uniqueTestId("atmn")}@autumn.test` }),
+			],
+			config: `{ features: [
+				feature({ featureId: "${featureId}", name: "Wire", type: "metered" }),
+			] }`,
+		});
+
+		try {
+			const wire = await scenario.wireFromConfig();
+
+			// The CLI states the payload is the whole catalog, and asks for drafts
+			// wherever the server thinks one is warranted. Both are constants.
+			expect(wire.skip_deletions).toBe(false);
+			expect(wire.migration).toEqual({ draft: true });
+
+			// Fields the server owns must never appear.
+			for (const forbidden of ["versioning", "propagate", "new_plan_id"]) {
+				expect(wire[forbidden]).toBeUndefined();
+			}
+
+			// camelCase in the config, snake_case on the wire.
+			expect(wire.features).toEqual([
+				{ feature_id: featureId, name: "Wire", type: "metered" },
+			]);
+
+			await scenario.push();
+			expect(await liveFeatureIds({ ctx: scenario.ctx })).toEqual([featureId]);
+		} finally {
+			scenario.cleanup();
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/full-state/full-state-absent-collections.test.ts
+++ b/server/tests/integration/catalog-v2/plans/full-state/full-state-absent-collections.test.ts
@@ -17,8 +17,8 @@
  * Contract:
  *   G1  stating plans while omitting features leaves features alone
  *   G2  stating features while omitting plans leaves plans alone
- *   G3  an explicit empty array still means "I manage this and it is empty",
- *       so the wipe backstop still fires — omission and [] are not the same
+ *   G3  an explicit empty array means "I manage this and it is empty", so it
+ *       removes everything — omission and [] are not the same
  *
  * Red (current): the zod default turns an absent key into [], so the absentee
  *   sweep runs over the whole collection and G1/G2 delete.
@@ -137,19 +137,19 @@ test.concurrent(
 			plans: [],
 		});
 
-		// G3: stating `features: []` is a claim about features — "I manage them
-		// and there are none" — which is the wipe the backstop exists to refuse.
-		// If omission and [] were the same thing, this would pass silently.
-		const wipe = autumnV2_3.catalogV2.update({
+		// G3: stating `features: []` is a claim — "I manage them and there are
+		// none" — so it removes them. This is the assertion that proves omission
+		// and [] are different: the test above omits the key and the feature
+		// survives; here it is stated empty and the feature goes.
+		await autumnV2_3.catalogV2.update({
 			skip_deletions: false,
 			features: [],
 			plans: [],
 		});
-		await expect(wipe).rejects.toThrow();
 
 		expect(
 			await featureExists({ ctx, featureId }),
-			"stated-empty was refused, not applied",
-		).toBe(true);
+			"stated-empty removed the feature",
+		).toBe(false);
 	},
 );

--- a/server/tests/integration/catalog-v2/plans/full-state/full-state-removals.test.ts
+++ b/server/tests/integration/catalog-v2/plans/full-state/full-state-removals.test.ts
@@ -101,7 +101,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 full-state: an empty payload is refused rather than wiping the catalog")}`,
+	`${chalk.yellowBright("catalogV2 full-state: a stated empty collection removes everything in it")}`,
 	async () => {
 		// Full state speaks for the entire org catalog, so it needs an org of its
 		// own — in a shared one it would remove every concurrent test's plans.
@@ -123,17 +123,57 @@ test.concurrent(
 					plans: [{ plan_id: planId, name: "Survivor", items: [] }],
 				});
 
-				// C5: a config that failed to load looks exactly like this. Deleting
-				// a live catalog is not recoverable, so it is refused.
-				const wipe = autumnV2_3.catalogV2.update({
+				// C5: `plans: []` is a claim — "I manage plans and there are none".
+				// This was refused until 2026-09-03 on the theory that a config which
+				// failed to load looks the same. It does not any more: a payload that
+				// failed to state plans omits the key, and an omitted key returns
+				// before the sweep. Refusing it also fired from preview_update, so it
+				// blocked SEEING the deletions as well as doing them.
+				await autumnV2_3.catalogV2.update({
 					skip_deletions: false,
 					plans: [],
 				});
-				await expect(wipe).rejects.toThrow();
 
 				expect(
 					await planExists({ ctx, planId }),
-					"catalog survived the empty payload",
+					"a stated empty collection removed the plan",
+				).toBe(false);
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 full-state: an omitted collection is still untouchable")}`,
+	async () => {
+		// The protection that actually matters, and the one a client too old to
+		// know about a collection relies on: it sends no key, so nothing is swept.
+		const { autumnV2_3, ctx } = await initScenario({
+			setup: [
+				s.platform.create({
+					userEmail: `${uniqueTestId("fs")}@autumn.test`,
+				}),
+			],
+			actions: [],
+		});
+		const planId = uniqueTestId("cv2_fs_omitted");
+
+		await withCatalogPlans({
+			ctx,
+			planIds: [planId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: planId, name: "Untouched", items: [] }],
+				});
+
+				await autumnV2_3.catalogV2.update({
+					skip_deletions: false,
+					features: [],
+				});
+
+				expect(
+					await planExists({ ctx, planId }),
+					"plans were never mentioned, so they were never swept",
 				).toBe(true);
 			},
 		});

--- a/server/tests/utils/atmnUtils/initAtmnScenario.ts
+++ b/server/tests/utils/atmnUtils/initAtmnScenario.ts
@@ -1,0 +1,105 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import { generateId } from "@/utils/genUtils.js";
+// Relative rather than a package import: atmn-nightly publishes only its bin,
+// and exposing src through `exports` for a test's benefit would leak internals
+// into the published package.
+import { runPush } from "../../../../packages/atmn-nightly/src/actions/push";
+import { createClient } from "../../../../packages/atmn-nightly/src/generated/client";
+
+/**
+ * atmn e2e lives here rather than in the CLI package for one reason: this is
+ * where a fresh org and a working key are one line. Rebuilding sub-org
+ * provisioning inside atmn-nightly to avoid an import would be the tail wagging
+ * the dog.
+ *
+ * Configs are written to real files because that is what the CLI reads, and
+ * because pull's whole job is surgery on a file. They live under the workspace
+ * so `import from "atmn-nightly"` resolves, and are gitignored.
+ */
+
+const CLI_PACKAGE_DIR = join(
+	import.meta.dir,
+	"../../../../packages/atmn-nightly",
+);
+const TMP_ROOT = join(CLI_PACKAGE_DIR, "test/.tmp");
+
+type ScenarioSetup = Parameters<typeof initScenario>[0]["setup"];
+
+export type AtmnScenario = {
+	/** Directory holding autumn.config.ts — the CLI's cwd. */
+	cwd: string;
+	/** Rewrite the config between steps. */
+	writeConfig: (source: string) => void;
+	push: (options?: { dryRun?: boolean }) => Promise<{
+		output: string;
+		migrationIds: string[];
+	}>;
+	/** What the config currently evaluates to — the wire document. */
+	wireFromConfig: () => Promise<Record<string, unknown>>;
+	cleanup: () => void;
+};
+
+/**
+ * Source for a config that imports the generated builders by absolute path.
+ * Absolute because a temp dir deep under the package still resolves, and it
+ * keeps the fixture readable in the test.
+ */
+export const atmnConfigSource = ({ body }: { body: string }): string =>
+	`import { feature } from "${CLI_PACKAGE_DIR}/src/generated/features";
+import { atmn } from "${CLI_PACKAGE_DIR}/src/generated/wire";
+
+export default atmn(${body});
+`;
+
+export const initAtmnScenario = async ({
+	setup,
+	config,
+	baseUrl = process.env.AUTUMN_TEST_BASE_URL ?? "http://localhost:8080",
+}: {
+	setup: ScenarioSetup;
+	/** Body passed to `atmn({...})`, as source. */
+	config: string;
+	baseUrl?: string;
+}): Promise<AtmnScenario & Awaited<ReturnType<typeof initScenario>>> => {
+	const scenario = await initScenario({ setup, actions: [] });
+
+	const cwd = join(TMP_ROOT, generateId("atmn"));
+	mkdirSync(cwd, { recursive: true });
+
+	const configPath = join(cwd, "autumn.config.ts");
+	const writeConfig = (source: string): void => {
+		writeFileSync(configPath, source, "utf8");
+	};
+	writeConfig(atmnConfigSource({ body: config }));
+
+	const client = createClient({
+		secretKey: scenario.ctx.orgSecretKey,
+		baseUrl,
+	});
+
+	return {
+		...scenario,
+		cwd,
+		writeConfig,
+		push: async ({ dryRun = false } = {}) => {
+			let output = "";
+			const result = await runPush({
+				client,
+				cwd,
+				dryRun,
+				write: (text: string) => {
+					output += text;
+				},
+			});
+			return { output, migrationIds: result.migrationIds };
+		},
+		wireFromConfig: async () => {
+			// Cache-bust: the same path is rewritten between steps.
+			const module = await import(`${configPath}?v=${Date.now()}`);
+			return module.default as Record<string, unknown>;
+		},
+		cleanup: () => rmSync(cwd, { recursive: true, force: true }),
+	};
+};


### PR DESCRIPTION
`atmn push` works end to end: a TypeScript config becomes a catalog on a real server.

```
autumn.config.ts ──► atmn() ──► preview_update ──► render ──► update
                                                              └─► draft migration links
```

The CLI decides nothing. It sends the same document to both calls, which is what makes a clean preview a guarantee rather than a guess.

### What landed

- **`runPush`** — preview, render, apply. `client`, `cwd` and `write` are all injectable, which is what lets tests capture output without a subprocess. `--dry-run` stops after the preview; an empty preview skips the write entirely.
- **A headless renderer** — `+` create, `~` update, `-` delete, plus a draft-migrations section. Deliberately plain for now; the interactive view reads the same fields later.
- **`atmn-nightly push` wired for real**, reading `AUTUMN_SECRET_KEY`, or `AUTUMN_PROD_SECRET_KEY` under `--prod`.
- **An e2e harness** in `server/tests/utils/atmnUtils/`, and the first suite.

### Testing

E2E lives in `server/tests` for one reason: `s.platform.create()` already provisions a fresh sub-org and a working key, and `ctx.db` lets us assert on rows the API does not expose. Rebuilding sub-org provisioning inside `atmn-nightly` to avoid an import would be the tail wagging the dog.

```ts
const scenario = await initAtmnScenario({
  setup: [s.platform.create({ userEmail: … })],
  config: `{ features: [feature({ featureId: "…", name: "…", type: "metered" })] }`,
});
await scenario.push();
```

Configs are written to real files under `packages/atmn-nightly/test/.tmp/` (gitignored, cleaned in a `finally`) because that is what the CLI reads — and because pull's whole job will be surgery on a file, so the filesystem is needed regardless.

The suite asserts the config that went in and the catalog that came out, and nothing about rendering, since rendering is a report rather than a decision. Five properties: dry-run writes nothing, the same document previews and applies, an unchanged config is a no-op, and **removing a feature from the config removes it from the catalog** — omission-as-removal working end to end.

The harness imports the CLI by relative path rather than as a package: `atmn-nightly` publishes only its bin, and adding `exports` for `src/**` to satisfy a test would leak internals into the published package.

### Three bugs the first real run found

- **The renderer read wire casing.** It looked for `feature_id` while the client had already recased responses to `featureId`, so every row printed as `?`.
- **The action enum was guessed.** It is `create | update | delete | skip | none`, and I had omitted `none` — the unchanged case — so re-pushing an identical config reported phantom changes. The check is now positive (list what counts as a change) so a no-op value added later reads as nothing-to-do instead of leaking through.
- **`loadConfig` never re-read the file.** Bun caches modules, so a second push in the same process got the first config. Invisible in a real `atmn push`, which runs once and exits; wrong for tests today and a watch mode later. Note the first fix did not work: appending `?v=` to a `file://` href gets normalised away, so the query has to go on the plain path.

Isolating the last one was worth the detour — sending an identical body through both the test harness and the generated client returned `delete` from both, which ruled out client and server together and pointed at the config read.

### Note

The dev database needed `bun db migrate` (two pending, `0074` adds `entitlements.feature_override`). Not a change in this PR, but anyone running these tests locally will hit it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`atmn push` now evaluates `autumn.config.ts`, previews catalog changes, and applies them end to end; `atmn login` authenticates via OAuth and writes org keys to the env file. Previously push only loaded the config and login was a stub.

Since the config is authoritative, removing an item removes it from the catalog. A stated empty collection (`features: []`, `plans: []`) now removes everything in it, while an omitted key leaves that collection untouched. Draft migrations are displayed but not run.

**New Features**

- `atmn login` runs a PKCE OAuth flow, mints sandbox and prod keys, and writes them to the env file; the authorization URL is printed so headless machines can finish login elsewhere.
- `--local`, `--port`, and `--base-url` select the target server, with the most specific flag winning; `--prod` swaps `AUTUMN_SECRET_KEY` for `AUTUMN_PROD_SECRET_KEY`, and `AUTUMN_BASE_URL` pins a directory to a server.
- Config and env search covers the current dir, `atmn` subdir, package root, and repo root; config is cache-busted so every push re-reads the file.
- Renders feature, plan, and draft-migration changes with optional migration links, and adds a runnable example config plus end-to-end coverage.

Known gaps: the `--yes` flag is declared but unused, so destructive pushes apply without confirmation, and draft migration previews print unusable IDs because preview responses do not include them.

<sup>Written for commit 27eb8bec9b8cca168012b151a29042eccc016e7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds end-to-end catalog pushing and OAuth-based CLI login. Two previously reported CLI issues remain outstanding: destructive pushes lack confirmation, and draft migration previews lack usable identifiers.
- **[API changes, Improvements]** Adds preview-and-apply catalog pushing with dry-run and no-op handling.
- **[API changes, Improvements]** Adds PKCE OAuth login, API-key creation, environment-file persistence, and configurable server targeting.
- **[Bug fixes]** Treats omitted catalog collections differently from explicitly empty collections so complete configurations can remove absent features and plans.
- **[Improvements]** Adds headless preview rendering and end-to-end catalog tests.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because catalog deletions can still be applied without confirmation and migration previews still produce unusable identifiers.

A normal non-dry-run push proceeds directly from preview to update even though `--yes` is unused, while draft migration output continues to read an identifier absent from preview responses.

**Files Needing Attention:** packages/atmn-nightly/src/cli.ts, packages/atmn-nightly/src/actions/push.ts, packages/atmn-nightly/src/render/renderPreview.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/atmn-nightly/src/actions/push.ts | Implements the preview, render, dry-run, no-op, and apply sequence using the same configuration document. |
| packages/atmn-nightly/src/actions/login.ts | Coordinates OAuth authorization, API-key creation, and environment-file persistence. |
| packages/atmn-nightly/src/auth/runOAuthFlow.ts | Implements PKCE authorization through a temporary HTTP callback listener. |
| packages/atmn-nightly/src/render/renderPreview.ts | Formats feature, plan, and draft-migration preview data for terminal output. |
| packages/atmn-nightly/src/cli.ts | Wires login and push into the CLI with environment and target-selection flags. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveFeaturesPlan/resolveAbsenteeFeatureIds.ts | Updates full-state feature-removal behavior to distinguish omitted and explicitly supplied collections. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveProductsPlan/resolveAbsenteePlanTargets.ts | Updates full-state plan-removal behavior to distinguish omitted and explicitly supplied collections. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as atmn push
    participant Config as autumn.config.ts
    participant API as Catalog API
    CLI->>Config: Load configuration
    CLI->>API: previewUpdate(document)
    API-->>CLI: Feature, plan, and migration changes
    CLI->>CLI: Render preview
    alt Dry run or empty preview
        CLI-->>CLI: Stop without applying
    else Changes exist
        CLI->>API: update(same document)
        API-->>CLI: Applied catalog
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat: 🎸 let the most specific target fl..."](https://github.com/useautumn/autumn/commit/27eb8bec9b8cca168012b151a29042eccc016e7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59659294)</sub>

<!-- /greptile_comment -->