### PR TITLE
fix: one-off top-up entitlement no longer inherits the recurring pack's quantity

### DIFF
--- a/shared/utils/productUtils/convertProductUtils.ts
+++ b/shared/utils/productUtils/convertProductUtils.ts
@@ -12,6 +12,7 @@ import type {
 	Product,
 } from "../../models/productModels/productModels.js";
 import type { EntitlementPrice } from "./entitlementPriceUtils/entitlementPriceTypes.js";
+import { isLifetimeEntitlement } from "./entUtils/classifyEntUtils.js";
 import { isFixedPrice } from "./priceUtils/classifyPriceUtils.js";
 
 // Must stay symmetric with priceToEnt: if one direction resolves a pair across
@@ -92,11 +93,17 @@ export const entToOptions = ({
 	ent: Entitlement;
 	options: FeatureOptions[];
 }) => {
-	return options.find(
+	const matches = options.filter(
 		(option) =>
 			option.internal_feature_id === ent.internal_feature_id ||
 			(ent.feature_id && option.feature_id === ent.feature_id),
 	);
+	if (matches.length <= 1) return matches[0];
+
+	// Several prepaid slots on one feature: the recurring price owns the caller's
+	// quantity, and the one-off top-up beside it stays on its own allowance.
+	if (isLifetimeEntitlement({ entitlement: ent })) return undefined;
+	return matches.find((option) => option.quantity > 0) ?? matches[0];
 };
 
 export const productToStripeId = ({

--- a/shared/utils/productUtils/entUtils/classifyEntUtils.ts
+++ b/shared/utils/productUtils/entUtils/classifyEntUtils.ts
@@ -2,6 +2,7 @@ import type { Entity } from "../../../models/cusModels/entityModels/entityModels
 import { FeatureType } from "../../../models/featureModels/featureEnums";
 import {
 	AllowanceType,
+	type Entitlement,
 	type EntitlementWithFeature,
 } from "../../../models/productModels/entModels/entModels";
 import { EntInterval } from "../../../models/productModels/intervals/entitlementInterval";
@@ -34,7 +35,7 @@ export const isEntityScopedEntitlement = ({
 export const isLifetimeEntitlement = ({
 	entitlement,
 }: {
-	entitlement: EntitlementWithFeature;
+	entitlement: Entitlement;
 }) => {
 	return !entitlement.interval || entitlement.interval === EntInterval.Lifetime;
 };


### PR DESCRIPTION
When a plan has two prepaid prices on the same feature (Bloom's Scale plan: a monthly credit pack plus a one-off top-up), Autumn looked up the purchased quantity by feature id only, so a customer who bought 2,000 monthly credits also received 2,000 free credits in the one-off bucket — all 22 of Bloom's active Scale customers have this today, 14,700 unpaid credits in total.

The fix makes `entToOptions` give the one-off (lifetime) entitlement no quantity when a sibling slot exists and lets the recurring entitlement take the non-zero slot regardless of array order, so the caller's quantity lands only on the price they actually paid for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes one-off top-up entitlements inheriting the recurring pack's quantity on the same feature. Previously `entToOptions` matched prepaid slots by feature id only, so a monthly credit pack and a one-off top-up on the same feature seeded both from the same quantity—Bloom's 22 active Scale customers hold ~14,700 unpaid credits this way.

- The one-off (lifetime) entitlement now takes no slot when a sibling prepaid slot exists.
- The recurring entitlement takes the non-zero slot regardless of array order.

<sup>Written for commit 94cc6f43167d41721dc17569786695e196dd8537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects how quantities are assigned when recurring and one-off prepaid prices share a feature.
- **Bug fixes:** Prevents a one-off lifetime entitlement from inheriting the recurring pack’s requested quantity.
- **Improvements:** Makes recurring quantity selection independent of whether the non-zero sibling option appears first.
- **Improvements:** Widens the lifetime-classification helper to accept entitlements without an embedded feature.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with non-blocking regression-test coverage recommended for the corrected duplicate-feature quantity behavior.

The implementation addresses the reported over-crediting path, and no concrete blocking failure was established, but the subtle sibling ordering and lifetime-selection behavior is currently unprotected by tests.

**Files Needing Attention:** shared/utils/productUtils/convertProductUtils.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/productUtils/convertProductUtils.ts | Adds duplicate-feature option handling that suppresses quantity inheritance for lifetime entitlements and selects the positive slot for recurring entitlements; regression coverage is missing. |
| shared/utils/productUtils/entUtils/classifyEntUtils.ts | Widens the lifetime-entitlement classifier input type without changing its established interval semantics. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Entitlement and feature options] --> B{Matching options}
  B -->|Zero or one| C[Return the sole match]
  B -->|Several| D{Lifetime entitlement?}
  D -->|Yes| E[Return no quantity option]
  D -->|No| F[Return first positive option]
  F --> G[Apply quantity to recurring entitlement]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
shared/utils/productUtils/convertProductUtils.ts:101-105
**Duplicate-slot logic lacks coverage**

The new behavior depends on sibling ordering, lifetime classification, and zero-versus-positive quantities, but this PR adds no regression tests for those combinations. Without coverage, a later option-ordering change can silently restore the original over-crediting behavior, such as granting a 2,000-credit recurring purchase to the one-off bucket too.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): stop one-off prepaid entitl..."](https://github.com/useautumn/autumn/commit/94cc6f43167d41721dc17569786695e196dd8537) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59902363)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->