### PR TITLE
feat(balances): reject usage_limit alerts with no resolvable cap

### DIFF
--- a/server/src/internal/balances/usageAlerts/validate/assertCustomerUsageLimitAlertsResolvable.ts
+++ b/server/src/internal/balances/usageAlerts/validate/assertCustomerUsageLimitAlertsResolvable.ts
@@ -3,7 +3,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubject } from "@/internal/customers/repos/getFullSubject/getFullSubject.js";
 import { assertUsageLimitAlertsResolvable } from "./assertUsageLimitAlertsResolvable.js";
 import { fullSubjectToPlanUsageLimits } from "./fullSubjectToPlanUsageLimits.js";
-import { writesUsageLimitAlert } from "./writesUsageLimitAlert.js";
+import { hasUsageLimitBasisAlert } from "./hasUsageLimitBasisAlert.js";
 
 export const assertCustomerUsageLimitAlertsResolvable = async ({
 	ctx,
@@ -15,7 +15,7 @@ export const assertCustomerUsageLimitAlertsResolvable = async ({
 	billingControls: CustomerBillingControlsParams | null | undefined;
 }): Promise<void> => {
 	const usageAlerts = billingControls?.usage_alerts;
-	if (!writesUsageLimitAlert(usageAlerts)) return;
+	if (!hasUsageLimitBasisAlert(usageAlerts)) return;
 
 	const fullSubject = await getFullSubject({
 		ctx,
@@ -23,6 +23,7 @@ export const assertCustomerUsageLimitAlertsResolvable = async ({
 	});
 	assertUsageLimitAlertsResolvable({
 		usageAlerts,
+		storedUsageAlerts: customer.usage_alerts,
 		usageLimitLists: [
 			billingControls?.usage_limits ?? customer.usage_limits,
 			fullSubjectToPlanUsageLimits({ ctx, fullSubject }),

--- a/server/src/internal/balances/usageAlerts/validate/assertCustomerUsageLimitAlertsResolvable.ts
+++ b/server/src/internal/balances/usageAlerts/validate/assertCustomerUsageLimitAlertsResolvable.ts
@@ -5,7 +5,6 @@ import { assertUsageLimitAlertsResolvable } from "./assertUsageLimitAlertsResolv
 import { fullSubjectToPlanUsageLimits } from "./fullSubjectToPlanUsageLimits.js";
 import { writesUsageLimitAlert } from "./writesUsageLimitAlert.js";
 
-/** Customer alerts see the customer's limits as this write leaves them, then the plans'. */
 export const assertCustomerUsageLimitAlertsResolvable = async ({
 	ctx,
 	customer,

--- a/server/src/internal/balances/usageAlerts/validate/assertCustomerUsageLimitAlertsResolvable.ts
+++ b/server/src/internal/balances/usageAlerts/validate/assertCustomerUsageLimitAlertsResolvable.ts
@@ -1,0 +1,32 @@
+import type { Customer, CustomerBillingControlsParams } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getFullSubject } from "@/internal/customers/repos/getFullSubject/getFullSubject.js";
+import { assertUsageLimitAlertsResolvable } from "./assertUsageLimitAlertsResolvable.js";
+import { fullSubjectToPlanUsageLimits } from "./fullSubjectToPlanUsageLimits.js";
+import { writesUsageLimitAlert } from "./writesUsageLimitAlert.js";
+
+/** Customer alerts see the customer's limits as this write leaves them, then the plans'. */
+export const assertCustomerUsageLimitAlertsResolvable = async ({
+	ctx,
+	customer,
+	billingControls,
+}: {
+	ctx: AutumnContext;
+	customer: Customer;
+	billingControls: CustomerBillingControlsParams | null | undefined;
+}): Promise<void> => {
+	const usageAlerts = billingControls?.usage_alerts;
+	if (!writesUsageLimitAlert(usageAlerts)) return;
+
+	const fullSubject = await getFullSubject({
+		ctx,
+		customerId: customer.id ?? customer.internal_id,
+	});
+	assertUsageLimitAlertsResolvable({
+		usageAlerts,
+		usageLimitLists: [
+			billingControls?.usage_limits ?? customer.usage_limits,
+			fullSubjectToPlanUsageLimits({ ctx, fullSubject }),
+		],
+	});
+};

--- a/server/src/internal/balances/usageAlerts/validate/assertEntityUsageLimitAlertsResolvable.ts
+++ b/server/src/internal/balances/usageAlerts/validate/assertEntityUsageLimitAlertsResolvable.ts
@@ -6,7 +6,7 @@ import type {
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { assertUsageLimitAlertsResolvable } from "./assertUsageLimitAlertsResolvable.js";
 import { fullSubjectToPlanUsageLimits } from "./fullSubjectToPlanUsageLimits.js";
-import { writesUsageLimitAlert } from "./writesUsageLimitAlert.js";
+import { hasUsageLimitBasisAlert } from "./hasUsageLimitBasisAlert.js";
 
 export const assertEntityUsageLimitAlertsResolvable = ({
 	ctx,
@@ -20,10 +20,11 @@ export const assertEntityUsageLimitAlertsResolvable = ({
 	billingControls: ApiEntityBillingControlsParams | null | undefined;
 }): void => {
 	const usageAlerts = billingControls?.usage_alerts;
-	if (!writesUsageLimitAlert(usageAlerts)) return;
+	if (!hasUsageLimitBasisAlert(usageAlerts)) return;
 
 	assertUsageLimitAlertsResolvable({
 		usageAlerts,
+		storedUsageAlerts: entity.usage_alerts,
 		usageLimitLists: [
 			billingControls?.usage_limits ?? entity.usage_limits,
 			fullSubject.customer.usage_limits,

--- a/server/src/internal/balances/usageAlerts/validate/assertEntityUsageLimitAlertsResolvable.ts
+++ b/server/src/internal/balances/usageAlerts/validate/assertEntityUsageLimitAlertsResolvable.ts
@@ -8,7 +8,6 @@ import { assertUsageLimitAlertsResolvable } from "./assertUsageLimitAlertsResolv
 import { fullSubjectToPlanUsageLimits } from "./fullSubjectToPlanUsageLimits.js";
 import { writesUsageLimitAlert } from "./writesUsageLimitAlert.js";
 
-/** Entity alerts see the entity's limits as this write leaves them, then the customer's, then the plans'. */
 export const assertEntityUsageLimitAlertsResolvable = ({
 	ctx,
 	entity,

--- a/server/src/internal/balances/usageAlerts/validate/assertEntityUsageLimitAlertsResolvable.ts
+++ b/server/src/internal/balances/usageAlerts/validate/assertEntityUsageLimitAlertsResolvable.ts
@@ -1,0 +1,34 @@
+import type {
+	ApiEntityBillingControlsParams,
+	Entity,
+	FullSubject,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { assertUsageLimitAlertsResolvable } from "./assertUsageLimitAlertsResolvable.js";
+import { fullSubjectToPlanUsageLimits } from "./fullSubjectToPlanUsageLimits.js";
+import { writesUsageLimitAlert } from "./writesUsageLimitAlert.js";
+
+/** Entity alerts see the entity's limits as this write leaves them, then the customer's, then the plans'. */
+export const assertEntityUsageLimitAlertsResolvable = ({
+	ctx,
+	entity,
+	fullSubject,
+	billingControls,
+}: {
+	ctx: AutumnContext;
+	entity: Entity;
+	fullSubject: FullSubject;
+	billingControls: ApiEntityBillingControlsParams | null | undefined;
+}): void => {
+	const usageAlerts = billingControls?.usage_alerts;
+	if (!writesUsageLimitAlert(usageAlerts)) return;
+
+	assertUsageLimitAlertsResolvable({
+		usageAlerts,
+		usageLimitLists: [
+			billingControls?.usage_limits ?? entity.usage_limits,
+			fullSubject.customer.usage_limits,
+			fullSubjectToPlanUsageLimits({ ctx, fullSubject }),
+		],
+	});
+};

--- a/server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts
+++ b/server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts
@@ -28,18 +28,18 @@ export const writesUsageLimitAlert = (
 ): boolean => (usageAlerts ?? []).some(isUsageLimitBasisAlert);
 
 /**
- * A usage_limit alert must point at a cap the subject can already see:
- * its own limits (as they will be after this write), then the customer's,
- * then the plans enforcement reads. Throws 400 naming the first orphaned alert.
+ * A usage_limit alert must point at a cap the subject will see after this
+ * write: the caller passes the scope's limits as they will be stored, and the
+ * plans enforcement reads are added here. Throws 400 naming the first orphan.
  */
 export const assertUsageLimitAlertsResolvable = ({
 	usageAlerts,
-	ownUsageLimits,
+	scopeUsageLimits,
 	fullSubject,
 	inStatuses,
 }: {
 	usageAlerts: DbUsageAlertLike[];
-	ownUsageLimits: Array<DbUsageLimit[] | null | undefined>;
+	scopeUsageLimits: Array<DbUsageLimit[] | null | undefined>;
 	fullSubject: FullSubject | null | undefined;
 	inStatuses: CusProductStatus[];
 }): void => {
@@ -48,8 +48,7 @@ export const assertUsageLimitAlertsResolvable = ({
 	const unresolvable = findUnresolvableUsageLimitAlerts({
 		usageAlerts,
 		usageLimitLists: [
-			...ownUsageLimits,
-			fullSubject?.customer.usage_limits,
+			...scopeUsageLimits,
 			fullSubject ? planUsageLimitsOf({ fullSubject, inStatuses }) : [],
 		],
 	});

--- a/server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts
+++ b/server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts
@@ -6,7 +6,6 @@ import {
 	RecaseError,
 } from "@autumn/shared";
 
-/** Every usage_limit alert must match a cap in one of the lists the scope will see after this write. */
 export const assertUsageLimitAlertsResolvable = ({
 	usageAlerts,
 	usageLimitLists,

--- a/server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts
+++ b/server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts
@@ -2,27 +2,36 @@ import {
 	type DbUsageAlertLike,
 	type DbUsageLimitLike,
 	ErrCode,
-	findUnresolvableUsageLimitAlerts,
+	filterUnresolvableUsageLimitAlerts,
 	RecaseError,
+	usageAlertIdentity,
 } from "@autumn/shared";
 
+// Stored alerts stay dormant when their cap goes away; only newly written alerts must resolve one.
 export const assertUsageLimitAlertsResolvable = ({
 	usageAlerts,
+	storedUsageAlerts,
 	usageLimitLists,
 }: {
 	usageAlerts: DbUsageAlertLike[];
+	storedUsageAlerts: DbUsageAlertLike[] | null | undefined;
 	usageLimitLists: Array<
 		Array<Pick<DbUsageLimitLike, "feature_id" | "filter">> | null | undefined
 	>;
 }): void => {
-	const orphan = findUnresolvableUsageLimitAlerts({
+	const storedIdentities = new Set(
+		(storedUsageAlerts ?? []).map(usageAlertIdentity),
+	);
+	const orphan = filterUnresolvableUsageLimitAlerts({
 		usageAlerts,
 		usageLimitLists,
-	})[0];
+	}).find(
+		({ usageAlert }) => !storedIdentities.has(usageAlertIdentity(usageAlert)),
+	);
 	if (!orphan) return;
 
 	throw new RecaseError({
-		message: `usage_alerts[${orphan.index}] uses basis usage_limit but no usage limit matches feature ${orphan.usageAlert.feature_id ?? "(any)"} and its filter`,
+		message: `usage_alerts[${orphan.index}] uses basis usage_limit but no usage limit matches feature ${orphan.usageAlert.feature_id} and its filter`,
 		code: ErrCode.InvalidRequest,
 		statusCode: 400,
 	});

--- a/server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts
+++ b/server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts
@@ -1,6 +1,6 @@
 import {
-	type DbUsageAlert,
-	type DbUsageAlertParams,
+	type CusProductStatus,
+	type DbUsageAlertLike,
 	type DbUsageLimit,
 	ErrCode,
 	type FullSubject,
@@ -11,33 +11,46 @@ import {
 	RecaseError,
 } from "@autumn/shared";
 
-const planUsageLimitsOf = (fullSubject: FullSubject): DbUsageLimit[] =>
+const planUsageLimitsOf = ({
+	fullSubject,
+	inStatuses,
+}: {
+	fullSubject: FullSubject;
+	inStatuses: CusProductStatus[];
+}): DbUsageLimit[] =>
 	getPlanBillingControlProducts({
 		customerProducts: fullSubjectToPlanProducts({ fullSubject }),
+		inStatuses,
 	}).flatMap((customerProduct) => customerProduct.product?.usage_limits ?? []);
+
+export const writesUsageLimitAlert = (
+	usageAlerts: DbUsageAlertLike[] | null | undefined,
+): boolean => (usageAlerts ?? []).some(isUsageLimitBasisAlert);
 
 /**
  * A usage_limit alert must point at a cap the subject can already see:
  * its own limits (as they will be after this write), then the customer's,
- * then the active plans'. Throws 400 naming the first orphaned alert.
+ * then the plans enforcement reads. Throws 400 naming the first orphaned alert.
  */
 export const assertUsageLimitAlertsResolvable = ({
 	usageAlerts,
 	ownUsageLimits,
 	fullSubject,
+	inStatuses,
 }: {
-	usageAlerts: Array<DbUsageAlert | DbUsageAlertParams>;
+	usageAlerts: DbUsageAlertLike[];
 	ownUsageLimits: Array<DbUsageLimit[] | null | undefined>;
 	fullSubject: FullSubject | null | undefined;
+	inStatuses: CusProductStatus[];
 }): void => {
-	if (!usageAlerts.some(isUsageLimitBasisAlert)) return;
+	if (!writesUsageLimitAlert(usageAlerts)) return;
 
 	const unresolvable = findUnresolvableUsageLimitAlerts({
 		usageAlerts,
 		usageLimitLists: [
 			...ownUsageLimits,
 			fullSubject?.customer.usage_limits,
-			fullSubject ? planUsageLimitsOf(fullSubject) : [],
+			fullSubject ? planUsageLimitsOf({ fullSubject, inStatuses }) : [],
 		],
 	});
 	const orphan = unresolvable[0];

--- a/server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts
+++ b/server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts
@@ -1,58 +1,25 @@
 import {
-	type CusProductStatus,
 	type DbUsageAlertLike,
-	type DbUsageLimit,
+	type DbUsageLimitLike,
 	ErrCode,
-	type FullSubject,
 	findUnresolvableUsageLimitAlerts,
-	fullSubjectToPlanProducts,
-	getPlanBillingControlProducts,
-	isUsageLimitBasisAlert,
 	RecaseError,
 } from "@autumn/shared";
 
-const planUsageLimitsOf = ({
-	fullSubject,
-	inStatuses,
-}: {
-	fullSubject: FullSubject;
-	inStatuses: CusProductStatus[];
-}): DbUsageLimit[] =>
-	getPlanBillingControlProducts({
-		customerProducts: fullSubjectToPlanProducts({ fullSubject }),
-		inStatuses,
-	}).flatMap((customerProduct) => customerProduct.product?.usage_limits ?? []);
-
-export const writesUsageLimitAlert = (
-	usageAlerts: DbUsageAlertLike[] | null | undefined,
-): boolean => (usageAlerts ?? []).some(isUsageLimitBasisAlert);
-
-/**
- * A usage_limit alert must point at a cap the subject will see after this
- * write: the caller passes the scope's limits as they will be stored, and the
- * plans enforcement reads are added here. Throws 400 naming the first orphan.
- */
+/** Every usage_limit alert must match a cap in one of the lists the scope will see after this write. */
 export const assertUsageLimitAlertsResolvable = ({
 	usageAlerts,
-	scopeUsageLimits,
-	fullSubject,
-	inStatuses,
+	usageLimitLists,
 }: {
 	usageAlerts: DbUsageAlertLike[];
-	scopeUsageLimits: Array<DbUsageLimit[] | null | undefined>;
-	fullSubject: FullSubject | null | undefined;
-	inStatuses: CusProductStatus[];
+	usageLimitLists: Array<
+		Array<Pick<DbUsageLimitLike, "feature_id" | "filter">> | null | undefined
+	>;
 }): void => {
-	if (!writesUsageLimitAlert(usageAlerts)) return;
-
-	const unresolvable = findUnresolvableUsageLimitAlerts({
+	const orphan = findUnresolvableUsageLimitAlerts({
 		usageAlerts,
-		usageLimitLists: [
-			...scopeUsageLimits,
-			fullSubject ? planUsageLimitsOf({ fullSubject, inStatuses }) : [],
-		],
-	});
-	const orphan = unresolvable[0];
+		usageLimitLists,
+	})[0];
 	if (!orphan) return;
 
 	throw new RecaseError({

--- a/server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts
+++ b/server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts
@@ -1,0 +1,51 @@
+import {
+	type DbUsageAlert,
+	type DbUsageAlertParams,
+	type DbUsageLimit,
+	ErrCode,
+	type FullSubject,
+	findUnresolvableUsageLimitAlerts,
+	fullSubjectToPlanProducts,
+	getPlanBillingControlProducts,
+	isUsageLimitBasisAlert,
+	RecaseError,
+} from "@autumn/shared";
+
+const planUsageLimitsOf = (fullSubject: FullSubject): DbUsageLimit[] =>
+	getPlanBillingControlProducts({
+		customerProducts: fullSubjectToPlanProducts({ fullSubject }),
+	}).flatMap((customerProduct) => customerProduct.product?.usage_limits ?? []);
+
+/**
+ * A usage_limit alert must point at a cap the subject can already see:
+ * its own limits (as they will be after this write), then the customer's,
+ * then the active plans'. Throws 400 naming the first orphaned alert.
+ */
+export const assertUsageLimitAlertsResolvable = ({
+	usageAlerts,
+	ownUsageLimits,
+	fullSubject,
+}: {
+	usageAlerts: Array<DbUsageAlert | DbUsageAlertParams>;
+	ownUsageLimits: Array<DbUsageLimit[] | null | undefined>;
+	fullSubject: FullSubject | null | undefined;
+}): void => {
+	if (!usageAlerts.some(isUsageLimitBasisAlert)) return;
+
+	const unresolvable = findUnresolvableUsageLimitAlerts({
+		usageAlerts,
+		usageLimitLists: [
+			...ownUsageLimits,
+			fullSubject?.customer.usage_limits,
+			fullSubject ? planUsageLimitsOf(fullSubject) : [],
+		],
+	});
+	const orphan = unresolvable[0];
+	if (!orphan) return;
+
+	throw new RecaseError({
+		message: `usage_alerts[${orphan.index}] uses basis usage_limit but no usage limit matches feature ${orphan.usageAlert.feature_id ?? "(any)"} and its filter`,
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+	});
+};

--- a/server/src/internal/balances/usageAlerts/validate/fullSubjectToPlanUsageLimits.ts
+++ b/server/src/internal/balances/usageAlerts/validate/fullSubjectToPlanUsageLimits.ts
@@ -17,6 +17,7 @@ export const fullSubjectToPlanUsageLimits = ({
 	fullSubject
 		? getPlanBillingControlProducts({
 				customerProducts: fullSubjectToPlanProducts({ fullSubject }),
+				now: ctx.timestamp,
 				inStatuses: orgToInStatuses({ org: ctx.org }),
 			}).flatMap(
 				(customerProduct) => customerProduct.product?.usage_limits ?? [],

--- a/server/src/internal/balances/usageAlerts/validate/fullSubjectToPlanUsageLimits.ts
+++ b/server/src/internal/balances/usageAlerts/validate/fullSubjectToPlanUsageLimits.ts
@@ -7,7 +7,6 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
-/** Caps the subject's plans supply, on the statuses enforcement reads. */
 export const fullSubjectToPlanUsageLimits = ({
 	ctx,
 	fullSubject,

--- a/server/src/internal/balances/usageAlerts/validate/fullSubjectToPlanUsageLimits.ts
+++ b/server/src/internal/balances/usageAlerts/validate/fullSubjectToPlanUsageLimits.ts
@@ -1,0 +1,25 @@
+import {
+	type DbUsageLimit,
+	type FullSubject,
+	fullSubjectToPlanProducts,
+	getPlanBillingControlProducts,
+	orgToInStatuses,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+/** Caps the subject's plans supply, on the statuses enforcement reads. */
+export const fullSubjectToPlanUsageLimits = ({
+	ctx,
+	fullSubject,
+}: {
+	ctx: AutumnContext;
+	fullSubject: FullSubject | null | undefined;
+}): DbUsageLimit[] =>
+	fullSubject
+		? getPlanBillingControlProducts({
+				customerProducts: fullSubjectToPlanProducts({ fullSubject }),
+				inStatuses: orgToInStatuses({ org: ctx.org }),
+			}).flatMap(
+				(customerProduct) => customerProduct.product?.usage_limits ?? [],
+			)
+		: [];

--- a/server/src/internal/balances/usageAlerts/validate/hasUsageLimitBasisAlert.ts
+++ b/server/src/internal/balances/usageAlerts/validate/hasUsageLimitBasisAlert.ts
@@ -1,6 +1,6 @@
 import { type DbUsageAlertLike, isUsageLimitBasisAlert } from "@autumn/shared";
 
-export const writesUsageLimitAlert = (
+export const hasUsageLimitBasisAlert = (
 	usageAlerts: DbUsageAlertLike[] | null | undefined,
 ): usageAlerts is DbUsageAlertLike[] =>
 	(usageAlerts ?? []).some(isUsageLimitBasisAlert);

--- a/server/src/internal/balances/usageAlerts/validate/writesUsageLimitAlert.ts
+++ b/server/src/internal/balances/usageAlerts/validate/writesUsageLimitAlert.ts
@@ -1,0 +1,6 @@
+import { type DbUsageAlertLike, isUsageLimitBasisAlert } from "@autumn/shared";
+
+export const writesUsageLimitAlert = (
+	usageAlerts: DbUsageAlertLike[] | null | undefined,
+): usageAlerts is DbUsageAlertLike[] =>
+	(usageAlerts ?? []).some(isUsageLimitBasisAlert);

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUpsertProductErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUpsertProductErrors.ts
@@ -66,9 +66,12 @@ export const handleUpsertProductErrors = ({
 		});
 		const latestExistingVersion = maxVersion === 0 ? undefined : maxVersion;
 
-		// 1. Free trial errors (one-off products cannot trial)
+		// 1. Free trial errors (one-off products cannot trial); new usage_limit alerts need a cap
 		handleFreeTrialErrors({ nextFullProduct });
-		handleUsageLimitAlertErrors({ nextFullProduct });
+		handleUsageLimitAlertErrors({
+			nextFullProduct,
+			currentFullProduct: upsert.row.currentFullProduct,
+		});
 
 		// 2. Default flag errors (historical version; paid default; never on a variant)
 		handleDefaultFlagErrors({

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUpsertProductErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUpsertProductErrors.ts
@@ -4,6 +4,7 @@ import { handleDirectBaseAndVariantPairErrors } from "@/internal/catalogV2/actio
 import { handleFreeTrialErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleFreeTrialErrors";
 import { handleLicenseParentPropagationErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleLicenseParentPropagationErrors";
 import { handlePlanLicenseErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handlePlanLicenseErrors";
+import { handleUsageLimitAlertErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUsageLimitAlertErrors";
 import { handleVariantErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleVariantErrors";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
@@ -67,6 +68,7 @@ export const handleUpsertProductErrors = ({
 
 		// 1. Free trial errors (one-off products cannot trial)
 		handleFreeTrialErrors({ nextFullProduct });
+		handleUsageLimitAlertErrors({ nextFullProduct });
 
 		// 2. Default flag errors (historical version; paid default; never on a variant)
 		handleDefaultFlagErrors({

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUsageLimitAlertErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUsageLimitAlertErrors.ts
@@ -1,7 +1,6 @@
 import type { FullProduct } from "@autumn/shared";
 import { assertUsageLimitAlertsResolvable } from "@/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable";
 
-/** A plan's usage_limit alerts must match a usage limit on the same plan, read off the merged row. */
 export const handleUsageLimitAlertErrors = ({
 	nextFullProduct,
 }: {

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUsageLimitAlertErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUsageLimitAlertErrors.ts
@@ -3,10 +3,13 @@ import { assertUsageLimitAlertsResolvable } from "@/internal/balances/usageAlert
 
 export const handleUsageLimitAlertErrors = ({
 	nextFullProduct,
+	currentFullProduct,
 }: {
 	nextFullProduct: FullProduct;
+	currentFullProduct: FullProduct | null | undefined;
 }): void =>
 	assertUsageLimitAlertsResolvable({
 		usageAlerts: nextFullProduct.usage_alerts ?? [],
+		storedUsageAlerts: currentFullProduct?.usage_alerts,
 		usageLimitLists: [nextFullProduct.usage_limits],
 	});

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUsageLimitAlertErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUsageLimitAlertErrors.ts
@@ -1,0 +1,13 @@
+import type { FullProduct } from "@autumn/shared";
+import { assertUsageLimitAlertsResolvable } from "@/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable";
+
+/** A plan's usage_limit alerts must match a usage limit on the same plan, read off the merged row. */
+export const handleUsageLimitAlertErrors = ({
+	nextFullProduct,
+}: {
+	nextFullProduct: FullProduct;
+}): void =>
+	assertUsageLimitAlertsResolvable({
+		usageAlerts: nextFullProduct.usage_alerts ?? [],
+		usageLimitLists: [nextFullProduct.usage_limits],
+	});

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -3,6 +3,7 @@ import {
 	CustomerAlreadyExistsError,
 	CustomerNotFoundError,
 	notNullish,
+	orgToInStatuses,
 	ProcessorType,
 	RecaseError,
 	shouldForwardCustomerMetadata,
@@ -18,7 +19,10 @@ import {
 } from "@/external/stripe/customers/utils/autumnToStripeMetadata";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { triggerAutoTopUpsOnEnabled } from "@/internal/balances/autoTopUp/triggerAutoTopUpsOnEnabled";
-import { assertUsageLimitAlertsResolvable } from "@/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable";
+import {
+	assertUsageLimitAlertsResolvable,
+	writesUsageLimitAlert,
+} from "@/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable";
 import { CusService } from "@/internal/customers/CusService";
 import { getFullSubject } from "@/internal/customers/repos/getFullSubject/getFullSubject";
 import { getApiCustomerByRollout } from "../getApiCustomerByRollout";
@@ -61,13 +65,14 @@ export const updateCustomer = async ({
 		autoTopups: billing_controls?.auto_topups ?? [],
 	});
 
-	if (billing_controls?.usage_alerts !== undefined) {
+	if (writesUsageLimitAlert(billing_controls?.usage_alerts)) {
 		assertUsageLimitAlertsResolvable({
-			usageAlerts: billing_controls.usage_alerts,
+			usageAlerts: billing_controls?.usage_alerts ?? [],
 			ownUsageLimits: [
-				billing_controls.usage_limits ?? originalCustomer.usage_limits,
+				billing_controls?.usage_limits ?? originalCustomer.usage_limits,
 			],
 			fullSubject: await getFullSubject({ ctx, customerId }),
+			inStatuses: orgToInStatuses({ org }),
 		});
 	}
 

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -68,7 +68,7 @@ export const updateCustomer = async ({
 	if (writesUsageLimitAlert(billing_controls?.usage_alerts)) {
 		assertUsageLimitAlertsResolvable({
 			usageAlerts: billing_controls?.usage_alerts ?? [],
-			ownUsageLimits: [
+			scopeUsageLimits: [
 				billing_controls?.usage_limits ?? originalCustomer.usage_limits,
 			],
 			fullSubject: await getFullSubject({ ctx, customerId }),

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -3,7 +3,6 @@ import {
 	CustomerAlreadyExistsError,
 	CustomerNotFoundError,
 	notNullish,
-	orgToInStatuses,
 	ProcessorType,
 	RecaseError,
 	shouldForwardCustomerMetadata,
@@ -19,12 +18,8 @@ import {
 } from "@/external/stripe/customers/utils/autumnToStripeMetadata";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { triggerAutoTopUpsOnEnabled } from "@/internal/balances/autoTopUp/triggerAutoTopUpsOnEnabled";
-import {
-	assertUsageLimitAlertsResolvable,
-	writesUsageLimitAlert,
-} from "@/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable";
+import { assertCustomerUsageLimitAlertsResolvable } from "@/internal/balances/usageAlerts/validate/assertCustomerUsageLimitAlertsResolvable";
 import { CusService } from "@/internal/customers/CusService";
-import { getFullSubject } from "@/internal/customers/repos/getFullSubject/getFullSubject";
 import { getApiCustomerByRollout } from "../getApiCustomerByRollout";
 import {
 	syncAutoTopupPurchaseLimitCounts,
@@ -65,16 +60,11 @@ export const updateCustomer = async ({
 		autoTopups: billing_controls?.auto_topups ?? [],
 	});
 
-	if (writesUsageLimitAlert(billing_controls?.usage_alerts)) {
-		assertUsageLimitAlertsResolvable({
-			usageAlerts: billing_controls?.usage_alerts ?? [],
-			scopeUsageLimits: [
-				billing_controls?.usage_limits ?? originalCustomer.usage_limits,
-			],
-			fullSubject: await getFullSubject({ ctx, customerId }),
-			inStatuses: orgToInStatuses({ org }),
-		});
-	}
+	await assertCustomerUsageLimitAlertsResolvable({
+		ctx,
+		customer: originalCustomer,
+		billingControls: billing_controls,
+	});
 
 	if (newCustomerId === null) {
 		throw new RecaseError({

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -60,12 +60,6 @@ export const updateCustomer = async ({
 		autoTopups: billing_controls?.auto_topups ?? [],
 	});
 
-	await assertCustomerUsageLimitAlertsResolvable({
-		ctx,
-		customer: originalCustomer,
-		billingControls: billing_controls,
-	});
-
 	if (newCustomerId === null) {
 		throw new RecaseError({
 			message: "Customer ID cannot be set to null",
@@ -89,6 +83,12 @@ export const updateCustomer = async ({
 			});
 		}
 	}
+
+	await assertCustomerUsageLimitAlertsResolvable({
+		ctx,
+		customer: originalCustomer,
+		billingControls: billing_controls,
+	});
 
 	// Try to update stripe ID. Distinguish omitted (undefined -> leave as is)
 	// from explicitly cleared (null/"" -> unlink the Stripe customer).

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -18,7 +18,9 @@ import {
 } from "@/external/stripe/customers/utils/autumnToStripeMetadata";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { triggerAutoTopUpsOnEnabled } from "@/internal/balances/autoTopUp/triggerAutoTopUpsOnEnabled";
+import { assertUsageLimitAlertsResolvable } from "@/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable";
 import { CusService } from "@/internal/customers/CusService";
+import { getFullSubject } from "@/internal/customers/repos/getFullSubject/getFullSubject";
 import { getApiCustomerByRollout } from "../getApiCustomerByRollout";
 import {
 	syncAutoTopupPurchaseLimitCounts,
@@ -58,6 +60,16 @@ export const updateCustomer = async ({
 	validateAutoTopupPurchaseLimitCounts({
 		autoTopups: billing_controls?.auto_topups ?? [],
 	});
+
+	if (billing_controls?.usage_alerts !== undefined) {
+		assertUsageLimitAlertsResolvable({
+			usageAlerts: billing_controls.usage_alerts,
+			ownUsageLimits: [
+				billing_controls.usage_limits ?? originalCustomer.usage_limits,
+			],
+			fullSubject: await getFullSubject({ ctx, customerId }),
+		});
+	}
 
 	if (newCustomerId === null) {
 		throw new RecaseError({

--- a/server/src/internal/entities/actions/updateEntity.ts
+++ b/server/src/internal/entities/actions/updateEntity.ts
@@ -7,6 +7,7 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { EntityService } from "@/internal/api/entities/EntityService.js";
+import { assertUsageLimitAlertsResolvable } from "@/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.js";
 import { updateCachedEntityData } from "@/internal/customers/cache/fullSubject/actions/updateCachedEntityData.js";
 import { getFullSubject } from "@/internal/customers/repos/getFullSubject/getFullSubject.js";
 
@@ -44,6 +45,14 @@ export const updateEntity = async ({
 
 	if (!entity) {
 		throw new EntityNotFoundError({ entityId });
+	}
+
+	if (billing_controls?.usage_alerts !== undefined) {
+		assertUsageLimitAlertsResolvable({
+			usageAlerts: billing_controls.usage_alerts,
+			ownUsageLimits: [billing_controls.usage_limits ?? entity.usage_limits],
+			fullSubject,
+		});
 	}
 
 	const filteredUpdates = Object.fromEntries(

--- a/server/src/internal/entities/actions/updateEntity.ts
+++ b/server/src/internal/entities/actions/updateEntity.ts
@@ -2,16 +2,12 @@ import {
 	CustomerNotFoundError,
 	EntityNotFoundError,
 	ErrCode,
-	orgToInStatuses,
 	RecaseError,
 	type UpdateEntityParams,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { EntityService } from "@/internal/api/entities/EntityService.js";
-import {
-	assertUsageLimitAlertsResolvable,
-	writesUsageLimitAlert,
-} from "@/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.js";
+import { assertEntityUsageLimitAlertsResolvable } from "@/internal/balances/usageAlerts/validate/assertEntityUsageLimitAlertsResolvable.js";
 import { updateCachedEntityData } from "@/internal/customers/cache/fullSubject/actions/updateCachedEntityData.js";
 import { getFullSubject } from "@/internal/customers/repos/getFullSubject/getFullSubject.js";
 
@@ -51,17 +47,12 @@ export const updateEntity = async ({
 		throw new EntityNotFoundError({ entityId });
 	}
 
-	if (writesUsageLimitAlert(billing_controls?.usage_alerts)) {
-		assertUsageLimitAlertsResolvable({
-			usageAlerts: billing_controls?.usage_alerts ?? [],
-			scopeUsageLimits: [
-				billing_controls?.usage_limits ?? entity.usage_limits,
-				fullSubject.customer.usage_limits,
-			],
-			fullSubject,
-			inStatuses: orgToInStatuses({ org: ctx.org }),
-		});
-	}
+	assertEntityUsageLimitAlertsResolvable({
+		ctx,
+		entity,
+		fullSubject,
+		billingControls: billing_controls,
+	});
 
 	const filteredUpdates = Object.fromEntries(
 		Object.entries({

--- a/server/src/internal/entities/actions/updateEntity.ts
+++ b/server/src/internal/entities/actions/updateEntity.ts
@@ -54,7 +54,10 @@ export const updateEntity = async ({
 	if (writesUsageLimitAlert(billing_controls?.usage_alerts)) {
 		assertUsageLimitAlertsResolvable({
 			usageAlerts: billing_controls?.usage_alerts ?? [],
-			ownUsageLimits: [billing_controls?.usage_limits ?? entity.usage_limits],
+			scopeUsageLimits: [
+				billing_controls?.usage_limits ?? entity.usage_limits,
+				fullSubject.customer.usage_limits,
+			],
 			fullSubject,
 			inStatuses: orgToInStatuses({ org: ctx.org }),
 		});

--- a/server/src/internal/entities/actions/updateEntity.ts
+++ b/server/src/internal/entities/actions/updateEntity.ts
@@ -2,12 +2,16 @@ import {
 	CustomerNotFoundError,
 	EntityNotFoundError,
 	ErrCode,
+	orgToInStatuses,
 	RecaseError,
 	type UpdateEntityParams,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { EntityService } from "@/internal/api/entities/EntityService.js";
-import { assertUsageLimitAlertsResolvable } from "@/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.js";
+import {
+	assertUsageLimitAlertsResolvable,
+	writesUsageLimitAlert,
+} from "@/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.js";
 import { updateCachedEntityData } from "@/internal/customers/cache/fullSubject/actions/updateCachedEntityData.js";
 import { getFullSubject } from "@/internal/customers/repos/getFullSubject/getFullSubject.js";
 
@@ -47,11 +51,12 @@ export const updateEntity = async ({
 		throw new EntityNotFoundError({ entityId });
 	}
 
-	if (billing_controls?.usage_alerts !== undefined) {
+	if (writesUsageLimitAlert(billing_controls?.usage_alerts)) {
 		assertUsageLimitAlertsResolvable({
-			usageAlerts: billing_controls.usage_alerts,
-			ownUsageLimits: [billing_controls.usage_limits ?? entity.usage_limits],
+			usageAlerts: billing_controls?.usage_alerts ?? [],
+			ownUsageLimits: [billing_controls?.usage_limits ?? entity.usage_limits],
 			fullSubject,
+			inStatuses: orgToInStatuses({ org: ctx.org }),
 		});
 	}
 

--- a/server/tests/integration/crud/customers/customer-usage-alert-basis-validation.test.ts
+++ b/server/tests/integration/crud/customers/customer-usage-alert-basis-validation.test.ts
@@ -120,6 +120,7 @@ test.concurrent(
 		await setupCustomer(customerId, "alert-basis-filter-only-ul");
 
 		await expectAutumnError({
+			errMessage: "filter is only valid when basis is usage_limit",
 			func: () =>
 				autumnV2_3.customers.update(customerId, {
 					billing_controls: {
@@ -133,6 +134,7 @@ test.concurrent(
 				}),
 		});
 		await expectAutumnError({
+			errMessage: "filter is only valid when basis is usage_limit",
 			func: () =>
 				autumnV2_3.customers.update(customerId, {
 					billing_controls: {
@@ -152,6 +154,7 @@ test.concurrent(
 		await setupCustomer(customerId, "alert-basis-identity");
 
 		await expectAutumnError({
+			errMessage: "Only one usage alert entry",
 			func: () =>
 				autumnV2_3.customers.update(customerId, {
 					billing_controls: {
@@ -180,6 +183,7 @@ test.concurrent(
 		await setupCustomer(customerId, "alert-basis-needs-limit");
 
 		await expectAutumnError({
+			errMessage: "no usage limit matches",
 			func: () =>
 				autumnV2_3.customers.update(customerId, {
 					billing_controls: {
@@ -192,6 +196,7 @@ test.concurrent(
 			billing_controls: { usage_limits: [dailyLimit()] },
 		});
 		await expectAutumnError({
+			errMessage: "no usage limit matches",
 			func: () =>
 				autumnV2_3.customers.update(customerId, {
 					billing_controls: {
@@ -259,6 +264,7 @@ test.concurrent(
 		const entityId = entities[0].id;
 
 		await expectAutumnError({
+			errMessage: "no usage limit matches",
 			func: () =>
 				autumnV2_3.entities.update(customerId, entityId, {
 					billing_controls: {
@@ -268,6 +274,7 @@ test.concurrent(
 		});
 
 		await expectAutumnError({
+			errMessage: "Only one usage limit entry",
 			func: () =>
 				autumnV2_3.entities.update(customerId, entityId, {
 					billing_controls: {
@@ -316,6 +323,7 @@ test.concurrent(
 			},
 		});
 		await expectAutumnError({
+			errMessage: "No usage limit on this plan matches",
 			func: () => autumnV2_3.products.create(withoutLimit),
 		});
 
@@ -354,6 +362,7 @@ test.concurrent(
 		const usageLimitAlerts = [percentAlert({ basis: "usage_limit" })];
 
 		await expectAutumnError({
+			errMessage: "no usage limit matches",
 			func: () =>
 				autumnV2_3.catalogV2.update({
 					plans: [
@@ -373,10 +382,24 @@ test.concurrent(
 				},
 			],
 		});
+		await autumnV2_3.catalogV2.update({
+			plans: [{ plan_id: planId, billing_controls: { usage_limits: [] } }],
+		});
 		await expectAutumnError({
+			errMessage: "no usage limit matches",
 			func: () =>
 				autumnV2_3.catalogV2.update({
-					plans: [{ plan_id: planId, billing_controls: { usage_limits: [] } }],
+					plans: [
+						{
+							plan_id: planId,
+							billing_controls: {
+								usage_alerts: [
+									...usageLimitAlerts,
+									percentAlert({ basis: "usage_limit", threshold: 90 }),
+								],
+							},
+						},
+					],
 				}),
 		});
 	},

--- a/server/tests/integration/crud/customers/customer-usage-alert-basis-validation.test.ts
+++ b/server/tests/integration/crud/customers/customer-usage-alert-basis-validation.test.ts
@@ -34,6 +34,7 @@ import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { deleteDbPlans } from "../../catalog-v2/plans/utils/expectCatalogPlans.js";
 
 const autumnV2_3 = new AutumnInt({ version: ApiVersion.V2_3 });
 
@@ -337,31 +338,32 @@ test.concurrent(
 	`${chalk.yellowBright("alert-basis-validation8: catalog updates check usage_limit alerts against the merged plan")}`,
 	async () => {
 		const planId = "alert-basis-catalog-merged";
-		await initScenario({ setup: [], actions: [] });
-		const messages = [items.monthlyMessages({ includedUsage: 1000 })];
+		const { ctx } = await initScenario({ setup: [], actions: [] });
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		const plan = {
+			plan_id: planId,
+			name: "Alert basis catalog",
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 1000,
+					reset: { interval: ResetInterval.Month },
+				},
+			],
+		};
 		const usageLimitAlerts = [percentAlert({ basis: "usage_limit" })];
 
 		await expectAutumnError({
 			func: () =>
 				autumnV2_3.catalogV2.update({
 					plans: [
-						{
-							plan_id: planId,
-							items: messages,
-							billing_controls: { usage_alerts: usageLimitAlerts },
-						},
+						{ ...plan, billing_controls: { usage_alerts: usageLimitAlerts } },
 					],
 				}),
 		});
 
 		await autumnV2_3.catalogV2.update({
-			plans: [
-				{
-					plan_id: planId,
-					items: messages,
-					billing_controls: { usage_limits: [dailyLimit()] },
-				},
-			],
+			plans: [{ ...plan, billing_controls: { usage_limits: [dailyLimit()] } }],
 		});
 		await autumnV2_3.catalogV2.update({
 			plans: [

--- a/server/tests/integration/crud/customers/customer-usage-alert-basis-validation.test.ts
+++ b/server/tests/integration/crud/customers/customer-usage-alert-basis-validation.test.ts
@@ -334,6 +334,53 @@ test.concurrent(
 );
 
 test.concurrent(
+	`${chalk.yellowBright("alert-basis-validation8: catalog updates check usage_limit alerts against the merged plan")}`,
+	async () => {
+		const planId = "alert-basis-catalog-merged";
+		await initScenario({ setup: [], actions: [] });
+		const messages = [items.monthlyMessages({ includedUsage: 1000 })];
+		const usageLimitAlerts = [percentAlert({ basis: "usage_limit" })];
+
+		await expectAutumnError({
+			func: () =>
+				autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: planId,
+							items: messages,
+							billing_controls: { usage_alerts: usageLimitAlerts },
+						},
+					],
+				}),
+		});
+
+		await autumnV2_3.catalogV2.update({
+			plans: [
+				{
+					plan_id: planId,
+					items: messages,
+					billing_controls: { usage_limits: [dailyLimit()] },
+				},
+			],
+		});
+		await autumnV2_3.catalogV2.update({
+			plans: [
+				{
+					plan_id: planId,
+					billing_controls: { usage_alerts: usageLimitAlerts },
+				},
+			],
+		});
+		await expectAutumnError({
+			func: () =>
+				autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: planId, billing_controls: { usage_limits: [] } }],
+				}),
+		});
+	},
+);
+
+test.concurrent(
 	`${chalk.yellowBright("alert-basis-validation7: org config rejects basis usage_limit")}`,
 	async () => {
 		const rejected = OrgConfigSchema.safeParse({

--- a/server/tests/integration/crud/customers/customer-usage-alert-basis-validation.test.ts
+++ b/server/tests/integration/crud/customers/customer-usage-alert-basis-validation.test.ts
@@ -1,0 +1,349 @@
+/**
+ * TDD test for usage alert `basis` / `filter` validation and round-trip.
+ *
+ * Contract under test:
+ *   New types/fields:
+ *     - usage_alerts[].basis defaults to "balance" and is echoed on reads
+ *     - usage_alerts[].filter is echoed on reads (values canonicalised to strings)
+ *   Validation:
+ *     - filter without basis usage_limit → 400
+ *     - duplicate (feature_id, basis, filterKey, threshold_type, threshold) → 400; differing basis accepted
+ *     - basis usage_limit with no resolvable (feature_id, filter) limit → 400 on
+ *       customers.update, entities.update and product create; resolves through
+ *       customer-own, entity-own and plan limits
+ *     - entity usage_limits dedup is filter-aware
+ *     - org config rejects basis usage_limit
+ *
+ * Pre-impl red: basis/filter do not exist on the schema (compile), then the
+ * validation rules are absent so updates succeed.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	type ApiEntityV2,
+	ApiVersion,
+	type EntityBillingControls,
+	OrgConfigSchema,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+const autumnV2_3 = new AutumnInt({ version: ApiVersion.V2_3 });
+
+const numericFilterValue = (value: number) => value as unknown as string;
+
+const dailyLimit = (filter?: { properties: Record<string, string> }) => ({
+	feature_id: TestFeature.Messages,
+	enabled: true,
+	limit: 200,
+	interval: ResetInterval.Day as const,
+	...(filter && { filter }),
+});
+
+const percentAlert = ({
+	basis,
+	threshold = 80,
+	filter,
+}: {
+	basis?: "balance" | "included" | "recurring" | "usage_limit";
+	threshold?: number;
+	filter?: { properties: Record<string, string> };
+} = {}) => ({
+	feature_id: TestFeature.Messages,
+	threshold,
+	threshold_type: "usage_percentage" as const,
+	enabled: true,
+	...(basis && { basis }),
+	...(filter && { filter }),
+});
+
+const setupCustomer = async (customerId: string, planId: string) => {
+	const plan = products.base({
+		id: planId,
+		items: [items.monthlyMessages({ includedUsage: 1000 })],
+	});
+	return initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.attach({ productId: plan.id })],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("alert-basis-validation1: basis defaults to balance and round-trips with filter")}`,
+	async () => {
+		const customerId = "alert-basis-roundtrip-1";
+		await setupCustomer(customerId, "alert-basis-roundtrip");
+
+		await autumnV2_3.customers.update(customerId, {
+			billing_controls: {
+				usage_limits: [
+					dailyLimit({ properties: { apiKeyId: numericFilterValue(123) } }),
+				],
+				usage_alerts: [
+					percentAlert(),
+					percentAlert({
+						basis: "usage_limit",
+						filter: { properties: { apiKeyId: numericFilterValue(123) } },
+					}),
+				],
+			},
+		});
+
+		for (const skipCache of [false, true]) {
+			const customer = await autumnV2_3.customers.get<ApiCustomerV5>(
+				customerId,
+				skipCache ? { skip_cache: "true" } : undefined,
+			);
+			const alerts = customer.billing_controls?.usage_alerts ?? [];
+			expect(alerts).toHaveLength(2);
+			expect(alerts[0].basis).toBe("balance");
+			expect(alerts[0].filter).toBeUndefined();
+			expect(alerts[1].basis).toBe("usage_limit");
+			expect(alerts[1].filter).toEqual({ properties: { apiKeyId: "123" } });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("alert-basis-validation2: filter is only valid with basis usage_limit")}`,
+	async () => {
+		const customerId = "alert-basis-filter-only-ul-1";
+		await setupCustomer(customerId, "alert-basis-filter-only-ul");
+
+		await expectAutumnError({
+			func: () =>
+				autumnV2_3.customers.update(customerId, {
+					billing_controls: {
+						usage_alerts: [
+							percentAlert({
+								basis: "included",
+								filter: { properties: { apiKeyId: "a" } },
+							}),
+						],
+					},
+				}),
+		});
+		await expectAutumnError({
+			func: () =>
+				autumnV2_3.customers.update(customerId, {
+					billing_controls: {
+						usage_alerts: [
+							percentAlert({ filter: { properties: { apiKeyId: "a" } } }),
+						],
+					},
+				}),
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("alert-basis-validation3: identity is (feature, basis, filter, type, threshold)")}`,
+	async () => {
+		const customerId = "alert-basis-identity-1";
+		await setupCustomer(customerId, "alert-basis-identity");
+
+		await expectAutumnError({
+			func: () =>
+				autumnV2_3.customers.update(customerId, {
+					billing_controls: {
+						usage_alerts: [percentAlert(), percentAlert({ basis: "balance" })],
+					},
+				}),
+		});
+
+		await autumnV2_3.customers.update(customerId, {
+			billing_controls: {
+				usage_alerts: [
+					percentAlert({ basis: "balance" }),
+					percentAlert({ basis: "included" }),
+				],
+			},
+		});
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expect(customer.billing_controls?.usage_alerts).toHaveLength(2);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("alert-basis-validation4: usage_limit alert needs a resolvable cap on customer or plan")}`,
+	async () => {
+		const customerId = "alert-basis-needs-limit-1";
+		await setupCustomer(customerId, "alert-basis-needs-limit");
+
+		await expectAutumnError({
+			func: () =>
+				autumnV2_3.customers.update(customerId, {
+					billing_controls: {
+						usage_alerts: [percentAlert({ basis: "usage_limit" })],
+					},
+				}),
+		});
+
+		await autumnV2_3.customers.update(customerId, {
+			billing_controls: { usage_limits: [dailyLimit()] },
+		});
+		await expectAutumnError({
+			func: () =>
+				autumnV2_3.customers.update(customerId, {
+					billing_controls: {
+						usage_alerts: [
+							percentAlert({
+								basis: "usage_limit",
+								filter: { properties: { apiKeyId: "a" } },
+							}),
+						],
+					},
+				}),
+		});
+		await autumnV2_3.customers.update(customerId, {
+			billing_controls: {
+				usage_alerts: [percentAlert({ basis: "usage_limit" })],
+			},
+		});
+
+		const planCustomerId = "alert-basis-plan-limit-ok-1";
+		const plan = products.base({
+			id: "alert-basis-plan-limit-ok",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+			billingControls: { usage_limits: [dailyLimit()] },
+		});
+		await initScenario({
+			customerId: planCustomerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [s.attach({ productId: plan.id })],
+		});
+		await autumnV2_3.customers.update(planCustomerId, {
+			billing_controls: {
+				usage_alerts: [percentAlert({ basis: "usage_limit" })],
+			},
+		});
+		const customer =
+			await autumnV2_3.customers.get<ApiCustomerV5>(planCustomerId);
+		expect(customer.billing_controls?.usage_alerts?.[0]?.basis).toBe(
+			"usage_limit",
+		);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("alert-basis-validation5: entity alerts accept basis/filter and entity limit dedup is filter-aware")}`,
+	async () => {
+		const customerId = "alert-basis-entity-1";
+		const plan = products.base({
+			id: "alert-basis-entity",
+			items: [
+				items.monthlyMessages({
+					includedUsage: 1000,
+					entityFeatureId: TestFeature.Users,
+				}),
+			],
+		});
+		const { entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [plan] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [s.attach({ productId: plan.id })],
+		});
+		const entityId = entities[0].id;
+
+		await expectAutumnError({
+			func: () =>
+				autumnV2_3.entities.update(customerId, entityId, {
+					billing_controls: {
+						usage_alerts: [percentAlert({ basis: "usage_limit" })],
+					} as EntityBillingControls,
+				}),
+		});
+
+		await expectAutumnError({
+			func: () =>
+				autumnV2_3.entities.update(customerId, entityId, {
+					billing_controls: {
+						usage_limits: [
+							dailyLimit({ properties: { apiKeyId: "a" } }),
+							dailyLimit({ properties: { apiKeyId: "a" } }),
+						],
+					} as EntityBillingControls,
+				}),
+		});
+
+		await autumnV2_3.entities.update(customerId, entityId, {
+			billing_controls: {
+				usage_limits: [
+					dailyLimit(),
+					dailyLimit({ properties: { apiKeyId: "a" } }),
+				],
+				usage_alerts: [
+					percentAlert({ basis: "usage_limit" }),
+					percentAlert({
+						basis: "usage_limit",
+						filter: { properties: { apiKeyId: "a" } },
+					}),
+				],
+			} as EntityBillingControls,
+		});
+		const entity = await autumnV2_3.entities.get<ApiEntityV2>(
+			customerId,
+			entityId,
+		);
+		expect(entity.billing_controls?.usage_alerts).toHaveLength(2);
+		expect(entity.billing_controls?.usage_alerts?.[1]?.filter).toEqual({
+			properties: { apiKeyId: "a" },
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("alert-basis-validation6: a plan alert on basis usage_limit needs a plan cap")}`,
+	async () => {
+		const withoutLimit = products.base({
+			id: "alert-basis-plan-no-limit",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+			billingControls: {
+				usage_alerts: [percentAlert({ basis: "usage_limit" })],
+			},
+		});
+		await expectAutumnError({
+			func: () => autumnV2_3.products.create(withoutLimit),
+		});
+
+		const withLimit = products.base({
+			id: "alert-basis-plan-with-limit",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+			billingControls: {
+				usage_limits: [dailyLimit()],
+				usage_alerts: [percentAlert({ basis: "usage_limit" })],
+			},
+		});
+		await initScenario({
+			setup: [s.products({ list: [withLimit] })],
+			actions: [],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("alert-basis-validation7: org config rejects basis usage_limit")}`,
+	async () => {
+		const rejected = OrgConfigSchema.safeParse({
+			usage_alerts: [percentAlert({ basis: "usage_limit" })],
+		});
+		expect(rejected.success).toBe(false);
+
+		const accepted = OrgConfigSchema.safeParse({
+			sandbox_usage_alerts: [percentAlert({ basis: "included" })],
+		});
+		expect(accepted.success).toBe(true);
+	},
+);


### PR DESCRIPTION
Layer 2 of 6 (write-time validation). Base: #3246.
the cap the way enforcement does (own limits, then customer, then plan)
and return 400 when nothing matches. A cap removed or disabled later
leaves the alert dormant rather than invalid.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Customer, entity, and catalog plan updates now reject newly written `usage_limit` alerts with no resolvable cap, returning 400 for the first unmatched alert. Retained alerts stay dormant when their cap is removed or disabled.

**Notes**
- Resolution follows enforcement order: own limits, then customer, then runtime-eligible plan limits.
- Validation uses the replacement customer limits, so caps removed in the same update aren't treated as available.
- Known gap: validation excludes Trialing plans from plan-cap resolution, but runtime alert resolution includes them.

<sup>Written for commit 08e3495fffb940b3f3ee8b401c1e247252b62f32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds write-time validation so new usage-limit-based alerts must reference a resolvable cap, while existing alerts may become dormant if their cap is later removed.

- **API changes, Improvements:** Customer and entity updates now return HTTP 400 when a newly written usage-limit alert has no matching entity, customer, or eligible plan cap.
- **API changes, Improvements:** Catalog updates validate new plan alerts against the merged plan configuration.
- **Bug fixes:** Validation uses the replacement limits that will actually be stored and preserves existing alerts when their cap is removed or disabled later.
- **Improvements:** Integration coverage exercises customer, entity, plan, filter, identity, and retained-alert behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/usageAlerts/validate/assertUsageLimitAlertsResolvable.ts | Centralizes orphan-alert detection while exempting retained alert identities so later cap removal can leave existing alerts dormant. |
| server/src/internal/balances/usageAlerts/validate/assertCustomerUsageLimitAlertsResolvable.ts | Validates newly written customer alerts against the limits that will be stored and eligible attached-plan limits. |
| server/src/internal/balances/usageAlerts/validate/assertEntityUsageLimitAlertsResolvable.ts | Resolves entity alerts in entity, customer, and eligible-plan precedence order. |
| server/src/internal/balances/usageAlerts/validate/fullSubjectToPlanUsageLimits.ts | Selects plan caps using the organization-derived lifecycle statuses used by usage-window enforcement. |
| server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUsageLimitAlertErrors.ts | Validates new plan alerts against merged plan limits while preserving retained alerts whose caps disappear. |
| server/src/internal/customers/actions/update/updateCustomer.ts | Adds usage-limit alert validation before customer billing-control persistence. |
| server/src/internal/entities/actions/updateEntity.ts | Adds equivalent validation before entity billing-control persistence. |
| server/tests/integration/crud/customers/customer-usage-alert-basis-validation.test.ts | Covers usage-limit alert resolution, filters, identity, scope inheritance, plan validation, and dormant retained alerts. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Customer, entity, or catalog update] --> B{Contains a new usage_limit alert?}
  B -- No --> E[Continue update]
  B -- Yes --> C[Resolve own, customer, then eligible plan limits]
  C --> D{Matching feature and filter cap?}
  D -- Yes --> E
  D -- No --> F[Return HTTP 400]
```
</details>

<sub>Reviews (10): Last reviewed commit: ["fix(balances): only newly written usage\_..."](https://github.com/useautumn/autumn/commit/08e3495fffb940b3f3ee8b401c1e247252b62f32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59941864)</sub>

<!-- /greptile_comment -->