### PR TITLE
fix: release the checkout reservation when a pending plan is discarded

### DIFF
--- a/server/src/internal/billing/v2/execute/discardPendingCustomerProduct.ts
+++ b/server/src/internal/billing/v2/execute/discardPendingCustomerProduct.ts
@@ -1,6 +1,9 @@
-import type { FullCusProduct } from "@autumn/shared";
+import type {
+	DeferredAutumnBillingPlanData,
+	FullCusProduct,
+} from "@autumn/shared";
 import { createStripeCli } from "@/external/connect/createStripeCli";
-import { expireStripeCheckoutSession } from "@/external/stripe/checkoutSessions/operations/expireStripeCheckoutSession";
+import { checkoutSessionLock } from "@/external/redis/actions/checkoutSessionLock/checkoutSessionLock";
 import { voidStripeInvoiceIfOpen } from "@/external/stripe/invoices/operations/voidStripeInvoiceIfOpen";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
@@ -19,8 +22,17 @@ export const discardPendingCustomerProduct = async ({
 		const metadata = await MetadataService.get({ db: ctx.db, id: metadataId });
 
 		if (metadata?.stripe_checkout_session_id) {
-			await expireStripeCheckoutSession({
+			const deferredData = metadata.data as
+				| DeferredAutumnBillingPlanData
+				| undefined;
+			const lockCustomerId =
+				deferredData?.billingContext?.fullCustomer?.id ??
+				deferredData?.billingContext?.fullCustomer?.internal_id ??
+				customerProduct.internal_customer_id;
+
+			await checkoutSessionLock.expireAndClearIfOwned({
 				ctx,
+				customerId: lockCustomerId,
 				checkoutSessionId: metadata.stripe_checkout_session_id,
 			});
 		}

--- a/server/src/internal/billing/v2/execute/discardPendingCustomerProduct.ts
+++ b/server/src/internal/billing/v2/execute/discardPendingCustomerProduct.ts
@@ -2,6 +2,7 @@ import type {
 	DeferredAutumnBillingPlanData,
 	FullCusProduct,
 } from "@autumn/shared";
+import { ErrCode, RecaseError } from "@autumn/shared";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import { checkoutSessionLock } from "@/external/redis/actions/checkoutSessionLock/checkoutSessionLock";
 import { voidStripeInvoiceIfOpen } from "@/external/stripe/invoices/operations/voidStripeInvoiceIfOpen";
@@ -30,11 +31,22 @@ export const discardPendingCustomerProduct = async ({
 				deferredData?.billingContext?.fullCustomer?.internal_id ??
 				customerProduct.internal_customer_id;
 
-			await checkoutSessionLock.expireAndClearIfOwned({
+			const sessionExpired = await checkoutSessionLock.expireAndClearIfOwned({
 				ctx,
 				customerId: lockCustomerId,
 				checkoutSessionId: metadata.stripe_checkout_session_id,
 			});
+
+			// A completed session is about to materialize via webhook; discarding
+			// its metadata now would lose the paid plan.
+			if (!sessionExpired) {
+				throw new RecaseError({
+					message:
+						"A checkout session for this customer was just completed and is still being processed",
+					code: ErrCode.LockAlreadyExists,
+					statusCode: 423,
+				});
+			}
 		}
 
 		if (metadata?.stripe_invoice_id) {

--- a/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-pending-cancel.test.ts
+++ b/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-pending-cancel.test.ts
@@ -1,0 +1,230 @@
+/**
+ * TDD test: cancelling a plan that is pending on a Stripe checkout session must
+ * expire that session at Stripe and let the customer start a fresh checkout.
+ *
+ * Red-failure mode (current behavior):
+ *  - the checkout session stays "open" at Stripe after the pending plan is
+ *    cancelled, and/or a re-attach hands back the stale checkout URL.
+ *
+ * Green-success criteria (after fix):
+ *  - session.status === "expired", the pending row is expired, the metadata
+ *    row is gone, and a re-attach returns a new open checkout session.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	ALL_STATUSES,
+	type AttachParamsV1Input,
+	CusProductStatus,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import { MetadataService } from "@/internal/metadata/MetadataService";
+
+type ScenarioContext = Awaited<ReturnType<typeof initScenario>>["ctx"];
+
+const findPendingRow = async ({
+	ctx,
+	internalCustomerId,
+	productId,
+}: {
+	ctx: ScenarioContext;
+	internalCustomerId: string;
+	productId: string;
+}) => {
+	const customerProducts = await CusProductService.list({
+		db: ctx.db,
+		internalCustomerId,
+		inStatuses: ALL_STATUSES,
+	});
+
+	return customerProducts.find(
+		(customerProduct) => customerProduct.product.id === productId,
+	);
+};
+
+const startPendingCheckout = async ({
+	customerId,
+	productId,
+}: {
+	customerId: string;
+	productId: string;
+}) => {
+	const pro = products.pro({
+		id: productId,
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	const scenario = await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [pro] })],
+		actions: [],
+	});
+
+	const { ctx, autumnV2_2, customer } = scenario;
+
+	const attachResult = await autumnV2_2.billing.attach<AttachParamsV1Input>({
+		customer_id: customerId,
+		plan_id: pro.id,
+	});
+
+	expect(attachResult.payment_url).toContain("checkout.stripe.com");
+
+	const pendingRow = await findPendingRow({
+		ctx,
+		internalCustomerId: customer?.internal_id ?? "",
+		productId: pro.id,
+	});
+
+	expect(pendingRow?.status).toBe(CusProductStatus.Pending);
+
+	const metadataId = pendingRow?.metadata_id ?? "";
+	const metadata = await MetadataService.get({ db: ctx.db, id: metadataId });
+	const checkoutSessionId = metadata?.stripe_checkout_session_id ?? "";
+
+	expect(checkoutSessionId).toStartWith("cs_");
+
+	const openSession =
+		await ctx.stripeCli.checkout.sessions.retrieve(checkoutSessionId);
+	expect(openSession.status).toBe("open");
+
+	return {
+		...scenario,
+		pro,
+		metadataId,
+		checkoutSessionId,
+		originalPaymentUrl: attachResult.payment_url as string,
+	};
+};
+
+const expectPendingCheckoutDiscarded = async ({
+	ctx,
+	internalCustomerId,
+	productId,
+	metadataId,
+	checkoutSessionId,
+}: {
+	ctx: ScenarioContext;
+	internalCustomerId: string;
+	productId: string;
+	metadataId: string;
+	checkoutSessionId: string;
+}) => {
+	const session =
+		await ctx.stripeCli.checkout.sessions.retrieve(checkoutSessionId);
+	expect(session.status).toBe("expired");
+
+	const row = await findPendingRow({ ctx, internalCustomerId, productId });
+	expect(row?.status).toBe(CusProductStatus.Expired);
+	expect(row?.metadata_id).toBeNull();
+
+	const remainingMetadata = await MetadataService.get({
+		db: ctx.db,
+		id: metadataId,
+	});
+	expect(remainingMetadata).toBeNull();
+};
+
+test.concurrent(
+	`${chalk.yellowBright("stripe-checkout pending cancel: /cancel expires the open checkout session")}`,
+	async () => {
+		const customerId = `checkout-pending-cancel-v1-${Date.now()}`;
+		const { ctx, autumnV1, customer, pro, metadataId, checkoutSessionId } =
+			await startPendingCheckout({
+				customerId,
+				productId: "pro-checkout-pending-cancel-v1",
+			});
+
+		await autumnV1.cancel({ customer_id: customerId, product_id: pro.id });
+
+		await expectPendingCheckoutDiscarded({
+			ctx,
+			internalCustomerId: customer?.internal_id ?? "",
+			productId: pro.id,
+			metadataId,
+			checkoutSessionId,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("stripe-checkout pending cancel: billing.update cancel_action expires the open checkout session")}`,
+	async () => {
+		const customerId = `checkout-pending-cancel-update-${Date.now()}`;
+		const { ctx, autumnV2_2, customer, pro, metadataId, checkoutSessionId } =
+			await startPendingCheckout({
+				customerId,
+				productId: "pro-checkout-pending-cancel-update",
+			});
+
+		await autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			cancel_action: "cancel_end_of_cycle",
+		});
+
+		await expectPendingCheckoutDiscarded({
+			ctx,
+			internalCustomerId: customer?.internal_id ?? "",
+			productId: pro.id,
+			metadataId,
+			checkoutSessionId,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("stripe-checkout pending cancel: re-attaching after cancel opens a fresh checkout session")}`,
+	async () => {
+		const customerId = `checkout-pending-cancel-reattach-${Date.now()}`;
+		const {
+			ctx,
+			autumnV1,
+			autumnV2_2,
+			customer,
+			pro,
+			checkoutSessionId,
+			originalPaymentUrl,
+		} = await startPendingCheckout({
+			customerId,
+			productId: "pro-checkout-pending-cancel-reattach",
+		});
+
+		await autumnV1.cancel({ customer_id: customerId, product_id: pro.id });
+
+		const reattachResult = await autumnV2_2.billing.attach<AttachParamsV1Input>(
+			{
+				customer_id: customerId,
+				plan_id: pro.id,
+			},
+		);
+
+		expect(reattachResult.payment_url).toContain("checkout.stripe.com");
+		expect(reattachResult.payment_url).not.toBe(originalPaymentUrl);
+
+		const customerProducts = await CusProductService.list({
+			db: ctx.db,
+			internalCustomerId: customer?.internal_id ?? "",
+			inStatuses: [CusProductStatus.Pending],
+		});
+		const freshRow = customerProducts.find(
+			(customerProduct) => customerProduct.product.id === pro.id,
+		);
+		const freshMetadata = await MetadataService.get({
+			db: ctx.db,
+			id: freshRow?.metadata_id ?? "",
+		});
+		const freshSessionId = freshMetadata?.stripe_checkout_session_id ?? "";
+
+		expect(freshSessionId).toStartWith("cs_");
+		expect(freshSessionId).not.toBe(checkoutSessionId);
+
+		const freshSession =
+			await ctx.stripeCli.checkout.sessions.retrieve(freshSessionId);
+		expect(freshSession.status).toBe("open");
+	},
+);

--- a/server/tests/unit/billing/discard-pending-checkout-conflict.test.ts
+++ b/server/tests/unit/billing/discard-pending-checkout-conflict.test.ts
@@ -1,0 +1,130 @@
+/**
+ * TDD: discarding a pending plan whose checkout session already completed at
+ * Stripe must not delete the deferred metadata or expire the row, otherwise the
+ * checkout.session.completed webhook finds nothing and the paid plan is lost.
+ *
+ * Red-failure mode (current behavior):
+ *  - expireAndClearIfOwned returns false, cleanup runs anyway, no error.
+ *
+ * Green-success criteria (after fix):
+ *  - a 423 conflict is thrown before any cleanup.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	AppEnv,
+	type CusProductStatus,
+	ErrCode,
+	type FullCusProduct,
+	RecaseError,
+} from "@autumn/shared";
+
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const state = {
+	sessionExpired: true,
+	expiredSessionIds: [] as string[],
+	deletedMetadataIds: [] as string[],
+	expiredCustomerProductIds: [] as string[],
+};
+
+const metadataId = "meta_pending_checkout";
+const checkoutSessionId = "cs_test_pending_checkout";
+
+await mockModuleWithRestore(
+	"@/external/redis/actions/checkoutSessionLock/checkoutSessionLock.js",
+	() => ({
+		checkoutSessionLock: {
+			expireAndClearIfOwned: async ({
+				checkoutSessionId: sessionId,
+			}: {
+				checkoutSessionId: string;
+			}) => {
+				state.expiredSessionIds.push(sessionId);
+				return state.sessionExpired;
+			},
+		},
+	}),
+);
+
+await mockModuleWithRestore("@/internal/metadata/MetadataService.js", () => ({
+	MetadataService: {
+		get: async () => ({
+			id: metadataId,
+			stripe_checkout_session_id: checkoutSessionId,
+			stripe_invoice_id: null,
+			data: {
+				billingContext: {
+					fullCustomer: { id: "cus_pending_checkout", internal_id: "icus_1" },
+				},
+			},
+		}),
+		delete: async ({ id }: { id: string }) => {
+			state.deletedMetadataIds.push(id);
+		},
+	},
+}));
+
+await mockModuleWithRestore(
+	"@/internal/customers/cusProducts/CusProductService.js",
+	() => ({
+		CusProductService: {
+			expireIfPending: async ({ cusProductId }: { cusProductId: string }) => {
+				state.expiredCustomerProductIds.push(cusProductId);
+			},
+		},
+	}),
+);
+
+const { discardPendingCustomerProduct } = await import(
+	"@/internal/billing/v2/execute/discardPendingCustomerProduct.js"
+);
+
+const customerProduct = {
+	id: "cp_pending_checkout",
+	internal_customer_id: "icus_1",
+	metadata_id: metadataId,
+	status: "pending" as CusProductStatus,
+} as unknown as FullCusProduct;
+
+const ctx = {
+	db: {} as never,
+	org: { id: "org_1" },
+	env: AppEnv.Sandbox,
+	logger: { info: () => {}, warn: () => {}, error: () => {} },
+} as never;
+
+const resetState = () => {
+	state.sessionExpired = true;
+	state.expiredSessionIds = [];
+	state.deletedMetadataIds = [];
+	state.expiredCustomerProductIds = [];
+};
+
+test("discards the pending plan once its checkout session is expired", async () => {
+	resetState();
+
+	await discardPendingCustomerProduct({ ctx, customerProduct });
+
+	expect(state.expiredSessionIds).toEqual([checkoutSessionId]);
+	expect(state.deletedMetadataIds).toEqual([metadataId]);
+	expect(state.expiredCustomerProductIds).toEqual([customerProduct.id]);
+});
+
+test("refuses to discard when the checkout session already completed", async () => {
+	resetState();
+	state.sessionExpired = false;
+
+	let thrown: unknown;
+	try {
+		await discardPendingCustomerProduct({ ctx, customerProduct });
+	} catch (error) {
+		thrown = error;
+	}
+
+	expect(thrown).toBeInstanceOf(RecaseError);
+	expect((thrown as RecaseError).statusCode).toBe(423);
+	expect((thrown as RecaseError).code).toBe(ErrCode.LockAlreadyExists);
+	expect(state.deletedMetadataIds).toEqual([]);
+	expect(state.expiredCustomerProductIds).toEqual([]);
+});


### PR DESCRIPTION
## Bug

Cancelling a plan that is pending on a Stripe checkout session (via `/cancel` or `billing.update` with a `cancel_action`) expired the session at Stripe but left the Redis checkout reservation in place. The next attach with the same params matched the reservation in `checkCheckoutSessionLock` and returned the expired checkout URL, so the customer got a dead payment link.

```
attach ──► session cs_A ──► checkout_lock{customer} = cs_A
cancel ──► discardPendingCustomerProduct
             expire cs_A at Stripe          ✓
             (reservation left behind)      ✗
attach ──► same params hash → cached cs_A url (expired)
```

## Fix

`discardPendingCustomerProduct` now expires the session and clears the reservation through `checkoutSessionLock.expireAndClearIfOwned`, the same helper `checkCheckoutSessionLock` uses. A re-attach after cancel opens a fresh session.

## Race guard (second commit)

If the customer pays at the same moment the plan is cancelled, Stripe rejects the expire call and the helper returns `false`. The discard used to delete the deferred metadata and expire the row anyway, so `checkout.session.completed` found no metadata and the paid plan was never materialized. The discard now throws the same 423 conflict as `checkCheckoutSessionLock` in that case and leaves the metadata and pending row for the webhook to promote. Callers surface it as a 423 on `/cancel` and `billing.update`.

## Tests

New `stripe-checkout-pending-cancel.test.ts` (integration):

- `/cancel` expires the open session, expires the row, deletes the metadata
- `billing.update cancel_action` does the same
- re-attaching after cancel returns a new open checkout session (red before, green after)

New `discard-pending-checkout-conflict.test.ts` (unit):

- expired session → metadata deleted, row expired
- completed session → 423 thrown, no cleanup

Also re-ran the invoice-mode pending-cancel tests and `checkout-lock-basic` — green.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR coordinates cancellation of pending Stripe checkouts with removal of their Redis reservations while preserving completed checkouts for webhook processing.
- **[Bug fixes]** Expires an open Stripe checkout and clears its owned reservation before removing the pending plan.
- **[Improvements]** Stops cancellation cleanup when checkout completion may already be in progress.
- **[Improvements]** Adds integration coverage for both cancellation APIs and fresh checkout creation after cancellation, plus unit coverage for completion conflicts.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the scope of this follow-up review.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/execute/discardPendingCustomerProduct.ts | Coordinates checkout expiration, reservation release, and pending-state cleanup while preserving records when completion may be underway. |
| server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-pending-cancel.test.ts | Covers cancellation through both supported APIs and verifies that reattachment creates a fresh open checkout. |
| server/tests/unit/billing/discard-pending-checkout-conflict.test.ts | Verifies successful cleanup and preservation of pending state when checkout expiration reports a completion conflict. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Billing
  participant Lock as Checkout reservation
  participant Stripe
  participant DB
  Client->>Billing: Cancel pending plan
  Billing->>Stripe: Expire checkout session
  alt Session expired
    Billing->>Lock: Clear reservation if owned
    Billing->>DB: Expire pending plan and delete metadata
    Billing-->>Client: Cancellation succeeds
  else Session may have completed
    Billing-->>Client: Processing conflict
    Note over Billing,DB: Preserve metadata for completion webhook
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: refuse to discard a pending plan wh..."](https://github.com/useautumn/autumn/commit/a4a97ee3750972a8aacb986e79901455273adece) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59900917)</sub>

**Context used:**

- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)

<!-- /greptile_comment -->