### PR TITLE
fix: drop cached subject on checkout.session.expired

### DIFF
--- a/server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts
@@ -11,11 +11,15 @@ const updateProductEvents = [
 	"customer.subscription.updated",
 ];
 
+// checkout.session.expired included: the handler expires cusProducts that were
+// pre-inserted for enable_plan_immediately / pending checkouts, which must also
+// drop the cached subject or the API keeps serving the plan as active.
 const coreEvents = [
 	"customer.subscription.deleted",
 	"subscription_schedule.canceled",
 	"subscription_schedule.updated",
 	"checkout.session.completed",
+	"checkout.session.expired",
 ];
 
 const updateInvoiceEvents = [

--- a/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-enable-plan-immediately.test.ts
+++ b/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-enable-plan-immediately.test.ts
@@ -1,7 +1,7 @@
 /**
  * Stripe Checkout — Top-level enable_plan_immediately
  *
- * Feature under test (currently unimplemented — these tests are RED on purpose):
+ * Feature under test:
  * - Top-level `enable_plan_immediately` on attach params (no longer nested under `invoice_mode`).
  * - When set on a stripe_checkout flow, the customer_product is inserted as Active
  *   BEFORE the customer completes the Stripe-hosted checkout, with a new
@@ -26,6 +26,7 @@ import { TestFeature } from "@tests/setup/v2Features";
 import { completeStripeCheckoutFormV2 as completeStripeCheckoutForm } from "@tests/utils/browserPool/completeStripeCheckoutFormV2";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
+import { waitForStripeWebhook } from "@tests/utils/stripeUtils/waitForStripeWebhook";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { eq } from "drizzle-orm";
@@ -156,11 +157,12 @@ test.concurrent(`${chalk.yellowBright("stripe-checkout enable_plan_immediately: 
 // TEST 2: Abandoned checkout — cusProduct cleaned up on session.expired
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// NOTE: Skipped until the implementation lands. Stripe checkout sessions auto-expire
-// 24h after creation; we'll drive expiry via `s.advanceTestClock` once the handler
-// for `checkout.session.expired` exists. The assertions are written out so flipping
-// `test.skip` → `test.concurrent` is the only change needed.
-test.skip(`${chalk.yellowBright("stripe-checkout enable_plan_immediately: expired session cleans up cusProduct")}`, async () => {
+// Expiry is driven by expiring the session on Stripe, which emits
+// `checkout.session.expired`. The API assertion at the end is the regression
+// check for the subject cache: the handler expires the row in Postgres, and the
+// webhook refresh middleware must drop the cached subject so `customers.get`
+// stops reporting the plan as active.
+test.concurrent(`${chalk.yellowBright("stripe-checkout enable_plan_immediately: expired session cleans up cusProduct")}`, async () => {
 	const customerId = "stripe-checkout-eppi-expired";
 
 	const prepaidMessagesItem = items.prepaidMessages({
@@ -197,6 +199,9 @@ test.skip(`${chalk.yellowBright("stripe-checkout enable_plan_immediately: expire
 	const result = await autumnV1.billing.attach(attachParams);
 	expect(result.payment_url).toBeDefined();
 
+	const checkoutSessionId = parseCheckoutSessionId(result.payment_url!);
+	expect(checkoutSessionId).toBeTruthy();
+
 	// Sanity: cusProduct exists Active before expiry.
 	const before = await CusProductService.list({
 		db: ctx.db,
@@ -205,19 +210,29 @@ test.skip(`${chalk.yellowBright("stripe-checkout enable_plan_immediately: expire
 	});
 	expect(before.some((cp) => cp.product.id === pro.id)).toBe(true);
 
-	// 2. Drive past the Stripe session expiry (sessions auto-expire after 24h).
-	// TODO: replace with the proper test-clock advance helper once we wire up
-	// `checkout.session.expired` simulation alongside the implementation.
-	// For now this test is `.skip`'d so the typed shape doesn't have to be exact.
-	void s;
+	// 2. Abandon the checkout: expire the session on Stripe, which emits
+	// `checkout.session.expired`, then wait for Autumn to expire the row.
+	await ctx.stripeCli.checkout.sessions.expire(checkoutSessionId!);
+
+	const isProActiveInDb = async () => {
+		const active = await CusProductService.list({
+			db: ctx.db,
+			internalCustomerId,
+			inStatuses: [CusProductStatus.Active],
+		});
+		return active.some((cp) => cp.product.id === pro.id);
+	};
+
+	await waitForStripeWebhook({
+		stripeCli: ctx.stripeCli,
+		env: ctx.env,
+		types: ["checkout.session.expired"],
+		objectId: checkoutSessionId!,
+		until: async () => !(await isProActiveInDb()),
+	});
 
 	// 3. After expiry: cusProduct should no longer be Active.
-	const after = await CusProductService.list({
-		db: ctx.db,
-		internalCustomerId,
-		inStatuses: [CusProductStatus.Active],
-	});
-	expect(after.some((cp) => cp.product.id === pro.id)).toBe(false);
+	expect(await isProActiveInDb()).toBe(false);
 
 	// API view: pro is not active.
 	const customerAfter = await autumnV1.customers.get<ApiCustomerV3>(customerId);

--- a/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-enable-plan-immediately.test.ts
+++ b/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-enable-plan-immediately.test.ts
@@ -211,16 +211,15 @@ test.concurrent(`${chalk.yellowBright("stripe-checkout enable_plan_immediately: 
 	expect(before.some((cp) => cp.product.id === pro.id)).toBe(true);
 
 	// 2. Abandon the checkout: expire the session on Stripe, which emits
-	// `checkout.session.expired`, then wait for Autumn to expire the row.
+	// `checkout.session.expired`. Wait on the cache-backed API view, not the
+	// DB row: the handler expires the row first and the refresh middleware
+	// drops the cached subject after it returns, so a DB-only predicate can
+	// resolve before `customers.get` stops reporting the plan.
 	await ctx.stripeCli.checkout.sessions.expire(checkoutSessionId!);
 
-	const isProActiveInDb = async () => {
-		const active = await CusProductService.list({
-			db: ctx.db,
-			internalCustomerId,
-			inStatuses: [CusProductStatus.Active],
-		});
-		return active.some((cp) => cp.product.id === pro.id);
+	const isProActiveInApi = async () => {
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		return (customer.products ?? []).some((product) => product.id === pro.id);
 	};
 
 	await waitForStripeWebhook({
@@ -228,11 +227,16 @@ test.concurrent(`${chalk.yellowBright("stripe-checkout enable_plan_immediately: 
 		env: ctx.env,
 		types: ["checkout.session.expired"],
 		objectId: checkoutSessionId!,
-		until: async () => !(await isProActiveInDb()),
+		until: async () => !(await isProActiveInApi()),
 	});
 
 	// 3. After expiry: cusProduct should no longer be Active.
-	expect(await isProActiveInDb()).toBe(false);
+	const after = await CusProductService.list({
+		db: ctx.db,
+		internalCustomerId,
+		inStatuses: [CusProductStatus.Active],
+	});
+	expect(after.some((cp) => cp.product.id === pro.id)).toBe(false);
 
 	// API view: pro is not active.
 	const customerAfter = await autumnV1.customers.get<ApiCustomerV3>(customerId);


### PR DESCRIPTION
## Bug

`enable_product_immediately` on a Stripe Checkout attach pre-inserts the customer_product as **active** before payment. When the session expires unpaid (1h, `DEFAULT_SESSION_LIFETIME_SECONDS`), `handleStripeCheckoutSessionExpired` expires the row, but only in Postgres. `stripeWebhookRefreshMiddleware` never listed `checkout.session.expired` in its event lists, so the Redis full-subject cache kept serving the plan as active for up to the 3-day TTL.

Result: `customers.get` (Redis) reported an active plan with usable balances, while the dashboard Plans table (`internalCusRouter` → `CusService.getFull` → Postgres) showed nothing. Observed on a live customer where the phantom plan stayed visible for ~3.5h and had usage tracked against it until an unrelated attach rebuilt the cache. The same gap applies to pending rows for deferred checkouts.

Broken since the flow landed on Aug 18 (#2863), not a regression from the Aug 31 pending-plan changes.

## Fix

Add `"checkout.session.expired"` to `coreEvents` so the middleware drops the cached subject the same way it does for `checkout.session.completed`. Everything else was already in place: `stripeToAutumnCustomerMiddleware` resolves `fullCustomer` for this event, the session carries `customer`, and the event is a sync ack so it goes through the router chain (the replay worker already invalidated unconditionally, which is why only the primary path leaked).

Scope: this only propagates an expiry Postgres already made. It does not change which rows the handler expires, and long-lived `/co/` checkouts are untouched (they hold no Stripe session or row until the customer clicks through, and a lapsed inner session is re-minted on the next click).

## Test

Un-skipped `stripe-checkout enable_plan_immediately: expired session cleans up cusProduct`. It was `test.skip` with a stale note saying the handler didn't exist yet. It now drives expiry with `stripeCli.checkout.sessions.expire`, waits via `waitForStripeWebhook` (scoped to the session id) until the cache-backed `customers.get` view no longer reports the plan, then asserts both Postgres and the API. The `customers.get` check is the one that fails without the middleware change.

Not run locally (needs the infisical env + Stripe + DB).

## Side effects considered

- Adds an invalidate + `flushBalances` per expired session (~2x the `completed` volume, ~85% of it from a single org). One extra cache rebuild for a customer who just abandoned checkout. Same class of event as `checkout.session.completed`, which already does this.
- `flushBalances` is safe here: the handler only touches `customer_products.status`, never writes balances to Postgres directly.
- The multi-target flush during a Redis ramp (raised by cubic) is pre-existing: `flushBalances: true` on this middleware landed in 3b40eadf for every listed event, and the fan-out lives in `invalidateCachedFullSubject`. This PR adds one event to that same path and doesn't change flush semantics; if the fan-out needs scoping to `ctx.redisV2`, that's a separate change affecting all webhook events.
- Customers already in the stale state are not fixed retroactively; they clear on the TTL or via `handleClearCustomerCache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUxZ3wtxSsZ1nC9YrPwjG1

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR invalidates cached customer state after an unpaid Stripe Checkout session expires and restores integration coverage for the behavior.
- **[Bug fixes]** Adds `checkout.session.expired` to the webhook events that invalidate the full-customer cache after processing.
- **[Improvements]** Re-enables the abandoned-checkout integration test and waits until the cache-backed customer API no longer reports the expired plan.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts | Adds expired Checkout sessions to the existing post-handler customer-cache invalidation path. |
| server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-enable-plan-immediately.test.ts | Re-enables expiry coverage and resolves the previously reported race by polling the cache-backed API until the plan disappears. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test
    participant Stripe
    participant Handler as Expiry handler
    participant DB as Postgres
    participant Cache as Customer cache
    participant API as customers.get
    Test->>Stripe: Expire Checkout session
    Stripe->>Handler: checkout.session.expired
    Handler->>DB: Expire abandoned customer product
    Handler-->>Cache: Continue to refresh middleware
    Cache->>Cache: Delete cached full customer
    loop Until plan is absent
        Test->>API: Read customer
        API->>Cache: Resolve current customer state
        API-->>Test: Customer products
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: wait on the API view before assert..."](https://github.com/useautumn/autumn/commit/6e7ba990be783efdb8f3f4a19a1e1d9748c10bae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59921369)</sub>

<!-- /greptile_comment -->