### PR TITLE
fix(licenses): reset transition usage unless carry-over is enabled

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
@@ -73,6 +73,7 @@ export const computeAttachPlan = ({
 				customerLicenseBillingContext:
 					attachBillingContext.customerLicenseBillingContext,
 				carryCustomerLicenseState: planTiming === "immediate",
+				carryOverUsages: params.carry_over_usages,
 			})
 		: [];
 	const customerLicenseTransitions =

--- a/server/src/internal/billing/v2/actions/batchTransition/batchTransition.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/batchTransition.ts
@@ -43,6 +43,7 @@ export const batchTransition = async ({
 
 	const hasEntitlementPriceTransitions =
 		entitlementPriceTransitions.transitions.length > 0 ||
+		entitlementPriceTransitions.retained.length > 0 ||
 		entitlementPriceTransitions.added.length > 0 ||
 		entitlementPriceTransitions.deleted.length > 0;
 

--- a/server/src/internal/billing/v2/actions/batchTransition/compute/operations/computeBatchTransitionOperations.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/compute/operations/computeBatchTransitionOperations.ts
@@ -1,4 +1,5 @@
 import type {
+	CarryOverUsages,
 	EntitlementWithFeature,
 	InitCustomerEntitlementContext,
 	InitFullCustomerProductOptions,
@@ -20,12 +21,14 @@ export const computeBatchTransitionOperations = ({
 	productTransitions,
 	customerEntitlementInitContext,
 	customerEntitlementInitOptions,
+	carryOverUsages,
 }: {
 	candidateOutgoingEntitlements: EntitlementWithFeature[];
 	candidateOutgoingBasePrices: Price[];
 	productTransitions: ProductTransitions;
 	customerEntitlementInitContext: InitCustomerEntitlementContext;
 	customerEntitlementInitOptions: InitFullCustomerProductOptions;
+	carryOverUsages?: CarryOverUsages;
 }): Pick<
 	CustomerEntitlementBatchTransition,
 	"operations" | "unhandledTransitions"
@@ -36,6 +39,7 @@ export const computeBatchTransitionOperations = ({
 			entitlementPriceTransitions: productTransitions.entitlementPrices,
 			customerEntitlementInitContext,
 			customerEntitlementInitOptions,
+			carryOverUsages,
 		});
 	const basePriceOperation = computeBasePriceOperation({
 		basePriceTransition: productTransitions.basePrice,

--- a/server/src/internal/billing/v2/actions/batchTransition/compute/operations/entitlementPriceOperations/computeCustomerEntitlementPatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/compute/operations/entitlementPriceOperations/computeCustomerEntitlementPatch.ts
@@ -1,5 +1,7 @@
 import {
+	type CarryOverUsages,
 	type EntitlementWithFeature,
+	featureUtils,
 	getStartingBalance,
 	isBooleanEntitlement,
 	isUnlimitedEntitlement,
@@ -32,14 +34,35 @@ export const computeCustomerEntitlementInitialState = ({
 	};
 };
 
+/** Mirrors attach: allocated usage always carries, `carry_from_previous`
+ * carries its own entitlement, and the param carries listed consumables. */
+export const shouldCarryOverUsage = ({
+	toEntitlement,
+	carryOverUsages,
+}: {
+	toEntitlement: EntitlementWithFeature;
+	carryOverUsages: CarryOverUsages;
+}): boolean => {
+	if (featureUtils.isAllocated(toEntitlement.feature)) return true;
+	if (toEntitlement.carry_from_previous) return true;
+	if (!carryOverUsages?.enabled) return false;
+	if (!carryOverUsages.feature_ids) return true;
+	return carryOverUsages.feature_ids.includes(toEntitlement.feature.id);
+};
+
 const computeBalancePatch = ({
 	fromInitialState,
 	toInitialState,
+	carryUsage,
 }: {
 	fromInitialState: CustomerEntitlementInitialState;
 	toInitialState: CustomerEntitlementInitialState;
+	carryUsage: boolean;
 }): CustomerEntitlementBalancePatch | undefined => {
 	if (fromInitialState.tracksBalance && toInitialState.tracksBalance) {
+		if (!carryUsage) {
+			return { type: "set", amount: toInitialState.granted };
+		}
 		const amount = new Decimal(toInitialState.granted).sub(
 			fromInitialState.granted,
 		);
@@ -57,9 +80,11 @@ const computeBalancePatch = ({
 export const computeCustomerEntitlementPatch = ({
 	fromEntitlement,
 	toEntitlement,
+	carryOverUsages,
 }: {
 	fromEntitlement: EntitlementWithFeature;
 	toEntitlement: EntitlementWithFeature;
+	carryOverUsages?: CarryOverUsages;
 }): CustomerEntitlementPatch => {
 	if (
 		isBooleanEntitlement({ entitlement: fromEntitlement }) ||
@@ -75,7 +100,11 @@ export const computeCustomerEntitlementPatch = ({
 		entitlement: toEntitlement,
 	});
 	const patch: CustomerEntitlementPatch = {};
-	const balance = computeBalancePatch({ fromInitialState, toInitialState });
+	const balance = computeBalancePatch({
+		fromInitialState,
+		toInitialState,
+		carryUsage: shouldCarryOverUsage({ toEntitlement, carryOverUsages }),
+	});
 
 	if (balance) patch.balance = balance;
 	if (fromInitialState.unlimited !== toInitialState.unlimited) {

--- a/server/src/internal/billing/v2/actions/batchTransition/compute/operations/entitlementPriceOperations/computeEntitlementPriceOperations.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/compute/operations/entitlementPriceOperations/computeEntitlementPriceOperations.ts
@@ -1,12 +1,14 @@
 import {
+	type CarryOverUsages,
 	EntInterval,
 	type EntitlementPrice,
 	type EntitlementWithFeature,
-	entToPooledBalanceIdentity,
 	entsAreSame,
 	entsHaveSamePooledIdentity,
+	entToPooledBalanceIdentity,
 	type InitCustomerEntitlementContext,
 	type InitFullCustomerProductOptions,
+	isBooleanEntitlement,
 	PooledBalanceResetMode,
 } from "@autumn/shared";
 import { initCustomerEntitlementFields } from "@/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlementFields";
@@ -23,6 +25,7 @@ import type {
 import {
 	computeCustomerEntitlementInitialState,
 	computeCustomerEntitlementPatch,
+	shouldCarryOverUsage,
 } from "./computeCustomerEntitlementPatch";
 
 const findCandidateEntitlementIds = ({
@@ -47,9 +50,11 @@ const findCandidateEntitlementIds = ({
 const computeReplaceOperation = ({
 	candidateOutgoingEntitlements,
 	transition,
+	carryOverUsages,
 }: {
 	candidateOutgoingEntitlements: EntitlementWithFeature[];
 	transition: EntitlementPriceTransition;
+	carryOverUsages?: CarryOverUsages;
 }): ReplaceEntitlementPriceOperation | undefined => {
 	const { fromEntitlementPrice, toEntitlementPrice } = transition;
 	const fromEntitlement = fromEntitlementPrice.entitlement;
@@ -62,15 +67,19 @@ const computeReplaceOperation = ({
 		(entitlementId) =>
 			!definitionsAreSame || entitlementId !== toEntitlement.id,
 	);
-	if (fromEntitlementIds.length === 0) return undefined;
+	if (fromEntitlementIds.length === 0) {
+		if (!definitionsAreSame) return undefined;
+		fromEntitlementIds.push(toEntitlement.id);
+	}
 
-	const customerEntitlementPatch = computeCustomerEntitlementPatch({
-		fromEntitlement,
-		toEntitlement,
-	});
 	const fromIsPooled = fromEntitlement.pooled === true;
 	const toIsPooled = toEntitlement.pooled === true;
 	const isPooledReplace = fromIsPooled && toIsPooled;
+	const customerEntitlementPatch = computeCustomerEntitlementPatch({
+		fromEntitlement,
+		toEntitlement,
+		carryOverUsages,
+	});
 	if (!isPooledReplace) {
 		return {
 			type: "replace",
@@ -82,10 +91,15 @@ const computeReplaceOperation = ({
 		};
 	}
 
-	const incrementAmount =
+	const pooledContributionPatch =
 		customerEntitlementPatch.balance?.type === "increment"
-			? customerEntitlementPatch.balance.amount
-			: 0;
+			? customerEntitlementPatch.balance
+			: {
+					type: "set" as const,
+					amount: computeCustomerEntitlementInitialState({
+						entitlement: toEntitlement,
+					}).granted,
+				};
 
 	return {
 		type: "replace",
@@ -96,7 +110,7 @@ const computeReplaceOperation = ({
 		customerEntitlementPatch: {
 			unlimited: customerEntitlementPatch.unlimited,
 		},
-		pooledContributionPatch: { type: "increment", amount: incrementAmount },
+		pooledContributionPatch,
 	};
 };
 
@@ -196,11 +210,13 @@ const computeTransitionOperations = ({
 	transition,
 	initContext,
 	initOptions,
+	carryOverUsages,
 }: {
 	candidateOutgoingEntitlements: EntitlementWithFeature[];
 	transition: EntitlementPriceTransition;
 	initContext: InitCustomerEntitlementContext;
 	initOptions: InitFullCustomerProductOptions;
+	carryOverUsages?: CarryOverUsages;
 }): EntitlementPriceOperation[] => {
 	const fromEntitlement = transition.fromEntitlementPrice.entitlement;
 	const toEntitlement = transition.toEntitlementPrice.entitlement;
@@ -215,6 +231,7 @@ const computeTransitionOperations = ({
 		const operation = computeReplaceOperation({
 			candidateOutgoingEntitlements,
 			transition,
+			carryOverUsages,
 		});
 		return operation ? [operation] : [];
 	}
@@ -244,11 +261,13 @@ export const computeEntitlementPriceOperations = ({
 	entitlementPriceTransitions,
 	customerEntitlementInitContext,
 	customerEntitlementInitOptions,
+	carryOverUsages,
 }: {
 	candidateOutgoingEntitlements: EntitlementWithFeature[];
 	entitlementPriceTransitions: ComputedEntitlementPriceTransitions;
 	customerEntitlementInitContext: InitCustomerEntitlementContext;
 	customerEntitlementInitOptions: InitFullCustomerProductOptions;
+	carryOverUsages?: CarryOverUsages;
 }): {
 	operations: EntitlementPriceOperation[];
 	unhandled: ComputedEntitlementPriceTransitions;
@@ -256,6 +275,7 @@ export const computeEntitlementPriceOperations = ({
 	const operations: EntitlementPriceOperation[] = [];
 	const unhandled: ComputedEntitlementPriceTransitions = {
 		transitions: [],
+		retained: [],
 		added: [],
 		deleted: [],
 	};
@@ -275,8 +295,42 @@ export const computeEntitlementPriceOperations = ({
 				transition,
 				initContext: customerEntitlementInitContext,
 				initOptions: customerEntitlementInitOptions,
+				carryOverUsages,
 			}),
 		);
+	}
+
+	for (const transition of entitlementPriceTransitions.retained) {
+		if (
+			isBooleanEntitlement({
+				entitlement: transition.toEntitlementPrice.entitlement,
+			})
+		) {
+			continue;
+		}
+		if (
+			hasPrice(transition.fromEntitlementPrice) ||
+			hasPrice(transition.toEntitlementPrice)
+		) {
+			unhandled.retained.push(transition);
+			continue;
+		}
+
+		if (
+			shouldCarryOverUsage({
+				toEntitlement: transition.toEntitlementPrice.entitlement,
+				carryOverUsages,
+			})
+		) {
+			continue;
+		}
+
+		const operation = computeReplaceOperation({
+			candidateOutgoingEntitlements,
+			transition,
+			carryOverUsages,
+		});
+		if (operation) operations.push(operation);
 	}
 
 	for (const entitlementPrice of entitlementPriceTransitions.added) {

--- a/server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computeEntitlementPriceTransitions.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computeEntitlementPriceTransitions.ts
@@ -14,6 +14,8 @@ export type EntitlementPriceTransition = {
 
 export type ComputedEntitlementPriceTransitions = {
 	transitions: EntitlementPriceTransition[];
+	/** Same-definition survivors. They still need a replace when usage resets. */
+	retained: EntitlementPriceTransition[];
 	added: EntitlementPrice[];
 	deleted: EntitlementPrice[];
 };
@@ -53,6 +55,7 @@ export const computeEntitlementPriceTransitions = ({
 	}
 
 	const transitions: EntitlementPriceTransition[] = [];
+	const retained: EntitlementPriceTransition[] = [];
 	const deleted: EntitlementPrice[] = [];
 	fromEntitlementPrices.forEach((fromEntitlementPrice, fromIndex) => {
 		const toEntitlementPrice = matchedByFromIndex.get(fromIndex);
@@ -73,7 +76,10 @@ export const computeEntitlementPriceTransitions = ({
 			})
 		) {
 			transitions.push({ fromEntitlementPrice, toEntitlementPrice });
+			return;
 		}
+
+		retained.push({ fromEntitlementPrice, toEntitlementPrice });
 	});
 
 	const added = toEntitlementPrices.filter(
@@ -81,5 +87,5 @@ export const computeEntitlementPriceTransitions = ({
 			!claimedToEntitlementIds.has(toEntitlementPrice.entitlement.id),
 	);
 
-	return { transitions, added, deleted };
+	return { transitions, retained, added, deleted };
 };

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/executeCustomerEntitlementOperations.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/executeCustomerEntitlementOperations.ts
@@ -25,11 +25,6 @@ const executeReplacement = async ({
 	operation: ReplaceEntitlementPriceOperation;
 }) => {
 	if (operation.fromEntitlementIds.length === 0) return 0;
-	if (operation.fromEntitlementIds.includes(operation.toEntitlementId)) {
-		throw new Error(
-			"Batch replacement requires different outgoing and incoming entitlement IDs",
-		);
-	}
 
 	return executeBatchedMutation({
 		db: ctx.db,

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/deleteCustomerEntitlementsBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/deleteCustomerEntitlementsBatch.ts
@@ -5,13 +5,6 @@ import type { BatchMutationResult } from "../../types/types";
 import { activeStatusesSql, sqlList } from "./batchTransitionSqlUtils";
 import { pooledRemoveBatchCtes } from "./pooledRemoveBatchCtes";
 
-const assignedSeatFilter = (
-	operation: RemoveEntitlementPriceOperation,
-): SQL =>
-	operation.entitlementPrice.entitlement.pooled === true
-		? sql``
-		: sql`AND seat.internal_entity_id IS NOT NULL`;
-
 const pooledRemoveCtes = ({
 	operation,
 	now,
@@ -45,19 +38,17 @@ const deletedCte = ({
 			RETURNING 1
 		)`;
 
-export const deleteCustomerEntitlementsBatch = async ({
-	db,
+export const buildDeleteCustomerEntitlementsBatchQuery = ({
 	customerLicenseLinkId,
 	operation,
 	batchSize,
+	now,
 }: {
-	db: DrizzleCli;
 	customerLicenseLinkId: string;
 	operation: RemoveEntitlementPriceOperation;
 	batchSize: number;
-}): Promise<BatchMutationResult> => {
-	const now = Date.now();
-	const [result] = await db.execute<BatchMutationResult>(sql`
+	now: number;
+}): SQL => sql`
 		WITH candidate_rows AS MATERIALIZED (
 			SELECT
 				customer_entitlement.ctid AS target_ctid,
@@ -66,7 +57,6 @@ export const deleteCustomerEntitlementsBatch = async ({
 			INNER JOIN customer_entitlements AS customer_entitlement
 				ON customer_entitlement.customer_product_id = seat.id
 			WHERE seat.customer_license_link_id = ${customerLicenseLinkId}
-				${assignedSeatFilter(operation)}
 				AND seat.status IN (${activeStatusesSql})
 				AND customer_entitlement.entitlement_id IN (${sqlList({ values: operation.fromEntitlementIds })})
 			ORDER BY seat.created_at, seat.id, customer_entitlement.id
@@ -83,7 +73,25 @@ export const deleteCustomerEntitlementsBatch = async ({
 		SELECT
 			(SELECT COUNT(*)::int FROM deleted) AS affected,
 			(SELECT COUNT(*) > ${batchSize} FROM candidate_rows) AS "hasMore"
-	`);
+	`;
 
+export const deleteCustomerEntitlementsBatch = async ({
+	db,
+	customerLicenseLinkId,
+	operation,
+	batchSize,
+}: {
+	db: DrizzleCli;
+	customerLicenseLinkId: string;
+	operation: RemoveEntitlementPriceOperation;
+	batchSize: number;
+}): Promise<BatchMutationResult> => {
+	const query = buildDeleteCustomerEntitlementsBatchQuery({
+		customerLicenseLinkId,
+		operation,
+		batchSize,
+		now: Date.now(),
+	});
+	const [result] = await db.execute<BatchMutationResult>(query);
 	return result ?? { affected: 0, hasMore: false };
 };

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch.ts
@@ -22,68 +22,107 @@ const assignedSeatFilter = (
 		? sql``
 		: sql`AND seat.internal_entity_id IS NOT NULL`;
 
+const retainedResetFilter = (
+	operation: ReplaceEntitlementPriceOperation,
+): SQL => {
+	if (operation.fromEntitlementIds.length !== 1) return sql``;
+	if (operation.fromEntitlementIds[0] !== operation.toEntitlementId)
+		return sql``;
+	const balancePatch = operation.customerEntitlementPatch.balance;
+	if (balancePatch?.type === "set") {
+		return sql`AND customer_entitlement.balance IS DISTINCT FROM ${balancePatch.amount}`;
+	}
+	return sql``;
+};
+
 const pooledAggregateCtes = (
 	operation: ReplaceEntitlementPriceOperation,
 ): SQL => {
-	const amount = operation.pooledContributionPatch?.amount;
-	if (!amount) return sql``;
+	const patch = operation.pooledContributionPatch;
+	if (!patch) return sql``;
 	const now = Date.now();
+	const contributionAssignment =
+		patch.type === "increment"
+			? sql`
+				current_contribution = contribution.current_contribution + ${patch.amount},
+				next_cycle_contribution = contribution.next_cycle_contribution + ${patch.amount}`
+			: sql`
+				current_contribution = ${patch.amount},
+				next_cycle_contribution = ${patch.amount}`;
+	const syntheticBalanceAssignment =
+		patch.type === "increment"
+			? sql`COALESCE(synthetic.balance, 0) + pool_deltas.amount`
+			: sql`updated_pools.granted`;
 	return sql`,
+		contribution_rows AS MATERIALIZED (
+			SELECT
+				contribution.ctid AS target_ctid,
+				contribution.pooled_balance_id,
+				contribution.current_contribution
+			FROM updated
+			INNER JOIN pooled_balance_contributions AS contribution
+				ON contribution.id = updated.pooled_contribution_id
+		),
 		updated_contributions AS (
 			UPDATE pooled_balance_contributions AS contribution
 			SET
-				current_contribution = contribution.current_contribution + ${amount},
-				next_cycle_contribution = contribution.next_cycle_contribution + ${amount},
+				${contributionAssignment},
 				updated_at = ${now}
-			FROM updated
-			WHERE contribution.source_customer_entitlement_id = updated.id
-			RETURNING contribution.pooled_balance_id
+			FROM contribution_rows
+			WHERE contribution.ctid = contribution_rows.target_ctid
+			RETURNING
+				contribution.pooled_balance_id,
+				${
+					patch.type === "increment"
+						? sql`${patch.amount}`
+						: sql`${patch.amount} - contribution_rows.current_contribution`
+				} AS amount
 		),
 		pool_deltas AS (
 			SELECT
 				pooled_balance_id,
-				COUNT(*)::int AS contribution_count
+				SUM(amount::numeric) AS amount
 			FROM updated_contributions
 			GROUP BY pooled_balance_id
 		),
 		updated_pools AS (
 			UPDATE pooled_balances AS pool
 			SET
-				granted = pool.granted + (${amount} * pool_deltas.contribution_count),
+				granted = pool.granted + pool_deltas.amount,
 				updated_at = ${now}
 			FROM pool_deltas
 			WHERE pool.id = pool_deltas.pooled_balance_id
-			RETURNING 1
+			RETURNING pool.id, pool.granted
 		),
 		updated_synthetic AS (
 			UPDATE customer_entitlements AS synthetic
 			SET
-				balance = COALESCE(synthetic.balance, 0) + (${amount} * pool_deltas.contribution_count),
+				balance = ${syntheticBalanceAssignment},
 				cache_version = COALESCE(synthetic.cache_version, 0) + 1
 			FROM pool_deltas
-			WHERE synthetic.pooled_balance_id = pool_deltas.pooled_balance_id
+			INNER JOIN updated_pools
+				ON updated_pools.id = pool_deltas.pooled_balance_id
+			WHERE synthetic.pooled_balance_id = updated_pools.id
 				AND synthetic.customer_product_id IS NULL
 			RETURNING 1
 		)`;
 };
 
-export const replaceCustomerEntitlementsBatch = async ({
-	db,
+export const buildReplaceCustomerEntitlementsBatchQuery = ({
 	customerLicenseLinkId,
 	operation,
 	batchSize,
 }: {
-	db: DrizzleCli;
 	customerLicenseLinkId: string;
 	operation: ReplaceEntitlementPriceOperation;
 	batchSize: number;
-}): Promise<BatchMutationResult> => {
+}): SQL => {
 	const targetEntitlement = operation.toEntitlementPrice.entitlement;
 	const unlimitedAssignment =
 		operation.customerEntitlementPatch.unlimited === undefined
 			? sql``
 			: sql`, unlimited = ${operation.customerEntitlementPatch.unlimited}`;
-	const [result] = await db.execute<BatchMutationResult>(sql`
+	return sql`
 		WITH candidate_rows AS MATERIALIZED (
 			SELECT customer_entitlement.ctid AS target_ctid
 			FROM customer_products AS seat
@@ -93,6 +132,7 @@ export const replaceCustomerEntitlementsBatch = async ({
 				${assignedSeatFilter(operation)}
 				AND seat.status IN (${activeStatusesSql})
 				AND customer_entitlement.entitlement_id IN (${sqlList({ values: operation.fromEntitlementIds })})
+				${retainedResetFilter(operation)}
 			ORDER BY seat.created_at, seat.id, customer_entitlement.id
 			FOR UPDATE OF customer_entitlement
 			LIMIT ${batchSize + 1}
@@ -113,13 +153,33 @@ export const replaceCustomerEntitlementsBatch = async ({
 				${unlimitedAssignment}
 			FROM target_rows
 			WHERE customer_entitlement.ctid = target_rows.target_ctid
-			RETURNING customer_entitlement.id
+			RETURNING
+				customer_entitlement.id,
+				customer_entitlement.pooled_contribution_id
 		)
 		${pooledAggregateCtes(operation)}
 		SELECT
 			(SELECT COUNT(*)::int FROM updated) AS affected,
 			(SELECT COUNT(*) > ${batchSize} FROM candidate_rows) AS "hasMore"
-	`);
+	`;
+};
 
+export const replaceCustomerEntitlementsBatch = async ({
+	db,
+	customerLicenseLinkId,
+	operation,
+	batchSize,
+}: {
+	db: DrizzleCli;
+	customerLicenseLinkId: string;
+	operation: ReplaceEntitlementPriceOperation;
+	batchSize: number;
+}): Promise<BatchMutationResult> => {
+	const query = buildReplaceCustomerEntitlementsBatchQuery({
+		customerLicenseLinkId,
+		operation,
+		batchSize,
+	});
+	const [result] = await db.execute<BatchMutationResult>(query);
 	return result ?? { affected: 0, hasMore: false };
 };

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch.ts
@@ -15,13 +15,6 @@ const balanceAssignment = (
 	return sql`, balance = ${patch.amount}`;
 };
 
-const assignedSeatFilter = (
-	operation: ReplaceEntitlementPriceOperation,
-): SQL =>
-	operation.pooledContributionPatch
-		? sql``
-		: sql`AND seat.internal_entity_id IS NOT NULL`;
-
 const retainedResetFilter = (
 	operation: ReplaceEntitlementPriceOperation,
 ): SQL => {
@@ -129,7 +122,6 @@ export const buildReplaceCustomerEntitlementsBatchQuery = ({
 			INNER JOIN customer_entitlements AS customer_entitlement
 				ON customer_entitlement.customer_product_id = seat.id
 			WHERE seat.customer_license_link_id = ${customerLicenseLinkId}
-				${assignedSeatFilter(operation)}
 				AND seat.status IN (${activeStatusesSql})
 				AND customer_entitlement.entitlement_id IN (${sqlList({ values: operation.fromEntitlementIds })})
 				${retainedResetFilter(operation)}

--- a/server/src/internal/billing/v2/actions/batchTransition/logs/logBatchTransitionProductTransitions.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/logs/logBatchTransitionProductTransitions.ts
@@ -38,6 +38,14 @@ export const logBatchTransitionProductTransitions = ({
 						toPriceId: toEntitlementPrice.price?.id ?? null,
 					}),
 				),
+				retainedEntitlementPrices: entitlementPrices.retained.map(
+					({ fromEntitlementPrice, toEntitlementPrice }) => ({
+						fromEntitlementId: fromEntitlementPrice.entitlement.id,
+						toEntitlementId: toEntitlementPrice.entitlement.id,
+						fromPriceId: fromEntitlementPrice.price?.id ?? null,
+						toPriceId: toEntitlementPrice.price?.id ?? null,
+					}),
+				),
 				addedEntitlementPrices: entitlementPrices.added.map(
 					({ entitlement, price }) => ({
 						entitlementId: entitlement.id,

--- a/server/src/internal/billing/v2/actions/batchTransition/setup/setupCustomerEntitlementBatchTransition.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/setup/setupCustomerEntitlementBatchTransition.ts
@@ -50,6 +50,7 @@ export const setupCustomerEntitlementBatchTransition = async ({
 	const entitlementPriceTransitions = productTransitions.entitlementPrices;
 	const hasEntitlementPriceTransitions =
 		entitlementPriceTransitions.transitions.length > 0 ||
+		entitlementPriceTransitions.retained.length > 0 ||
 		entitlementPriceTransitions.added.length > 0 ||
 		entitlementPriceTransitions.deleted.length > 0;
 	const shouldReanchorCustomerEntitlements =
@@ -93,6 +94,7 @@ export const setupCustomerEntitlementBatchTransition = async ({
 			customerEntitlementInitOptions: {
 				customerLicenseLinkId: transition.updates.linkId,
 			},
+			carryOverUsages: transition.carryOverUsages,
 		},
 	);
 

--- a/server/src/internal/billing/v2/actions/batchTransition/types/entitlementPriceOperationTypes.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/types/entitlementPriceOperationTypes.ts
@@ -16,7 +16,7 @@ export type CustomerEntitlementPatch = {
 };
 
 export type PooledContributionPatch = {
-	type: "increment";
+	type: "increment" | "set";
 	amount: number;
 };
 
@@ -27,7 +27,8 @@ export type ReplaceEntitlementPriceOperation = {
 	fromEntitlementPrice: EntitlementPrice;
 	toEntitlementPrice: EntitlementPrice;
 	customerEntitlementPatch: CustomerEntitlementPatch;
-	/** Present when both sides are pooled: source balance stays 0; Δ goes to contributions + pool. */
+	/** Present when both sides are pooled: source balance stays 0; contributions
+	 * and the shared pool either carry by Δ or reset to the incoming grant. */
 	pooledContributionPatch?: PooledContributionPatch;
 };
 

--- a/server/src/internal/billing/v2/actions/batchTransition/utils/batchTransitionConstants.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/utils/batchTransitionConstants.ts
@@ -9,3 +9,7 @@ export const MAX_BATCH_TRANSITION_BATCHES = Math.ceil(
 	MAX_BATCH_TRANSITION_ROWS_PER_OPERATION / BATCH_TRANSITION_ROW_BATCH_SIZE,
 );
 export const BATCH_TRANSITION_STATEMENT_TIMEOUT_MS = 30_000;
+
+/** Customers below this entity count get their batch transition awaited in the
+ * request instead of queued, so upgrades converge before the API responds. */
+export const SYNC_BATCH_TRANSITION_MAX_ENTITIES = 1_000;

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/customPlan/computeCustomPlan.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/customPlan/computeCustomPlan.ts
@@ -70,6 +70,7 @@ export const computeCustomPlan = async ({
 				incomingCustomerProducts: [newFullCustomerProduct],
 				customerLicenseBillingContext:
 					updateSubscriptionContext.customerLicenseBillingContext,
+				carryOverUsages: updateSubscriptionContext.carryOverUsages,
 			});
 
 	// A scheduled cusProduct hasn't started billing yet, so there's nothing to

--- a/server/src/internal/billing/v2/compute/computePatchPlan/computePatchCustomerProductPlan.ts
+++ b/server/src/internal/billing/v2/compute/computePatchPlan/computePatchCustomerProductPlan.ts
@@ -43,6 +43,7 @@ export const computePatchCustomerProductPlan = ({
 		incomingCustomerProducts: [finalCustomerProduct],
 		customerLicenseBillingContext:
 			updateSubscriptionContext.customerLicenseBillingContext,
+		carryOverUsages: updateSubscriptionContext.carryOverUsages,
 	});
 
 	// A scheduled cusProduct hasn't started billing yet, so there's nothing to

--- a/server/src/internal/billing/v2/compute/customerLicenseTransitions/computeCustomerLicenseTransitions.ts
+++ b/server/src/internal/billing/v2/compute/customerLicenseTransitions/computeCustomerLicenseTransitions.ts
@@ -1,4 +1,5 @@
 import type {
+	CarryOverUsages,
 	CustomerLicenseBillingContext,
 	CustomerLicenseTransition,
 	FullCusProduct,
@@ -43,11 +44,13 @@ export const computeCustomerLicenseTransitions = ({
 	incomingCustomerProducts,
 	customerLicenseBillingContext,
 	carryCustomerLicenseState = true,
+	carryOverUsages,
 }: {
 	outgoingCustomerProducts: FullCusProduct[];
 	incomingCustomerProducts: FullCusProduct[];
 	customerLicenseBillingContext?: CustomerLicenseBillingContext;
 	carryCustomerLicenseState?: boolean;
+	carryOverUsages?: CarryOverUsages;
 }): CustomerLicenseTransition[] => {
 	const customerLicenseTransitions: CustomerLicenseTransition[] = [];
 
@@ -69,7 +72,7 @@ export const computeCustomerLicenseTransitions = ({
 			const transition = customerLicensePairToTransition(customerLicensePair);
 			if (isNoopTransition(transition)) continue;
 
-			customerLicenseTransitions.push(transition);
+			customerLicenseTransitions.push({ ...transition, carryOverUsages });
 		}
 	}
 

--- a/server/src/internal/billing/v2/execute/executeAutumnActions/executeCustomerLicenseTransitions.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnActions/executeCustomerLicenseTransitions.ts
@@ -2,7 +2,9 @@ import type { CustomerLicenseTransition } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { batchTransition } from "@/internal/billing/v2/actions/batchTransition/batchTransition";
 import { batchTransitionTask } from "@/internal/billing/v2/actions/batchTransition/tasks/batchTransitionTask";
+import { SYNC_BATCH_TRANSITION_MAX_ENTITIES } from "@/internal/billing/v2/actions/batchTransition/utils/batchTransitionConstants";
 import { isSameRowTransition } from "@/internal/billing/v2/compute/customerLicenseTransitions/isSameRowTransition";
+import { countEntitiesByInternalCustomerId } from "@/internal/entities/repos/countEntitiesByInternalCustomerId";
 import { customerLicenseRepo } from "@/internal/licenses/repos/customerLicenseRepo";
 import { shouldRunTriggerTasksInline } from "@/trigger/utils/shouldRunTriggerTasksInline";
 import { generateId } from "@/utils/genUtils";
@@ -16,6 +18,21 @@ export const executeCustomerLicenseTransitions = async ({
 	ctx: AutumnContext;
 	customerLicenseTransitions: CustomerLicenseTransition[] | undefined;
 }) => {
+	const hasTransitions = (customerLicenseTransitions ?? []).length > 0;
+	// Small customers get their transition awaited in-request so upgrades are
+	// synchronous; the capped count keeps this probe O(threshold) for whales.
+	const customerEntityCount = hasTransitions
+		? await countEntitiesByInternalCustomerId({
+				db: ctx.db,
+				internalCustomerId:
+					customerLicenseTransitions![0].incomingCustomerLicense
+						.internal_customer_id,
+				cap: SYNC_BATCH_TRANSITION_MAX_ENTITIES,
+			})
+		: 0;
+	const runSynchronously =
+		customerEntityCount < SYNC_BATCH_TRANSITION_MAX_ENTITIES;
+
 	for (const transition of customerLicenseTransitions ?? []) {
 		const { incomingCustomerLicense, updates } = transition;
 		const planLicense = incomingCustomerLicense.planLicense;
@@ -57,6 +74,11 @@ export const executeCustomerLicenseTransitions = async ({
 			batchTransitionId: generateId("batch_transition"),
 			assignmentCutoffMs: Date.now(),
 		};
+
+		if (runSynchronously) {
+			await batchTransition({ ctx, transition, executionScope });
+			continue;
+		}
 
 		if (shouldRunTriggerTasksInline()) {
 			void batchTransition({ ctx, transition, executionScope }).catch(

--- a/server/src/internal/customers/cusProducts/actions/activateScheduled.ts
+++ b/server/src/internal/customers/cusProducts/actions/activateScheduled.ts
@@ -10,6 +10,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
 import { computeCustomerLicenseTransitions } from "@/internal/billing/v2/compute/customerLicenseTransitions/computeCustomerLicenseTransitions.js";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan.js";
+import { resolveCarryOverUsagesParam } from "@/internal/billing/v2/utils/handleCarryOvers/resolveCarryOverUsagesParam";
 import { findTransitionSourceCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/findTransitionSourceCustomerProduct";
 import { reapplyExistingRolloversToCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/reapplyExistingRolloversToCustomerProduct";
 import { reapplyExistingUsagesToCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/reapplyExistingUsagesToCustomerProduct";
@@ -61,10 +62,16 @@ export const activateScheduledCustomerProduct = async ({
 		scheduled_ids: scheduledIds,
 		starts_at: Math.min(customerProduct.starts_at, activatedAt),
 	};
+	// Scheduled activations have no request params — the org transition rule
+	// is the only carry-over source.
 	const customerLicenseTransitions = transitionSource
 		? computeCustomerLicenseTransitions({
 				outgoingCustomerProducts: [transitionSource],
 				incomingCustomerProducts: [customerProduct],
+				carryOverUsages: await resolveCarryOverUsagesParam({
+					ctx,
+					carryOverUsages: undefined,
+				}),
 			})
 		: [];
 

--- a/server/src/internal/entities/repos/countEntitiesByInternalCustomerId.ts
+++ b/server/src/internal/entities/repos/countEntitiesByInternalCustomerId.ts
@@ -1,0 +1,31 @@
+import { entities } from "@autumn/shared";
+import { and, eq, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+/** Capped count of a customer's live entities. The inner LIMIT stops the scan
+ * at `cap` rows, so huge customers cost O(cap) instead of a full count. */
+export const countEntitiesByInternalCustomerId = async ({
+	db,
+	internalCustomerId,
+	cap,
+}: {
+	db: DrizzleCli;
+	internalCustomerId: string;
+	cap: number;
+}): Promise<number> => {
+	const capped = db
+		.select({ one: sql`1`.as("one") })
+		.from(entities)
+		.where(
+			and(
+				eq(entities.internal_customer_id, internalCustomerId),
+				eq(entities.deleted, false),
+			),
+		)
+		.limit(cap)
+		.as("capped_entities");
+	const [row] = await db
+		.select({ value: sql<number>`count(*)::int` })
+		.from(capped);
+	return row?.value ?? 0;
+};

--- a/server/src/internal/migrations/v2/batchOperations/actions/replaceLicenseEntitlementsForPage/replaceLicenseEntitlementsForPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/replaceLicenseEntitlementsForPage/replaceLicenseEntitlementsForPage.ts
@@ -171,9 +171,12 @@ export const replaceLicenseEntitlementsForPage = async ({
 		return emptyResult({ distinctEntitlements: distinct.length });
 	}
 
+	// Migration edits amend the definition in place — usage always carries;
+	// the delta credit is the migration's contract, unlike plan transitions.
 	const customerEntitlementPatch = computeCustomerEntitlementPatch({
 		fromEntitlement,
 		toEntitlement,
+		carryOverUsages: { enabled: true },
 	});
 
 	await iterateCustomerProductPages({

--- a/server/src/internal/migrations/v2/batchOperations/actions/utils/groupFilterReplaceRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/utils/groupFilterReplaceRows.ts
@@ -28,9 +28,11 @@ const patchForLiveRow = ({
 	toEntitlement: EntitlementWithFeature;
 }): CustomerEntitlementPatch => {
 	if (entsAreSame(liveDefinition, toEntitlement)) return {};
+	// Migration edits amend the definition in place — usage always carries.
 	return computeCustomerEntitlementPatch({
 		fromEntitlement: liveDefinition,
 		toEntitlement,
+		carryOverUsages: { enabled: true },
 	});
 };
 

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/run/run-license-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/run/run-license-drafts.test.ts
@@ -37,7 +37,7 @@ import {
 	versionPinnedFilter,
 } from "../utils/expectLicenseMigrationDrafts.js";
 import {
-	expectAssignmentCustomerProductUntouched,
+	expectAssignmentCustomerProductNotChildMatched,
 	expectCustomerLicenseEntitlementsCorrect,
 } from "./utils/expectCustomerLicenseEntitlementsCorrect.js";
 import { runCatalogDraftInline } from "./utils/runCatalogDraftInline.js";
@@ -313,9 +313,10 @@ test.concurrent(
 						migrationId,
 						customerIds: [parentCustomerId, childCustomerId],
 					});
-					await expectAssignmentCustomerProductUntouched({
+					await expectAssignmentCustomerProductNotChildMatched({
 						ctx,
 						assignmentCustomerProductId: assigned.assignmentCustomerProductId,
+						internalProductId: assigned.internalProductId,
 					});
 					expectFlagCorrect({
 						customer: await autumnV2_3.customers.get<ApiCustomerV5>(

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/run/utils/expectCustomerLicenseEntitlementsCorrect.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/run/utils/expectCustomerLicenseEntitlementsCorrect.ts
@@ -1,5 +1,5 @@
 import { expect } from "bun:test";
-import { customerEntitlements } from "@autumn/shared";
+import { customerProducts } from "@autumn/shared";
 import { eq } from "drizzle-orm";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { CusService } from "@/internal/customers/CusService.js";
@@ -47,18 +47,24 @@ export const expectCustomerLicenseEntitlementsCorrect = async ({
 	}
 };
 
-export const expectAssignmentCustomerProductUntouched = async ({
+/** Child update_plan must not remint this seat as a standalone child attach. */
+export const expectAssignmentCustomerProductNotChildMatched = async ({
 	ctx,
 	assignmentCustomerProductId,
+	internalProductId,
 }: {
 	ctx: AutumnContext;
 	assignmentCustomerProductId: string;
+	internalProductId: string;
 }) => {
-	const entitlements = await ctx.db.query.customerEntitlements.findMany({
-		where: eq(
-			customerEntitlements.customer_product_id,
-			assignmentCustomerProductId,
-		),
-	});
-	expect(entitlements).toHaveLength(0);
+	const [assignment] = await ctx.db
+		.select({
+			internalProductId: customerProducts.internal_product_id,
+			customerLicenseLinkId: customerProducts.customer_license_link_id,
+		})
+		.from(customerProducts)
+		.where(eq(customerProducts.id, assignmentCustomerProductId));
+	expect(assignment).toBeDefined();
+	expect(assignment?.internalProductId).toBe(internalProductId);
+	expect(assignment?.customerLicenseLinkId).not.toBeNull();
 };

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/run/utils/seedAssignmentCpOnExistingCustomer.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/run/utils/seedAssignmentCpOnExistingCustomer.ts
@@ -39,5 +39,8 @@ export const seedAssignmentCpOnExistingCustomer = async ({
 		is_custom: false,
 		customer_license_link_id: pool.link_id,
 	});
-	return { assignmentCustomerProductId };
+	return {
+		assignmentCustomerProductId,
+		internalProductId: child.internal_id,
+	};
 };

--- a/server/tests/integration/licenses/billing/attach/attach-parent-customized-license-switch.test.ts
+++ b/server/tests/integration/licenses/billing/attach/attach-parent-customized-license-switch.test.ts
@@ -1,5 +1,7 @@
 // Contract: Pro and Pro Annual price the same 200-message dev seat at $20/mo and $200/yr.
-// Switching preserves assignments, usage/reset timestamps, and re-prices every seat annually.
+// Switching preserves assignments and reset timestamps, and re-prices every seat
+// annually. The entitlement is retained (same definition), so usage resets to the
+// grant unless carry_over_usages is set.
 import { expect, test } from "bun:test";
 import type {
 	ApiCustomerV5,
@@ -29,15 +31,24 @@ const INCLUDED_MESSAGES = 200;
 const SEAT_QUANTITY = 3;
 const ENTITY_USAGES = [25, 60, 110] as const;
 
-test(`${chalk.yellowBright("license attach switch: monthly to annual parent preserves entity seat state")}`, async () => {
-	const customerId = "attach-parent-customized-license-switch";
+const runMonthlyToAnnualSwitch = async ({
+	customerId,
+	idPrefix,
+	carryOverUsages,
+	expectUsageCarried,
+}: {
+	customerId: string;
+	idPrefix: string;
+	carryOverUsages?: { enabled: boolean; feature_ids?: string[] };
+	expectUsageCarried: boolean;
+}) => {
 	const pro = products.base({
-		id: "customized-license-switch-pro",
+		id: `${idPrefix}-pro`,
 		items: [items.dashboard()],
 	});
 	const devSeat = products.base({
-		id: "customized-license-switch-dev-seat",
-		group: "customized-license-switch-dev-seats",
+		id: `${idPrefix}-dev-seat`,
+		group: `${idPrefix}-dev-seats`,
 		items: [items.monthlyMessages({ includedUsage: INCLUDED_MESSAGES })],
 	});
 	const { ctx, entities, autumnV2_3 } = await initScenario({
@@ -201,6 +212,7 @@ test(`${chalk.yellowBright("license attach switch: monthly to annual parent pres
 		license_quantities: [
 			{ license_plan_id: devSeat.id, quantity: SEAT_QUANTITY },
 		],
+		carry_over_usages: carryOverUsages,
 	});
 
 	customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
@@ -276,8 +288,8 @@ test(`${chalk.yellowBright("license attach switch: monthly to annual parent pres
 			featureId: TestFeature.Messages,
 			planId: devSeat.id,
 			granted: INCLUDED_MESSAGES,
-			remaining: stateBefore.remaining,
-			usage: stateBefore.usage,
+			remaining: expectUsageCarried ? stateBefore.remaining : INCLUDED_MESSAGES,
+			usage: expectUsageCarried ? stateBefore.usage : 0,
 			nextResetAt: stateBefore.nextResetAt,
 			toleranceMs: 0,
 		});
@@ -314,4 +326,27 @@ test(`${chalk.yellowBright("license attach switch: monthly to annual parent pres
 		amount: ANNUAL_SEAT_PRICE,
 		count: SEAT_QUANTITY,
 	});
-});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license attach switch: monthly to annual parent resets retained seat usage by default")}`,
+	async () => {
+		await runMonthlyToAnnualSwitch({
+			customerId: "attach-parent-customized-license-switch",
+			idPrefix: "customized-license-switch",
+			expectUsageCarried: false,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license attach switch: monthly to annual parent carries retained seat usage when enabled")}`,
+	async () => {
+		await runMonthlyToAnnualSwitch({
+			customerId: "attach-parent-customized-license-switch-carry",
+			idPrefix: "customized-license-switch-carry",
+			carryOverUsages: { enabled: true },
+			expectUsageCarried: true,
+		});
+	},
+);

--- a/server/tests/integration/licenses/billing/transitions/immediate-switch/base-price-transitions/attach-base-price-transitions.test.ts
+++ b/server/tests/integration/licenses/billing/transitions/immediate-switch/base-price-transitions/attach-base-price-transitions.test.ts
@@ -20,111 +20,165 @@ import { constructPriceItem } from "@/internal/products/product-items/productIte
 import { expectAssignmentBasePrices } from "../../utils/basePriceTransitionTestUtils";
 
 const SEAT_COUNT = 2;
+const SAME_SEAT_GRANT = 100;
+const SAME_SEAT_USAGE = 25;
+
+const runSameSeatParentSwitch = async ({
+	customerId,
+	idPrefix,
+	carryOverUsages,
+	expectUsageCarried,
+}: {
+	customerId: string;
+	idPrefix: string;
+	carryOverUsages?: { enabled: boolean };
+	expectUsageCarried: boolean;
+}) => {
+	const parentA = {
+		...products.base({
+			id: `${idPrefix}-pro-a`,
+			group: `${idPrefix}-pro`,
+			items: [items.dashboard()],
+		}),
+		name: "Pro A",
+	};
+	const parentB = {
+		...products.base({
+			id: `${idPrefix}-pro-b`,
+			group: `${idPrefix}-pro`,
+			items: [items.dashboard()],
+		}),
+		name: "Pro B",
+	};
+	const seat = {
+		...products.base({
+			id: `${idPrefix}-seat`,
+			items: [items.monthlyMessages({ includedUsage: SAME_SEAT_GRANT })],
+		}),
+		name: "Dev Seat",
+	};
+	const scenario = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
+			s.products({ list: [parentA, parentB, seat] }),
+		],
+		actions: [],
+	});
+	const rpc = new AutumnRpcCli({
+		secretKey: scenario.ctx.orgSecretKey,
+		version: ApiVersion.V2_1,
+	});
+	for (const [parentPlanId, amount] of [
+		[parentA.id, 20],
+		[parentB.id, 40],
+	] as const) {
+		await rpc.post("/plans.update", {
+			plan_id: parentPlanId,
+			licenses: [
+				{
+					license_plan_id: seat.id,
+					included: 0,
+					customize: {
+						price: { amount, interval: BillingInterval.Month },
+					},
+				},
+			],
+		});
+	}
+
+	await scenario.autumnV2_3.billing.attach<AttachParamsV1Input>({
+		customer_id: customerId,
+		plan_id: parentA.id,
+		license_quantities: [{ license_plan_id: seat.id, quantity: SEAT_COUNT }],
+		redirect_mode: "if_required",
+	});
+	await scenario.autumnV2_3.licenses.attach({
+		customer_id: customerId,
+		plan_id: seat.id,
+		entities: scenario.entities.map((entity) => ({ entity_id: entity.id })),
+	});
+	await scenario.autumnV2_3.track(
+		{
+			customer_id: customerId,
+			entity_id: scenario.entities[0].id,
+			feature_id: TestFeature.Messages,
+			value: SAME_SEAT_USAGE,
+		},
+		{ timeout: 2000 },
+	);
+	const params: AttachParamsV1Input = {
+		customer_id: customerId,
+		plan_id: parentB.id,
+		license_quantities: [{ license_plan_id: seat.id, quantity: SEAT_COUNT }],
+		redirect_mode: "if_required",
+		carry_over_usages: carryOverUsages,
+	};
+	const preview =
+		await scenario.autumnV2_3.billing.previewAttach<AttachParamsV1Input>(
+			params,
+		);
+	await expectLicenseUpdatePreviewCorrect({
+		preview,
+		customerId,
+		advancedTo: scenario.advancedTo,
+		oldRecurringTotal: 40,
+		newRecurringTotal: 80,
+	});
+	await scenario.autumnV2_3.billing.attach(params);
+
+	await expectAssignmentBasePrices({
+		ctx: scenario.ctx,
+		autumn: scenario.autumnV2_3,
+		customerId,
+		licensePlanId: seat.id,
+		amount: 40,
+		count: SEAT_COUNT,
+	});
+	const entity = await scenario.autumnV2_3.entities.get<ApiEntityV2>(
+		customerId,
+		scenario.entities[0].id,
+	);
+	const usage = expectUsageCarried ? SAME_SEAT_USAGE : 0;
+	expectBalanceCorrect({
+		customer: entity,
+		featureId: TestFeature.Messages,
+		planId: seat.id,
+		granted: SAME_SEAT_GRANT,
+		usage,
+		remaining: SAME_SEAT_GRANT - usage,
+	});
+	await expectCustomerInvoiceCorrect({
+		customerId,
+		count: 2,
+		latestTotal: preview.total,
+	});
+	await expectStripeSubscriptionCorrect({
+		ctx: scenario.ctx,
+		customerId,
+	});
+};
 
 test.concurrent(
-	`${chalk.yellowBright("base price transition: attach replaces the same license plan")}`,
+	`${chalk.yellowBright("base price transition: same seat resets retained usage by default")}`,
 	async () => {
-		const customerId = "bp-attach-same";
-		const parentA = {
-			...products.base({
-				id: "same-pro-a",
-				group: "same-pro",
-				items: [items.dashboard()],
-			}),
-			name: "Pro A",
-		};
-		const parentB = {
-			...products.base({
-				id: "same-pro-b",
-				group: "same-pro",
-				items: [items.dashboard()],
-			}),
-			name: "Pro B",
-		};
-		const seat = {
-			...products.base({
-				id: "same-seat",
-				items: [items.monthlyMessages({ includedUsage: 100 })],
-			}),
-			name: "Dev Seat",
-		};
-		const scenario = await initScenario({
-			customerId,
-			setup: [
-				s.customer({ paymentMethod: "success", testClock: false }),
-				s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
-				s.products({ list: [parentA, parentB, seat] }),
-			],
-			actions: [],
+		await runSameSeatParentSwitch({
+			customerId: "bp-attach-same",
+			idPrefix: "same",
+			expectUsageCarried: false,
 		});
-		const rpc = new AutumnRpcCli({
-			secretKey: scenario.ctx.orgSecretKey,
-			version: ApiVersion.V2_1,
-		});
-		for (const [parentPlanId, amount] of [
-			[parentA.id, 20],
-			[parentB.id, 40],
-		] as const) {
-			await rpc.post("/plans.update", {
-				plan_id: parentPlanId,
-				licenses: [
-					{
-						license_plan_id: seat.id,
-						included: 0,
-						customize: {
-							price: { amount, interval: BillingInterval.Month },
-						},
-					},
-				],
-			});
-		}
+	},
+);
 
-		await scenario.autumnV2_3.billing.attach<AttachParamsV1Input>({
-			customer_id: customerId,
-			plan_id: parentA.id,
-			license_quantities: [{ license_plan_id: seat.id, quantity: SEAT_COUNT }],
-			redirect_mode: "if_required",
-		});
-		await scenario.autumnV2_3.licenses.attach({
-			customer_id: customerId,
-			plan_id: seat.id,
-			entities: scenario.entities.map((entity) => ({ entity_id: entity.id })),
-		});
-		const params: AttachParamsV1Input = {
-			customer_id: customerId,
-			plan_id: parentB.id,
-			license_quantities: [{ license_plan_id: seat.id, quantity: SEAT_COUNT }],
-			redirect_mode: "if_required",
-		};
-		const preview =
-			await scenario.autumnV2_3.billing.previewAttach<AttachParamsV1Input>(
-				params,
-			);
-		await expectLicenseUpdatePreviewCorrect({
-			preview,
-			customerId,
-			advancedTo: scenario.advancedTo,
-			oldRecurringTotal: 40,
-			newRecurringTotal: 80,
-		});
-		await scenario.autumnV2_3.billing.attach(params);
-
-		await expectAssignmentBasePrices({
-			ctx: scenario.ctx,
-			autumn: scenario.autumnV2_3,
-			customerId,
-			licensePlanId: seat.id,
-			amount: 40,
-			count: SEAT_COUNT,
-		});
-		await expectCustomerInvoiceCorrect({
-			customerId,
-			count: 2,
-			latestTotal: preview.total,
-		});
-		await expectStripeSubscriptionCorrect({
-			ctx: scenario.ctx,
-			customerId,
+test.concurrent(
+	`${chalk.yellowBright("base price transition: same seat carries retained usage when enabled")}`,
+	async () => {
+		await runSameSeatParentSwitch({
+			customerId: "bp-attach-same-carry",
+			idPrefix: "same-carry",
+			carryOverUsages: { enabled: true },
+			expectUsageCarried: true,
 		});
 	},
 );
@@ -322,8 +376,8 @@ test.concurrent(
 			featureId: TestFeature.Messages,
 			planId: devB.id,
 			granted: 500,
-			usage: 25,
-			remaining: 475,
+			usage: 0,
+			remaining: 500,
 		});
 		const dashboard = await scenario.autumnV2_3.check<CheckResponseV3>({
 			customer_id: customerId,

--- a/server/tests/integration/licenses/billing/transitions/immediate-switch/item-transitions/carry-over-item-transitions.test.ts
+++ b/server/tests/integration/licenses/billing/transitions/immediate-switch/item-transitions/carry-over-item-transitions.test.ts
@@ -1,0 +1,134 @@
+/** Contract: carry_over_usages on the upgrade attach carries seat usage through
+ * a license item transition, mirroring the attach param's semantics:
+ * - { enabled: true } carries every consumable feature (remaining = grant - usage)
+ * - feature_ids narrows the carry — unlisted consumables reset to full grant
+ * - { enabled: false } is the explicit reset (same as the default)
+ */
+import { test } from "bun:test";
+import type { ApiEntityV2 } from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import chalk from "chalk";
+import {
+	completeImmediateItemTransition,
+	ITEM_TRANSITION_ENTITY_USAGES,
+	setupItemTransitionScenario,
+} from "../../utils/itemTransitionTestUtils";
+
+const FROM_MESSAGES = 100;
+const TO_MESSAGES = 500;
+const FROM_WORDS = 200;
+const TO_WORDS = 800;
+
+const expectEntityBalances = async ({
+	scenario,
+	featureId,
+	granted,
+	carried,
+}: {
+	scenario: Awaited<ReturnType<typeof setupItemTransitionScenario>>;
+	featureId: string;
+	granted: number;
+	carried: boolean;
+}) => {
+	for (let index = 0; index < scenario.entities.length; index++) {
+		const entity = await scenario.autumnV2_3.entities.get<ApiEntityV2>(
+			scenario.customerId,
+			scenario.entities[index].id,
+		);
+		const usage = carried ? ITEM_TRANSITION_ENTITY_USAGES[index] : 0;
+		expectBalanceCorrect({
+			customer: entity,
+			featureId,
+			planId: scenario.toSeat.id,
+			granted,
+			remaining: granted - usage,
+			usage,
+		});
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license carry-over transition: enabled carries seat usage into the new grant")}`,
+	async () => {
+		const scenario = await setupItemTransitionScenario({
+			idPrefix: "license-carry-all",
+			fromItems: [items.monthlyMessages({ includedUsage: FROM_MESSAGES })],
+			toItems: [items.monthlyMessages({ includedUsage: TO_MESSAGES })],
+			trackedFeatureIds: [TestFeature.Messages],
+		});
+
+		await completeImmediateItemTransition({
+			scenario,
+			carryOverUsages: { enabled: true },
+		});
+		await expectEntityBalances({
+			scenario,
+			featureId: TestFeature.Messages,
+			granted: TO_MESSAGES,
+			carried: true,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license carry-over transition: feature_ids carries listed features and resets the rest")}`,
+	async () => {
+		const scenario = await setupItemTransitionScenario({
+			idPrefix: "license-carry-filtered",
+			fromItems: [
+				items.monthlyMessages({ includedUsage: FROM_MESSAGES }),
+				items.monthlyWords({ includedUsage: FROM_WORDS }),
+			],
+			toItems: [
+				items.monthlyMessages({ includedUsage: TO_MESSAGES }),
+				items.monthlyWords({ includedUsage: TO_WORDS }),
+			],
+			trackedFeatureIds: [TestFeature.Messages, TestFeature.Words],
+		});
+
+		await completeImmediateItemTransition({
+			scenario,
+			carryOverUsages: {
+				enabled: true,
+				feature_ids: [TestFeature.Messages],
+			},
+		});
+		await expectEntityBalances({
+			scenario,
+			featureId: TestFeature.Messages,
+			granted: TO_MESSAGES,
+			carried: true,
+		});
+		await expectEntityBalances({
+			scenario,
+			featureId: TestFeature.Words,
+			granted: TO_WORDS,
+			carried: false,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license carry-over transition: explicit disabled resets seat usage")}`,
+	async () => {
+		const scenario = await setupItemTransitionScenario({
+			idPrefix: "license-carry-disabled",
+			fromItems: [items.monthlyMessages({ includedUsage: FROM_MESSAGES })],
+			toItems: [items.monthlyMessages({ includedUsage: TO_MESSAGES })],
+			trackedFeatureIds: [TestFeature.Messages],
+		});
+
+		await completeImmediateItemTransition({
+			scenario,
+			carryOverUsages: { enabled: false },
+		});
+		await expectEntityBalances({
+			scenario,
+			featureId: TestFeature.Messages,
+			granted: TO_MESSAGES,
+			carried: false,
+		});
+	},
+);

--- a/server/tests/integration/licenses/billing/transitions/immediate-switch/item-transitions/free-item-transitions.test.ts
+++ b/server/tests/integration/licenses/billing/transitions/immediate-switch/item-transitions/free-item-transitions.test.ts
@@ -1,5 +1,8 @@
-/** Contract: replacements preserve usage/reset state; additions inherit Stripe cycles.
- * Mixed metered/boolean transitions repoint assignments and keep Stripe converged. */
+/** Contract: replacements RESET consumable usage by default — seats start the
+ * incoming plan at its full grant (reset cycles untouched); additions inherit
+ * Stripe cycles. Mixed metered/boolean transitions repoint assignments and
+ * keep Stripe converged. Usage carry-over is opt-in via carry_over_usages
+ * (see carry-over-item-transitions.test.ts). */
 import { expect, test } from "bun:test";
 import type { ApiEntityV2 } from "@autumn/shared";
 import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
@@ -62,7 +65,7 @@ const captureMeteredStates = async ({
 	return states;
 };
 
-const expectMessagesPreserved = async ({
+const expectMessagesReset = async ({
 	scenario,
 	states,
 }: {
@@ -81,8 +84,8 @@ const expectMessagesPreserved = async ({
 			featureId: TestFeature.Messages,
 			planId: scenario.toSeat.id,
 			granted: TO_MESSAGES,
-			remaining: TO_MESSAGES - before.usage,
-			usage: before.usage,
+			remaining: TO_MESSAGES,
+			usage: 0,
 			nextResetAt: before.nextResetAt,
 			toleranceMs: 0,
 		});
@@ -90,7 +93,7 @@ const expectMessagesPreserved = async ({
 };
 
 test.concurrent(
-	`${chalk.yellowBright("license item transition: increases the monthly grant without resetting usage")}`,
+	`${chalk.yellowBright("license item transition: increases the monthly grant and resets usage by default")}`,
 	async () => {
 		const scenario = await setupItemTransitionScenario({
 			idPrefix: "license-item-replace",
@@ -105,7 +108,7 @@ test.concurrent(
 		});
 
 		await completeImmediateItemTransition({ scenario });
-		await expectMessagesPreserved({ scenario, states });
+		await expectMessagesReset({ scenario, states });
 	},
 );
 
@@ -129,7 +132,7 @@ test.concurrent(
 		});
 
 		await completeImmediateItemTransition({ scenario });
-		await expectMessagesPreserved({ scenario, states });
+		await expectMessagesReset({ scenario, states });
 		for (const entity of scenario.entities) {
 			const apiEntity = await scenario.autumnV2_3.entities.get<ApiEntityV2>(
 				scenario.customerId,
@@ -172,7 +175,7 @@ test.concurrent(
 		});
 
 		await completeImmediateItemTransition({ scenario });
-		await expectMessagesPreserved({ scenario, states });
+		await expectMessagesReset({ scenario, states });
 		for (const entity of scenario.entities) {
 			const apiEntity = await scenario.autumnV2_3.entities.get<ApiEntityV2>(
 				scenario.customerId,

--- a/server/tests/integration/licenses/billing/transitions/immediate-switch/item-transitions/pooled-item-transitions.test.ts
+++ b/server/tests/integration/licenses/billing/transitions/immediate-switch/item-transitions/pooled-item-transitions.test.ts
@@ -1,0 +1,100 @@
+/** Pooled license replacements reset the shared balance by default and carry
+ * aggregate usage only when carry_over_usages enables the feature. */
+import { test } from "bun:test";
+import { EntInterval, PooledBalanceResetMode } from "@autumn/shared";
+import { expectPooledBalanceCorrect } from "@tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect";
+import { getPooledBalanceDbState } from "@tests/integration/billing/pooled-balances/utils/getPooledBalanceDbState";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import chalk from "chalk";
+import {
+	completeImmediateItemTransition,
+	ITEM_TRANSITION_ENTITY_COUNT,
+	ITEM_TRANSITION_ENTITY_USAGES,
+	setupItemTransitionScenario,
+} from "../../utils/itemTransitionTestUtils";
+
+const FROM_GRANT = 100;
+const TO_GRANT = 500;
+const TOTAL_USAGE = ITEM_TRANSITION_ENTITY_USAGES.reduce(
+	(total, usage) => total + usage,
+	0,
+);
+
+const pooledMessages = ({ grant }: { grant: number }) => ({
+	...items.monthlyMessages({ includedUsage: grant }),
+	pooled: true,
+});
+
+const runPooledTransition = async ({
+	idPrefix,
+	carryOverUsages,
+	expectUsageCarried,
+}: {
+	idPrefix: string;
+	carryOverUsages?: { enabled: boolean; feature_ids?: string[] };
+	expectUsageCarried: boolean;
+}) => {
+	const scenario = await setupItemTransitionScenario({
+		idPrefix,
+		fromItems: [pooledMessages({ grant: FROM_GRANT })],
+		toItems: [pooledMessages({ grant: TO_GRANT })],
+		trackedFeatureIds: [TestFeature.Messages],
+	});
+
+	await completeImmediateItemTransition({ scenario, carryOverUsages });
+
+	const totalGrant = TO_GRANT * ITEM_TRANSITION_ENTITY_COUNT;
+	const state = await getPooledBalanceDbState({
+		db: scenario.ctx.db,
+		customerId: scenario.customerId,
+	});
+	const livePool = state.pools.find((pool) => pool.expires_at === null);
+	if (!livePool) throw new Error("Expected a live pooled license balance");
+	await expectPooledBalanceCorrect({
+		db: scenario.ctx.db,
+		customerId: scenario.customerId,
+		pool: {
+			balance: expectUsageCarried ? totalGrant - TOTAL_USAGE : totalGrant,
+			adjustment: 0,
+			granted: totalGrant,
+			interval: EntInterval.Month,
+			nextResetAt: "present",
+			resetCycleAnchor: "present",
+			resetMode: PooledBalanceResetMode.Lazy,
+			stripeSubscriptionId: null,
+			customerLicenseLinkId: livePool.customer_license_link_id,
+		},
+		contributions: {
+			count: ITEM_TRANSITION_ENTITY_COUNT,
+			currentContribution: TO_GRANT,
+			nextCycleContribution: TO_GRANT,
+		},
+		sources: {
+			count: ITEM_TRANSITION_ENTITY_COUNT,
+			balance: 0,
+			adjustment: 0,
+		},
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("pooled license transition: resets shared usage by default")}`,
+	async () => {
+		await runPooledTransition({
+			idPrefix: "license-pooled-reset",
+			expectUsageCarried: false,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("pooled license transition: carries shared usage when enabled")}`,
+	async () => {
+		await runPooledTransition({
+			idPrefix: "license-pooled-carry",
+			carryOverUsages: { enabled: true },
+			expectUsageCarried: true,
+		});
+	},
+);

--- a/server/tests/integration/licenses/billing/transitions/scheduled-switch/item-transitions/retained-consumable-item-transition.test.ts
+++ b/server/tests/integration/licenses/billing/transitions/scheduled-switch/item-transitions/retained-consumable-item-transition.test.ts
@@ -1,0 +1,162 @@
+/** Scheduled paid→free seat switches keep the same messages entitlement.
+ * Activation resolves carry from the org transition rule only — the original
+ * attach's carry_over_usages is not persisted — so default is a usage reset. */
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV5,
+	ApiEntityV2,
+	AttachParamsV1Input,
+} from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
+import { getBillingPeriod } from "@tests/integration/billing/utils/proration";
+import { listLicenseAssignments } from "@tests/integration/licenses/licenseTestUtils";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { hoursToFinalizeInvoice } from "@tests/utils/constants";
+import { items } from "@tests/utils/fixtures/items";
+import { pollUntil } from "@tests/utils/genUtils";
+import { advanceTestClock } from "@tests/utils/stripeUtils";
+import chalk from "chalk";
+import { addHours } from "date-fns";
+import {
+	ITEM_TRANSITION_ENTITY_COUNT,
+	ITEM_TRANSITION_ENTITY_USAGES,
+	setupItemTransitionScenario,
+} from "../../utils/itemTransitionTestUtils";
+
+const MESSAGES = 250;
+
+const completeScheduledRetainedTransition = async ({
+	idPrefix,
+}: {
+	idPrefix: string;
+}) => {
+	const scenario = await setupItemTransitionScenario({
+		idPrefix,
+		fromItems: [items.monthlyMessages({ includedUsage: MESSAGES })],
+		toItems: [items.monthlyMessages({ includedUsage: MESSAGES })],
+		trackedFeatureIds: [TestFeature.Messages],
+		fromParentPrice: 50,
+		toParentPrice: 20,
+		testClock: true,
+	});
+	const assignmentsBefore = await listLicenseAssignments({
+		autumn: scenario.autumnV2_3,
+		customerId: scenario.customerId,
+		licensePlanId: scenario.fromSeat.id,
+		active: true,
+	});
+	const assignmentIds = assignmentsBefore.map(({ id }) => id).sort();
+	const params: AttachParamsV1Input = {
+		customer_id: scenario.customerId,
+		plan_id: scenario.toParent.id,
+		redirect_mode: "if_required",
+	};
+
+	await scenario.autumnV2_3.billing.attach<AttachParamsV1Input>(params);
+
+	const midCycle = await scenario.autumnV2_3.customers.get<ApiCustomerV5>(
+		scenario.customerId,
+	);
+	await expectCustomerProducts({
+		customer: midCycle,
+		canceling: [scenario.fromParent.id],
+		scheduled: [scenario.toParent.id],
+	});
+	const assignmentsMidCycle = await listLicenseAssignments({
+		autumn: scenario.autumnV2_3,
+		customerId: scenario.customerId,
+		licensePlanId: scenario.fromSeat.id,
+		active: true,
+	});
+	expect(assignmentsMidCycle.map(({ id }) => id).sort()).toEqual(
+		assignmentIds,
+	);
+	for (let index = 0; index < scenario.entities.length; index++) {
+		const entity = await scenario.autumnV2_3.entities.get<ApiEntityV2>(
+			scenario.customerId,
+			scenario.entities[index].id,
+		);
+		const usage = ITEM_TRANSITION_ENTITY_USAGES[index];
+		expectBalanceCorrect({
+			customer: entity,
+			featureId: TestFeature.Messages,
+			planId: scenario.fromSeat.id,
+			granted: MESSAGES,
+			usage,
+			remaining: MESSAGES - usage,
+		});
+	}
+
+	const { billingPeriod } = await getBillingPeriod({
+		customerId: scenario.customerId,
+	});
+	if (!scenario.testClockId) throw new Error("Expected a test clock");
+	await advanceTestClock({
+		stripeCli: scenario.ctx.stripeCli,
+		testClockId: scenario.testClockId,
+		advanceTo: billingPeriod.end,
+		waitForSeconds: 10,
+	});
+	await advanceTestClock({
+		stripeCli: scenario.ctx.stripeCli,
+		testClockId: scenario.testClockId,
+		advanceTo: addHours(
+			new Date(billingPeriod.end),
+			hoursToFinalizeInvoice,
+		).getTime(),
+		waitForSeconds: 10,
+	});
+
+	const assignmentsAfter = await pollUntil({
+		fetch: () =>
+			listLicenseAssignments({
+				autumn: scenario.autumnV2_3,
+				customerId: scenario.customerId,
+				licensePlanId: scenario.toSeat.id,
+				active: true,
+			}),
+		until: (assignments) =>
+			assignments.length === ITEM_TRANSITION_ENTITY_COUNT,
+	});
+	expect(assignmentsAfter.map(({ id }) => id).sort()).toEqual(assignmentIds);
+
+	for (let index = 0; index < scenario.entities.length; index++) {
+		const entity = await scenario.autumnV2_3.entities.get<ApiEntityV2>(
+			scenario.customerId,
+			scenario.entities[index].id,
+		);
+		const usage = 0;
+		expectBalanceCorrect({
+			customer: entity,
+			featureId: TestFeature.Messages,
+			planId: scenario.toSeat.id,
+			granted: MESSAGES,
+			usage,
+			remaining: MESSAGES - usage,
+		});
+	}
+
+	const customer = await scenario.autumnV2_3.customers.get<ApiCustomerV5>(
+		scenario.customerId,
+	);
+	await expectCustomerProducts({
+		customer,
+		active: [scenario.toParent.id],
+		notPresent: [scenario.fromParent.id],
+	});
+	await expectStripeSubscriptionCorrect({
+		ctx: scenario.ctx,
+		customerId: scenario.customerId,
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license scheduled transition: resets retained consumable usage at activation")}`,
+	async () => {
+		await completeScheduledRetainedTransition({
+			idPrefix: "license-retained-sched-reset",
+		});
+	},
+);

--- a/server/tests/integration/licenses/billing/transitions/utils/itemTransitionTestUtils.ts
+++ b/server/tests/integration/licenses/billing/transitions/utils/itemTransitionTestUtils.ts
@@ -140,8 +140,10 @@ export type ItemTransitionScenario = Awaited<
 
 export const completeImmediateItemTransition = async ({
 	scenario,
+	carryOverUsages,
 }: {
 	scenario: ItemTransitionScenario;
+	carryOverUsages?: { enabled: boolean; feature_ids?: string[] };
 }) => {
 	const {
 		autumnV2_3,
@@ -157,6 +159,7 @@ export const completeImmediateItemTransition = async ({
 		customer_id: customerId,
 		plan_id: toParent.id,
 		redirect_mode: "if_required",
+		carry_over_usages: carryOverUsages,
 	});
 
 	const customer = await pollUntil({

--- a/server/tests/perf/benchReplaceCustomerEntitlementsBatch.ts
+++ b/server/tests/perf/benchReplaceCustomerEntitlementsBatch.ts
@@ -1,0 +1,547 @@
+/**
+ * EXPLAIN ANALYZE the exact batch-transition replacement query in an isolated
+ * DEV schema. Every measured mutation runs in a rolled-back transaction.
+ *
+ *   NODE_ENV=development infisical run --env=dev --recursive -- \
+ *     bun tests/perf/benchReplaceCustomerEntitlementsBatch.ts
+ */
+import { type SQL, sql } from "drizzle-orm";
+import { assertNotProductionDb } from "@/db/dbUtils.js";
+import { buildReplaceCustomerEntitlementsBatchQuery } from "@/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch.js";
+import type { ReplaceEntitlementPriceOperation } from "@/internal/billing/v2/actions/batchTransition/types/entitlementPriceOperationTypes.js";
+import { assertBenchDatabaseSafe } from "./batch-migrations/utils/benchContext.js";
+
+const ROW_COUNTS = [1_000, 5_000] as const;
+const RUNS_PER_SCENARIO = 3;
+const STATEMENT_TIMEOUT_MS = 30_000;
+const NOISE_ROWS = Number(process.env.BENCHMARK_NOISE_ROWS ?? "1000000");
+const OLD_GRANT = 100;
+const NEW_GRANT = 500;
+const USED_BALANCE = 75;
+const FEATURE_INTERNAL_ID = "replace_bench_feature_internal";
+const FEATURE_ID = "messages";
+const FROM_ENTITLEMENT_ID = "replace_bench_ent_from";
+const TO_ENTITLEMENT_ID = "replace_bench_ent_to";
+const RETAINED_ENTITLEMENT_ID = "replace_bench_ent_retained";
+
+if (process.env.NODE_ENV !== "development") {
+	throw new Error("Run this benchmark with NODE_ENV=development");
+}
+if (
+	process.env.INFISICAL_ENVIRONMENT &&
+	process.env.INFISICAL_ENVIRONMENT !== "dev"
+) {
+	throw new Error("Run this benchmark with the Infisical dev environment");
+}
+if (process.env.ENV_FILE && process.env.ENV_FILE !== ".env") {
+	throw new Error("Run this benchmark with the dev ENV_FILE");
+}
+if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is required");
+assertNotProductionDb(process.env.DATABASE_URL);
+assertBenchDatabaseSafe();
+if (!Number.isInteger(NOISE_ROWS) || NOISE_ROWS < 0 || NOISE_ROWS > 2_000_000) {
+	throw new Error("BENCHMARK_NOISE_ROWS must be 0..2000000");
+}
+
+const benchmarkDatabaseUrl = new URL(process.env.DATABASE_URL);
+benchmarkDatabaseUrl.hostname = benchmarkDatabaseUrl.hostname.replace(
+	"-pooler.",
+	".",
+);
+
+const BENCHMARK_SCHEMA = `replace_entitlements_bench_${process.pid}_${Date.now()}`;
+if (!/^replace_entitlements_bench_\d+_\d+$/.test(BENCHMARK_SCHEMA)) {
+	throw new Error("Invalid benchmark schema name");
+}
+
+const { initDrizzle } = await import("@/db/initDrizzle.js");
+const { db: bootstrapDb, client: bootstrapClient } = initDrizzle({
+	databaseUrl: benchmarkDatabaseUrl.toString(),
+	maxConnections: 1,
+	poolConfig: {
+		application_name: "replace-entitlements-bench-bootstrap",
+		query_timeout: 0,
+	},
+});
+await bootstrapDb.execute(
+	sql`CREATE SCHEMA ${sql.identifier(BENCHMARK_SCHEMA)}`,
+);
+
+const { db, client } = initDrizzle({
+	databaseUrl: benchmarkDatabaseUrl.toString(),
+	maxConnections: 1,
+	poolConfig: {
+		application_name: "replace-entitlements-bench",
+		options: `-c search_path=${BENCHMARK_SCHEMA},public -c statement_timeout=0`,
+		query_timeout: 0,
+	},
+});
+
+type PlanNode = {
+	"Node Type": string;
+	"Relation Name"?: string;
+	"Actual Rows"?: number;
+	"Actual Loops"?: number;
+	"Shared Hit Blocks"?: number;
+	"Shared Read Blocks"?: number;
+	"Shared Dirtied Blocks"?: number;
+	"Shared Written Blocks"?: number;
+	"Temp Read Blocks"?: number;
+	"Temp Written Blocks"?: number;
+	Plans?: PlanNode[];
+};
+
+type ExplainResult = {
+	Plan: PlanNode;
+	"Planning Time": number;
+	"Execution Time": number;
+};
+
+type PlanSummary = {
+	executionMs: number;
+	planningMs: number;
+	sharedHits: number;
+	sharedReads: number;
+	sharedDirtied: number;
+	sharedWritten: number;
+	tempReads: number;
+	tempWritten: number;
+	maxLoops: number;
+	seqScans: string[];
+};
+
+const sumPlanMetrics = ({
+	node,
+	summary,
+}: {
+	node: PlanNode;
+	summary: PlanSummary;
+}) => {
+	summary.maxLoops = Math.max(summary.maxLoops, node["Actual Loops"] ?? 0);
+	if (node["Node Type"] === "Seq Scan") {
+		summary.seqScans.push(
+			`${node["Relation Name"] ?? "unknown"} rows=${node["Actual Rows"] ?? 0} loops=${node["Actual Loops"] ?? 0}`,
+		);
+	}
+	for (const child of node.Plans ?? []) {
+		sumPlanMetrics({ node: child, summary });
+	}
+};
+
+const summarizePlan = ({ result }: { result: ExplainResult }): PlanSummary => {
+	const summary: PlanSummary = {
+		executionMs: result["Execution Time"],
+		planningMs: result["Planning Time"],
+		sharedHits: result.Plan["Shared Hit Blocks"] ?? 0,
+		sharedReads: result.Plan["Shared Read Blocks"] ?? 0,
+		sharedDirtied: result.Plan["Shared Dirtied Blocks"] ?? 0,
+		sharedWritten: result.Plan["Shared Written Blocks"] ?? 0,
+		tempReads: result.Plan["Temp Read Blocks"] ?? 0,
+		tempWritten: result.Plan["Temp Written Blocks"] ?? 0,
+		maxLoops: 0,
+		seqScans: [],
+	};
+	sumPlanMetrics({ node: result.Plan, summary });
+	return summary;
+};
+
+const median = ({ values }: { values: number[] }) => {
+	const sorted = [...values].sort((left, right) => left - right);
+	return sorted[Math.floor(sorted.length / 2)] ?? 0;
+};
+
+const createTables = async () => {
+	for (const table of [
+		"customer_products",
+		"customer_entitlements",
+		"pooled_balances",
+		"pooled_balance_contributions",
+	]) {
+		await db.execute(
+			sql`CREATE TABLE ${sql.identifier(table)} (LIKE public.${sql.identifier(table)} INCLUDING ALL)`,
+		);
+	}
+};
+
+const seedNoise = async () => {
+	const now = Date.now();
+	await db.execute(sql`
+		INSERT INTO customer_products (
+			id, internal_customer_id, internal_product_id, internal_entity_id,
+			created_at, status, customer_license_link_id
+		)
+		SELECT
+			'noise_seat_' || i,
+			'noise_customer_' || i,
+			'noise_product',
+			'noise_entity_' || i,
+			${now},
+			'active',
+			'noise_link_' || i
+		FROM generate_series(1, ${NOISE_ROWS}) AS i
+	`);
+	await db.execute(sql`
+		INSERT INTO customer_entitlements (
+			id, customer_product_id, entitlement_id, internal_customer_id,
+			internal_feature_id, feature_id, unlimited, balance, created_at,
+			usage_allowed, separate_interval, cache_version
+		)
+		SELECT
+			'noise_ce_' || i,
+			'noise_seat_' || i,
+			'noise_entitlement',
+			'noise_customer_' || i,
+			'noise_feature_internal',
+			'noise_feature',
+			false,
+			100,
+			${now},
+			true,
+			false,
+			0
+		FROM generate_series(1, ${NOISE_ROWS}) AS i
+	`);
+	await db.execute(sql`
+		INSERT INTO pooled_balance_contributions (
+			id, pooled_balance_id, source_customer_product_id,
+			source_customer_entitlement_id, current_contribution,
+			next_cycle_contribution, created_at, updated_at
+		)
+		SELECT
+			'noise_contribution_' || i,
+			'noise_pool_' || i,
+			'noise_seat_' || i,
+			'noise_ce_' || i,
+			100,
+			100,
+			${now},
+			${now}
+		FROM generate_series(1, ${NOISE_ROWS}) AS i
+	`);
+};
+
+const seedRetained = async ({ rowCount }: { rowCount: number }) => {
+	const linkId = `retained_link_${rowCount}`;
+	await db.execute(sql`
+		INSERT INTO customer_products (
+			id, internal_customer_id, internal_product_id, internal_entity_id,
+			created_at, status, customer_license_link_id
+		)
+		SELECT
+			${`retained_seat_${rowCount}_`} || i,
+			${`retained_customer_${rowCount}`},
+			'retained_product',
+			${`retained_entity_${rowCount}_`} || i,
+			${Date.now()},
+			'active',
+			${linkId}
+		FROM generate_series(1, ${rowCount}) AS i
+	`);
+	await db.execute(sql`
+		INSERT INTO customer_entitlements (
+			id, customer_product_id, entitlement_id, internal_customer_id,
+			internal_feature_id, feature_id, unlimited, balance, created_at,
+			usage_allowed, separate_interval, cache_version
+		)
+		SELECT
+			${`retained_ce_${rowCount}_`} || i,
+			${`retained_seat_${rowCount}_`} || i,
+			${RETAINED_ENTITLEMENT_ID},
+			${`retained_customer_${rowCount}`},
+			${FEATURE_INTERNAL_ID},
+			${FEATURE_ID},
+			false,
+			${USED_BALANCE},
+			${Date.now()},
+			true,
+			false,
+			0
+		FROM generate_series(1, ${rowCount}) AS i
+	`);
+	return linkId;
+};
+
+const seedPooled = async ({ rowCount }: { rowCount: number }) => {
+	const linkId = `pooled_link_${rowCount}`;
+	const poolId = `pooled_pool_${rowCount}`;
+	const syntheticId = `pooled_synthetic_${rowCount}`;
+	const customerInternalId = `pooled_customer_${rowCount}`;
+	const totalGrant = OLD_GRANT * rowCount;
+	const totalBalance = USED_BALANCE * rowCount;
+
+	await db.execute(sql`
+		INSERT INTO customer_products (
+			id, internal_customer_id, internal_product_id, internal_entity_id,
+			created_at, status, customer_license_link_id
+		)
+		SELECT
+			${`pooled_seat_${rowCount}_`} || i,
+			${customerInternalId},
+			'pooled_product',
+			${`pooled_entity_${rowCount}_`} || i,
+			${Date.now()},
+			'active',
+			${linkId}
+		FROM generate_series(1, ${rowCount}) AS i
+	`);
+	await db.execute(sql`
+		INSERT INTO customer_entitlements (
+			id, customer_product_id, entitlement_id, internal_customer_id,
+			internal_feature_id, feature_id, unlimited, balance, created_at,
+			usage_allowed, separate_interval, cache_version, is_pooled_balance,
+			pooled_balance_id
+		)
+		VALUES (
+			${syntheticId},
+			NULL,
+			${FROM_ENTITLEMENT_ID},
+			${customerInternalId},
+			${FEATURE_INTERNAL_ID},
+			${FEATURE_ID},
+			false,
+			${totalBalance},
+			${Date.now()},
+			false,
+			false,
+			0,
+			true,
+			${poolId}
+		)
+	`);
+	await db.execute(sql`
+		INSERT INTO pooled_balances (
+			id, org_id, env, internal_customer_id, internal_feature_id,
+			unlimited, granted, interval, interval_count, reset_mode,
+			rollover_signature, customer_entitlement_id,
+			customer_license_link_id, created_at, updated_at
+		)
+		VALUES (
+			${poolId},
+			'replace_bench_org',
+			'sandbox',
+			${customerInternalId},
+			${FEATURE_INTERNAL_ID},
+			false,
+			${totalGrant},
+			'month',
+			1,
+			'lazy',
+			'none',
+			${syntheticId},
+			${linkId},
+			${Date.now()},
+			${Date.now()}
+		)
+	`);
+	await db.execute(sql`
+		INSERT INTO customer_entitlements (
+			id, customer_product_id, entitlement_id, internal_customer_id,
+			internal_feature_id, feature_id, unlimited, balance, created_at,
+			usage_allowed, separate_interval, cache_version,
+			pooled_contribution_id
+		)
+		SELECT
+			${`pooled_ce_${rowCount}_`} || i,
+			${`pooled_seat_${rowCount}_`} || i,
+			${FROM_ENTITLEMENT_ID},
+			${customerInternalId},
+			${FEATURE_INTERNAL_ID},
+			${FEATURE_ID},
+			false,
+			0,
+			${Date.now()},
+			false,
+			false,
+			0,
+			${`pooled_contribution_${rowCount}_`} || i
+		FROM generate_series(1, ${rowCount}) AS i
+	`);
+	await db.execute(sql`
+		INSERT INTO pooled_balance_contributions (
+			id, pooled_balance_id, source_customer_product_id,
+			source_customer_entitlement_id, current_contribution,
+			next_cycle_contribution, created_at, updated_at
+		)
+		SELECT
+			${`pooled_contribution_${rowCount}_`} || i,
+			${poolId},
+			${`pooled_seat_${rowCount}_`} || i,
+			${`pooled_ce_${rowCount}_`} || i,
+			${OLD_GRANT},
+			${OLD_GRANT},
+			${Date.now()},
+			${Date.now()}
+		FROM generate_series(1, ${rowCount}) AS i
+	`);
+	return linkId;
+};
+
+const retainedOperation = {
+	type: "replace",
+	fromEntitlementIds: [RETAINED_ENTITLEMENT_ID],
+	toEntitlementId: RETAINED_ENTITLEMENT_ID,
+	fromEntitlementPrice: {
+		entitlement: {
+			id: RETAINED_ENTITLEMENT_ID,
+			internal_feature_id: FEATURE_INTERNAL_ID,
+			feature: { id: FEATURE_ID },
+		},
+	},
+	toEntitlementPrice: {
+		entitlement: {
+			id: RETAINED_ENTITLEMENT_ID,
+			internal_feature_id: FEATURE_INTERNAL_ID,
+			feature: { id: FEATURE_ID },
+		},
+	},
+	customerEntitlementPatch: {
+		balance: { type: "set", amount: NEW_GRANT },
+	},
+} as ReplaceEntitlementPriceOperation;
+
+const pooledOperation = ({ patchType }: { patchType: "increment" | "set" }) =>
+	({
+		type: "replace",
+		fromEntitlementIds: [FROM_ENTITLEMENT_ID],
+		toEntitlementId: TO_ENTITLEMENT_ID,
+		fromEntitlementPrice: {
+			entitlement: {
+				id: FROM_ENTITLEMENT_ID,
+				internal_feature_id: FEATURE_INTERNAL_ID,
+				feature: { id: FEATURE_ID },
+			},
+		},
+		toEntitlementPrice: {
+			entitlement: {
+				id: TO_ENTITLEMENT_ID,
+				internal_feature_id: FEATURE_INTERNAL_ID,
+				feature: { id: FEATURE_ID },
+			},
+		},
+		customerEntitlementPatch: {},
+		pooledContributionPatch: {
+			type: patchType,
+			amount: patchType === "increment" ? NEW_GRANT - OLD_GRANT : NEW_GRANT,
+		},
+	}) as ReplaceEntitlementPriceOperation;
+
+const runExplain = async ({ query }: { query: SQL }): Promise<PlanSummary> => {
+	const rollback = new Error("replace benchmark rollback");
+	let result: ExplainResult | undefined;
+	try {
+		await db.transaction(async (transaction) => {
+			await transaction.execute(
+				sql.raw(`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`),
+			);
+			const queryResult = await transaction.execute(
+				sql`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${query}`,
+			);
+			const rows = queryResult as unknown as Record<string, unknown>[];
+			const raw = Object.values(rows[0] ?? {})[0];
+			const parsed = (typeof raw === "string" ? JSON.parse(raw) : raw) as
+				| ExplainResult[]
+				| undefined;
+			result = parsed?.[0];
+			throw rollback;
+		});
+	} catch (error) {
+		if (error !== rollback) throw error;
+	}
+	if (!result) throw new Error("EXPLAIN returned no plan");
+	return summarizePlan({ result });
+};
+
+const printScenario = ({
+	label,
+	rowCount,
+	runs,
+}: {
+	label: string;
+	rowCount: number;
+	runs: PlanSummary[];
+}) => {
+	const executionTimes = runs.map((run) => run.executionMs);
+	const medianRun = [...runs].sort(
+		(left, right) => left.executionMs - right.executionMs,
+	)[Math.floor(runs.length / 2)]!;
+	console.log(
+		`${label} rows=${rowCount.toLocaleString()}: median=${median({ values: executionTimes }).toFixed(2)}ms range=${Math.min(...executionTimes).toFixed(2)}–${Math.max(...executionTimes).toFixed(2)}ms`,
+	);
+	console.log(
+		`  buffers hit=${medianRun.sharedHits} read=${medianRun.sharedReads} dirtied=${medianRun.sharedDirtied} written=${medianRun.sharedWritten} tempRead=${medianRun.tempReads} tempWritten=${medianRun.tempWritten} maxLoops=${medianRun.maxLoops}`,
+	);
+	console.log(
+		`  sequential scans: ${medianRun.seqScans.length === 0 ? "none" : medianRun.seqScans.join("; ")}`,
+	);
+};
+
+const benchmarkScenario = async ({
+	label,
+	rowCount,
+	query,
+}: {
+	label: string;
+	rowCount: number;
+	query: SQL;
+}) => {
+	const runs: PlanSummary[] = [];
+	for (let run = 1; run <= RUNS_PER_SCENARIO; run++) {
+		const summary = await runExplain({ query });
+		runs.push(summary);
+		console.log(
+			`  ${label} ${rowCount.toLocaleString()} run ${run}: ${summary.executionMs.toFixed(2)}ms`,
+		);
+	}
+	printScenario({ label, rowCount, runs });
+};
+
+try {
+	console.log(`DEV schema ${BENCHMARK_SCHEMA}`);
+	await createTables();
+	console.log(`seeding ${NOISE_ROWS.toLocaleString()} unrelated rows`);
+	await seedNoise();
+	for (const rowCount of ROW_COUNTS) {
+		const retainedLinkId = await seedRetained({ rowCount });
+		const pooledLinkId = await seedPooled({ rowCount });
+		await db.execute(sql`
+			ANALYZE customer_products, customer_entitlements,
+				pooled_balances, pooled_balance_contributions
+		`);
+
+		await benchmarkScenario({
+			label: "retained set",
+			rowCount,
+			query: buildReplaceCustomerEntitlementsBatchQuery({
+				customerLicenseLinkId: retainedLinkId,
+				operation: retainedOperation,
+				batchSize: rowCount,
+			}),
+		});
+		await benchmarkScenario({
+			label: "pooled set",
+			rowCount,
+			query: buildReplaceCustomerEntitlementsBatchQuery({
+				customerLicenseLinkId: pooledLinkId,
+				operation: pooledOperation({ patchType: "set" }),
+				batchSize: rowCount,
+			}),
+		});
+		await benchmarkScenario({
+			label: "pooled increment",
+			rowCount,
+			query: buildReplaceCustomerEntitlementsBatchQuery({
+				customerLicenseLinkId: pooledLinkId,
+				operation: pooledOperation({ patchType: "increment" }),
+				batchSize: rowCount,
+			}),
+		});
+	}
+} finally {
+	await client.end();
+	await bootstrapDb.execute(
+		sql`DROP SCHEMA ${sql.identifier(BENCHMARK_SCHEMA)} CASCADE`,
+	);
+	await bootstrapClient.end();
+}
+
+process.exit(0);

--- a/server/tests/unit/billing/batch-transition/compute-customer-entitlement-patch.test.ts
+++ b/server/tests/unit/billing/batch-transition/compute-customer-entitlement-patch.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Contract: batch transition replaces RESET usage by default — the balance patch
+ * is `set toGranted` unless the feature is carried. A feature carries when:
+ * - carryOverUsages.enabled and the feature is listed (or no feature_ids filter), or
+ * - the feature is allocated (continuous_use) — allocated usage always carries, or
+ * - the incoming entitlement has carry_from_previous set.
+ * Carried patches keep today's increment-by-delta math. Boolean/unlimited
+ * boundary behavior and pooled delta routing are unchanged.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	AllowanceType,
+	type CarryOverUsages,
+	EntInterval,
+	type EntitlementWithFeature,
+	FeatureType,
+	FeatureUsageType,
+} from "@autumn/shared";
+import { computeCustomerEntitlementPatch } from "@/internal/billing/v2/actions/batchTransition/compute/operations/entitlementPriceOperations/computeCustomerEntitlementPatch";
+
+const NOW = 1_700_000_000_000;
+
+const feature = ({
+	id,
+	type = FeatureType.Metered,
+	usageType = FeatureUsageType.Single,
+}: {
+	id: string;
+	type?: FeatureType;
+	usageType?: FeatureUsageType;
+}) => ({
+	internal_id: `internal_${id}`,
+	org_id: "org_test",
+	created_at: NOW,
+	env: "sandbox",
+	id,
+	name: id,
+	type,
+	config: type === FeatureType.Boolean ? null : { usage_type: usageType },
+	display: null,
+	archived: false,
+	event_names: [],
+	model_markups: null,
+	stripe_meter: null,
+});
+
+const entitlement = ({
+	id,
+	feature: entFeature,
+	allowance,
+	allowanceType = AllowanceType.Fixed,
+	carryFromPrevious = false,
+}: {
+	id: string;
+	feature: ReturnType<typeof feature>;
+	allowance?: number | null;
+	allowanceType?: AllowanceType;
+	carryFromPrevious?: boolean;
+}): EntitlementWithFeature =>
+	({
+		id,
+		created_at: NOW,
+		internal_feature_id: entFeature.internal_id,
+		internal_product_id: "product_test",
+		internal_reward_id: null,
+		is_custom: false,
+		allowance_type:
+			entFeature.type === FeatureType.Boolean
+				? AllowanceType.None
+				: allowanceType,
+		allowance: allowance ?? null,
+		interval:
+			entFeature.type === FeatureType.Boolean ? null : EntInterval.Month,
+		interval_count: 1,
+		carry_from_previous: carryFromPrevious,
+		entity_feature_id: null,
+		usage_limit: null,
+		feature: entFeature,
+	}) as EntitlementWithFeature;
+
+const messages = feature({ id: "messages" });
+const workflows = feature({
+	id: "workflows",
+	usageType: FeatureUsageType.Continuous,
+});
+const admin = feature({ id: "admin", type: FeatureType.Boolean });
+
+const meteredPair = ({
+	fromAllowance,
+	toAllowance,
+	withFeature = messages,
+}: {
+	fromAllowance: number;
+	toAllowance: number;
+	withFeature?: ReturnType<typeof feature>;
+}) => ({
+	fromEntitlement: entitlement({
+		id: "ent_from",
+		feature: withFeature,
+		allowance: fromAllowance,
+	}),
+	toEntitlement: entitlement({
+		id: "ent_to",
+		feature: withFeature,
+		allowance: toAllowance,
+	}),
+});
+
+const carryAll: CarryOverUsages = { enabled: true };
+const carryNone: CarryOverUsages = { enabled: false };
+
+describe("computeCustomerEntitlementPatch", () => {
+	// u1
+	test("default (no carry config) resets the balance to the new grant", () => {
+		const patch = computeCustomerEntitlementPatch({
+			...meteredPair({ fromAllowance: 100, toAllowance: 500 }),
+		});
+		expect(patch.balance).toEqual({ type: "set", amount: 500 });
+	});
+
+	// u2
+	test("carryOverUsages disabled resets the balance to the new grant", () => {
+		const patch = computeCustomerEntitlementPatch({
+			...meteredPair({ fromAllowance: 100, toAllowance: 500 }),
+			carryOverUsages: carryNone,
+		});
+		expect(patch.balance).toEqual({ type: "set", amount: 500 });
+	});
+
+	// u3
+	test("carryOverUsages enabled increments by the allowance delta", () => {
+		const patch = computeCustomerEntitlementPatch({
+			...meteredPair({ fromAllowance: 100, toAllowance: 500 }),
+			carryOverUsages: carryAll,
+		});
+		expect(patch.balance).toEqual({ type: "increment", amount: 400 });
+	});
+
+	// u4
+	test("feature_ids excluding the feature resets the balance", () => {
+		const patch = computeCustomerEntitlementPatch({
+			...meteredPair({ fromAllowance: 100, toAllowance: 500 }),
+			carryOverUsages: { enabled: true, feature_ids: ["words"] },
+		});
+		expect(patch.balance).toEqual({ type: "set", amount: 500 });
+	});
+
+	// u5
+	test("feature_ids including the feature carries the usage", () => {
+		const patch = computeCustomerEntitlementPatch({
+			...meteredPair({ fromAllowance: 100, toAllowance: 500 }),
+			carryOverUsages: { enabled: true, feature_ids: ["messages"] },
+		});
+		expect(patch.balance).toEqual({ type: "increment", amount: 400 });
+	});
+
+	// u6
+	test("equal allowances still reset by default — usage clears", () => {
+		const patch = computeCustomerEntitlementPatch({
+			...meteredPair({ fromAllowance: 100, toAllowance: 100 }),
+		});
+		expect(patch.balance).toEqual({ type: "set", amount: 100 });
+	});
+
+	// u7
+	test("equal allowances with carry enabled emit no balance patch", () => {
+		const patch = computeCustomerEntitlementPatch({
+			...meteredPair({ fromAllowance: 100, toAllowance: 100 }),
+			carryOverUsages: carryAll,
+		});
+		expect(patch.balance).toBeUndefined();
+	});
+
+	// u8
+	test("allocated (continuous_use) features always carry, even by default", () => {
+		const patch = computeCustomerEntitlementPatch({
+			...meteredPair({
+				fromAllowance: 100,
+				toAllowance: 500,
+				withFeature: workflows,
+			}),
+		});
+		expect(patch.balance).toEqual({ type: "increment", amount: 400 });
+	});
+
+	// u9
+	test("incoming carry_from_previous entitlement carries by default", () => {
+		const patch = computeCustomerEntitlementPatch({
+			fromEntitlement: entitlement({
+				id: "ent_from",
+				feature: messages,
+				allowance: 100,
+			}),
+			toEntitlement: entitlement({
+				id: "ent_to",
+				feature: messages,
+				allowance: 500,
+				carryFromPrevious: true,
+			}),
+		});
+		expect(patch.balance).toEqual({ type: "increment", amount: 400 });
+	});
+
+	// u10
+	test("unlimited -> metered boundary sets the new grant regardless of carry", () => {
+		const fromEntitlement = entitlement({
+			id: "ent_from",
+			feature: messages,
+			allowanceType: AllowanceType.Unlimited,
+		});
+		const toEntitlement = entitlement({
+			id: "ent_to",
+			feature: messages,
+			allowance: 500,
+		});
+		for (const carryOverUsages of [undefined, carryAll, carryNone]) {
+			const patch = computeCustomerEntitlementPatch({
+				fromEntitlement,
+				toEntitlement,
+				carryOverUsages,
+			});
+			expect(patch.balance).toEqual({ type: "set", amount: 500 });
+			expect(patch.unlimited).toBe(false);
+		}
+	});
+
+	// u11
+	test("boolean entitlements never receive a patch", () => {
+		const patch = computeCustomerEntitlementPatch({
+			fromEntitlement: entitlement({ id: "ent_from", feature: admin }),
+			toEntitlement: entitlement({ id: "ent_to", feature: admin }),
+		});
+		expect(patch).toEqual({});
+	});
+});

--- a/server/tests/unit/billing/batch-transition/compute-retained-entitlement-operations.test.ts
+++ b/server/tests/unit/billing/batch-transition/compute-retained-entitlement-operations.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Contract: same-definition survivors (`retained`) only emit a replace when
+ * usage is NOT carried. Carry-enabled / allocated / carry_from_previous leave
+ * those rows untouched. Default reset writes `set toGranted` on the existing id.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	AllowanceType,
+	type CarryOverUsages,
+	EntInterval,
+	type EntitlementPrice,
+	type EntitlementWithFeature,
+	FeatureType,
+	FeatureUsageType,
+	type InitCustomerEntitlementContext,
+} from "@autumn/shared";
+import { computeEntitlementPriceOperations } from "@/internal/billing/v2/actions/batchTransition/compute/operations/entitlementPriceOperations/computeEntitlementPriceOperations";
+
+const NOW = 1_700_000_000_000;
+
+const feature = ({
+	id,
+	type = FeatureType.Metered,
+	usageType = FeatureUsageType.Single,
+}: {
+	id: string;
+	type?: FeatureType;
+	usageType?: FeatureUsageType;
+}) => ({
+	internal_id: `internal_${id}`,
+	org_id: "org_test",
+	created_at: NOW,
+	env: "sandbox",
+	id,
+	name: id,
+	type,
+	config: type === FeatureType.Boolean ? null : { usage_type: usageType },
+	display: null,
+	archived: false,
+	event_names: [],
+	model_markups: null,
+	stripe_meter: null,
+});
+
+const entitlement = ({
+	id,
+	feature: entFeature,
+	allowance = 200,
+	carryFromPrevious = false,
+}: {
+	id: string;
+	feature: ReturnType<typeof feature>;
+	allowance?: number;
+	carryFromPrevious?: boolean;
+}): EntitlementWithFeature =>
+	({
+		id,
+		created_at: NOW,
+		internal_feature_id: entFeature.internal_id,
+		internal_product_id: "product_test",
+		internal_reward_id: null,
+		is_custom: false,
+		allowance_type:
+			entFeature.type === FeatureType.Boolean
+				? AllowanceType.None
+				: AllowanceType.Fixed,
+		allowance,
+		interval:
+			entFeature.type === FeatureType.Boolean ? null : EntInterval.Month,
+		interval_count: 1,
+		carry_from_previous: carryFromPrevious,
+		entity_feature_id: null,
+		usage_limit: null,
+		feature: entFeature,
+	}) as EntitlementWithFeature;
+
+const messages = feature({ id: "messages" });
+const words = feature({ id: "words" });
+const workflows = feature({
+	id: "workflows",
+	usageType: FeatureUsageType.Continuous,
+});
+const admin = feature({ id: "admin", type: FeatureType.Boolean });
+
+const entitlementPrice = (
+	ent: EntitlementWithFeature,
+): EntitlementPrice => ({ entitlement: ent });
+
+const initContext = {
+	fullCustomer: { id: "cus", internal_id: "cus_internal", entities: [] },
+	fullProduct: { id: "seat", internal_id: "seat_internal" },
+	featureQuantities: [],
+	resetCycleAnchor: NOW,
+	freeTrial: null,
+	now: NOW,
+} as unknown as InitCustomerEntitlementContext;
+
+const computeRetained = ({
+	ent,
+	carryOverUsages,
+}: {
+	ent: EntitlementWithFeature;
+	carryOverUsages?: CarryOverUsages;
+}) =>
+	computeEntitlementPriceOperations({
+		candidateOutgoingEntitlements: [ent],
+		entitlementPriceTransitions: {
+			transitions: [],
+			retained: [
+				{
+					fromEntitlementPrice: entitlementPrice(ent),
+					toEntitlementPrice: entitlementPrice(ent),
+				},
+			],
+			added: [],
+			deleted: [],
+		},
+		customerEntitlementInitContext: initContext,
+		customerEntitlementInitOptions: { customerLicenseLinkId: "link_1" },
+		carryOverUsages,
+	});
+
+describe("retained entitlement operations", () => {
+	test("default (no carry) emits a same-id replace that sets the grant", () => {
+		const messagesEnt = entitlement({ id: "ent_messages", feature: messages });
+		const { operations, unhandled } = computeRetained({ ent: messagesEnt });
+		expect(unhandled.retained).toEqual([]);
+		expect(operations).toEqual([
+			{
+				type: "replace",
+				fromEntitlementIds: ["ent_messages"],
+				toEntitlementId: "ent_messages",
+				fromEntitlementPrice: entitlementPrice(messagesEnt),
+				toEntitlementPrice: entitlementPrice(messagesEnt),
+				customerEntitlementPatch: {
+					balance: { type: "set", amount: 200 },
+				},
+			},
+		]);
+	});
+
+	test("carryOverUsages enabled emits no retained replace", () => {
+		const messagesEnt = entitlement({ id: "ent_messages", feature: messages });
+		const { operations } = computeRetained({
+			ent: messagesEnt,
+			carryOverUsages: { enabled: true },
+		});
+		expect(operations).toEqual([]);
+	});
+
+	test("carryOverUsages disabled still resets a retained entitlement", () => {
+		const messagesEnt = entitlement({ id: "ent_messages", feature: messages });
+		const { operations } = computeRetained({
+			ent: messagesEnt,
+			carryOverUsages: { enabled: false },
+		});
+		expect(operations).toHaveLength(1);
+		expect(operations[0]).toMatchObject({
+			type: "replace",
+			fromEntitlementIds: ["ent_messages"],
+			customerEntitlementPatch: {
+				balance: { type: "set", amount: 200 },
+			},
+		});
+	});
+
+	test("allocated retained entitlements never emit a replace", () => {
+		const workflowsEnt = entitlement({
+			id: "ent_workflows",
+			feature: workflows,
+		});
+		const { operations } = computeRetained({ ent: workflowsEnt });
+		expect(operations).toEqual([]);
+	});
+
+	test("carry_from_previous retained entitlements never emit a replace", () => {
+		const messagesEnt = entitlement({
+			id: "ent_messages",
+			feature: messages,
+			carryFromPrevious: true,
+		});
+		const { operations } = computeRetained({ ent: messagesEnt });
+		expect(operations).toEqual([]);
+	});
+
+	test("feature_ids excluding the retained feature still resets it", () => {
+		const messagesEnt = entitlement({ id: "ent_messages", feature: messages });
+		const { operations } = computeRetained({
+			ent: messagesEnt,
+			carryOverUsages: { enabled: true, feature_ids: ["words"] },
+		});
+		expect(operations).toHaveLength(1);
+		expect(operations[0]).toMatchObject({
+			type: "replace",
+			fromEntitlementIds: ["ent_messages"],
+			customerEntitlementPatch: {
+				balance: { type: "set", amount: 200 },
+			},
+		});
+	});
+
+	test("feature_ids including the retained feature emits no replace", () => {
+		const messagesEnt = entitlement({ id: "ent_messages", feature: messages });
+		const { operations } = computeRetained({
+			ent: messagesEnt,
+			carryOverUsages: { enabled: true, feature_ids: ["messages"] },
+		});
+		expect(operations).toEqual([]);
+	});
+
+	test("boolean retained entitlements never emit a replace", () => {
+		const adminEnt = entitlement({ id: "ent_admin", feature: admin });
+		const { operations } = computeRetained({ ent: adminEnt });
+		expect(operations).toEqual([]);
+	});
+
+	test("mixed retained features only replace the ones that are not carried", () => {
+		const messagesEnt = entitlement({ id: "ent_messages", feature: messages });
+		const wordsEnt = entitlement({ id: "ent_words", feature: words });
+		const workflowsEnt = entitlement({
+			id: "ent_workflows",
+			feature: workflows,
+		});
+		const { operations } = computeEntitlementPriceOperations({
+			candidateOutgoingEntitlements: [messagesEnt, wordsEnt, workflowsEnt],
+			entitlementPriceTransitions: {
+				transitions: [],
+				retained: [messagesEnt, wordsEnt, workflowsEnt].map((ent) => ({
+					fromEntitlementPrice: entitlementPrice(ent),
+					toEntitlementPrice: entitlementPrice(ent),
+				})),
+				added: [],
+				deleted: [],
+			},
+			customerEntitlementInitContext: initContext,
+			customerEntitlementInitOptions: { customerLicenseLinkId: "link_1" },
+			carryOverUsages: { enabled: true, feature_ids: ["words"] },
+		});
+		expect(operations).toHaveLength(1);
+		expect(operations[0]).toMatchObject({
+			type: "replace",
+			fromEntitlementIds: ["ent_messages"],
+			toEntitlementId: "ent_messages",
+			customerEntitlementPatch: {
+				balance: { type: "set", amount: 200 },
+			},
+		});
+	});
+});

--- a/server/tests/unit/billing/batch-transition/unused-assignment-entitlement-batch-sql.test.ts
+++ b/server/tests/unit/billing/batch-transition/unused-assignment-entitlement-batch-sql.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unused assignment CPs (license link set, entity null) are part of
+ * entitlement add / replace / delete. The candidate WHERE must not
+ * require internal_entity_id.
+ *
+ * Red (current): replace and delete still filter entity IS NOT NULL.
+ * Green (after): replace and delete candidate WHERE matches add — link + status only.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import {
+	AllowanceType,
+	EntInterval,
+	type EntitlementPrice,
+	type EntitlementWithFeature,
+	FeatureType,
+	FeatureUsageType,
+} from "@autumn/shared";
+import { buildDeleteCustomerEntitlementsBatchQuery } from "@/internal/billing/v2/actions/batchTransition/execute/sql/deleteCustomerEntitlementsBatch";
+import { buildReplaceCustomerEntitlementsBatchQuery } from "@/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch";
+import type {
+	RemoveEntitlementPriceOperation,
+	ReplaceEntitlementPriceOperation,
+} from "@/internal/billing/v2/actions/batchTransition/types/entitlementPriceOperationTypes";
+
+const ENTITY_REQUIRED = "internal_entity_id IS NOT NULL";
+
+const flattenSql = (query: SQL): string =>
+	JSON.stringify(query, (_key, value) =>
+		typeof value === "string" ? value : value,
+	);
+
+const messages = {
+	internal_id: "internal_messages",
+	org_id: "org_test",
+	created_at: 0,
+	env: "sandbox",
+	id: "messages",
+	name: "messages",
+	type: FeatureType.Metered,
+	config: { usage_type: FeatureUsageType.Single },
+	display: null,
+	archived: false,
+	event_names: [],
+	model_markups: null,
+	stripe_meter: null,
+};
+
+const entitlement = (id: string): EntitlementWithFeature =>
+	({
+		id,
+		created_at: 0,
+		internal_feature_id: messages.internal_id,
+		internal_product_id: "product_test",
+		internal_reward_id: null,
+		is_custom: false,
+		allowance_type: AllowanceType.Fixed,
+		allowance: 100,
+		interval: EntInterval.Month,
+		interval_count: 1,
+		carry_from_previous: false,
+		entity_feature_id: null,
+		usage_limit: null,
+		pooled: false,
+		feature: messages,
+	}) as EntitlementWithFeature;
+
+const entitlementPrice = (id: string): EntitlementPrice => ({
+	entitlement: entitlement(id),
+});
+
+const replaceOperation = (): ReplaceEntitlementPriceOperation => ({
+	type: "replace",
+	fromEntitlementIds: ["ent_from"],
+	toEntitlementId: "ent_to",
+	fromEntitlementPrice: entitlementPrice("ent_from"),
+	toEntitlementPrice: entitlementPrice("ent_to"),
+	customerEntitlementPatch: { balance: { type: "set", amount: 100 } },
+});
+
+const removeOperation = (): RemoveEntitlementPriceOperation => ({
+	type: "remove",
+	entitlementPrice: entitlementPrice("ent_from"),
+	fromEntitlementIds: ["ent_from"],
+});
+
+describe("unused assignment seats stay in entitlement batch SQL", () => {
+	test("replace does not require an entity on the seat", () => {
+		const query = buildReplaceCustomerEntitlementsBatchQuery({
+			customerLicenseLinkId: "link_unused",
+			operation: replaceOperation(),
+			batchSize: 50,
+		});
+		expect(flattenSql(query)).not.toContain(ENTITY_REQUIRED);
+	});
+
+	test("delete does not require an entity on the seat", () => {
+		const query = buildDeleteCustomerEntitlementsBatchQuery({
+			customerLicenseLinkId: "link_unused",
+			operation: removeOperation(),
+			batchSize: 50,
+			now: 0,
+		});
+		expect(flattenSql(query)).not.toContain(ENTITY_REQUIRED);
+	});
+});

--- a/server/tests/unit/migrations-v2/batch-operations/compute-license-operations.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/compute-license-operations.test.ts
@@ -124,7 +124,7 @@ describe("license transitions lower into operations", () => {
 			productTransitions: {
 				basePrice: undefined,
 				customerProduct: undefined,
-				entitlementPrices: { transitions: [], added: [], deleted: [] },
+				entitlementPrices: { transitions: [], retained: [], added: [], deleted: [] },
 				toProduct: fromProduct,
 			},
 			licenseLinks,
@@ -264,7 +264,7 @@ describe("version link diff", () => {
 			productTransitions: {
 				basePrice: undefined,
 				customerProduct: undefined,
-				entitlementPrices: { transitions: [], added: [], deleted: [] },
+				entitlementPrices: { transitions: [], retained: [], added: [], deleted: [] },
 				toProduct: fromProduct,
 			},
 			licenseLinks: links,
@@ -332,7 +332,7 @@ describe("version link diff", () => {
 			productTransitions: {
 				basePrice: undefined,
 				customerProduct: undefined,
-				entitlementPrices: { transitions: [], added: [], deleted: [] },
+				entitlementPrices: { transitions: [], retained: [], added: [], deleted: [] },
 				toProduct: fromProduct,
 			},
 			licenseLinks: links,

--- a/shared/models/billingModels/plan/customerLicensePlan.ts
+++ b/shared/models/billingModels/plan/customerLicensePlan.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { CarryOverUsagesSchema } from "../../../api/billing/common/carryOverUsages.js";
 import { FullCustomerLicenseSchema } from "../../licenseModels/fullCustomerLicense.js";
 import type { DbPlanLicense } from "../../licenseModels/planLicenseTable.js";
 import { EntitlementSchema } from "../../productModels/entModels/entModels.js";
@@ -37,6 +38,10 @@ export const CustomerLicenseTransitionSchema = z.object({
 		remaining: z.number(),
 		paidQuantity: z.number(),
 	}),
+	// Resolved at plan compute (request param or org transition rule) and
+	// carried on the transition so the async batch task sees the same choice.
+	// Absent means reset: seat usage clears to the incoming grant.
+	carryOverUsages: CarryOverUsagesSchema,
 });
 export type CustomerLicenseTransition = z.infer<
 	typeof CustomerLicenseTransitionSchema


### PR DESCRIPTION
Run smaller license transitions synchronously and preserve explicit carry-over semantics across retained and pooled entitlements.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resets license transition usage unless carry-over is enabled, and runs smaller transitions synchronously. Retained (same-definition) entitlements now reset to the incoming grant by default, pooled balances reset to the new grant, and usage carries only when `carry_over_usages` is enabled, the feature is allocated, or the entitlement has `carry_from_previous` set.

- Adds `carryOverUsages` resolution and propagation through plan compute, batch transition setup, and the transition record.
- Tracks retained (same-definition) entitlement transitions separately so they only replace when usage resets.
- Reworks pooled replacement SQL to support both increment (carry) and set (reset) contribution patches.
- Removes the same-ID replacement restriction and the entity filter so unused seats receive add/replace/delete in batch transitions.
- Migration item replaces keep carrying usage after the default-reset change.
- Customers under 1,000 entities get transitions run synchronously in the request instead of queued.

<sup>Written for commit 68c7e4c6989ba683fc46a36832857e54f7547c72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes license transitions so usage resets unless carry-over is explicitly enabled, while preserving carry-over for allocated features, selected consumables, and migration edits.

- **[Bug fixes]** Reset retained and pooled entitlement usage to the incoming grant when carry-over is disabled.
- **[Improvements]** Propagate carry-over settings through immediate, scheduled, and batch license transitions.
- **[Improvements]** Include active reusable seats when replacing or deleting license entitlements.
- **[Improvements]** Run transitions synchronously for customers classified as small.
</details>


<h3>Confidence Score: 4/5</h3>

The PR does not appear safe to merge until synchronous execution is based on the actual transition workload rather than only the number of live entities.

A customer can have fewer than 1,000 live entities but many active unassigned seats; the new threshold then awaits a transition in the billing request even though replacement and deletion SQL process all of those seat entitlement rows.

**Files Needing Attention:** server/src/internal/billing/v2/execute/executeAutumnActions/executeCustomerLicenseTransitions.ts, server/src/internal/entities/repos/countEntitiesByInternalCustomerId.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/batchTransition/compute/operations/entitlementPriceOperations/computeCustomerEntitlementPatch.ts | Adds explicit carry-over resolution and set-versus-increment balance patches for license transitions. |
| server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch.ts | Extends replacement SQL to reset retained and pooled entitlement state and to include active reusable seats. |
| server/src/internal/billing/v2/execute/executeAutumnActions/executeCustomerLicenseTransitions.ts | Introduces synchronous execution for customers below the live-entity threshold, while the outstanding workload-estimation defect remains. |
| server/src/internal/entities/repos/countEntitiesByInternalCustomerId.ts | Adds a capped live-entity count, but that count does not represent all seat rows processed by license transitions. |
| shared/models/billingModels/plan/customerLicensePlan.ts | Carries explicit usage carry-over settings on the license transition model. |

<sub>Reviews (2): Last reviewed commit: ["fix(licenses): include unused seats in e..."](https://github.com/useautumn/autumn/commit/68c7e4c6989ba683fc46a36832857e54f7547c72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59981933)</sub>

**Context used:**

- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)

<!-- /greptile_comment -->