### PR TITLE
feat(balances): describe the blocking cap on limit_reached

### DIFF
--- a/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
+++ b/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
@@ -6,101 +6,12 @@ import {
 	type FullCustomer,
 	type FullSubject,
 	fullCustomerToTags,
-	fullSubjectToUsageWindowLimits,
-	getCurrentUsageWindowUsage,
-	orgToInStatuses,
-	type UsageLimitFilter,
-	type UsageLimitWebhookBlock,
-	usageLimitFilterMatchesProperties,
 	WebhookEventType,
 } from "@autumn/shared";
 import { sendSvixEvent } from "@/external/svix/svixHelpers.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { usageWindowLimitToWebhookBlock } from "@/internal/balances/utils/usageWindows/usageWindowLimitToWebhookBlock.js";
-
-type BlockingUsageLimit = {
-	block: UsageLimitWebhookBlock;
-	filter: UsageLimitFilter | undefined;
-};
-
-/**
- * The cap that blocked this event. Enforcement stops at the cap with the least
- * headroom, so the webhook reports that one, filter included, from one source.
- */
-const findBlockingUsageLimit = ({
-	ctx,
-	fullSubject,
-	feature,
-	eventProperties,
-	now,
-}: {
-	ctx: AutumnContext;
-	fullSubject: FullSubject;
-	feature: Feature;
-	eventProperties?: Record<string, unknown> | null;
-	now: number;
-}): BlockingUsageLimit | undefined => {
-	const usageWindows = fullSubject.usage_windows ?? [];
-	const measured = fullSubjectToUsageWindowLimits({
-		fullSubject,
-		featureIds: [feature.id],
-		features: ctx.features,
-		now,
-		inStatuses: orgToInStatuses({ org: ctx.org }),
-	})
-		.filter((limit) =>
-			usageLimitFilterMatchesProperties({
-				filterProperties: limit.filter_properties,
-				eventProperties,
-			}),
-		)
-		.map((limit) => ({
-			limit,
-			usage: getCurrentUsageWindowUsage({ usageWindows, limit, now }),
-		}))
-		.sort(
-			(left, right) =>
-				left.limit.limit - left.usage - (right.limit.limit - right.usage),
-		);
-
-	const tightest = measured[0];
-	if (!tightest || tightest.usage < tightest.limit.limit) return undefined;
-
-	const block = usageWindowLimitToWebhookBlock({
-		limit: tightest.limit,
-		usage: tightest.usage,
-	});
-	if (!block) return undefined;
-
-	return {
-		block,
-		filter: tightest.limit.filter_properties
-			? { properties: tightest.limit.filter_properties }
-			: undefined,
-	};
-};
-
-/** Legacy deductions carry no FullSubject; read the exhausted filtered cap off the evaluated subject. */
-const findBlockedFilterOnSubject = ({
-	subject,
-	feature,
-	eventProperties,
-}: {
-	subject: ApiCustomerV5 | ApiEntityV2;
-	feature: Feature;
-	eventProperties?: Record<string, unknown> | null;
-}): UsageLimitFilter | undefined =>
-	subject.billing_controls?.usage_limits?.find(
-		(usageLimit) =>
-			usageLimit.feature_id === feature.id &&
-			usageLimit.enabled !== false &&
-			usageLimit.filter != null &&
-			usageLimitFilterMatchesProperties({
-				filterProperties: usageLimit.filter.properties,
-				eventProperties,
-			}) &&
-			(usageLimit.usage ?? 0) >= usageLimit.limit,
-	)?.filter;
+import { findBlockedFilterOnSubject } from "./limitReached/findBlockedFilterOnSubject.js";
+import { findBlockingUsageLimit } from "./limitReached/findBlockingUsageLimit.js";
 
 // Subjects must be built via buildEvaluationSubject, or plan-level / percentage
 // caps are invisible here and the allowed -> blocked transition never fires.

--- a/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
+++ b/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
@@ -24,7 +24,6 @@ export const checkLimitReached = async ({
 	feature,
 	entityId,
 	eventProperties,
-	now = Date.now(),
 }: {
 	ctx: AutumnContext;
 	oldEvalSubject: ApiCustomerV5 | ApiEntityV2;
@@ -34,8 +33,8 @@ export const checkLimitReached = async ({
 	feature: Feature;
 	entityId?: string;
 	eventProperties?: Record<string, unknown> | null;
-	now?: number;
 }) => {
+	const now = ctx.timestamp;
 	try {
 		const oldBalance = oldEvalSubject.balances?.[feature.id];
 		const newBalance = newEvalSubject.balances?.[feature.id];

--- a/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
+++ b/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
@@ -4,12 +4,56 @@ import {
 	apiBalanceToAllowed,
 	type Feature,
 	type FullCustomer,
+	type FullSubject,
 	fullCustomerToTags,
+	fullSubjectToUsageWindowLimits,
+	getCurrentUsageWindowUsage,
+	orgToInStatuses,
+	type UsageLimitWebhookBlock,
 	usageLimitFilterMatchesProperties,
 	WebhookEventType,
 } from "@autumn/shared";
 import { sendSvixEvent } from "@/external/svix/svixHelpers.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { usageWindowLimitToWebhookBlock } from "@/internal/balances/utils/usageWindows/usageWindowLimitToWebhookBlock.js";
+
+/** The exhausted cap that blocked this event: the first matching limit with no headroom left. */
+const findBlockingUsageLimit = ({
+	ctx,
+	fullSubject,
+	feature,
+	eventProperties,
+	now,
+}: {
+	ctx: AutumnContext;
+	fullSubject: FullSubject;
+	feature: Feature;
+	eventProperties?: Record<string, unknown> | null;
+	now: number;
+}): UsageLimitWebhookBlock | undefined => {
+	const limits = fullSubjectToUsageWindowLimits({
+		fullSubject,
+		featureIds: [feature.id],
+		features: ctx.features,
+		now,
+		inStatuses: orgToInStatuses({ org: ctx.org }),
+	});
+	const usageWindows = fullSubject.usage_windows ?? [];
+
+	for (const limit of limits) {
+		const appliesToEvent = usageLimitFilterMatchesProperties({
+			filterProperties: limit.filter_properties,
+			eventProperties,
+		});
+		if (!appliesToEvent) continue;
+
+		const usage = getCurrentUsageWindowUsage({ usageWindows, limit, now });
+		if (usage < limit.limit) continue;
+
+		return usageWindowLimitToWebhookBlock({ limit, usage }) ?? undefined;
+	}
+	return undefined;
+};
 
 // Subjects must be built via buildEvaluationSubject, or plan-level / percentage
 // caps are invisible here and the allowed -> blocked transition never fires.
@@ -18,17 +62,21 @@ export const checkLimitReached = async ({
 	oldEvalSubject,
 	newEvalSubject,
 	newFullCus,
+	newFullSubject,
 	feature,
 	entityId,
 	eventProperties,
+	now = Date.now(),
 }: {
 	ctx: AutumnContext;
 	oldEvalSubject: ApiCustomerV5 | ApiEntityV2;
 	newEvalSubject: ApiCustomerV5 | ApiEntityV2;
 	newFullCus: FullCustomer;
+	newFullSubject?: FullSubject;
 	feature: Feature;
 	entityId?: string;
 	eventProperties?: Record<string, unknown> | null;
+	now?: number;
 }) => {
 	try {
 		const oldBalance = oldEvalSubject.balances?.[feature.id];
@@ -54,10 +102,12 @@ export const checkLimitReached = async ({
 
 		if (!oldResult.allowed || newResult.allowed) return;
 
+		const blockedByUsageLimit = newResult.limitType === "usage_limit";
+
 		// When the blocking cap is a filtered usage limit, attach its filter so
 		// the receiver knows WHICH slice (e.g. which API key) hit its cap.
 		const blockedFilter =
-			newResult.limitType === "usage_limit" && eventProperties
+			blockedByUsageLimit && eventProperties
 				? newEvalSubject.billing_controls?.usage_limits?.find(
 						(usageLimit) =>
 							usageLimit.feature_id === feature.id &&
@@ -69,6 +119,17 @@ export const checkLimitReached = async ({
 							}) &&
 							(usageLimit.usage ?? 0) >= usageLimit.limit,
 					)?.filter
+				: undefined;
+
+		const usageLimitBlock =
+			blockedByUsageLimit && newFullSubject
+				? findBlockingUsageLimit({
+						ctx,
+						fullSubject: newFullSubject,
+						feature,
+						eventProperties,
+						now,
+					})
 				: undefined;
 
 		const customerId = newFullCus.id || newFullCus.internal_id;
@@ -83,6 +144,7 @@ export const checkLimitReached = async ({
 				limit_type: newResult.limitType ?? "included",
 				...(entityId && { entity_id: entityId }),
 				...(blockedFilter && { filter: blockedFilter }),
+				...(usageLimitBlock && { usage_limit: usageLimitBlock }),
 			},
 			tags,
 		});

--- a/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
+++ b/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
@@ -9,6 +9,7 @@ import {
 	fullSubjectToUsageWindowLimits,
 	getCurrentUsageWindowUsage,
 	orgToInStatuses,
+	type UsageLimitFilter,
 	type UsageLimitWebhookBlock,
 	usageLimitFilterMatchesProperties,
 	WebhookEventType,
@@ -17,7 +18,15 @@ import { sendSvixEvent } from "@/external/svix/svixHelpers.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { usageWindowLimitToWebhookBlock } from "@/internal/balances/utils/usageWindows/usageWindowLimitToWebhookBlock.js";
 
-/** The exhausted cap that blocked this event: the first matching limit with no headroom left. */
+type BlockingUsageLimit = {
+	block: UsageLimitWebhookBlock;
+	filter: UsageLimitFilter | undefined;
+};
+
+/**
+ * The cap that blocked this event. Enforcement stops at the cap with the least
+ * headroom, so the webhook reports that one, filter included, from one source.
+ */
 const findBlockingUsageLimit = ({
 	ctx,
 	fullSubject,
@@ -30,30 +39,68 @@ const findBlockingUsageLimit = ({
 	feature: Feature;
 	eventProperties?: Record<string, unknown> | null;
 	now: number;
-}): UsageLimitWebhookBlock | undefined => {
-	const limits = fullSubjectToUsageWindowLimits({
+}): BlockingUsageLimit | undefined => {
+	const usageWindows = fullSubject.usage_windows ?? [];
+	const measured = fullSubjectToUsageWindowLimits({
 		fullSubject,
 		featureIds: [feature.id],
 		features: ctx.features,
 		now,
 		inStatuses: orgToInStatuses({ org: ctx.org }),
+	})
+		.filter((limit) =>
+			usageLimitFilterMatchesProperties({
+				filterProperties: limit.filter_properties,
+				eventProperties,
+			}),
+		)
+		.map((limit) => ({
+			limit,
+			usage: getCurrentUsageWindowUsage({ usageWindows, limit, now }),
+		}))
+		.sort(
+			(left, right) =>
+				left.limit.limit - left.usage - (right.limit.limit - right.usage),
+		);
+
+	const tightest = measured[0];
+	if (!tightest || tightest.usage < tightest.limit.limit) return undefined;
+
+	const block = usageWindowLimitToWebhookBlock({
+		limit: tightest.limit,
+		usage: tightest.usage,
 	});
-	const usageWindows = fullSubject.usage_windows ?? [];
+	if (!block) return undefined;
 
-	for (const limit of limits) {
-		const appliesToEvent = usageLimitFilterMatchesProperties({
-			filterProperties: limit.filter_properties,
-			eventProperties,
-		});
-		if (!appliesToEvent) continue;
-
-		const usage = getCurrentUsageWindowUsage({ usageWindows, limit, now });
-		if (usage < limit.limit) continue;
-
-		return usageWindowLimitToWebhookBlock({ limit, usage }) ?? undefined;
-	}
-	return undefined;
+	return {
+		block,
+		filter: tightest.limit.filter_properties
+			? { properties: tightest.limit.filter_properties }
+			: undefined,
+	};
 };
+
+/** Legacy deductions carry no FullSubject; read the exhausted filtered cap off the evaluated subject. */
+const findBlockedFilterOnSubject = ({
+	subject,
+	feature,
+	eventProperties,
+}: {
+	subject: ApiCustomerV5 | ApiEntityV2;
+	feature: Feature;
+	eventProperties?: Record<string, unknown> | null;
+}): UsageLimitFilter | undefined =>
+	subject.billing_controls?.usage_limits?.find(
+		(usageLimit) =>
+			usageLimit.feature_id === feature.id &&
+			usageLimit.enabled !== false &&
+			usageLimit.filter != null &&
+			usageLimitFilterMatchesProperties({
+				filterProperties: usageLimit.filter.properties,
+				eventProperties,
+			}) &&
+			(usageLimit.usage ?? 0) >= usageLimit.limit,
+	)?.filter;
 
 // Subjects must be built via buildEvaluationSubject, or plan-level / percentage
 // caps are invisible here and the allowed -> blocked transition never fires.
@@ -103,25 +150,7 @@ export const checkLimitReached = async ({
 		if (!oldResult.allowed || newResult.allowed) return;
 
 		const blockedByUsageLimit = newResult.limitType === "usage_limit";
-
-		// When the blocking cap is a filtered usage limit, attach its filter so
-		// the receiver knows WHICH slice (e.g. which API key) hit its cap.
-		const blockedFilter =
-			blockedByUsageLimit && eventProperties
-				? newEvalSubject.billing_controls?.usage_limits?.find(
-						(usageLimit) =>
-							usageLimit.feature_id === feature.id &&
-							usageLimit.enabled !== false &&
-							usageLimit.filter != null &&
-							usageLimitFilterMatchesProperties({
-								filterProperties: usageLimit.filter.properties,
-								eventProperties,
-							}) &&
-							(usageLimit.usage ?? 0) >= usageLimit.limit,
-					)?.filter
-				: undefined;
-
-		const usageLimitBlock =
+		const blocking =
 			blockedByUsageLimit && newFullSubject
 				? findBlockingUsageLimit({
 						ctx,
@@ -131,6 +160,15 @@ export const checkLimitReached = async ({
 						now,
 					})
 				: undefined;
+		const blockedFilter =
+			blocking?.filter ??
+			(blockedByUsageLimit && eventProperties
+				? findBlockedFilterOnSubject({
+						subject: newEvalSubject,
+						feature,
+						eventProperties,
+					})
+				: undefined);
 
 		const customerId = newFullCus.id || newFullCus.internal_id;
 		const tags = fullCustomerToTags({ fullCustomer: newFullCus });
@@ -144,7 +182,7 @@ export const checkLimitReached = async ({
 				limit_type: newResult.limitType ?? "included",
 				...(entityId && { entity_id: entityId }),
 				...(blockedFilter && { filter: blockedFilter }),
-				...(usageLimitBlock && { usage_limit: usageLimitBlock }),
+				...(blocking && { usage_limit: blocking.block }),
 			},
 			tags,
 		});

--- a/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
+++ b/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
@@ -59,7 +59,7 @@ export const checkLimitReached = async ({
 		if (!oldResult.allowed || newResult.allowed) return;
 
 		const blockedByUsageLimit = newResult.limitType === "usage_limit";
-		const blocking =
+		const blockingUsageLimit =
 			blockedByUsageLimit && newFullSubject
 				? findBlockingUsageLimit({
 						ctx,
@@ -68,15 +68,15 @@ export const checkLimitReached = async ({
 						eventProperties,
 					})
 				: undefined;
-		const blockedFilter =
-			blocking?.filter ??
-			(blockedByUsageLimit && eventProperties
+		const blockedFilter = blockingUsageLimit
+			? blockingUsageLimit.filter
+			: blockedByUsageLimit && eventProperties
 				? findBlockedFilterOnSubject({
 						subject: newEvalSubject,
 						feature,
 						eventProperties,
 					})
-				: undefined);
+				: undefined;
 
 		const customerId = newFullCus.id || newFullCus.internal_id;
 		const tags = fullCustomerToTags({ fullCustomer: newFullCus });
@@ -90,7 +90,7 @@ export const checkLimitReached = async ({
 				limit_type: newResult.limitType ?? "included",
 				...(entityId && { entity_id: entityId }),
 				...(blockedFilter && { filter: blockedFilter }),
-				...(blocking && { usage_limit: blocking.block }),
+				...(blockingUsageLimit && { usage_limit: blockingUsageLimit.block }),
 			},
 			tags,
 		});

--- a/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
+++ b/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
@@ -34,7 +34,6 @@ export const checkLimitReached = async ({
 	entityId?: string;
 	eventProperties?: Record<string, unknown> | null;
 }) => {
-	const now = ctx.timestamp;
 	try {
 		const oldBalance = oldEvalSubject.balances?.[feature.id];
 		const newBalance = newEvalSubject.balances?.[feature.id];
@@ -67,7 +66,6 @@ export const checkLimitReached = async ({
 						fullSubject: newFullSubject,
 						feature,
 						eventProperties,
-						now,
 					})
 				: undefined;
 		const blockedFilter =

--- a/server/src/internal/balances/trackWebhooks/fireTrackWebhooks.ts
+++ b/server/src/internal/balances/trackWebhooks/fireTrackWebhooks.ts
@@ -107,6 +107,7 @@ export const fireTrackWebhooks = ({
 				oldEvalSubject,
 				newEvalSubject,
 				newFullCus,
+				newFullSubject,
 				feature: affectedFeature,
 				entityId,
 				eventProperties,

--- a/server/src/internal/balances/trackWebhooks/limitReached/findBlockedFilterOnSubject.ts
+++ b/server/src/internal/balances/trackWebhooks/limitReached/findBlockedFilterOnSubject.ts
@@ -1,0 +1,29 @@
+import {
+	type ApiCustomerV5,
+	type ApiEntityV2,
+	type Feature,
+	type UsageLimitFilter,
+	usageLimitFilterMatchesProperties,
+} from "@autumn/shared";
+
+/** Legacy deductions carry no FullSubject; read the exhausted filtered cap off the evaluated subject. */
+export const findBlockedFilterOnSubject = ({
+	subject,
+	feature,
+	eventProperties,
+}: {
+	subject: ApiCustomerV5 | ApiEntityV2;
+	feature: Feature;
+	eventProperties?: Record<string, unknown> | null;
+}): UsageLimitFilter | undefined =>
+	subject.billing_controls?.usage_limits?.find(
+		(usageLimit) =>
+			usageLimit.feature_id === feature.id &&
+			usageLimit.enabled !== false &&
+			usageLimit.filter != null &&
+			usageLimitFilterMatchesProperties({
+				filterProperties: usageLimit.filter.properties,
+				eventProperties,
+			}) &&
+			(usageLimit.usage ?? 0) >= usageLimit.limit,
+	)?.filter;

--- a/server/src/internal/balances/trackWebhooks/limitReached/findBlockedFilterOnSubject.ts
+++ b/server/src/internal/balances/trackWebhooks/limitReached/findBlockedFilterOnSubject.ts
@@ -6,7 +6,7 @@ import {
 	usageLimitFilterMatchesProperties,
 } from "@autumn/shared";
 
-/** Legacy deductions carry no FullSubject; read the exhausted filtered cap off the evaluated subject. */
+// Legacy deductions carry no FullSubject; the evaluated subject is all there is.
 export const findBlockedFilterOnSubject = ({
 	subject,
 	feature,

--- a/server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts
+++ b/server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts
@@ -23,7 +23,11 @@ export const findBlockingUsageLimit = ({
 }): BlockingUsageLimit | undefined => {
 	const now = ctx.timestamp;
 	const usageWindows = fullSubject.usage_windows ?? [];
-	const measured = resolveUsageWindowLimits({ ctx, fullSubject, feature })
+	const measured = resolveUsageWindowLimits({
+		ctx,
+		fullSubject,
+		featureIds: [feature.id],
+	})
 		.filter((limit) =>
 			usageLimitFilterMatchesProperties({
 				filterProperties: limit.filter_properties,

--- a/server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts
+++ b/server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts
@@ -1,12 +1,12 @@
 import {
 	type Feature,
 	type FullSubject,
-	getCurrentUsageWindowUsage,
+	subtractSafe,
 	usageLimitFilterMatchesProperties,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { measureUsageWindowLimit } from "@/internal/balances/utils/usageWindows/measureUsageWindowLimit.js";
 import { resolveUsageWindowLimits } from "@/internal/balances/utils/usageWindows/resolveUsageWindowLimits.js";
-import { usageWindowLimitToWebhookBlock } from "@/internal/balances/utils/usageWindows/usageWindowLimitToWebhookBlock.js";
 import type { BlockingUsageLimit } from "./types/blockingUsageLimit.js";
 
 // Enforcement stops at the cap with the least headroom; report that one, filter included.
@@ -34,24 +34,22 @@ export const findBlockingUsageLimit = ({
 				eventProperties,
 			}),
 		)
-		.map((limit) => ({
-			limit,
-			headroom:
-				limit.limit - getCurrentUsageWindowUsage({ usageWindows, limit, now }),
-		}))
+		.flatMap((limit) => {
+			const measurement = measureUsageWindowLimit({ limit, usageWindows, now });
+			if (!measurement) return [];
+			const headroom = subtractSafe({
+				left: limit.limit,
+				right: measurement.usage,
+			});
+			return [{ limit, block: measurement.block, headroom }];
+		})
 		.sort((left, right) => left.headroom - right.headroom);
 
 	const tightest = measured[0];
 	if (!tightest || tightest.headroom > 0) return undefined;
 
-	const block = usageWindowLimitToWebhookBlock({
-		limit: tightest.limit,
-		usage: tightest.limit.limit - tightest.headroom,
-	});
-	if (!block) return undefined;
-
 	return {
-		block,
+		block: tightest.block,
 		filter: tightest.limit.filter_properties
 			? { properties: tightest.limit.filter_properties }
 			: undefined,

--- a/server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts
+++ b/server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts
@@ -1,0 +1,66 @@
+import {
+	type Feature,
+	type FullSubject,
+	fullSubjectToUsageWindowLimits,
+	getCurrentUsageWindowUsage,
+	orgToInStatuses,
+	usageLimitFilterMatchesProperties,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { usageWindowLimitToWebhookBlock } from "@/internal/balances/utils/usageWindows/usageWindowLimitToWebhookBlock.js";
+import type { BlockingUsageLimit } from "./types/blockingUsageLimit.js";
+
+/**
+ * The cap that blocked this event. Enforcement stops at the cap with the least
+ * headroom, so the webhook reports that one, filter included, from one source.
+ */
+export const findBlockingUsageLimit = ({
+	ctx,
+	fullSubject,
+	feature,
+	eventProperties,
+	now,
+}: {
+	ctx: AutumnContext;
+	fullSubject: FullSubject;
+	feature: Feature;
+	eventProperties?: Record<string, unknown> | null;
+	now: number;
+}): BlockingUsageLimit | undefined => {
+	const usageWindows = fullSubject.usage_windows ?? [];
+	const measured = fullSubjectToUsageWindowLimits({
+		fullSubject,
+		featureIds: [feature.id],
+		features: ctx.features,
+		now,
+		inStatuses: orgToInStatuses({ org: ctx.org }),
+	})
+		.filter((limit) =>
+			usageLimitFilterMatchesProperties({
+				filterProperties: limit.filter_properties,
+				eventProperties,
+			}),
+		)
+		.map((limit) => ({
+			limit,
+			headroom:
+				limit.limit - getCurrentUsageWindowUsage({ usageWindows, limit, now }),
+		}))
+		.sort((left, right) => left.headroom - right.headroom);
+
+	const tightest = measured[0];
+	if (!tightest || tightest.headroom > 0) return undefined;
+
+	const block = usageWindowLimitToWebhookBlock({
+		limit: tightest.limit,
+		usage: tightest.limit.limit - tightest.headroom,
+	});
+	if (!block) return undefined;
+
+	return {
+		block,
+		filter: tightest.limit.filter_properties
+			? { properties: tightest.limit.filter_properties }
+			: undefined,
+	};
+};

--- a/server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts
+++ b/server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts
@@ -18,16 +18,15 @@ export const findBlockingUsageLimit = ({
 	fullSubject,
 	feature,
 	eventProperties,
-	now,
 }: {
 	ctx: AutumnContext;
 	fullSubject: FullSubject;
 	feature: Feature;
 	eventProperties?: Record<string, unknown> | null;
-	now: number;
 }): BlockingUsageLimit | undefined => {
+	const now = ctx.timestamp;
 	const usageWindows = fullSubject.usage_windows ?? [];
-	const measured = resolveUsageWindowLimits({ ctx, fullSubject, feature, now })
+	const measured = resolveUsageWindowLimits({ ctx, fullSubject, feature })
 		.filter((limit) =>
 			usageLimitFilterMatchesProperties({
 				filterProperties: limit.filter_properties,

--- a/server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts
+++ b/server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts
@@ -1,12 +1,11 @@
 import {
 	type Feature,
 	type FullSubject,
-	fullSubjectToUsageWindowLimits,
 	getCurrentUsageWindowUsage,
-	orgToInStatuses,
 	usageLimitFilterMatchesProperties,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { resolveUsageWindowLimits } from "@/internal/balances/utils/usageWindows/resolveUsageWindowLimits.js";
 import { usageWindowLimitToWebhookBlock } from "@/internal/balances/utils/usageWindows/usageWindowLimitToWebhookBlock.js";
 import type { BlockingUsageLimit } from "./types/blockingUsageLimit.js";
 
@@ -28,13 +27,7 @@ export const findBlockingUsageLimit = ({
 	now: number;
 }): BlockingUsageLimit | undefined => {
 	const usageWindows = fullSubject.usage_windows ?? [];
-	const measured = fullSubjectToUsageWindowLimits({
-		fullSubject,
-		featureIds: [feature.id],
-		features: ctx.features,
-		now,
-		inStatuses: orgToInStatuses({ org: ctx.org }),
-	})
+	const measured = resolveUsageWindowLimits({ ctx, fullSubject, feature, now })
 		.filter((limit) =>
 			usageLimitFilterMatchesProperties({
 				filterProperties: limit.filter_properties,

--- a/server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts
+++ b/server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts
@@ -9,10 +9,7 @@ import { resolveUsageWindowLimits } from "@/internal/balances/utils/usageWindows
 import { usageWindowLimitToWebhookBlock } from "@/internal/balances/utils/usageWindows/usageWindowLimitToWebhookBlock.js";
 import type { BlockingUsageLimit } from "./types/blockingUsageLimit.js";
 
-/**
- * The cap that blocked this event. Enforcement stops at the cap with the least
- * headroom, so the webhook reports that one, filter included, from one source.
- */
+// Enforcement stops at the cap with the least headroom; report that one, filter included.
 export const findBlockingUsageLimit = ({
 	ctx,
 	fullSubject,

--- a/server/src/internal/balances/trackWebhooks/limitReached/types/blockingUsageLimit.ts
+++ b/server/src/internal/balances/trackWebhooks/limitReached/types/blockingUsageLimit.ts
@@ -1,0 +1,6 @@
+import type { UsageLimitFilter, UsageLimitWebhookBlock } from "@autumn/shared";
+
+export type BlockingUsageLimit = {
+	block: UsageLimitWebhookBlock;
+	filter: UsageLimitFilter | undefined;
+};

--- a/server/tests/integration/balances/track/limit-reached/limit-reached-usage-limit-block.test.ts
+++ b/server/tests/integration/balances/track/limit-reached/limit-reached-usage-limit-block.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { ApiVersion, ResetInterval } from "@autumn/shared";
+import { ApiVersion, ms, ResetInterval } from "@autumn/shared";
 import {
 	getTestSvixAppId,
 	setupWebhookTest,
@@ -31,7 +31,6 @@ import { setCustomerUsageLimit } from "../../utils/usage-limit-utils/customerUsa
 import { expectUsageLimitWindowContains } from "../../utils/usage-limit-utils/expectUsageLimitWindowContains.js";
 
 const autumnV2_3 = new AutumnInt({ version: ApiVersion.V2_3 });
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 type LimitReachedPayload = {
 	type: string;
@@ -128,7 +127,7 @@ test(`${chalk.yellowBright("limit-reached-ul1: a usage_limit block describes the
 	expectUsageLimitWindowContains({
 		usageLimit: result!.payload.data.usage_limit,
 		at: trackedAt,
-		intervalMs: ONE_DAY_MS,
+		intervalMs: ms.days(1),
 	});
 });
 

--- a/server/tests/integration/balances/track/limit-reached/limit-reached-usage-limit-block.test.ts
+++ b/server/tests/integration/balances/track/limit-reached/limit-reached-usage-limit-block.test.ts
@@ -1,0 +1,210 @@
+/**
+ * TDD test for the `usage_limit` block on `balances.limit_reached`.
+ *
+ * Contract under test:
+ *   New types/fields:
+ *     - limit_reached.filter (schema catch-up; already emitted for filtered caps)
+ *     - limit_reached.usage_limit { limit, interval, anchor, usage, remaining, window_start_at, window_end_at }
+ *       present iff limit_type is usage_limit; absent for included / spend_limit / max_purchase
+ *
+ * Pre-impl red: payload has no usage_limit block.
+ * Post-impl green: checkLimitReached reads the resolved window limit off the FullSubject.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import {
+	ApiVersion,
+	EntInterval,
+	getUsageWindowBounds,
+	ResetInterval,
+} from "@autumn/shared";
+import {
+	getTestSvixAppId,
+	setupWebhookTest,
+	type WebhookTestSetup,
+	waitForWebhook,
+} from "@tests/integration/utils/svixWebhookTestUtils.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { setCustomerUsageLimit } from "../../utils/usage-limit-utils/customerUsageLimitUtils.js";
+
+const autumnV2_3 = new AutumnInt({ version: ApiVersion.V2_3 });
+
+type LimitReachedPayload = {
+	type: string;
+	data: {
+		customer_id: string;
+		feature_id: string;
+		limit_type: string;
+		entity_id?: string;
+		filter?: { properties: Record<string, string> };
+		usage_limit?: {
+			limit: number;
+			interval: string;
+			anchor: string;
+			usage: number;
+			remaining: number;
+			window_start_at: number;
+			window_end_at: number;
+		};
+	};
+};
+
+let webhook: WebhookTestSetup;
+let playToken: string;
+
+beforeAll(async () => {
+	const appId = getTestSvixAppId({ svixConfig: ctx.org.svix_config });
+	webhook = await setupWebhookTest({
+		appId,
+		filterTypes: ["balances.limit_reached"],
+	});
+	playToken = webhook.playToken;
+});
+
+afterAll(async () => {
+	await webhook?.cleanup();
+});
+
+const waitForLimitReached = ({
+	customerId,
+	limitType,
+}: {
+	customerId: string;
+	limitType: string;
+}) =>
+	waitForWebhook<LimitReachedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.limit_reached" &&
+			payload.data?.customer_id === customerId &&
+			payload.data?.limit_type === limitType,
+		timeoutMs: 15000,
+	});
+
+test(`${chalk.yellowBright("limit-reached-ul1: a usage_limit block describes the cap that blocked")}`, async () => {
+	const customerId = "lr-ul-block-1";
+	const plan = products.base({
+		id: "lr-ul-block",
+		items: [items.monthlyMessages({ includedUsage: 10000 })],
+	});
+	await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.billing.attach({ productId: plan.id })],
+	});
+	await setCustomerUsageLimit({
+		autumn: autumnV2_3,
+		customerId,
+		featureId: TestFeature.Messages,
+		limit: 5,
+		interval: ResetInterval.Day,
+		anchor: "utc",
+	});
+
+	await autumnV2_3.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 5,
+	});
+
+	const result = await waitForLimitReached({
+		customerId,
+		limitType: "usage_limit",
+	});
+	expect(result).not.toBeNull();
+	const bounds = getUsageWindowBounds({
+		interval: EntInterval.Day,
+		now: Date.now(),
+	});
+	expect(result!.payload.data.filter).toBeUndefined();
+	expect(result!.payload.data.usage_limit).toEqual({
+		limit: 5,
+		interval: "day",
+		anchor: "utc",
+		usage: 5,
+		remaining: 0,
+		window_start_at: bounds.windowStartAt,
+		window_end_at: bounds.windowEndAt,
+	});
+});
+
+test(`${chalk.yellowBright("limit-reached-ul2: a filtered cap echoes its filter and filtered counter")}`, async () => {
+	const customerId = "lr-ul-filter-1";
+	const plan = products.base({
+		id: "lr-ul-filter",
+		items: [items.monthlyMessages({ includedUsage: 10000 })],
+	});
+	await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.billing.attach({ productId: plan.id })],
+	});
+	await timeout(2000);
+	await autumnV2_3.customers.update(customerId, {
+		billing_controls: {
+			usage_limits: [
+				{
+					feature_id: TestFeature.Messages,
+					enabled: true,
+					limit: 5,
+					interval: ResetInterval.Day,
+					anchor: "utc",
+					filter: { properties: { apiKeyId: "key-a" } },
+				},
+			],
+		},
+	});
+	await timeout(3000);
+
+	await autumnV2_3.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 5,
+		properties: { apiKeyId: "key-a" },
+	});
+
+	const result = await waitForLimitReached({
+		customerId,
+		limitType: "usage_limit",
+	});
+	expect(result).not.toBeNull();
+	expect(result!.payload.data.filter).toEqual({
+		properties: { apiKeyId: "key-a" },
+	});
+	expect(result!.payload.data.usage_limit?.limit).toBe(5);
+	expect(result!.payload.data.usage_limit?.usage).toBe(5);
+	expect(result!.payload.data.usage_limit?.remaining).toBe(0);
+});
+
+test(`${chalk.yellowBright("limit-reached-ul3: an included-allowance block carries no usage_limit")}`, async () => {
+	const customerId = "lr-ul-included-1";
+	const plan = products.base({
+		id: "lr-ul-included",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.billing.attach({ productId: plan.id })],
+	});
+
+	await autumnV2_3.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 100,
+	});
+
+	const result = await waitForLimitReached({
+		customerId,
+		limitType: "included",
+	});
+	expect(result).not.toBeNull();
+	expect(result!.payload.data.usage_limit).toBeUndefined();
+});

--- a/server/tests/integration/balances/track/limit-reached/limit-reached-usage-limit-block.test.ts
+++ b/server/tests/integration/balances/track/limit-reached/limit-reached-usage-limit-block.test.ts
@@ -17,7 +17,6 @@ import {
 	getTestSvixAppId,
 	setupWebhookTest,
 	type WebhookTestSetup,
-	waitForWebhook,
 } from "@tests/integration/utils/svixWebhookTestUtils.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
@@ -27,30 +26,11 @@ import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { waitForLimitReached } from "../../utils/limit-reached-utils/limitReachedWebhookUtils.js";
 import { setCustomerUsageLimit } from "../../utils/usage-limit-utils/customerUsageLimitUtils.js";
 import { expectUsageLimitWindowContains } from "../../utils/usage-limit-utils/expectUsageLimitWindowContains.js";
 
 const autumnV2_3 = new AutumnInt({ version: ApiVersion.V2_3 });
-
-type LimitReachedPayload = {
-	type: string;
-	data: {
-		customer_id: string;
-		feature_id: string;
-		limit_type: string;
-		entity_id?: string;
-		filter?: { properties: Record<string, string> };
-		usage_limit?: {
-			limit: number;
-			interval: string;
-			anchor: string;
-			usage: number;
-			remaining: number;
-			window_start_at: number;
-			window_end_at: number;
-		};
-	};
-};
 
 let webhook: WebhookTestSetup;
 let playToken: string;
@@ -67,22 +47,6 @@ beforeAll(async () => {
 afterAll(async () => {
 	await webhook?.cleanup();
 });
-
-const waitForLimitReached = ({
-	customerId,
-	limitType,
-}: {
-	customerId: string;
-	limitType: string;
-}) =>
-	waitForWebhook<LimitReachedPayload>({
-		token: playToken,
-		predicate: (payload) =>
-			payload.type === "balances.limit_reached" &&
-			payload.data?.customer_id === customerId &&
-			payload.data?.limit_type === limitType,
-		timeoutMs: 15000,
-	});
 
 test(`${chalk.yellowBright("limit-reached-ul1: a usage_limit block describes the cap that blocked")}`, async () => {
 	const customerId = "lr-ul-block-1";
@@ -112,6 +76,7 @@ test(`${chalk.yellowBright("limit-reached-ul1: a usage_limit block describes the
 	});
 
 	const result = await waitForLimitReached({
+		token: playToken,
 		customerId,
 		limitType: "usage_limit",
 	});
@@ -167,6 +132,7 @@ test(`${chalk.yellowBright("limit-reached-ul2: a filtered cap echoes its filter 
 	});
 
 	const result = await waitForLimitReached({
+		token: playToken,
 		customerId,
 		limitType: "usage_limit",
 	});
@@ -198,6 +164,7 @@ test(`${chalk.yellowBright("limit-reached-ul3: an included-allowance block carri
 	});
 
 	const result = await waitForLimitReached({
+		token: playToken,
 		customerId,
 		limitType: "included",
 	});

--- a/server/tests/integration/balances/track/limit-reached/limit-reached-usage-limit-block.test.ts
+++ b/server/tests/integration/balances/track/limit-reached/limit-reached-usage-limit-block.test.ts
@@ -12,12 +12,7 @@
  */
 
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import {
-	ApiVersion,
-	EntInterval,
-	getUsageWindowBounds,
-	ResetInterval,
-} from "@autumn/shared";
+import { ApiVersion, ResetInterval } from "@autumn/shared";
 import {
 	getTestSvixAppId,
 	setupWebhookTest,
@@ -33,8 +28,10 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { setCustomerUsageLimit } from "../../utils/usage-limit-utils/customerUsageLimitUtils.js";
+import { expectUsageLimitWindowContains } from "../../utils/usage-limit-utils/expectUsageLimitWindowContains.js";
 
 const autumnV2_3 = new AutumnInt({ version: ApiVersion.V2_3 });
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 type LimitReachedPayload = {
 	type: string;
@@ -108,6 +105,7 @@ test(`${chalk.yellowBright("limit-reached-ul1: a usage_limit block describes the
 		anchor: "utc",
 	});
 
+	const trackedAt = Date.now();
 	await autumnV2_3.track({
 		customer_id: customerId,
 		feature_id: TestFeature.Messages,
@@ -119,19 +117,18 @@ test(`${chalk.yellowBright("limit-reached-ul1: a usage_limit block describes the
 		limitType: "usage_limit",
 	});
 	expect(result).not.toBeNull();
-	const bounds = getUsageWindowBounds({
-		interval: EntInterval.Day,
-		now: Date.now(),
-	});
 	expect(result!.payload.data.filter).toBeUndefined();
-	expect(result!.payload.data.usage_limit).toEqual({
+	expect(result!.payload.data.usage_limit).toMatchObject({
 		limit: 5,
 		interval: "day",
 		anchor: "utc",
 		usage: 5,
 		remaining: 0,
-		window_start_at: bounds.windowStartAt,
-		window_end_at: bounds.windowEndAt,
+	});
+	expectUsageLimitWindowContains({
+		usageLimit: result!.payload.data.usage_limit,
+		at: trackedAt,
+		intervalMs: ONE_DAY_MS,
 	});
 });
 

--- a/server/tests/integration/balances/utils/limit-reached-utils/limitReachedWebhookUtils.ts
+++ b/server/tests/integration/balances/utils/limit-reached-utils/limitReachedWebhookUtils.ts
@@ -1,0 +1,29 @@
+import type { BalancesLimitReached } from "@autumn/shared";
+import { waitForWebhook } from "@tests/integration/utils/svixWebhookTestUtils.js";
+
+export const LIMIT_REACHED_EVENT_TYPE = "balances.limit_reached";
+
+export type LimitReachedWebhookPayload = {
+	type: string;
+	data: BalancesLimitReached;
+};
+
+export const waitForLimitReached = ({
+	token,
+	customerId,
+	limitType,
+	timeoutMs = 15000,
+}: {
+	token: string;
+	customerId: string;
+	limitType: string;
+	timeoutMs?: number;
+}) =>
+	waitForWebhook<LimitReachedWebhookPayload>({
+		token,
+		predicate: (payload) =>
+			payload.type === LIMIT_REACHED_EVENT_TYPE &&
+			payload.data?.customer_id === customerId &&
+			payload.data?.limit_type === limitType,
+		timeoutMs,
+	});

--- a/shared/api/webhooks/balances/balancesLimitReached.ts
+++ b/shared/api/webhooks/balances/balancesLimitReached.ts
@@ -1,4 +1,6 @@
 import { z } from "zod/v4";
+import { UsageLimitFilterSchema } from "../../../models/cusModels/billingControls/usageLimit.js";
+import { UsageLimitWebhookBlockSchema } from "./usageLimitWebhookBlock.js";
 
 export const LimitType = z.enum([
 	"included",
@@ -29,6 +31,14 @@ export const BalancesLimitReachedSchema = z
 		limit_type: LimitType.meta({
 			description:
 				"Which limit was hit: included allowance, max purchase cap, spend limit, or a usage-limit billing control.",
+		}),
+		filter: UsageLimitFilterSchema.optional().meta({
+			description:
+				"The filter of the usage limit that blocked, when a filtered cap was hit.",
+		}),
+		usage_limit: UsageLimitWebhookBlockSchema.optional().meta({
+			description:
+				"The usage limit that blocked, with its live window. Present only when limit_type is usage_limit.",
 		}),
 	})
 	.meta({


### PR DESCRIPTION
Layer 5 of 6 (limit_reached). Base: #3248.

`balances.limit_reached` carries a `usage_limit` block (limit, interval, anchor, usage, remaining, window bounds) when a usage limit blocked the event, resolved from the FullSubject through the same window-limit helper the alerts use. The schema also declares the `filter` field the payload was already sending.

Test: `limit-reached-usage-limit-block.test.ts`, green locally.



































<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR expands `balances.limit_reached` so FullSubject-backed usage-limit events describe the blocking cap and its live window.

- **[Improvements, Bug fixes]** Selects the tracked feature’s exhausted usage limit with the least remaining headroom and sources the filter from that same cap.
- **[API changes]** Adds the optional `filter` and `usage_limit` fields to the shared webhook schema.
- **[Improvements]** Adds integration coverage for unfiltered caps, filtered caps, and included-allowance events.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/trackWebhooks/checkLimitReached.ts | Connects FullSubject-backed blocking-limit resolution to the limit-reached webhook and emits the selected cap and filter together. |
| server/src/internal/balances/trackWebhooks/limitReached/findBlockingUsageLimit.ts | Resolves matching tracked-feature window limits, measures their current usage, and selects the exhausted cap with the least headroom. |
| shared/api/webhooks/balances/balancesLimitReached.ts | Declares the previously emitted filter and the new optional usage-limit details in the shared webhook contract. |
| server/tests/integration/balances/track/limit-reached/limit-reached-usage-limit-block.test.ts | Covers usage-limit window details, filtered-cap metadata, and omission for included-allowance events. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Track usage] --> B[Evaluate updated subject]
  B --> C{Usage limit blocked?}
  C -- No --> D[Emit limit event without usage_limit]
  C -- Yes --> E[Resolve tracked-feature window limits]
  E --> F[Select exhausted cap with least headroom]
  F --> G[Emit matching filter and usage_limit block]
```
</details>

<sub>Reviews (17): Last reviewed commit: ["fix(balances): limit\_reached filter alwa..."](https://github.com/useautumn/autumn/commit/3ecb60e18c753c380909043565918f5f664ac729) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59941887)</sub>

**Context used:**

- Knowledge Base — [Usage and billing API platform](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/api-platform.md)
- Knowledge Base — [Webhook contracts and delivery events](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/webhook-contracts.md)

<!-- /greptile_comment -->