### PR TITLE
feat(dashboard): choose a basis for usage alerts

### DIFF
--- a/vite/src/components/billing-controls/BillingControlsDisplay.tsx
+++ b/vite/src/components/billing-controls/BillingControlsDisplay.tsx
@@ -21,6 +21,7 @@ import { createContext, Fragment, type ReactNode, useContext } from "react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/views/customers2/components/table/EmptyState";
 import { skipOverageBillingLabel } from "./overageBillingOptions";
+import { USAGE_ALERT_BASIS_LABELS } from "./usageAlertBasisOptions";
 
 const ROW_SWAP_TRANSITION = {
 	duration: 0.2,
@@ -361,10 +362,12 @@ export const UsageAlertRow = ({
 
 	const thresholdTypeLabel: Record<string, string> = {
 		usage: "Absolute usage",
-		usage_percentage: "% used of allowance",
+		usage_percentage: "% used",
 		remaining: "Absolute remaining",
-		remaining_percentage: "% remaining of allowance",
+		remaining_percentage: "% remaining",
 	};
+	const basis = usageAlert.basis ?? "balance";
+	const filterEntries = Object.entries(usageAlert.filter?.properties ?? {});
 
 	return (
 		<RowButton enabled={usageAlert.enabled} onClick={onClick}>
@@ -382,6 +385,18 @@ export const UsageAlertRow = ({
 					{
 						label: "Type",
 						value: thresholdTypeLabel[usageAlert.threshold_type],
+					},
+					{ label: "Of", value: USAGE_ALERT_BASIS_LABELS[basis] },
+					{
+						label: "Filter",
+						value: filterEntries.length
+							? filterEntries
+									.map(
+										([key, value]) =>
+											`${key} = ${truncateFilterValue(String(value))}`,
+									)
+									.join(", ")
+							: null,
 					},
 					{ label: "Name", value: usageAlert.name || null },
 				]}

--- a/vite/src/components/billing-controls/BillingControlsDisplay.tsx
+++ b/vite/src/components/billing-controls/BillingControlsDisplay.tsx
@@ -9,6 +9,7 @@ import type {
 	DbUsageAlert,
 	DbUsageLimit,
 } from "@autumn/shared";
+import { DEFAULT_USAGE_ALERT_BASIS } from "@autumn/shared";
 import {
 	SectionTag,
 	Tooltip,
@@ -22,6 +23,7 @@ import { cn } from "@/lib/utils";
 import { EmptyState } from "@/views/customers2/components/table/EmptyState";
 import { skipOverageBillingLabel } from "./overageBillingOptions";
 import { USAGE_ALERT_BASIS_LABELS } from "./usageAlertBasisOptions";
+import { USAGE_ALERT_THRESHOLD_TYPE_LABELS } from "./usageAlertThresholdTypeOptions";
 
 const ROW_SWAP_TRANSITION = {
 	duration: 0.2,
@@ -283,6 +285,15 @@ export const SpendLimitRow = ({
 
 const FILTER_VALUE_DISPLAY_LENGTH = 24;
 
+const filterSummary = (entries: Array<[string, unknown]>) =>
+	entries.length ? (
+		<span title={entries.map(([key, value]) => `${key} = ${value}`).join(", ")}>
+			{entries
+				.map(([key, value]) => `${key} = ${truncateFilterValue(String(value))}`)
+				.join(", ")}
+		</span>
+	) : null;
+
 const truncateFilterValue = (value: string) =>
 	value.length > FILTER_VALUE_DISPLAY_LENGTH
 		? `${value.slice(0, FILTER_VALUE_DISPLAY_LENGTH - 1)}…`
@@ -297,9 +308,7 @@ export const UsageLimitRow = ({
 	const usage = "usage" in usageLimit ? usageLimit.usage : undefined;
 	const enabled = "enabled" in usageLimit ? usageLimit.enabled : true;
 	const filterProperties = usageLimit.filter?.properties;
-	const filterEntries = filterProperties
-		? Object.entries(filterProperties)
-		: [];
+	const filterEntries = Object.entries(filterProperties ?? {});
 	return (
 		<RowButton enabled={enabled} onClick={onClick}>
 			<RowHeader
@@ -318,20 +327,7 @@ export const UsageLimitRow = ({
 					},
 					{
 						label: "Filter",
-						value: filterEntries.length ? (
-							<span
-								title={filterEntries
-									.map(([key, value]) => `${key} = ${value}`)
-									.join(", ")}
-							>
-								{filterEntries
-									.map(
-										([key, value]) =>
-											`${key} = ${truncateFilterValue(String(value))}`,
-									)
-									.join(", ")}
-							</span>
-						) : null,
+						value: filterSummary(filterEntries),
 					},
 					{
 						label: "Usage",
@@ -360,13 +356,7 @@ export const UsageAlertRow = ({
 		? `${usageAlert.threshold}%`
 		: usageAlert.threshold.toLocaleString();
 
-	const thresholdTypeLabel: Record<string, string> = {
-		usage: "Absolute usage",
-		usage_percentage: "% used",
-		remaining: "Absolute remaining",
-		remaining_percentage: "% remaining",
-	};
-	const basis = usageAlert.basis ?? "balance";
+	const basis = usageAlert.basis ?? DEFAULT_USAGE_ALERT_BASIS;
 	const filterEntries = Object.entries(usageAlert.filter?.properties ?? {});
 
 	return (
@@ -384,19 +374,12 @@ export const UsageAlertRow = ({
 					{ label: "At", value: thresholdLabel },
 					{
 						label: "Type",
-						value: thresholdTypeLabel[usageAlert.threshold_type],
+						value: USAGE_ALERT_THRESHOLD_TYPE_LABELS[usageAlert.threshold_type],
 					},
 					{ label: "Of", value: USAGE_ALERT_BASIS_LABELS[basis] },
 					{
 						label: "Filter",
-						value: filterEntries.length
-							? filterEntries
-									.map(
-										([key, value]) =>
-											`${key} = ${truncateFilterValue(String(value))}`,
-									)
-									.join(", ")
-							: null,
+						value: filterSummary(filterEntries),
 					},
 					{ label: "Name", value: usageAlert.name || null },
 				]}

--- a/vite/src/components/billing-controls/UsageAlertBasisSelect.tsx
+++ b/vite/src/components/billing-controls/UsageAlertBasisSelect.tsx
@@ -1,0 +1,48 @@
+import type { UsageAlertBasis } from "@autumn/shared";
+import {
+	FormLabel,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@autumn/ui";
+import {
+	USAGE_ALERT_BASIS_DESCRIPTIONS,
+	type UsageAlertBasisOption,
+} from "./usageAlertBasisOptions";
+
+export const UsageAlertBasisSelect = ({
+	value,
+	options,
+	onChange,
+}: {
+	value: UsageAlertBasis;
+	options: readonly UsageAlertBasisOption[];
+	onChange: (basis: UsageAlertBasis) => void;
+}) => (
+	<div>
+		<FormLabel>Measured against</FormLabel>
+		<Select
+			value={value}
+			onValueChange={(next) => onChange(next as UsageAlertBasis)}
+			items={Object.fromEntries(
+				options.map((option) => [option.value, option.label]),
+			)}
+		>
+			<SelectTrigger className="w-full">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				{options.map((option) => (
+					<SelectItem key={option.value} value={option.value}>
+						{option.label}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+		<p className="mt-1 text-tertiary-foreground text-xs">
+			{USAGE_ALERT_BASIS_DESCRIPTIONS[value]}
+		</p>
+	</div>
+);

--- a/vite/src/components/billing-controls/UsageAlertBasisSelect.tsx
+++ b/vite/src/components/billing-controls/UsageAlertBasisSelect.tsx
@@ -7,6 +7,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@autumn/ui";
+import { useId } from "react";
 import {
 	USAGE_ALERT_BASIS_DESCRIPTIONS,
 	type UsageAlertBasisOption,
@@ -20,29 +21,34 @@ export const UsageAlertBasisSelect = ({
 	value: UsageAlertBasis;
 	options: readonly UsageAlertBasisOption[];
 	onChange: (basis: UsageAlertBasis) => void;
-}) => (
-	<div>
-		<FormLabel>Measured against</FormLabel>
-		<Select
-			value={value}
-			onValueChange={(next) => onChange(next as UsageAlertBasis)}
-			items={Object.fromEntries(
-				options.map((option) => [option.value, option.label]),
-			)}
-		>
-			<SelectTrigger className="w-full">
-				<SelectValue />
-			</SelectTrigger>
-			<SelectContent>
-				{options.map((option) => (
-					<SelectItem key={option.value} value={option.value}>
-						{option.label}
-					</SelectItem>
-				))}
-			</SelectContent>
-		</Select>
-		<p className="mt-1 text-tertiary-foreground text-xs">
-			{USAGE_ALERT_BASIS_DESCRIPTIONS[value]}
-		</p>
-	</div>
-);
+}) => {
+	const descriptionId = useId();
+	return (
+		<div>
+			<FormLabel>Measured against</FormLabel>
+			<Select
+				value={value}
+				onValueChange={(next) => onChange(next as UsageAlertBasis)}
+				items={options}
+			>
+				<SelectTrigger
+					className="w-full"
+					aria-label="Measured against"
+					aria-describedby={descriptionId}
+				>
+					<SelectValue />
+				</SelectTrigger>
+				<SelectContent>
+					{options.map((option) => (
+						<SelectItem key={option.value} value={option.value}>
+							{option.label}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+			<p id={descriptionId} className="mt-1 text-tertiary-foreground text-xs">
+				{USAGE_ALERT_BASIS_DESCRIPTIONS[value]}
+			</p>
+		</div>
+	);
+};

--- a/vite/src/components/billing-controls/usageAlertBasisOptions.ts
+++ b/vite/src/components/billing-controls/usageAlertBasisOptions.ts
@@ -17,14 +17,16 @@ export const USAGE_ALERT_BASIS_DESCRIPTIONS: Record<UsageAlertBasis, string> = {
 
 export type UsageAlertBasisOption = { value: UsageAlertBasis; label: string };
 
-const toOption = (basis: UsageAlertBasis): UsageAlertBasisOption => ({
+const basisToOption = (basis: UsageAlertBasis): UsageAlertBasisOption => ({
 	value: basis,
 	label: USAGE_ALERT_BASIS_LABELS[basis],
 });
 
 export const ALL_BASIS_OPTIONS: UsageAlertBasisOption[] =
-	USAGE_ALERT_BASES.map(toOption);
+	USAGE_ALERT_BASES.map(basisToOption);
 
 /** Org alerts have no single cap to measure, so usage_limit is not offered. */
 export const BALANCE_BASIS_OPTIONS: UsageAlertBasisOption[] =
-	USAGE_ALERT_BASES.filter((basis) => basis !== "usage_limit").map(toOption);
+	USAGE_ALERT_BASES.filter((basis) => basis !== "usage_limit").map(
+		basisToOption,
+	);

--- a/vite/src/components/billing-controls/usageAlertBasisOptions.ts
+++ b/vite/src/components/billing-controls/usageAlertBasisOptions.ts
@@ -1,4 +1,4 @@
-import type { UsageAlertBasis } from "@autumn/shared";
+import { USAGE_ALERT_BASES, type UsageAlertBasis } from "@autumn/shared";
 
 export const USAGE_ALERT_BASIS_LABELS: Record<UsageAlertBasis, string> = {
 	balance: "Total balance",
@@ -15,10 +15,16 @@ export const USAGE_ALERT_BASIS_DESCRIPTIONS: Record<UsageAlertBasis, string> = {
 		"The cap of the usage limit with the same feature and conditions.",
 };
 
-export const BALANCE_BASIS_OPTIONS = (
-	["balance", "included", "recurring"] as const
-).map((basis) => ({ value: basis, label: USAGE_ALERT_BASIS_LABELS[basis] }));
+export type UsageAlertBasisOption = { value: UsageAlertBasis; label: string };
 
-export const ALL_BASIS_OPTIONS = (
-	["balance", "included", "recurring", "usage_limit"] as const
-).map((basis) => ({ value: basis, label: USAGE_ALERT_BASIS_LABELS[basis] }));
+const toOption = (basis: UsageAlertBasis): UsageAlertBasisOption => ({
+	value: basis,
+	label: USAGE_ALERT_BASIS_LABELS[basis],
+});
+
+export const ALL_BASIS_OPTIONS: UsageAlertBasisOption[] =
+	USAGE_ALERT_BASES.map(toOption);
+
+/** Org alerts have no single cap to measure, so usage_limit is not offered. */
+export const BALANCE_BASIS_OPTIONS: UsageAlertBasisOption[] =
+	USAGE_ALERT_BASES.filter((basis) => basis !== "usage_limit").map(toOption);

--- a/vite/src/components/billing-controls/usageAlertBasisOptions.ts
+++ b/vite/src/components/billing-controls/usageAlertBasisOptions.ts
@@ -16,7 +16,7 @@ export const USAGE_ALERT_BASIS_DESCRIPTIONS: Record<UsageAlertBasis, string> = {
 	included: "Only the allowance granted by plans.",
 	recurring: "Only grants that reset each period.",
 	usage_limit:
-		"The cap of the usage limit with the same feature and conditions.",
+		"The cap of this feature's usage limit. With no conditions, that is the limit without conditions.",
 };
 
 export type UsageAlertBasisOption = { value: UsageAlertBasis; label: string };

--- a/vite/src/components/billing-controls/usageAlertBasisOptions.ts
+++ b/vite/src/components/billing-controls/usageAlertBasisOptions.ts
@@ -25,7 +25,7 @@ const basisToOption = (basis: UsageAlertBasis): UsageAlertBasisOption => ({
 export const ALL_BASIS_OPTIONS: UsageAlertBasisOption[] =
 	USAGE_ALERT_BASES.map(basisToOption);
 
-/** Org alerts have no single cap to measure, so usage_limit is not offered. */
+// Org alerts have no single cap to measure.
 export const BALANCE_BASIS_OPTIONS: UsageAlertBasisOption[] =
 	USAGE_ALERT_BASES.filter((basis) => basis !== "usage_limit").map(
 		basisToOption,

--- a/vite/src/components/billing-controls/usageAlertBasisOptions.ts
+++ b/vite/src/components/billing-controls/usageAlertBasisOptions.ts
@@ -1,0 +1,24 @@
+import type { UsageAlertBasis } from "@autumn/shared";
+
+export const USAGE_ALERT_BASIS_LABELS: Record<UsageAlertBasis, string> = {
+	balance: "Total balance",
+	included: "Plan allowance",
+	recurring: "Recurring grants",
+	usage_limit: "Usage limit cap",
+};
+
+export const USAGE_ALERT_BASIS_DESCRIPTIONS: Record<UsageAlertBasis, string> = {
+	balance: "Every grant on the feature, including top-ups and rollover.",
+	included: "Only the allowance granted by plans.",
+	recurring: "Only grants that reset each period.",
+	usage_limit:
+		"The cap of the usage limit with the same feature and conditions.",
+};
+
+export const BALANCE_BASIS_OPTIONS = (
+	["balance", "included", "recurring"] as const
+).map((basis) => ({ value: basis, label: USAGE_ALERT_BASIS_LABELS[basis] }));
+
+export const ALL_BASIS_OPTIONS = (
+	["balance", "included", "recurring", "usage_limit"] as const
+).map((basis) => ({ value: basis, label: USAGE_ALERT_BASIS_LABELS[basis] }));

--- a/vite/src/components/billing-controls/usageAlertBasisOptions.ts
+++ b/vite/src/components/billing-controls/usageAlertBasisOptions.ts
@@ -1,4 +1,8 @@
-import { USAGE_ALERT_BASES, type UsageAlertBasis } from "@autumn/shared";
+import {
+	BALANCE_BASES,
+	USAGE_ALERT_BASES,
+	type UsageAlertBasis,
+} from "@autumn/shared";
 
 export const USAGE_ALERT_BASIS_LABELS: Record<UsageAlertBasis, string> = {
 	balance: "Total balance",
@@ -22,11 +26,8 @@ const basisToOption = (basis: UsageAlertBasis): UsageAlertBasisOption => ({
 	label: USAGE_ALERT_BASIS_LABELS[basis],
 });
 
-export const ALL_BASIS_OPTIONS: UsageAlertBasisOption[] =
+export const USAGE_ALERT_BASIS_OPTIONS: readonly UsageAlertBasisOption[] =
 	USAGE_ALERT_BASES.map(basisToOption);
 
-// Org alerts have no single cap to measure.
-export const BALANCE_BASIS_OPTIONS: UsageAlertBasisOption[] =
-	USAGE_ALERT_BASES.filter((basis) => basis !== "usage_limit").map(
-		basisToOption,
-	);
+export const ORG_USAGE_ALERT_BASIS_OPTIONS: readonly UsageAlertBasisOption[] =
+	BALANCE_BASES.map(basisToOption);

--- a/vite/src/components/billing-controls/usageAlertThresholdTypeOptions.ts
+++ b/vite/src/components/billing-controls/usageAlertThresholdTypeOptions.ts
@@ -1,0 +1,17 @@
+import type { DbUsageAlert } from "@autumn/shared";
+
+type UsageAlertThresholdType = DbUsageAlert["threshold_type"];
+
+export const USAGE_ALERT_THRESHOLD_TYPE_LABELS: Record<
+	UsageAlertThresholdType,
+	string
+> = {
+	usage: "Usage (absolute value)",
+	usage_percentage: "Percentage used",
+	remaining: "Remaining (absolute value)",
+	remaining_percentage: "Percentage remaining",
+};
+
+export const USAGE_ALERT_THRESHOLD_TYPE_OPTIONS = Object.entries(
+	USAGE_ALERT_THRESHOLD_TYPE_LABELS,
+).map(([value, label]) => ({ value, label }));

--- a/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
@@ -358,8 +358,9 @@ export function BillingUsageAlertSheet() {
 									suggestions={propertySuggestions}
 								/>
 								<p className="mt-2 text-tertiary-foreground text-xs">
-									Match the conditions of the usage limit this alert should
-									measure.
+									Leave empty to measure this feature's usage limit without
+									conditions. Add conditions only to target a limit that has the
+									same ones.
 								</p>
 							</div>
 						)}

--- a/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
@@ -4,11 +4,14 @@ import {
 	cusEntsToGrantedBalance,
 	cusEntsToPrepaidQuantity,
 	type DbUsageAlert,
+	DEFAULT_USAGE_ALERT_BASIS,
 	type Feature,
 	FeatureType,
 	type FullCustomer,
+	filterUnresolvableUsageLimitAlerts,
 	fullCustomerToCustomerEntitlements,
 	nullish,
+	type UsageAlertBasis,
 } from "@autumn/shared";
 import {
 	Button,
@@ -24,7 +27,11 @@ import {
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { UsageAlertBasisSelect } from "@/components/billing-controls/UsageAlertBasisSelect";
-import { ALL_BASIS_OPTIONS } from "@/components/billing-controls/usageAlertBasisOptions";
+import { USAGE_ALERT_BASIS_OPTIONS } from "@/components/billing-controls/usageAlertBasisOptions";
+import {
+	USAGE_ALERT_THRESHOLD_TYPE_LABELS,
+	USAGE_ALERT_THRESHOLD_TYPE_OPTIONS,
+} from "@/components/billing-controls/usageAlertThresholdTypeOptions";
 import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 import {
 	LayoutGroup,
@@ -79,8 +86,8 @@ export function BillingUsageAlertSheet() {
 	const [thresholdType, setThresholdType] = useState<string>(
 		existingItem?.threshold_type ?? "usage",
 	);
-	const [basis, setBasis] = useState<DbUsageAlert["basis"]>(
-		existingItem?.basis ?? "balance",
+	const [basis, setBasis] = useState<UsageAlertBasis>(
+		existingItem?.basis ?? DEFAULT_USAGE_ALERT_BASIS,
 	);
 	const [conditions, setConditions] = useState<UsageLimitCondition[]>(
 		conditionsFromFilter(existingItem?.filter),
@@ -197,6 +204,20 @@ export function BillingUsageAlertSheet() {
 			...(filter && { filter }),
 			name: name.trim() || undefined,
 		};
+		const unresolvable = filterUnresolvableUsageLimitAlerts({
+			usageAlerts: [item],
+			usageLimitLists: [
+				selectedEntity?.usage_limits,
+				fullCustomer?.usage_limits,
+				fullCustomer?.customer_products?.flatMap(
+					(customerProduct) => customerProduct.product?.usage_limits ?? [],
+				),
+			],
+		});
+		if (unresolvable.length > 0) {
+			toast.error("No usage limit matches this feature and conditions");
+			return;
+		}
 
 		const currentUsageAlerts = getCurrentUsageAlerts();
 
@@ -307,34 +328,24 @@ export function BillingUsageAlertSheet() {
 							<Select
 								value={thresholdType}
 								onValueChange={setThresholdType}
-								items={{
-									usage: "Usage (absolute value)",
-									usage_percentage: "Percentage used of allowance",
-									remaining: "Remaining (absolute value)",
-									remaining_percentage: "Percentage remaining of allowance",
-								}}
+								items={USAGE_ALERT_THRESHOLD_TYPE_LABELS}
 							>
 								<SelectTrigger className="w-full">
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
-									<SelectItem value="usage">Usage (absolute value)</SelectItem>
-									<SelectItem value="usage_percentage">
-										Percentage used of allowance
-									</SelectItem>
-									<SelectItem value="remaining">
-										Remaining (absolute value)
-									</SelectItem>
-									<SelectItem value="remaining_percentage">
-										Percentage remaining of allowance
-									</SelectItem>
+									{USAGE_ALERT_THRESHOLD_TYPE_OPTIONS.map((option) => (
+										<SelectItem key={option.value} value={option.value}>
+											{option.label}
+										</SelectItem>
+									))}
 								</SelectContent>
 							</Select>
 						</div>
 
 						<UsageAlertBasisSelect
 							value={basis}
-							options={ALL_BASIS_OPTIONS}
+							options={USAGE_ALERT_BASIS_OPTIONS}
 							onChange={setBasis}
 						/>
 

--- a/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
@@ -89,7 +89,9 @@ export function BillingUsageAlertSheet() {
 	);
 	const measuresUsageLimit = basis === "usage_limit";
 	const propertySuggestions = useCustomerPropertyKeys({
-		customerId: fullCustomer?.id || fullCustomer?.internal_id,
+		customerId: measuresUsageLimit
+			? fullCustomer?.id || fullCustomer?.internal_id
+			: undefined,
 	});
 
 	const nonArchivedFeatures = (features ?? []).filter(
@@ -172,6 +174,11 @@ export function BillingUsageAlertSheet() {
 
 		if (thresholdType === "remaining_percentage" && parsedThreshold > 100) {
 			toast.error("Remaining percentage threshold must be between 0 and 100");
+			return;
+		}
+
+		if (measuresUsageLimit && !featureId) {
+			toast.error("Choose a feature to measure against a usage limit");
 			return;
 		}
 

--- a/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
@@ -23,10 +23,8 @@ import {
 } from "@autumn/ui";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
-import {
-	ALL_BASIS_OPTIONS,
-	USAGE_ALERT_BASIS_DESCRIPTIONS,
-} from "@/components/billing-controls/usageAlertBasisOptions";
+import { UsageAlertBasisSelect } from "@/components/billing-controls/UsageAlertBasisSelect";
+import { ALL_BASIS_OPTIONS } from "@/components/billing-controls/usageAlertBasisOptions";
 import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 import {
 	LayoutGroup,
@@ -334,35 +332,11 @@ export function BillingUsageAlertSheet() {
 							</Select>
 						</div>
 
-						<div>
-							<FormLabel>Measured against</FormLabel>
-							<Select
-								value={basis}
-								onValueChange={(value) =>
-									setBasis(value as DbUsageAlert["basis"])
-								}
-								items={Object.fromEntries(
-									ALL_BASIS_OPTIONS.map((option) => [
-										option.value,
-										option.label,
-									]),
-								)}
-							>
-								<SelectTrigger className="w-full">
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									{ALL_BASIS_OPTIONS.map((option) => (
-										<SelectItem key={option.value} value={option.value}>
-											{option.label}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-							<p className="mt-1 text-tertiary-foreground text-xs">
-								{USAGE_ALERT_BASIS_DESCRIPTIONS[basis]}
-							</p>
-						</div>
+						<UsageAlertBasisSelect
+							value={basis}
+							options={ALL_BASIS_OPTIONS}
+							onChange={setBasis}
+						/>
 
 						{measuresUsageLimit && (
 							<div>

--- a/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
@@ -23,6 +23,10 @@ import {
 } from "@autumn/ui";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import {
+	ALL_BASIS_OPTIONS,
+	USAGE_ALERT_BASIS_DESCRIPTIONS,
+} from "@/components/billing-controls/usageAlertBasisOptions";
 import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 import {
 	LayoutGroup,
@@ -37,6 +41,15 @@ import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { useCustomerContext } from "../../customer/CustomerContext";
+import {
+	type UsageLimitCondition,
+	UsageLimitConditionRows,
+} from "./UsageLimitConditionRows";
+import {
+	conditionsFromFilter,
+	conditionsToFilter,
+} from "./usageLimitFilterConditions";
+import { useCustomerPropertyKeys } from "./useCustomerPropertyKeys";
 
 export function BillingUsageAlertSheet() {
 	const closeSheet = useSheetStore((s) => s.closeSheet);
@@ -68,6 +81,16 @@ export function BillingUsageAlertSheet() {
 	const [thresholdType, setThresholdType] = useState<string>(
 		existingItem?.threshold_type ?? "usage",
 	);
+	const [basis, setBasis] = useState<DbUsageAlert["basis"]>(
+		existingItem?.basis ?? "balance",
+	);
+	const [conditions, setConditions] = useState<UsageLimitCondition[]>(
+		conditionsFromFilter(existingItem?.filter),
+	);
+	const measuresUsageLimit = basis === "usage_limit";
+	const propertySuggestions = useCustomerPropertyKeys({
+		customerId: fullCustomer?.id || fullCustomer?.internal_id,
+	});
 
 	const nonArchivedFeatures = (features ?? []).filter(
 		(f: Feature) => !f.archived && f.type !== FeatureType.Boolean,
@@ -152,11 +175,21 @@ export function BillingUsageAlertSheet() {
 			return;
 		}
 
+		const { filter, error: filterError } = measuresUsageLimit
+			? conditionsToFilter(conditions)
+			: {};
+		if (filterError) {
+			toast.error(filterError);
+			return;
+		}
+
 		const item: DbUsageAlert = {
 			feature_id: featureId || undefined,
 			enabled,
 			threshold: parsedThreshold,
 			threshold_type: thresholdType as DbUsageAlert["threshold_type"],
+			basis,
+			...(filter && { filter }),
 			name: name.trim() || undefined,
 		};
 
@@ -293,6 +326,51 @@ export function BillingUsageAlertSheet() {
 								</SelectContent>
 							</Select>
 						</div>
+
+						<div>
+							<FormLabel>Measured against</FormLabel>
+							<Select
+								value={basis}
+								onValueChange={(value) =>
+									setBasis(value as DbUsageAlert["basis"])
+								}
+								items={Object.fromEntries(
+									ALL_BASIS_OPTIONS.map((option) => [
+										option.value,
+										option.label,
+									]),
+								)}
+							>
+								<SelectTrigger className="w-full">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{ALL_BASIS_OPTIONS.map((option) => (
+										<SelectItem key={option.value} value={option.value}>
+											{option.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<p className="mt-1 text-tertiary-foreground text-xs">
+								{USAGE_ALERT_BASIS_DESCRIPTIONS[basis]}
+							</p>
+						</div>
+
+						{measuresUsageLimit && (
+							<div>
+								<FormLabel>Conditions</FormLabel>
+								<UsageLimitConditionRows
+									conditions={conditions}
+									onChange={setConditions}
+									suggestions={propertySuggestions}
+								/>
+								<p className="mt-2 text-tertiary-foreground text-xs">
+									Match the conditions of the usage limit this alert should
+									measure.
+								</p>
+							</div>
+						)}
 
 						<div>
 							<FormLabel>

--- a/vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx
@@ -4,7 +4,7 @@ import {
 	FeatureType,
 	type FullCustomer,
 	ResetInterval,
-	usageLimitFilterKey,
+	usageLimitIdentity,
 } from "@autumn/shared";
 import {
 	Button,
@@ -170,12 +170,11 @@ export function BillingUsageLimitSheet() {
 		});
 
 		const usageLimits = getCurrentUsageLimits();
-		const itemIdentity = `${item.feature_id}|${usageLimitFilterKey(item.filter)}`;
+		const itemIdentity = usageLimitIdentity(item);
 		const duplicate = usageLimits.some(
 			(existing, index) =>
 				!(isEdit && index === existingIndex) &&
-				`${existing.feature_id}|${usageLimitFilterKey(existing.filter)}` ===
-					itemIdentity,
+				usageLimitIdentity(existing) === itemIdentity,
 		);
 		if (duplicate) {
 			toast.error(

--- a/vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx
@@ -4,9 +4,6 @@ import {
 	FeatureType,
 	type FullCustomer,
 	ResetInterval,
-	USAGE_LIMIT_FILTER_MAX_KEY_LENGTH,
-	USAGE_LIMIT_FILTER_MAX_KEYS,
-	USAGE_LIMIT_FILTER_MAX_VALUE_LENGTH,
 	usageLimitFilterKey,
 } from "@autumn/shared";
 import {
@@ -41,6 +38,10 @@ import {
 	type UsageLimitCondition,
 	UsageLimitConditionRows,
 } from "./UsageLimitConditionRows";
+import {
+	conditionsFromFilter,
+	conditionsToFilter,
+} from "./usageLimitFilterConditions";
 import { useCustomerPropertyKeys } from "./useCustomerPropertyKeys";
 
 // Interval is required (no inherit) and one_off intervals are not supported.
@@ -74,64 +75,6 @@ export const buildUsageLimitItem = ({
 	anchor: anchorUtc ? "utc" : "billing_cycle",
 	...(filter && { filter }),
 });
-
-const conditionsFromFilter = (
-	filter: DbUsageLimit["filter"],
-): UsageLimitCondition[] =>
-	Object.entries(filter?.properties ?? {}).map(([key, value]) => ({
-		key,
-		value: String(value),
-	}));
-
-/** Trimmed, non-empty rows -> filter.properties; error on partial rows. */
-const conditionsToFilter = (
-	conditions: UsageLimitCondition[],
-): { filter?: DbUsageLimit["filter"]; error?: string } => {
-	const filled = conditions
-		.map(({ key, value }) => ({ key: key.trim(), value: value.trim() }))
-		.filter(({ key, value }) => key || value);
-	if (filled.length === 0) return {};
-
-	if (filled.some(({ key, value }) => !key || !value)) {
-		return { error: "Each condition needs both a property and a value" };
-	}
-	if (filled.length > USAGE_LIMIT_FILTER_MAX_KEYS) {
-		return {
-			error: `At most ${USAGE_LIMIT_FILTER_MAX_KEYS} conditions are allowed`,
-		};
-	}
-	if (
-		filled.some(({ key }) => key.length > USAGE_LIMIT_FILTER_MAX_KEY_LENGTH)
-	) {
-		return {
-			error: `Property names must be at most ${USAGE_LIMIT_FILTER_MAX_KEY_LENGTH} characters`,
-		};
-	}
-	if (
-		filled.some(
-			({ value }) => value.length > USAGE_LIMIT_FILTER_MAX_VALUE_LENGTH,
-		)
-	) {
-		return {
-			error: `Values must be at most ${USAGE_LIMIT_FILTER_MAX_VALUE_LENGTH} characters`,
-		};
-	}
-	const keys = filled.map(({ key }) => key);
-	const duplicateKey = keys.find((key, index) => keys.indexOf(key) !== index);
-	if (duplicateKey) {
-		return {
-			error: `"${duplicateKey}" can only be used once. To cap several values, create a separate limit for each.`,
-		};
-	}
-
-	return {
-		filter: {
-			properties: Object.fromEntries(
-				filled.map(({ key, value }) => [key, value]),
-			),
-		},
-	};
-};
 
 export function BillingUsageLimitSheet() {
 	const closeSheet = useSheetStore((s) => s.closeSheet);

--- a/vite/src/views/customers2/components/sheets/usageLimitFilterConditions.ts
+++ b/vite/src/views/customers2/components/sheets/usageLimitFilterConditions.ts
@@ -1,0 +1,65 @@
+import {
+	type DbUsageLimit,
+	USAGE_LIMIT_FILTER_MAX_KEY_LENGTH,
+	USAGE_LIMIT_FILTER_MAX_KEYS,
+	USAGE_LIMIT_FILTER_MAX_VALUE_LENGTH,
+} from "@autumn/shared";
+import type { UsageLimitCondition } from "./UsageLimitConditionRows";
+
+export const conditionsFromFilter = (
+	filter: DbUsageLimit["filter"],
+): UsageLimitCondition[] =>
+	Object.entries(filter?.properties ?? {}).map(([key, value]) => ({
+		key,
+		value: String(value),
+	}));
+
+/** Trimmed, non-empty rows -> filter.properties; error on partial rows. */
+export const conditionsToFilter = (
+	conditions: UsageLimitCondition[],
+): { filter?: DbUsageLimit["filter"]; error?: string } => {
+	const filled = conditions
+		.map(({ key, value }) => ({ key: key.trim(), value: value.trim() }))
+		.filter(({ key, value }) => key || value);
+	if (filled.length === 0) return {};
+
+	if (filled.some(({ key, value }) => !key || !value)) {
+		return { error: "Each condition needs both a property and a value" };
+	}
+	if (filled.length > USAGE_LIMIT_FILTER_MAX_KEYS) {
+		return {
+			error: `At most ${USAGE_LIMIT_FILTER_MAX_KEYS} conditions are allowed`,
+		};
+	}
+	if (
+		filled.some(({ key }) => key.length > USAGE_LIMIT_FILTER_MAX_KEY_LENGTH)
+	) {
+		return {
+			error: `Property names must be at most ${USAGE_LIMIT_FILTER_MAX_KEY_LENGTH} characters`,
+		};
+	}
+	if (
+		filled.some(
+			({ value }) => value.length > USAGE_LIMIT_FILTER_MAX_VALUE_LENGTH,
+		)
+	) {
+		return {
+			error: `Values must be at most ${USAGE_LIMIT_FILTER_MAX_VALUE_LENGTH} characters`,
+		};
+	}
+	const keys = filled.map(({ key }) => key);
+	const duplicateKey = keys.find((key, index) => keys.indexOf(key) !== index);
+	if (duplicateKey) {
+		return {
+			error: `"${duplicateKey}" can only be used once. To cap several values, create a separate limit for each.`,
+		};
+	}
+
+	return {
+		filter: {
+			properties: Object.fromEntries(
+				filled.map(({ key, value }) => [key, value]),
+			),
+		},
+	};
+};

--- a/vite/src/views/customers2/components/sheets/usageLimitFilterConditions.ts
+++ b/vite/src/views/customers2/components/sheets/usageLimitFilterConditions.ts
@@ -3,11 +3,12 @@ import {
 	USAGE_LIMIT_FILTER_MAX_KEY_LENGTH,
 	USAGE_LIMIT_FILTER_MAX_KEYS,
 	USAGE_LIMIT_FILTER_MAX_VALUE_LENGTH,
+	type UsageLimitFilter,
 } from "@autumn/shared";
 import type { UsageLimitCondition } from "./UsageLimitConditionRows";
 
 export const conditionsFromFilter = (
-	filter: DbUsageLimit["filter"],
+	filter: UsageLimitFilter | null | undefined,
 ): UsageLimitCondition[] =>
 	Object.entries(filter?.properties ?? {}).map(([key, value]) => ({
 		key,

--- a/vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx
@@ -76,8 +76,6 @@ const USAGE_INTERVAL_OPTIONS: SelectOption[] = [
 	{ value: ResetInterval.Year, label: "Year" },
 ];
 
-const ALERT_BASIS_OPTIONS: SelectOption[] = ALL_BASIS_OPTIONS;
-
 const THRESHOLD_TYPE_OPTIONS: SelectOption[] = [
 	{ value: "usage", label: "Absolute usage" },
 	{ value: "usage_percentage", label: "% used of allowance" },
@@ -489,7 +487,7 @@ function UsageAlertFields({ form }: { form: UsePlanBillingControlForm }) {
 				name="alert_basis"
 				label="Measured against"
 				placeholder="Measured against"
-				options={ALERT_BASIS_OPTIONS}
+				options={ALL_BASIS_OPTIONS}
 			/>
 		</div>
 	);

--- a/vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/components/billing-controls/BillingControlsDisplay";
 import { OVERAGE_BILLING_OPTIONS } from "@/components/billing-controls/overageBillingOptions";
 import { UsageAnchorTooltip } from "@/components/billing-controls/UsageAnchorTooltip";
+import { ALL_BASIS_OPTIONS } from "@/components/billing-controls/usageAlertBasisOptions";
 import { FieldInfo } from "@/components/general/form/field-info";
 import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
@@ -74,6 +75,8 @@ const USAGE_INTERVAL_OPTIONS: SelectOption[] = [
 	{ value: ResetInterval.Month, label: "Month" },
 	{ value: ResetInterval.Year, label: "Year" },
 ];
+
+const ALERT_BASIS_OPTIONS: SelectOption[] = ALL_BASIS_OPTIONS;
 
 const THRESHOLD_TYPE_OPTIONS: SelectOption[] = [
 	{ value: "usage", label: "Absolute usage" },
@@ -225,6 +228,7 @@ function SelectFieldRow({
 		| "purchase_limit_interval"
 		| "usage_interval"
 		| "threshold_type"
+		| "alert_basis"
 		| "overage_billing";
 	label: string;
 	placeholder: string;
@@ -480,6 +484,13 @@ function UsageAlertFields({ form }: { form: UsePlanBillingControlForm }) {
 					options={THRESHOLD_TYPE_OPTIONS}
 				/>
 			</div>
+			<SelectFieldRow
+				form={form}
+				name="alert_basis"
+				label="Measured against"
+				placeholder="Measured against"
+				options={ALERT_BASIS_OPTIONS}
+			/>
 		</div>
 	);
 }

--- a/vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx
@@ -1,9 +1,11 @@
 import {
 	type BillingControlKey,
 	type CustomerBillingControls,
+	type DbUsageAlert,
 	type Feature,
 	FeatureType,
 	FeatureUsageType,
+	filterUnresolvableUsageLimitAlerts,
 	PurchaseLimitInterval,
 	ResetInterval,
 	type SpendLimitType,
@@ -33,7 +35,8 @@ import {
 } from "@/components/billing-controls/BillingControlsDisplay";
 import { OVERAGE_BILLING_OPTIONS } from "@/components/billing-controls/overageBillingOptions";
 import { UsageAnchorTooltip } from "@/components/billing-controls/UsageAnchorTooltip";
-import { ALL_BASIS_OPTIONS } from "@/components/billing-controls/usageAlertBasisOptions";
+import { USAGE_ALERT_BASIS_OPTIONS } from "@/components/billing-controls/usageAlertBasisOptions";
+import { USAGE_ALERT_THRESHOLD_TYPE_OPTIONS } from "@/components/billing-controls/usageAlertThresholdTypeOptions";
 import { FieldInfo } from "@/components/general/form/field-info";
 import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
@@ -74,13 +77,6 @@ const USAGE_INTERVAL_OPTIONS: SelectOption[] = [
 	{ value: ResetInterval.Week, label: "Week" },
 	{ value: ResetInterval.Month, label: "Month" },
 	{ value: ResetInterval.Year, label: "Year" },
-];
-
-const THRESHOLD_TYPE_OPTIONS: SelectOption[] = [
-	{ value: "usage", label: "Absolute usage" },
-	{ value: "usage_percentage", label: "% used of allowance" },
-	{ value: "remaining", label: "Absolute remaining" },
-	{ value: "remaining_percentage", label: "% remaining of allowance" },
 ];
 
 const SPEND_LIMIT_TYPE_OPTIONS: SelectOption[] = [
@@ -479,15 +475,15 @@ function UsageAlertFields({ form }: { form: UsePlanBillingControlForm }) {
 					name="threshold_type"
 					label="Type"
 					placeholder="Type"
-					options={THRESHOLD_TYPE_OPTIONS}
+					options={USAGE_ALERT_THRESHOLD_TYPE_OPTIONS}
 				/>
 			</div>
 			<SelectFieldRow
 				form={form}
 				name="alert_basis"
 				label="Measured against"
-				placeholder="Measured against"
-				options={ALL_BASIS_OPTIONS}
+				placeholder="Basis"
+				options={USAGE_ALERT_BASIS_OPTIONS}
 			/>
 		</div>
 	);
@@ -540,7 +536,18 @@ function PlanBillingControlForm({
 			toast.error("Only one control is allowed per feature");
 			return;
 		}
-		onSave(buildControlItem(controlKey, values));
+		const item = buildControlItem(controlKey, values);
+		if (
+			controlKey === "usage_alerts" &&
+			filterUnresolvableUsageLimitAlerts({
+				usageAlerts: [item as DbUsageAlert],
+				usageLimitLists: [existingControls.usage_limits],
+			}).length > 0
+		) {
+			toast.error("No usage limit on this plan matches this feature");
+			return;
+		}
+		onSave(item);
 	};
 
 	const form = usePlanBillingControlForm({

--- a/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
+++ b/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
@@ -5,9 +5,11 @@ import {
 	type DbSpendLimit,
 	type DbUsageAlert,
 	type DbUsageLimit,
+	DEFAULT_USAGE_ALERT_BASIS,
 	PurchaseLimitInterval,
 	ResetInterval,
 	type SpendLimitType,
+	type UsageAlertBasis,
 } from "@autumn/shared";
 import { useRef } from "react";
 import { z } from "zod/v4";
@@ -44,7 +46,7 @@ export type PlanBillingControlFormValues = {
 	alert_name: string;
 	alert_threshold: number | null;
 	threshold_type: DbUsageAlert["threshold_type"];
-	alert_basis: DbUsageAlert["basis"];
+	alert_basis: UsageAlertBasis;
 };
 
 const requireNumber = (min: number, message: string) =>
@@ -106,11 +108,22 @@ const UsageLimitFormSchema = z.object({
 
 const UsageAlertFormSchema = z
 	.object({
+		feature_id: z.string(),
 		alert_threshold: requireNumber(0, "Please enter a valid threshold"),
 		threshold_type: z.string(),
+		alert_basis: z.string(),
 	})
 	.check((ctx) => {
-		const { alert_threshold, threshold_type } = ctx.value;
+		const { feature_id, alert_threshold, threshold_type, alert_basis } =
+			ctx.value;
+		if (alert_basis === "usage_limit" && !feature_id) {
+			ctx.issues.push({
+				code: "custom",
+				input: feature_id,
+				path: ["feature_id"],
+				message: "Choose a feature to measure against a usage limit",
+			});
+		}
 		if (threshold_type === "remaining_percentage" && alert_threshold > 100) {
 			ctx.issues.push({
 				code: "custom",
@@ -248,7 +261,7 @@ function toDefaultValues(
 		alert_name: usageAlert?.name ?? "",
 		alert_threshold: usageAlert?.threshold ?? null,
 		threshold_type: usageAlert?.threshold_type ?? "usage",
-		alert_basis: usageAlert?.basis ?? "balance",
+		alert_basis: usageAlert?.basis ?? DEFAULT_USAGE_ALERT_BASIS,
 	};
 }
 

--- a/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
+++ b/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
@@ -44,6 +44,7 @@ export type PlanBillingControlFormValues = {
 	alert_name: string;
 	alert_threshold: number | null;
 	threshold_type: DbUsageAlert["threshold_type"];
+	alert_basis: DbUsageAlert["basis"];
 };
 
 const requireNumber = (min: number, message: string) =>
@@ -187,6 +188,7 @@ export function buildControlItem(
 			enabled: values.enabled,
 			threshold: values.alert_threshold ?? 0,
 			threshold_type: values.threshold_type,
+			basis: values.alert_basis,
 			name: emptyToUndefined(values.alert_name),
 		} satisfies DbUsageAlert;
 	}
@@ -246,6 +248,7 @@ function toDefaultValues(
 		alert_name: usageAlert?.name ?? "",
 		alert_threshold: usageAlert?.threshold ?? null,
 		threshold_type: usageAlert?.threshold_type ?? "usage",
+		alert_basis: usageAlert?.basis ?? "balance",
 	};
 }
 

--- a/vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx
+++ b/vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx
@@ -17,10 +17,8 @@ import {
 } from "@autumn/ui";
 import { useState } from "react";
 import { toast } from "sonner";
-import {
-	BALANCE_BASIS_OPTIONS,
-	USAGE_ALERT_BASIS_DESCRIPTIONS,
-} from "@/components/billing-controls/usageAlertBasisOptions";
+import { UsageAlertBasisSelect } from "@/components/billing-controls/UsageAlertBasisSelect";
+import { BALANCE_BASIS_OPTIONS } from "@/components/billing-controls/usageAlertBasisOptions";
 import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 
 type ThresholdType = DbUsageAlert["threshold_type"];
@@ -150,29 +148,11 @@ export const OrgUsageAlertDialog = ({
 						</Select>
 					</div>
 
-					<div>
-						<FormLabel>Measured against</FormLabel>
-						<Select
-							value={draft.basis ?? "balance"}
-							onValueChange={(value) =>
-								updateDraft({ basis: value as DbUsageAlert["basis"] })
-							}
-						>
-							<SelectTrigger className="w-full">
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								{BALANCE_BASIS_OPTIONS.map((option) => (
-									<SelectItem key={option.value} value={option.value}>
-										{option.label}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-						<p className="mt-1 text-tertiary-foreground text-xs">
-							{USAGE_ALERT_BASIS_DESCRIPTIONS[draft.basis ?? "balance"]}
-						</p>
-					</div>
+					<UsageAlertBasisSelect
+						value={draft.basis ?? "balance"}
+						options={BALANCE_BASIS_OPTIONS}
+						onChange={(basis) => updateDraft({ basis })}
+					/>
 
 					<div>
 						<FormLabel>

--- a/vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx
+++ b/vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx
@@ -17,6 +17,10 @@ import {
 } from "@autumn/ui";
 import { useState } from "react";
 import { toast } from "sonner";
+import {
+	BALANCE_BASIS_OPTIONS,
+	USAGE_ALERT_BASIS_DESCRIPTIONS,
+} from "@/components/billing-controls/usageAlertBasisOptions";
 import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 
 type ThresholdType = DbUsageAlert["threshold_type"];
@@ -47,6 +51,7 @@ export const OrgUsageAlertDialog = ({
 			enabled: true,
 			threshold: 0,
 			threshold_type: "usage",
+			basis: "balance",
 			feature_id: undefined,
 			name: undefined,
 		},
@@ -143,6 +148,30 @@ export const OrgUsageAlertDialog = ({
 								</SelectItem>
 							</SelectContent>
 						</Select>
+					</div>
+
+					<div>
+						<FormLabel>Measured against</FormLabel>
+						<Select
+							value={draft.basis ?? "balance"}
+							onValueChange={(value) =>
+								updateDraft({ basis: value as DbUsageAlert["basis"] })
+							}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{BALANCE_BASIS_OPTIONS.map((option) => (
+									<SelectItem key={option.value} value={option.value}>
+										{option.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<p className="mt-1 text-tertiary-foreground text-xs">
+							{USAGE_ALERT_BASIS_DESCRIPTIONS[draft.basis ?? "balance"]}
+						</p>
 					</div>
 
 					<div>

--- a/vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx
+++ b/vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx
@@ -1,4 +1,9 @@
-import { type DbUsageAlert, type Feature, FeatureType } from "@autumn/shared";
+import {
+	type DbUsageAlert,
+	DEFAULT_USAGE_ALERT_BASIS,
+	type Feature,
+	FeatureType,
+} from "@autumn/shared";
 import {
 	Button,
 	Dialog,
@@ -18,7 +23,8 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 import { UsageAlertBasisSelect } from "@/components/billing-controls/UsageAlertBasisSelect";
-import { BALANCE_BASIS_OPTIONS } from "@/components/billing-controls/usageAlertBasisOptions";
+import { ORG_USAGE_ALERT_BASIS_OPTIONS } from "@/components/billing-controls/usageAlertBasisOptions";
+import { USAGE_ALERT_THRESHOLD_TYPE_OPTIONS } from "@/components/billing-controls/usageAlertThresholdTypeOptions";
 import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 
 type ThresholdType = DbUsageAlert["threshold_type"];
@@ -49,7 +55,7 @@ export const OrgUsageAlertDialog = ({
 			enabled: true,
 			threshold: 0,
 			threshold_type: "usage",
-			basis: "balance",
+			basis: DEFAULT_USAGE_ALERT_BASIS,
 			feature_id: undefined,
 			name: undefined,
 		},
@@ -134,23 +140,18 @@ export const OrgUsageAlertDialog = ({
 								<SelectValue />
 							</SelectTrigger>
 							<SelectContent>
-								<SelectItem value="usage">Usage (absolute value)</SelectItem>
-								<SelectItem value="usage_percentage">
-									Percentage used of allowance
-								</SelectItem>
-								<SelectItem value="remaining">
-									Remaining (absolute value)
-								</SelectItem>
-								<SelectItem value="remaining_percentage">
-									Percentage remaining of allowance
-								</SelectItem>
+								{USAGE_ALERT_THRESHOLD_TYPE_OPTIONS.map((option) => (
+									<SelectItem key={option.value} value={option.value}>
+										{option.label}
+									</SelectItem>
+								))}
 							</SelectContent>
 						</Select>
 					</div>
 
 					<UsageAlertBasisSelect
-						value={draft.basis ?? "balance"}
-						options={BALANCE_BASIS_OPTIONS}
+						value={draft.basis ?? DEFAULT_USAGE_ALERT_BASIS}
+						options={ORG_USAGE_ALERT_BASIS_OPTIONS}
 						onChange={(basis) => updateDraft({ basis })}
 					/>
 

--- a/vite/src/views/settings/sections/components/OrgUsageAlertsSubsection.tsx
+++ b/vite/src/views/settings/sections/components/OrgUsageAlertsSubsection.tsx
@@ -1,15 +1,19 @@
 import {
 	AppEnv,
 	type DbUsageAlert,
+	DEFAULT_USAGE_ALERT_BASIS,
 	type Feature,
 	type FrontendOrg,
 	type OrgConfig,
+	usageAlertIdentity,
 } from "@autumn/shared";
 import { Button } from "@autumn/ui";
 import { PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import { USAGE_ALERT_BASIS_LABELS } from "@/components/billing-controls/usageAlertBasisOptions";
+import { USAGE_ALERT_THRESHOLD_TYPE_LABELS } from "@/components/billing-controls/usageAlertThresholdTypeOptions";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { cn } from "@/lib/utils";
@@ -19,13 +23,6 @@ import { OrgUsageAlertDialog } from "./OrgUsageAlertDialog";
 
 const pillClassName =
 	"rounded-md bg-muted px-1.5 py-0.5 text-xs text-tertiary-foreground whitespace-nowrap";
-
-const thresholdTypeLabel: Record<DbUsageAlert["threshold_type"], string> = {
-	usage: "absolute usage",
-	usage_percentage: "% used of allowance",
-	remaining: "absolute remaining",
-	remaining_percentage: "% remaining of allowance",
-};
 
 const formatThreshold = (alert: DbUsageAlert) => {
 	const isPct =
@@ -151,7 +148,7 @@ export const OrgUsageAlertsSubsection = () => {
 				<div className="flex flex-col gap-1.5">
 					{orgAlerts.map((alert, index) => (
 						<div
-							key={`org-alert-${alert.feature_id ?? "global"}-${alert.threshold_type}-${alert.threshold}-${alert.name ?? index}`}
+							key={usageAlertIdentity(alert)}
 							className={cn(
 								"flex items-center gap-2 rounded-lg border bg-interactive-secondary px-3 py-2 min-w-0",
 							)}
@@ -187,7 +184,14 @@ export const OrgUsageAlertsSubsection = () => {
 										At: {formatThreshold(alert)}
 									</span>
 									<span className={cn(pillClassName, "hidden sm:inline")}>
-										{thresholdTypeLabel[alert.threshold_type]}
+										{USAGE_ALERT_THRESHOLD_TYPE_LABELS[alert.threshold_type]}
+									</span>
+									<span className={cn(pillClassName, "hidden sm:inline")}>
+										{
+											USAGE_ALERT_BASIS_LABELS[
+												alert.basis ?? DEFAULT_USAGE_ALERT_BASIS
+											]
+										}
 									</span>
 								</div>
 							</button>


### PR DESCRIPTION
Layer 6 of 6 (dashboard). Base: #3249.

- Plan form and org dialog: "Measured against" dropdown (org excludes `usage_limit`).
- Customer and entity alert sheet: basis dropdown plus the usage-limit condition editor when basis is `usage_limit`.
- Alert rows show basis and filter.
- The condition helpers move out of the usage-limit sheet into `usageLimitFilterConditions.ts` so both sheets share them.
- `atmn` CLI compose type for plan alerts carries `basis` and `filter`.

`autumn-js` and `sdk` generated types regenerate from the OpenAPI spec separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Usage alerts no longer always measure thresholds against total balance. Dashboard forms can now measure total balance, plan allowance, recurring grants, or a usage-limit cap, with feature and property conditions supported where applicable.

- Customer and entity alerts require a feature for usage-limit bases and can define matching conditions; plan alerts validate the cap against the plan's usage limits without a condition editor, while organization alerts exclude it.
- Alert rows show the selected basis and property filter, and percentage thresholds now read "% used" or "% remaining."
- Property suggestions load only for usage-limit alerts, and shared validation plus full feature/filter identity prevents duplicate usage limits.

<sup>Written for commit bd6f0fa52a052490d59de648b8e91910abe5bb63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds configurable measurement bases to usage-alert forms and displays the selected basis and property filters throughout the dashboard.

- **[Improvements]** Adds “Measured against” selection for customer, entity, plan, and organization usage alerts.
- **[Improvements]** Adds condition editing and matching-limit validation for customer and entity alerts measured against usage-limit caps.
- **[Improvements]** Shows alert basis, threshold type, and property filters in billing-control rows.
- **[Improvements]** Shares condition conversion and validation helpers between usage-limit and usage-alert sheets.
- **[API changes]** Includes the selected basis and filter when constructing usage-alert records.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx | Adds basis selection, conditional property filters, and validation that usage-limit alerts resolve to an existing cap. |
| vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx | Adds plan-alert basis selection and rejects usage-limit alerts without a matching unfiltered plan cap. |
| vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts | Extends plan-alert form state, validation, defaults, and serialization with the selected basis. |
| vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx | Adds organization-alert basis selection while excluding usage-limit caps. |
| vite/src/views/customers2/components/sheets/usageLimitFilterConditions.ts | Extracts shared condition conversion and validation helpers for usage limits and alerts. |
| vite/src/components/billing-controls/BillingControlsDisplay.tsx | Displays normalized basis, threshold-type, and property-filter details for usage alerts. |

<sub>Reviews (18): Last reviewed commit: ["fix(dashboard): say that an alert with n..."](https://github.com/useautumn/autumn/commit/bd6f0fa52a052490d59de648b8e91910abe5bb63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59941906)</sub>

<!-- /greptile_comment -->