### PR TITLE
fix(plans): include license prices in attach eligibility

### DIFF
--- a/server/src/internal/products/productUtils/productResponseUtils/buildCustomerEligibility.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/buildCustomerEligibility.ts
@@ -2,7 +2,7 @@ import {
 	type ApiPlanV1,
 	AttachAction,
 	AttachScenario,
-	cusProductToProduct,
+	customerProductToEffectivePrices,
 	EligibilityStatus,
 	type FullCustomer,
 	type FullProduct,
@@ -11,6 +11,7 @@ import {
 	findScheduledCustomerProductById,
 	isCustomerProductCanceling,
 	isCustomerProductTrialing,
+	productToEffectivePrices,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFreeTrialAfterFingerprint } from "../../free-trials/freeTrialUtils.js";
@@ -63,14 +64,12 @@ const getAttachAction = ({
 		return AttachAction.Activate;
 	}
 
-	// 5. Compare with current main product
-	const curFullProduct = cusProductToProduct({
-		cusProduct: curMainCusProduct,
-	});
-
+	// 5. Include license prices so eligibility matches attach previews.
 	const isUpgrade = isProductUpgrade({
-		prices1: curFullProduct.prices,
-		prices2: fullProduct.prices,
+		prices1: customerProductToEffectivePrices({
+			customerProduct: curMainCusProduct,
+		}),
+		prices2: productToEffectivePrices({ product: fullProduct }),
 	});
 
 	return isUpgrade ? AttachAction.Upgrade : AttachAction.Downgrade;

--- a/server/tests/integration/crud/plans/list/customer-eligibility.test.ts
+++ b/server/tests/integration/crud/plans/list/customer-eligibility.test.ts
@@ -142,6 +142,55 @@ test.concurrent(`${chalk.yellowBright("customer-eligibility: customer on pro, li
 	}
 });
 
+test.concurrent(
+	`${chalk.yellowBright("customer-eligibility: license prices match attach preview classification")}`,
+	async () => {
+		const group = "eligibility-license-parent-group";
+		const currentPlan = products.base({
+			id: "eligibility-license-current",
+			group,
+			items: [items.monthlyPrice({ price: 100 })],
+		});
+		const targetPlan = products.base({
+			id: "eligibility-license-target",
+			group,
+			items: [items.monthlyPrice({ price: 150 })],
+		});
+		const licensePlan = products.base({
+			id: "eligibility-license-seat",
+			group: "eligibility-license-seat-group",
+			items: [items.monthlyPrice({ price: 100 })],
+		});
+
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "cus-elig-license-prices",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [currentPlan, targetPlan, licensePlan] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: currentPlan.id,
+					licenseProductId: licensePlan.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: currentPlan.id }),
+			],
+		});
+
+		const { list: plans } = await autumnV2_2.products.list<ApiPlanV1[]>({
+			customer_id: customerId,
+		});
+
+		// The current plan costs $200 with its license. The target plan costs $150.
+		// The attach operation treats this change as a downgrade.
+		const target = findPlan({ plans, productId: targetPlan.id });
+		expect(target.customer_eligibility?.attach_action).toBe(
+			AttachAction.Downgrade,
+		);
+	},
+);
+
 test.concurrent(`${chalk.yellowBright("customer-eligibility: customer on pro canceling")}`, async () => {
 	const cancelPro = products.pro({ id: "pro", items: [creditsItem] });
 	const cancelPremium = products.premium({


### PR DESCRIPTION
Plan list eligibility compared only the direct prices of each parent plan. A license price could make `previewAttach` schedule a downgrade while `plans.list` reported an upgrade.

Use the same effective-price helpers as the attach path so both checks include license prices. Add coverage for a license that changes the transition direction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plan list eligibility so it includes license prices when classifying upgrades and downgrades. Previously `plans.list` compared only direct parent plan prices, so a license price could make it report an upgrade while `previewAttach` scheduled a downgrade. Now both paths use the same effective-price helpers, and a test covers a license that flips the transition direction.

<sup>Written for commit 3be0852cffe5b106b7396a930315adf5f22f79a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

