### PR TITLE
fix: prefer recurring prepaid over one-off for feature_quantities

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityDetails.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityDetails.ts
@@ -3,9 +3,9 @@ import {
 	addCusProductToCusEnt,
 	customerPriceToCustomerEntitlement,
 	type FeatureOptions,
-	findCusPriceByFeature,
 	findFeatureByInternalId,
 	findFeatureOptionsByFeature,
+	findPrepaidQuantityTargetPrice,
 	InternalError,
 	isOneOffPrice,
 	isPrepaidPrice,
@@ -80,13 +80,28 @@ export const computeUpdateQuantityDetails = ({
 		updatedOptions,
 	});
 
-	const customerPrice = findCusPriceByFeature({
-		internalFeatureId: internalFeatureId,
-		cusPrices: customerProduct.customer_prices.filter((cp) =>
-			isPrepaidPrice(cp.price),
+	// Tie-break: pick the prepaid price the quantity resolves to — a recurring
+	// prepaid wins over a one-off prepaid sibling of the same feature.
+	const prepaidCustomerPrices = customerProduct.customer_prices.filter(
+		(customerPriceCandidate) => isPrepaidPrice(customerPriceCandidate.price),
+	);
+	const targetPrice = findPrepaidQuantityTargetPrice({
+		prices: prepaidCustomerPrices.map(
+			(customerPriceCandidate) => customerPriceCandidate.price,
 		),
-		errorOnNotFound: true,
+		internalFeatureId,
+		featureId,
 	});
+	const customerPrice = prepaidCustomerPrices.find(
+		(customerPriceCandidate) =>
+			customerPriceCandidate.price.id === targetPrice?.id,
+	);
+
+	if (!customerPrice) {
+		throw new InternalError({
+			message: `Customer price not found for internal_feature_id: ${internalFeatureId}`,
+		});
+	}
 
 	if (isOneOffPrice(customerPrice.price)) {
 		throw new RecaseError({

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityDetails.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityDetails.ts
@@ -158,6 +158,7 @@ export const computeUpdateQuantityDetails = ({
 		ctx,
 		billingContext: updateSubscriptionContext,
 		customerProduct,
+		prepaidCustomerEntitlement: cusEntWithCusProduct,
 		feature,
 		billingPeriod,
 		quantityDifferenceForEntitlements:

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityLineItems.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityLineItems.ts
@@ -5,10 +5,9 @@ import {
 	billingContextToCurrency,
 	cloneEntitlementWithUpdatedQuantity,
 	cusEntToCusPrice,
-	cusProductToCusEnts,
 	type Feature,
+	type FullCusEntWithFullCusProduct,
 	type FullCusProduct,
-	findPrepaidCustomerEntitlement,
 	InternalError,
 	type LineItem,
 	type LineItemContext,
@@ -23,6 +22,7 @@ export const computeUpdateQuantityLineItems = ({
 	ctx,
 	billingContext,
 	customerProduct,
+	prepaidCustomerEntitlement,
 	feature,
 	billingPeriod,
 	quantityDifferenceForEntitlements,
@@ -31,24 +31,13 @@ export const computeUpdateQuantityLineItems = ({
 	ctx: AutumnContext;
 	billingContext: BillingContext;
 	customerProduct: FullCusProduct;
+	prepaidCustomerEntitlement: FullCusEntWithFullCusProduct;
 	feature: Feature;
 	billingPeriod?: BillingPeriod;
 	quantityDifferenceForEntitlements: number;
 	currentEpochMs: number;
 }) => {
 	const { org } = ctx;
-	const customerEntitlements = cusProductToCusEnts({ customerProduct });
-
-	const prepaidCustomerEntitlement = findPrepaidCustomerEntitlement({
-		customerEntitlements,
-		feature,
-	});
-
-	if (!prepaidCustomerEntitlement) {
-		throw new InternalError({
-			message: `[Quantity Update] Prepaid customer entitlement not found for feature: ${feature.internal_id}`,
-		});
-	}
 
 	const customerPrice = cusEntToCusPrice({
 		cusEnt: prepaidCustomerEntitlement,

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityPlan.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityPlan.ts
@@ -1,5 +1,6 @@
 import {
 	type AutumnBillingPlan,
+	findPrepaidQuantityTargetPrice,
 	isOneOffPrice,
 	notNullish,
 	type UpdateSubscriptionBillingContext,
@@ -17,15 +18,19 @@ export const computeUpdateQuantityPlan = ({
 }): AutumnBillingPlan => {
 	const { customerProduct, featureQuantities } = updateSubscriptionContext;
 
-	// One-off prepaid mutations belong to the ManualTopUp intent. setupFeature-
-	// QuantitiesContext synthesizes placeholders for every prepaid price (incl.
-	// one-off), so filter them out here before computeUpdateQuantityDetails.
+	// One-off prepaid mutations belong to the ManualTopUp intent. Drop an option
+	// only when the feature's prepaid tie-break target is one-off — a recurring
+	// prepaid sibling of the same feature wins the quantity instead.
+	const customerPrices = customerProduct.customer_prices.map(
+		(customerPrice) => customerPrice.price,
+	);
 	const newOptions = featureQuantities.filter((option) => {
-		const cusPrice = customerProduct.customer_prices.find(
-			(cp) =>
-				cp.price.config.internal_feature_id === option.internal_feature_id,
-		);
-		return cusPrice ? !isOneOffPrice(cusPrice.price) : true;
+		const targetPrice = findPrepaidQuantityTargetPrice({
+			prices: customerPrices,
+			internalFeatureId: option.internal_feature_id,
+			featureId: option.feature_id,
+		});
+		return targetPrice ? !isOneOffPrice(targetPrice) : true;
 	});
 
 	const quantityUpdateDetails = newOptions.map((updatedOptions) =>

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleOneOffErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleOneOffErrors.ts
@@ -5,10 +5,10 @@ import type {
 import {
 	cusProductToProduct,
 	ErrCode,
+	findPrepaidQuantityTargetPrice,
 	isCustomerProductOneOff,
 	isCustomerProductPaidRecurring,
 	isOneOffPrice,
-	isPrepaidPrice,
 	productsAreSame,
 	RecaseError,
 	resolveFreeTrialParam,
@@ -36,15 +36,14 @@ const blockOneOffQuantityChangeOutsideManualTopUp = ({
 	if (featureQuantities.length === 0) return;
 
 	for (const fq of featureQuantities) {
-		const oneOffPrepaidPrice = customerProduct.customer_prices
-			.map((cp) => cp.price)
-			.find((price) => {
-				if (!isOneOffPrice(price) || !isPrepaidPrice(price)) return false;
-				const config = price.config as { feature_id?: string };
-				return config.feature_id === fq.feature_id;
-			});
-
-		if (!oneOffPrepaidPrice) continue;
+		// Tie-break aware: only guard features whose prepaid quantity actually
+		// resolves to a one-off price — a recurring prepaid sibling wins instead.
+		const targetPrice = findPrepaidQuantityTargetPrice({
+			prices: customerProduct.customer_prices.map((cp) => cp.price),
+			featureId: fq.feature_id,
+		});
+		if (!targetPrice || !isOneOffPrice(targetPrice)) continue;
+		const oneOffPrepaidPrice = targetPrice;
 
 		const currentOption = customerProduct.options.find(
 			(o) => o.feature_id === fq.feature_id,

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionIntent.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionIntent.ts
@@ -1,10 +1,12 @@
 import { hasCustomItems } from "@api/billing/common/customizePlan/customizePlanV1";
 import {
 	type CheckoutMode,
-	customerProductHasOneOffPrepaidForFeature,
+	cusProductToPrices,
 	customerProductHasPrepaidPrice,
 	type FullCusProduct,
+	findPrepaidQuantityTargetPrice,
 	isCustomerProductOneOff,
+	isOneOffPrice,
 	resolveFreeTrialParam,
 	UpdateSubscriptionIntent,
 	type UpdateSubscriptionV1Params,
@@ -37,19 +39,21 @@ export const setupUpdateSubscriptionIntent = ({
 		return UpdateSubscriptionIntent.UpdateLicenseQuantity;
 
 	// ManualTopUp wins over UpdateQuantity (and CancelAction/None): once we know
-	// this isn't a plan restructure, any feature_quantities entry targeting a
-	// one-off prepaid price on a recurring host routes here. handleManualTopUpErrors
-	// then rejects extra fields with "Update too complex to perform."
+	// this isn't a plan restructure, a feature_quantities entry whose prepaid
+	// tie-break target is a one-off price on a recurring host routes here.
+	// A recurring prepaid of the same feature wins the tie-break instead.
 	if (
 		!isCustomerProductOneOff(customerProduct) &&
 		featureQuantitiesParams.length > 0
 	) {
-		const targetsOneOffPrepaid = featureQuantitiesParams.some((fq) =>
-			customerProductHasOneOffPrepaidForFeature({
-				customerProduct,
+		const prices = cusProductToPrices({ cusProduct: customerProduct });
+		const targetsOneOffPrepaid = featureQuantitiesParams.some((fq) => {
+			const targetPrice = findPrepaidQuantityTargetPrice({
+				prices,
 				featureId: fq.feature_id,
-			}),
-		);
+			});
+			return targetPrice !== undefined && isOneOffPrice(targetPrice);
+		});
 
 		if (targetsOneOffPrepaid) return UpdateSubscriptionIntent.ManualTopUp;
 	}

--- a/server/src/internal/billing/v2/setup/setupFeatureQuantitiesContext.ts
+++ b/server/src/internal/billing/v2/setup/setupFeatureQuantitiesContext.ts
@@ -5,6 +5,7 @@ import {
 	type FeatureQuantityParamsV0,
 	type FullCusProduct,
 	type FullProduct,
+	isLosingPrepaidQuantityPrice,
 	isOneOffPrice,
 	isPrepaidPrice,
 	priceToEnt,
@@ -40,6 +41,11 @@ export const setupFeatureQuantitiesContext = ({
 
 	for (const price of fullProduct.prices) {
 		if (!isPrepaidPrice(price)) continue;
+
+		// Tie-break: when the same feature has recurring + one-off prepaid prices,
+		// only the winning price consumes the feature-keyed quantity entry.
+		if (isLosingPrepaidQuantityPrice({ price, prices: fullProduct.prices }))
+			continue;
 
 		// const feature = priceToFeature({
 		// 	price,

--- a/server/src/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlementBalance.ts
+++ b/server/src/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlementBalance.ts
@@ -9,6 +9,7 @@ import {
 	getStartingBalance,
 	type InitCustomerEntitlementContext,
 	isBooleanEntitlement,
+	isLosingPrepaidQuantityPrice,
 	isUnlimitedEntitlement,
 } from "@autumn/shared";
 import { initCustomerEntitlementEntities } from "./initCustomerEntitlementEntities";
@@ -42,10 +43,21 @@ export const initCustomerEntitlementBalance = ({
 		prices: initContext.fullProduct?.prices ?? [],
 	});
 
-	const options = entToOptions({
-		ent: entitlement,
-		options: featureQuantities,
-	});
+	// Tie-break: a losing prepaid price (e.g. one-off alongside a recurring
+	// prepaid of the same feature) must not read the feature-keyed quantity.
+	const priceLosesQuantity =
+		price &&
+		isLosingPrepaidQuantityPrice({
+			price,
+			prices: initContext.fullProduct?.prices ?? [],
+		});
+
+	const options = priceLosesQuantity
+		? undefined
+		: entToOptions({
+				ent: entitlement,
+				options: featureQuantities,
+			});
 
 	const startingBalance = getStartingBalance({
 		entitlement,

--- a/server/tests/integration/billing/update-subscription/manual-top-up/prepaid-tie-break.test.ts
+++ b/server/tests/integration/billing/update-subscription/manual-top-up/prepaid-tie-break.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tie-break for `feature_quantities` when a plan hosts BOTH a recurring prepaid
+ * AND a one-off prepaid price for the SAME feature: the recurring price wins
+ * (shortest interval among recurring). Stop-gap semantics while the options
+ * model stays feature-keyed.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - billing.attach with feature_quantities on a mixed plan → quantity lands
+ *       on the recurring prepaid only; one-off contributes just included usage;
+ *       first invoice = base + recurring prepaid charge (no one-off charge).
+ *     - subscriptions.update with feature_quantities on a mixed plan → routed as
+ *       UpdateQuantity on the recurring price (absolute semantics), NOT
+ *       ManualTopUp (delta semantics + standalone pack invoice).
+ *     - a different feature with only a one-off prepaid on the same plan is
+ *       unaffected: update still routes ManualTopUp for that feature.
+ *
+ * Red (current):  attach double-charges (recurring + one-off both read the same
+ *                 feature-keyed options entry) and double-grants balance; update
+ *                 routes to ManualTopUp whenever any one-off prepaid matches.
+ * Green (after):  recurring prepaid wins the tie-break at both call sites.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV5,
+	UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect.js";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { expectCustomerProductOptions } from "@tests/integration/utils/expectCustomerProductOptions.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const RECURRING_PACK_PRICE = 8;
+const ONE_OFF_PACK_PRICE = 7;
+const BASE_PRICE = 20; // products.pro monthly base
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. attach: quantity applies to the recurring prepaid only.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("prepaid tie-break 1: attach with feature_quantities on mixed plan charges recurring prepaid only")}`,
+	async () => {
+		const plan = products.pro({
+			id: "tie-break-attach",
+			items: [
+				items.prepaidMessages({ price: RECURRING_PACK_PRICE }),
+				items.oneOffMessages({ price: ONE_OFF_PACK_PRICE }),
+			],
+		});
+
+		const customerId = "prepaid-tie-break-attach";
+
+		const { autumnV1, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: plan.id,
+					options: [{ feature_id: TestFeature.Messages, quantity: 200 }],
+				}),
+			],
+		});
+
+		// ── balance: 200 from recurring prepaid only (not 400)
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			remaining: 200,
+		});
+
+		// ── options: single feature entry at 2 packs
+		await expectCustomerProductOptions({
+			ctx,
+			customerId,
+			productId: plan.id,
+			featureId: TestFeature.Messages,
+			quantity: 2,
+		});
+
+		// ── invoice: base $20 + 2 packs × $8 recurring = $36 (no one-off charge)
+		await expectCustomerInvoiceCorrect({
+			autumn: autumnV1,
+			customerId,
+			count: 1,
+			latestTotal: BASE_PRICE + 2 * RECURRING_PACK_PRICE,
+		});
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. update: routed as UpdateQuantity (absolute) on the recurring prepaid,
+//    not ManualTopUp (delta on the one-off).
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("prepaid tie-break 2: update with feature_quantities on mixed plan is absolute on the recurring prepaid")}`,
+	async () => {
+		const plan = products.pro({
+			id: "tie-break-update",
+			items: [
+				items.prepaidMessages({ price: RECURRING_PACK_PRICE }),
+				items.oneOffMessages({ price: ONE_OFF_PACK_PRICE }),
+			],
+		});
+
+		const customerId = "prepaid-tie-break-update";
+
+		const { autumnV1, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: plan.id,
+					options: [{ feature_id: TestFeature.Messages, quantity: 100 }],
+				}),
+			],
+		});
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: plan.id,
+			feature_quantities: [{ feature_id: TestFeature.Messages, quantity: 300 }],
+		});
+
+		// ── absolute semantics: balance = 300 (ManualTopUp delta would give 400)
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			remaining: 300,
+		});
+
+		// ── options: 3 packs absolute on the recurring price
+		await expectCustomerProductOptions({
+			ctx,
+			customerId,
+			productId: plan.id,
+			featureId: TestFeature.Messages,
+			quantity: 3,
+		});
+
+		// ── upgrade invoice: +2 packs × $8 recurring = $16
+		// (ManualTopUp would have charged 3 packs × $7 one-off = $21)
+		await expectCustomerInvoiceCorrect({
+			autumn: autumnV1,
+			customerId,
+			count: 2,
+			latestTotal: 2 * RECURRING_PACK_PRICE,
+		});
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. isolation: a different feature with ONLY a one-off prepaid on the same
+//    plan still routes ManualTopUp.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("prepaid tie-break 3: one-off-only feature on the same plan still manual-tops-up")}`,
+	async () => {
+		const plan = products.pro({
+			id: "tie-break-isolation",
+			items: [
+				items.prepaidMessages({ price: RECURRING_PACK_PRICE }),
+				items.oneOffWords({ price: ONE_OFF_PACK_PRICE }),
+			],
+		});
+
+		const customerId = "prepaid-tie-break-isolation";
+
+		const { autumnV1, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: plan.id,
+					options: [{ feature_id: TestFeature.Messages, quantity: 100 }],
+				}),
+			],
+		});
+
+		// Manual top-up of Words (delta semantics on the one-off prepaid).
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: plan.id,
+			feature_quantities: [{ feature_id: TestFeature.Words, quantity: 100 }],
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Words,
+			remaining: 100,
+		});
+		// Messages untouched by the Words top-up.
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			remaining: 100,
+		});
+
+		await expectCustomerProductOptions({
+			ctx,
+			customerId,
+			productId: plan.id,
+			featureId: TestFeature.Words,
+			quantity: 1,
+		});
+
+		// Standalone pack invoice: 1 pack × $7 one-off.
+		await expectCustomerInvoiceCorrect({
+			autumn: autumnV1,
+			customerId,
+			count: 2,
+			latestTotal: ONE_OFF_PACK_PRICE,
+		});
+	},
+);

--- a/server/tests/unit/products/findPrepaidQuantityTargetPrice.test.ts
+++ b/server/tests/unit/products/findPrepaidQuantityTargetPrice.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "bun:test";
-import type { Price } from "@autumn/shared";
+import type { FullCusEntWithFullCusProduct, Price } from "@autumn/shared";
 import {
 	BillingInterval,
 	BillWhen,
+	customerEntitlementToOptions,
 	findPrepaidQuantityTargetPrice,
 	isLosingPrepaidQuantityPrice,
 	PriceType,
@@ -130,4 +131,61 @@ test("no prepaid price for the feature resolves to undefined", () => {
 	});
 
 	expect(target).toBeUndefined();
+});
+
+const cusEntForPrice = ({
+	price,
+	siblingPrices,
+	options,
+}: {
+	price: Price;
+	siblingPrices: Price[];
+	options: { feature_id: string; quantity: number; upcoming_quantity?: number }[];
+}) =>
+	({
+		customer_product_id: "cus_prod_1",
+		entitlement_id: `ent_${price.id}`,
+		entitlement: {
+			id: `ent_${price.id}`,
+			feature_id: "messages",
+			internal_feature_id: "internal_messages",
+			feature: { id: "messages", internal_id: "internal_messages" },
+		},
+		customer_product: {
+			options,
+			customer_prices: siblingPrices.map((siblingPrice) => ({
+				id: `cp_${siblingPrice.id}`,
+				customer_product_id: "cus_prod_1",
+				price: { ...siblingPrice, entitlement_id: `ent_${siblingPrice.id}` },
+			})),
+		},
+	}) as unknown as FullCusEntWithFullCusProduct;
+
+test("losing prepaid price reads a zeroed options copy, not undefined", () => {
+	const oneOff = prepaidPrice({ id: "pr_one_off", interval: BillingInterval.OneOff });
+	const monthly = prepaidPrice({ id: "pr_monthly", interval: BillingInterval.Month });
+	const options = [{ feature_id: "messages", quantity: 3, upcoming_quantity: 5 }];
+
+	const losingOptions = customerEntitlementToOptions({
+		customerEntitlement: cusEntForPrice({
+			price: oneOff,
+			siblingPrices: [oneOff, monthly],
+			options,
+		}),
+	});
+	// Zeroed copy: renewal resets still run, but the winner's quantity never leaks.
+	expect(losingOptions).toEqual({
+		feature_id: "messages",
+		quantity: 0,
+		upcoming_quantity: null,
+	});
+
+	const winningOptions = customerEntitlementToOptions({
+		customerEntitlement: cusEntForPrice({
+			price: monthly,
+			siblingPrices: [oneOff, monthly],
+			options,
+		}),
+	});
+	expect(winningOptions).toEqual(options[0]);
 });

--- a/server/tests/unit/products/findPrepaidQuantityTargetPrice.test.ts
+++ b/server/tests/unit/products/findPrepaidQuantityTargetPrice.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "bun:test";
+import type { Price } from "@autumn/shared";
+import {
+	BillingInterval,
+	BillWhen,
+	findPrepaidQuantityTargetPrice,
+	isLosingPrepaidQuantityPrice,
+	PriceType,
+} from "@autumn/shared";
+
+/**
+ * Tie-break rules for resolving a feature-keyed prepaid quantity to a single
+ * price when a product carries several prepaid prices for the same feature:
+ * recurring beats one-off, and among recurring the shortest interval wins.
+ */
+
+const prepaidPrice = ({
+	id,
+	interval,
+	intervalCount,
+	featureId = "messages",
+}: {
+	id: string;
+	interval: BillingInterval;
+	intervalCount?: number;
+	featureId?: string;
+}) =>
+	({
+		id,
+		config: {
+			type: PriceType.Usage,
+			bill_when: BillWhen.InAdvance,
+			interval,
+			interval_count: intervalCount,
+			feature_id: featureId,
+			internal_feature_id: `internal_${featureId}`,
+		},
+	}) as unknown as Price;
+
+const fixedPrice = ({ id }: { id: string }) =>
+	({
+		id,
+		config: { type: PriceType.Fixed, interval: BillingInterval.Month },
+	}) as unknown as Price;
+
+test("recurring prepaid beats one-off prepaid of the same feature", () => {
+	const oneOff = prepaidPrice({ id: "pr_one_off", interval: BillingInterval.OneOff });
+	const monthly = prepaidPrice({ id: "pr_monthly", interval: BillingInterval.Month });
+
+	const target = findPrepaidQuantityTargetPrice({
+		prices: [fixedPrice({ id: "pr_base" }), oneOff, monthly],
+		featureId: "messages",
+	});
+
+	expect(target?.id).toBe("pr_monthly");
+	expect(isLosingPrepaidQuantityPrice({ price: oneOff, prices: [oneOff, monthly] })).toBe(true);
+	expect(isLosingPrepaidQuantityPrice({ price: monthly, prices: [oneOff, monthly] })).toBe(false);
+});
+
+test("shortest interval wins among recurring prepaid prices", () => {
+	const yearly = prepaidPrice({ id: "pr_yearly", interval: BillingInterval.Year });
+	const monthly = prepaidPrice({ id: "pr_monthly", interval: BillingInterval.Month });
+	const quarterly = prepaidPrice({ id: "pr_quarterly", interval: BillingInterval.Quarter });
+
+	const target = findPrepaidQuantityTargetPrice({
+		prices: [yearly, quarterly, monthly],
+		featureId: "messages",
+	});
+
+	expect(target?.id).toBe("pr_monthly");
+});
+
+test("interval count breaks ties within the same interval", () => {
+	const threeMonthly = prepaidPrice({
+		id: "pr_three_monthly",
+		interval: BillingInterval.Month,
+		intervalCount: 3,
+	});
+	const monthly = prepaidPrice({ id: "pr_monthly", interval: BillingInterval.Month });
+
+	const target = findPrepaidQuantityTargetPrice({
+		prices: [threeMonthly, monthly],
+		featureId: "messages",
+	});
+
+	expect(target?.id).toBe("pr_monthly");
+});
+
+test("a lone one-off prepaid price still wins its own feature", () => {
+	const oneOff = prepaidPrice({ id: "pr_one_off", interval: BillingInterval.OneOff });
+
+	const target = findPrepaidQuantityTargetPrice({
+		prices: [fixedPrice({ id: "pr_base" }), oneOff],
+		featureId: "messages",
+	});
+
+	expect(target?.id).toBe("pr_one_off");
+	expect(isLosingPrepaidQuantityPrice({ price: oneOff, prices: [oneOff] })).toBe(false);
+});
+
+test("prices of other features never participate", () => {
+	const wordsOneOff = prepaidPrice({
+		id: "pr_words",
+		interval: BillingInterval.OneOff,
+		featureId: "words",
+	});
+	const messagesMonthly = prepaidPrice({
+		id: "pr_messages",
+		interval: BillingInterval.Month,
+	});
+
+	const target = findPrepaidQuantityTargetPrice({
+		prices: [wordsOneOff, messagesMonthly],
+		featureId: "words",
+	});
+
+	expect(target?.id).toBe("pr_words");
+	expect(
+		isLosingPrepaidQuantityPrice({
+			price: wordsOneOff,
+			prices: [wordsOneOff, messagesMonthly],
+		}),
+	).toBe(false);
+});
+
+test("no prepaid price for the feature resolves to undefined", () => {
+	const target = findPrepaidQuantityTargetPrice({
+		prices: [fixedPrice({ id: "pr_base" })],
+		featureId: "messages",
+	});
+
+	expect(target).toBeUndefined();
+});

--- a/shared/utils/cusEntUtils/balanceUtils/cusEntsToPrepaidQuantity.ts
+++ b/shared/utils/cusEntUtils/balanceUtils/cusEntsToPrepaidQuantity.ts
@@ -1,4 +1,5 @@
 import { cusEntToCusPrice } from "@utils/cusEntUtils/convertCusEntUtils/cusEntToCusPrice";
+import { isLosingPrepaidQuantityPrice } from "@utils/productUtils/priceUtils/findPrice/findPrepaidQuantityTargetPrice";
 import { Decimal } from "decimal.js";
 import {
 	type FullCusEntWithFullCusProduct,
@@ -23,6 +24,19 @@ export const cusEntToPrepaidQuantity = ({
 	if (!cusPrice || !isPrepaidPrice(cusPrice.price)) return 0;
 
 	if (!cusEnt.customer_product) return 0;
+
+	// Tie-break: a losing prepaid price (one-off alongside a recurring prepaid
+	// of the same feature) never owns the feature-keyed quantity.
+	const siblingPrices = cusEnt.customer_product.customer_prices.map(
+		(customerPrice) => customerPrice.price,
+	);
+	if (
+		isLosingPrepaidQuantityPrice({
+			price: cusPrice.price,
+			prices: siblingPrices,
+		})
+	)
+		return 0;
 
 	// 3. Get quantity
 	const options = cusProductToFeatureOptions({

--- a/shared/utils/cusEntUtils/convertCusEntUtils/customerEntitlementToOptions.ts
+++ b/shared/utils/cusEntUtils/convertCusEntUtils/customerEntitlementToOptions.ts
@@ -1,11 +1,31 @@
 import type { FullCusEntWithFullCusProduct } from "@models/cusProductModels/cusEntModels/cusEntWithProduct";
 import { entToOptions } from "@utils/productUtils/convertProductUtils";
+import { isLosingPrepaidQuantityPrice } from "@utils/productUtils/priceUtils/findPrice/findPrepaidQuantityTargetPrice";
+import { cusEntToCusPrice } from "./cusEntToCusPrice";
 
 export const customerEntitlementToOptions = ({
 	customerEntitlement,
 }: {
 	customerEntitlement: FullCusEntWithFullCusProduct;
 }) => {
+	// Tie-break: options are feature-keyed, so a losing prepaid price (one-off
+	// alongside a recurring prepaid of the same feature) must not read them.
+	const cusPrice = cusEntToCusPrice({ cusEnt: customerEntitlement });
+	const siblingPrices =
+		customerEntitlement.customer_product?.customer_prices.map(
+			(customerPrice) => customerPrice.price,
+		) ?? [];
+
+	if (
+		cusPrice &&
+		isLosingPrepaidQuantityPrice({
+			price: cusPrice.price,
+			prices: siblingPrices,
+		})
+	) {
+		return undefined;
+	}
+
 	return entToOptions({
 		ent: customerEntitlement.entitlement,
 		options: customerEntitlement.customer_product?.options ?? [],

--- a/shared/utils/cusEntUtils/convertCusEntUtils/customerEntitlementToOptions.ts
+++ b/shared/utils/cusEntUtils/convertCusEntUtils/customerEntitlementToOptions.ts
@@ -8,8 +8,15 @@ export const customerEntitlementToOptions = ({
 }: {
 	customerEntitlement: FullCusEntWithFullCusProduct;
 }) => {
-	// Tie-break: options are feature-keyed, so a losing prepaid price (one-off
-	// alongside a recurring prepaid of the same feature) must not read them.
+	const options = entToOptions({
+		ent: customerEntitlement.entitlement,
+		options: customerEntitlement.customer_product?.options ?? [],
+	});
+	if (!options) return undefined;
+
+	// Tie-break: options are feature-keyed, so a losing prepaid price (e.g. one-off
+	// alongside a recurring prepaid of the same feature) reads a zeroed copy —
+	// never the winner's quantity, but still present so renewal resets run.
 	const cusPrice = cusEntToCusPrice({ cusEnt: customerEntitlement });
 	const siblingPrices =
 		customerEntitlement.customer_product?.customer_prices.map(
@@ -23,11 +30,8 @@ export const customerEntitlementToOptions = ({
 			prices: siblingPrices,
 		})
 	) {
-		return undefined;
+		return { ...options, quantity: 0, upcoming_quantity: null };
 	}
 
-	return entToOptions({
-		ent: customerEntitlement.entitlement,
-		options: customerEntitlement.customer_product?.options ?? [],
-	});
+	return options;
 };

--- a/shared/utils/cusProductUtils/classifyCustomerProduct/classifyCustomerProduct.ts
+++ b/shared/utils/cusProductUtils/classifyCustomerProduct/classifyCustomerProduct.ts
@@ -5,7 +5,6 @@ import type {
 } from "@models/cusProductModels/cusProductModels.js";
 import type { Product } from "@models/productModels/productModels";
 import {
-	isOneOffPrice,
 	isPrepaidPrice,
 	orgDefaultAppliesToEntities,
 } from "../../..";
@@ -319,24 +318,6 @@ export const customerProductHasPrepaidPrice = (
 	if (!customerProduct) return false;
 	const prices = cusProductToPrices({ cusProduct: customerProduct });
 	return prices.some((price) => isPrepaidPrice(price));
-};
-
-/** A plan may host both a recurring price and a one-off prepaid price for the same
- * feature — this predicate finds the one-off prepaid variant specifically. */
-export const customerProductHasOneOffPrepaidForFeature = ({
-	customerProduct,
-	featureId,
-}: {
-	customerProduct?: FullCusProduct;
-	featureId?: string;
-}): boolean => {
-	if (!customerProduct || !featureId) return false;
-	const prices = cusProductToPrices({ cusProduct: customerProduct });
-	return prices.some((price) => {
-		if (!isOneOffPrice(price) || !isPrepaidPrice(price)) return false;
-		const config = price.config as { feature_id?: string };
-		return config.feature_id === featureId;
-	});
 };
 
 // ============================================================================

--- a/shared/utils/productUtils/priceUtils/findPrice/findPrepaidQuantityTargetPrice.ts
+++ b/shared/utils/productUtils/priceUtils/findPrice/findPrepaidQuantityTargetPrice.ts
@@ -1,0 +1,56 @@
+import type { UsagePriceConfig } from "@models/productModels/priceModels/priceConfig/usagePriceConfig";
+import type { Price } from "@models/productModels/priceModels/priceModels";
+import { intervalToValue } from "@utils/intervalUtils";
+import { isOneOffPrice, isPrepaidPrice } from "../classifyPriceUtils";
+
+/** Tie-breaker for feature-keyed prepaid quantities: when a feature has both
+ * recurring and one-off prepaid prices, recurring wins (shortest interval first). */
+export const findPrepaidQuantityTargetPrice = ({
+	prices,
+	featureId,
+	internalFeatureId,
+}: {
+	prices: Price[];
+	featureId?: string | null;
+	internalFeatureId?: string | null;
+}): (Price & { config: UsagePriceConfig }) | undefined => {
+	const prepaidPrices = prices.filter(
+		(price): price is Price & { config: UsagePriceConfig } => {
+			if (!isPrepaidPrice(price)) return false;
+			if (internalFeatureId)
+				return price.config.internal_feature_id === internalFeatureId;
+			if (featureId) return price.config.feature_id === featureId;
+			return false;
+		},
+	);
+
+	const recurringPrepaidPrices = prepaidPrices
+		.filter((price) => !isOneOffPrice(price))
+		.sort(
+			(a, b) =>
+				intervalToValue(a.config.interval, a.config.interval_count) -
+				intervalToValue(b.config.interval, b.config.interval_count),
+		);
+
+	return recurringPrepaidPrices[0] ?? prepaidPrices[0];
+};
+
+/** True when `price` is a prepaid price that loses the feature-quantity
+ * tie-break to a sibling prepaid price of the same feature. */
+export const isLosingPrepaidQuantityPrice = ({
+	price,
+	prices,
+}: {
+	price: Price;
+	prices: Price[];
+}): boolean => {
+	if (!isPrepaidPrice(price)) return false;
+
+	const targetPrice = findPrepaidQuantityTargetPrice({
+		prices,
+		internalFeatureId: price.config.internal_feature_id,
+		featureId: price.config.feature_id,
+	});
+
+	return targetPrice !== undefined && targetPrice.id !== price.id;
+};

--- a/shared/utils/productUtils/priceUtils/index.ts
+++ b/shared/utils/productUtils/priceUtils/index.ts
@@ -13,6 +13,7 @@ export * from "./convertPrice/priceToRequiredStripeSlots.js";
 export * from "./convertPrice/priceToStripeNickname.js";
 export * from "./convertPrice/priceToStripeTiersMode.js";
 export * from "./convertPriceUtils.js";
+export * from "./findPrice/findPrepaidQuantityTargetPrice.js";
 export * from "./findPrice/findPriceByFeatureId.js";
 export * from "./findPrice/findPriceSuccessor.js";
 export * from "./formatPriceUtils.js";


### PR DESCRIPTION
## Problem

`cusProduct.options` (FeatureOptions) is keyed by feature only. When a plan hosts **both** a recurring prepaid and a one-off prepaid price for the **same feature**, every consumer that resolves options or prices by feature (`entToOptions`, `cusProductToFeatureOptions`, `findCusPriceByFeature`) picks an arbitrary entry:

- **billing.attach** with `feature_quantities` applied the quantity to *both* prices → double charge + double balance grant.
- **billing.update** routed to ManualTopUp whenever *any* one-off prepaid matched the feature, even with a recurring prepaid present, and the complex-update guard misfired.

## Fix: tie-break, recurring wins

Stop-gap while the options model stays feature-keyed: when `feature_quantities` targets a feature with multiple prepaid prices, the **recurring** price wins (shortest interval among recurring); the one-off contributes only its included usage. A feature with only a one-off prepaid is unaffected.

New shared resolver `findPrepaidQuantityTargetPrice` / `isLosingPrepaidQuantityPrice` (`shared/utils/productUtils/priceUtils/findPrice/`), applied at:

- `setupFeatureQuantitiesContext` — only the winning price consumes the params entry (attach, createSchedule, multiAttach and sync inherit this)
- `initCustomerEntitlementBalance` — losing prepaid ent grants allowance only
- `customerEntitlementToOptions` — Stripe item specs for a losing price read no quantity
- `cusEntToPrepaidQuantity` — invoice/line-item quantity is 0 for a losing price
- `setupUpdateSubscriptionIntent` — ManualTopUp only when the tie-break target is the one-off (replaces `customerProductHasOneOffPrepaidForFeature`, now removed)
- `computeUpdateQuantityPlan` / `computeUpdateQuantityDetails` — quantity updates resolve to the winning recurring price
- `handleOneOffErrors` — complex-update guard only fires when the one-off is the target

## Tests

- `manual-top-up/prepaid-tie-break.test.ts` (integration, written red-first): attach on a mixed plan charges base + recurring only; update is absolute UpdateQuantity, not ManualTopUp delta; a one-off-only feature on the same plan still manual-tops-up.
- `unit/products/findPrepaidQuantityTargetPrice.test.ts`: recurring-beats-one-off, shortest interval (incl. interval_count), lone one-off wins its own feature, cross-feature isolation.

Sweep of `update-subscription/{manual-top-up,update-quantity,one-off-prepaid-preserve}`, feature-quantity error tests, and the unit suite: all failures observed also reproduce with the change stashed (pre-existing on this environment), none introduced by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `feature_quantities` handling when a plan has both a recurring prepaid and a one-off prepaid price for the same feature. Previously, quantity was applied to both prices (double charge) or routed to the wrong update intent; now the recurring prepaid wins, and one-off-only features still work as before.

**Changes**
- Adds `findPrepaidQuantityTargetPrice` and `isLosingPrepaidQuantityPrice` to resolve the winning price for a feature-keyed quantity.
- Applies the tie-break in attach, update, and entitlement balance flows so only the winning price consumes the quantity; losing prepaid entitlements keep a zeroed options copy so renewal resets still run.
- Removes `customerProductHasOneOffPrepaidForFeature` in favor of the new resolver.

<sup>Written for commit 34c4aafb65193b9a5cb37daa2d23db0d1ec2221f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR consistently resolves feature-level quantities to one prepaid price, preferring recurring prices over one-off prices and the shortest recurring interval when necessary.
- **Bug fixes:** Prevents the same quantity from being charged and granted through both recurring and one-off prepaid prices.
- **Bug fixes:** Routes mixed-price subscription updates through recurring quantity updates while preserving manual top-ups for one-off-only features.
- **Improvements:** Reuses the selected prepaid entitlement throughout line-item and balance calculations.
- **Improvements:** Adds integration and unit coverage for mixed prepaid prices, interval precedence, and feature isolation.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/productUtils/priceUtils/findPrice/findPrepaidQuantityTargetPrice.ts | Adds the shared feature-scoped resolver that prefers recurring prepaid prices and orders them by interval length. |
| server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityDetails.ts | Resolves the exact winning customer price and threads its matching entitlement into quantity line-item computation. |
| server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionIntent.ts | Selects manual top-up only when the resolved prepaid target is one-off. |
| server/src/internal/billing/v2/setup/setupFeatureQuantitiesContext.ts | Prevents losing prepaid prices from consuming the feature-level quantity. |
| shared/utils/cusEntUtils/convertCusEntUtils/customerEntitlementToOptions.ts | Supplies zeroed options for losing prepaid entitlements so the winning quantity does not leak into their billing representation. |
| server/tests/integration/billing/update-subscription/manual-top-up/prepaid-tie-break.test.ts | Covers attach charges, absolute recurring updates, balances, and one-off-only manual top-ups. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Request[feature_quantities request] --> Resolver[Resolve prepaid target for feature]
    Resolver --> HasRecurring{Recurring prepaid exists?}
    HasRecurring -->|Yes| Shortest[Select shortest recurring interval]
    HasRecurring -->|No| OneOff[Select one-off prepaid]
    Shortest --> QuantityUpdate[Apply absolute quantity update]
    OneOff --> ManualTopUp[Apply manual top-up]
    Resolver --> Losing[Other prepaid prices]
    Losing --> IncludedOnly[Preserve included allowance without consuming quantity]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address review — zeroed options for..."](https://github.com/useautumn/autumn/commit/34c4aafb65193b9a5cb37daa2d23db0d1ec2221f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59929744)</sub>

<!-- /greptile_comment -->