### PR TITLE
feat(catalog): address features by internal_id, return it in previews and results

### DIFF
--- a/packages/atmn-generator/package.json
+++ b/packages/atmn-generator/package.json
@@ -8,7 +8,8 @@
 		"ts": "bunx tsgo --build --noEmit",
 		"test": "bun test test",
 		"generate": "bun run src/generate.ts",
-		"check": "bun run src/checkClean.ts"
+		"check": "bun run src/checkClean.ts",
+		"fuzz": "bun run src/fuzz/runFuzz.ts"
 	},
 	"dependencies": {
 		"yaml": "2.9.0"

--- a/packages/atmn-generator/src/fuzz/coverageReport.ts
+++ b/packages/atmn-generator/src/fuzz/coverageReport.ts
@@ -1,0 +1,98 @@
+import type { FixturePath } from "./schemaPaths";
+
+/** The shape `schemaPaths` and `documentPaths` both produce. */
+type PathMap = Map<FixturePath, Set<string>>;
+
+export type CoverageReport = {
+	total: number;
+	touched: number;
+	percent: number;
+	untouched: string[];
+	unusedEnumValues: string[];
+};
+
+const inCollection = ({
+	path,
+	collection,
+}: {
+	path: FixturePath;
+	collection: string;
+}): boolean => path === collection || path.startsWith(`${collection}.`);
+
+/**
+ * How much of `collection`'s schema paths the document touches — structurally
+ * (the path was set at all) and by enum value (every value the schema allows
+ * there was written somewhere in the document, not necessarily at that exact
+ * path — a config can hit an enum value at any occurrence of the field).
+ */
+export const coverageReport = ({
+	schema,
+	document,
+	collection,
+}: {
+	schema: PathMap;
+	document: PathMap;
+	collection: string;
+}): CoverageReport => {
+	const paths = [...schema.keys()]
+		.filter((path) => inCollection({ path, collection }))
+		.sort();
+
+	const untouched = paths.filter((path) => !document.has(path));
+
+	const unusedEnumValues: string[] = [];
+	for (const path of paths) {
+		const enumValues = schema.get(path);
+		if (!enumValues || enumValues.size === 0) continue;
+		const usedValues = document.get(path);
+		for (const value of enumValues) {
+			if (!usedValues?.has(value)) unusedEnumValues.push(`${path} = ${value}`);
+		}
+	}
+
+	const total = paths.length;
+	const touched = total - untouched.length;
+
+	return {
+		total,
+		touched,
+		percent: total === 0 ? 0 : Math.round((100 * touched) / total),
+		untouched,
+		unusedEnumValues,
+	};
+};
+
+const MAX_LINES = 40;
+
+const cappedSection = ({
+	label,
+	entries,
+}: {
+	label: string;
+	entries: string[];
+}): string[] => {
+	if (entries.length === 0) return [];
+	const shown = entries.slice(0, MAX_LINES);
+	const remaining = entries.length - shown.length;
+	return [
+		`  ${label}:`,
+		...shown.map((entry) => `    ${entry}`),
+		...(remaining > 0 ? [`    +${remaining} more`] : []),
+	];
+};
+
+export const formatCoverageReport = ({
+	report,
+	collection,
+}: {
+	report: CoverageReport;
+	collection: string;
+}): string =>
+	[
+		`${collection}: ${report.touched}/${report.total} paths touched (${report.percent}%)`,
+		...cappedSection({ label: "untouched paths", entries: report.untouched }),
+		...cappedSection({
+			label: "unused enum values",
+			entries: report.unusedEnumValues,
+		}),
+	].join("\n");

--- a/packages/atmn-generator/src/fuzz/documentPaths.ts
+++ b/packages/atmn-generator/src/fuzz/documentPaths.ts
@@ -1,0 +1,48 @@
+import { toCamelCase } from "../casing/schemaKeyCasing";
+import type { FixturePath } from "./schemaPaths";
+
+/**
+ * Every path an executed config's wire document actually sets, recased to
+ * fixture (camelCase) keys with array indices elided — the same convention
+ * `schemaPaths` uses, so the two maps can be compared key for key. String
+ * leaf values are collected per path for enum coverage.
+ */
+export const documentPaths = ({
+	document,
+}: {
+	document: unknown;
+}): Map<FixturePath, Set<string>> => {
+	const paths = new Map<FixturePath, Set<string>>();
+
+	const visit = ({
+		value,
+		fixturePath,
+	}: {
+		value: unknown;
+		fixturePath: string;
+	}): void => {
+		if (Array.isArray(value)) {
+			for (const entry of value) visit({ value: entry, fixturePath });
+			return;
+		}
+		if (value === null || typeof value !== "object") return;
+
+		for (const [wireKey, entry] of Object.entries(
+			value as Record<string, unknown>,
+		)) {
+			const childFixturePath = fixturePath
+				? `${fixturePath}.${toCamelCase(wireKey)}`
+				: toCamelCase(wireKey);
+
+			const values = paths.get(childFixturePath) ?? new Set<string>();
+			if (typeof entry === "string") values.add(entry);
+			paths.set(childFixturePath, values);
+
+			visit({ value: entry, fixturePath: childFixturePath });
+		}
+	};
+
+	visit({ value: document, fixturePath: "" });
+
+	return paths;
+};

--- a/packages/atmn-generator/src/fuzz/runFuzz.ts
+++ b/packages/atmn-generator/src/fuzz/runFuzz.ts
@@ -1,0 +1,48 @@
+import { toCamelCase } from "../casing/schemaKeyCasing";
+import { COLLECTIONS } from "../collections";
+import { OVERLAY } from "../overlay/overlay";
+import { catalogUpdateSchema, loadSpec } from "../spec/loadSpec";
+import { coverageReport, formatCoverageReport } from "./coverageReport";
+import { documentPaths } from "./documentPaths";
+import { schemaPaths } from "./schemaPaths";
+
+/**
+ * How much of the catalog schema a config exercises: one report per
+ * top-level collection the config's wire document actually states.
+ */
+export const runFuzz = async ({
+	configPath,
+}: {
+	configPath: string;
+}): Promise<void> => {
+	// Cache-busted so a second run in the same process sees an edited config,
+	// not the first import cached under the plain path.
+	const module = await import(`${configPath}?v=${Date.now()}`);
+	const document = module.default as Record<string, unknown>;
+
+	const spec = loadSpec();
+	const root = spec as never;
+	const schema = schemaPaths({
+		schema: catalogUpdateSchema({ spec }),
+		root,
+		overlay: OVERLAY,
+	});
+	const touched = documentPaths({ document });
+
+	for (const wireKey of Object.keys(document)) {
+		// Constants like skip_deletions are not catalog collections.
+		if (!(wireKey in COLLECTIONS)) continue;
+		const collection = toCamelCase(wireKey);
+		const report = coverageReport({ schema, document: touched, collection });
+		console.log(formatCoverageReport({ report, collection }));
+	}
+};
+
+if (import.meta.main) {
+	const configPath = process.argv[2];
+	if (!configPath) {
+		console.error("usage: bun run fuzz <path/to/autumn.config.ts>");
+		process.exit(1);
+	}
+	await runFuzz({ configPath });
+}

--- a/packages/atmn-generator/src/fuzz/runFuzz.ts
+++ b/packages/atmn-generator/src/fuzz/runFuzz.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { toCamelCase } from "../casing/schemaKeyCasing";
 import { COLLECTIONS } from "../collections";
 import { OVERLAY } from "../overlay/overlay";
@@ -39,7 +40,8 @@ export const runFuzz = async ({
 };
 
 if (import.meta.main) {
-	const configPath = process.argv[2];
+	// A dynamic import resolves relative to this file, not the caller's shell.
+	const configPath = process.argv[2] && resolve(process.cwd(), process.argv[2]);
 	if (!configPath) {
 		console.error("usage: bun run fuzz <path/to/autumn.config.ts>");
 		process.exit(1);

--- a/packages/atmn-generator/src/fuzz/schemaPaths.ts
+++ b/packages/atmn-generator/src/fuzz/schemaPaths.ts
@@ -1,0 +1,140 @@
+import {
+	isRecordSchema,
+	type JsonSchema,
+	toCamelCase,
+} from "../casing/schemaKeyCasing";
+import { isHidden, isInternalField, type Overlay } from "../overlay/overlay";
+import { resolveRef } from "../spec/resolveRef";
+
+/** Fixture-side dot path with array indices elided, `*` for a record's values. */
+export type FixturePath = string;
+
+const branchesOf = (schema: JsonSchema): JsonSchema[] =>
+	[
+		...(schema.allOf ?? []),
+		...(schema.anyOf ?? []),
+		...(schema.oneOf ?? []),
+	].filter((branch) => branch.type !== "null");
+
+/** Every enum/const value a schema node can take, across its `anyOf`/`oneOf` alternatives. */
+const enumValuesOf = (schema: JsonSchema): Set<string> => {
+	const values = new Set<string>();
+	const collect = (node: JsonSchema) => {
+		if (Array.isArray(node.enum))
+			for (const value of node.enum) values.add(String(value));
+		if (node.const !== undefined) values.add(String(node.const));
+		for (const branch of [...(node.anyOf ?? []), ...(node.oneOf ?? [])])
+			collect(branch);
+	};
+	collect(schema);
+	return values;
+};
+
+/**
+ * Every leaf/object path under the envelope, keyed fixture-side, with the enum
+ * values the spec allows there. Skips overlay-hidden and x-internal fields —
+ * the same reach as the generated CLI, so "coverage" means coverage of what a
+ * config could actually state.
+ */
+export const schemaPaths = ({
+	schema,
+	root,
+	overlay,
+}: {
+	schema: JsonSchema;
+	root: JsonSchema;
+	overlay: Overlay;
+}): Map<FixturePath, Set<string>> => {
+	const paths = new Map<FixturePath, Set<string>>();
+
+	const visit = ({
+		schema: node,
+		fixturePath,
+		collection,
+		wirePath,
+		seen,
+	}: {
+		schema: JsonSchema | undefined;
+		fixturePath: string;
+		/** Top-level wire collection ("plans", "features") once inside one, else "". */
+		collection: string;
+		/** Relative to the collection ITEM root — resets when `collection` is entered. */
+		wirePath: string;
+		seen: Set<JsonSchema>;
+	}): void => {
+		const resolved = resolveRef({ schema: node, root });
+		if (!resolved || seen.has(resolved)) return;
+		const nextSeen = new Set(seen).add(resolved);
+
+		if (resolved.items) {
+			visit({
+				schema: resolved.items,
+				fixturePath,
+				collection,
+				wirePath,
+				seen: nextSeen,
+			});
+			return;
+		}
+
+		for (const branch of branchesOf(resolved)) {
+			visit({
+				schema: branch,
+				fixturePath,
+				collection,
+				wirePath,
+				seen: nextSeen,
+			});
+		}
+
+		if (isRecordSchema(resolved)) {
+			visit({
+				schema: resolved.additionalProperties as JsonSchema,
+				fixturePath: `${fixturePath}.*`,
+				collection,
+				wirePath,
+				seen: nextSeen,
+			});
+			return;
+		}
+
+		for (const [wireKey, property] of Object.entries(
+			resolved.properties ?? {},
+		)) {
+			if (isInternalField({ overlay, wireKey, schema: property })) continue;
+			const childWirePath = wirePath ? `${wirePath}.${wireKey}` : wireKey;
+			if (collection && isHidden({ overlay, collection, path: childWirePath }))
+				continue;
+
+			const childFixturePath = fixturePath
+				? `${fixturePath}.${toCamelCase(wireKey)}`
+				: toCamelCase(wireKey);
+			const resolvedProperty =
+				resolveRef({ schema: property, root }) ?? property;
+
+			const values = paths.get(childFixturePath) ?? new Set<string>();
+			for (const value of enumValuesOf(resolvedProperty)) values.add(value);
+			paths.set(childFixturePath, values);
+
+			// Entering a fresh top-level collection resets the item-relative wire
+			// path, matching the overlay's FieldPath convention.
+			visit({
+				schema: property,
+				fixturePath: childFixturePath,
+				collection: fixturePath === "" ? wireKey : collection,
+				wirePath: fixturePath === "" ? "" : childWirePath,
+				seen: nextSeen,
+			});
+		}
+	};
+
+	visit({
+		schema,
+		fixturePath: "",
+		collection: "",
+		wirePath: "",
+		seen: new Set(),
+	});
+
+	return paths;
+};

--- a/packages/atmn-generator/src/lint/rules/define.ts
+++ b/packages/atmn-generator/src/lint/rules/define.ts
@@ -48,3 +48,15 @@ export const compare = (rule: RuleOf<"compare">): LintRule => ({
 	kind: "compare",
 	...rule,
 });
+
+/** `field` must equal `mustBe` when `when` is `equals`. */
+export const valueWhen = (rule: RuleOf<"valueWhen">): LintRule => ({
+	kind: "valueWhen",
+	...rule,
+});
+
+/** `field` names a row of top-level collection `in`; that row's `target` must equal `equals`. */
+export const targetHas = (rule: RuleOf<"targetHas">): LintRule => ({
+	kind: "targetHas",
+	...rule,
+});

--- a/packages/atmn-generator/src/lint/rules/plans.ts
+++ b/packages/atmn-generator/src/lint/rules/plans.ts
@@ -1,5 +1,5 @@
 import type { LintRule } from "../runtime/lintDocument";
-import { exists } from "./define";
+import { exists, targetHas, valueWhen } from "./define";
 
 export const planItemRules: LintRule[] = [
 	exists({
@@ -7,5 +7,25 @@ export const planItemRules: LintRule[] = [
 		in: "features",
 		matching: "featureId",
 		because: "A plan item meters a feature this config does not declare.",
+	}),
+	targetHas({
+		when: "featureOverride",
+		field: "featureId",
+		in: "features",
+		matching: "featureId",
+		target: "type",
+		equals: "credit_system",
+		because:
+			"featureOverride is only honoured on classic credit-system features.",
+	}),
+];
+
+export const planItemPriceRules: LintRule[] = [
+	valueWhen({
+		when: "tierBehavior",
+		equals: "volume",
+		field: "billingMethod",
+		mustBe: "prepaid",
+		because: "Volume tiers are prepaid-only.",
 	}),
 ];

--- a/packages/atmn-generator/src/lint/rules/registry.ts
+++ b/packages/atmn-generator/src/lint/rules/registry.ts
@@ -1,6 +1,6 @@
 import type { LintRule } from "../runtime/lintDocument";
 import { featureRules } from "./features";
-import { planItemRules } from "./plans";
+import { planItemPriceRules, planItemRules } from "./plans";
 
 /**
  * Hand-written rules and names, keyed by fixture path with array indices
@@ -19,5 +19,6 @@ export const LINT_REGISTRY: Record<string, RegistryEntry> = {
 	features: { label: "feature", idField: "featureId", rules: featureRules },
 	plans: { label: "plan", idField: "planId" },
 	"plans.items": { label: "item", idField: "featureId", rules: planItemRules },
+	"plans.items.price": { label: "price", rules: planItemPriceRules },
 	"plans.licenses": { label: "license", idField: "licensePlanId" },
 };

--- a/packages/atmn-generator/src/lint/runtime/lintDocument.ts
+++ b/packages/atmn-generator/src/lint/runtime/lintDocument.ts
@@ -87,6 +87,27 @@ export type LintRule =
 			readonly op: "<" | "<=" | ">" | ">=";
 			readonly than: string;
 			readonly because: string;
+	  }
+	| {
+			/** `field` must equal `mustBe` when `when` is `equals`. */
+			readonly kind: "valueWhen";
+			readonly when: string;
+			readonly equals: string;
+			readonly field: string;
+			readonly mustBe: string;
+			readonly because: string;
+	  }
+	| {
+			/** `field` names a row of top-level collection `in` by `matching`;
+			 * that row's `target` must equal `equals`. Skipped when `when` is unset. */
+			readonly kind: "targetHas";
+			readonly when: string;
+			readonly field: string;
+			readonly in: string;
+			readonly matching: string;
+			readonly target: string;
+			readonly equals: string;
+			readonly because: string;
 	  };
 
 /** The part of a node's rules that an anyOf/oneOf branch can override. */
@@ -370,6 +391,27 @@ const entryRuleFailures = ({
 				: [
 						`${rule.field} must be ${words} ${rule.than} — got ${a} and ${b}. ${rule.because}`,
 					];
+		}
+		case "valueWhen": {
+			if (entry[rule.when] !== rule.equals) return [];
+			const value = entry[rule.field];
+			if (value === undefined || value === rule.mustBe) return [];
+			return [
+				`${rule.field} must be ${show(rule.mustBe)} when ${rule.when} is ${show(rule.equals)}. ${rule.because}`,
+			];
+		}
+		case "targetHas": {
+			if (entry[rule.when] === undefined) return [];
+			const target = document[rule.in];
+			if (!Array.isArray(target)) return [];
+			const row = target.find(
+				(candidate) =>
+					isEntry(candidate) && candidate[rule.matching] === entry[rule.field],
+			);
+			if (!row || row[rule.target] === rule.equals) return [];
+			return [
+				`${rule.when} needs ${rule.in} ${show(entry[rule.field])} to have ${rule.target} ${show(rule.equals)} — got ${show(row[rule.target])}. ${rule.because}`,
+			];
 		}
 		case "unique":
 			return [];

--- a/packages/atmn-generator/src/lint/validateRegistry.ts
+++ b/packages/atmn-generator/src/lint/validateRegistry.ts
@@ -24,6 +24,10 @@ const fieldsNamedBy = (rule: LintRule): string[] => {
 			return [rule.field];
 		case "compare":
 			return [rule.field, rule.than];
+		case "valueWhen":
+			return [rule.when, rule.field];
+		case "targetHas":
+			return [rule.when, rule.field];
 	}
 };
 
@@ -79,6 +83,30 @@ export const validateRegistry = ({
 				if (!targetFields?.has(rule.matching)) {
 					problems.push(
 						`"${path}": exists rule matches on "${rule.in}.${rule.matching}", which is not a field there.`,
+					);
+				}
+			}
+			if (rule.kind === "targetHas") {
+				if (!topLevel.has(rule.in)) {
+					problems.push(
+						`"${path}": targetHas rule points at "${rule.in}", which is not a top-level collection.`,
+					);
+					continue;
+				}
+				const targetFields = fieldsAtPath({
+					schema,
+					root,
+					path: rule.in,
+					overlay,
+				});
+				if (!targetFields?.has(rule.matching)) {
+					problems.push(
+						`"${path}": targetHas rule matches on "${rule.in}.${rule.matching}", which is not a field there.`,
+					);
+				}
+				if (!targetFields?.has(rule.target)) {
+					problems.push(
+						`"${path}": targetHas rule targets "${rule.in}.${rule.target}", which is not a field there.`,
 					);
 				}
 			}

--- a/packages/atmn-generator/src/overlay/overlay.ts
+++ b/packages/atmn-generator/src/overlay/overlay.ts
@@ -62,6 +62,11 @@ export const OVERLAY: Overlay = {
 			},
 		},
 		features: {
+			new_feature_id: {
+				hidden: true,
+				reason:
+					"Dead since internal_id: a changed featureId beside it is the rename.",
+			},
 			invoice_credit: {
 				hidden: true,
 				reason:

--- a/packages/atmn-generator/test/fixtureKeys.test.ts
+++ b/packages/atmn-generator/test/fixtureKeys.test.ts
@@ -61,11 +61,12 @@ test("overlay and spec-order rules hold for features", () => {
 		"modelMarkups",
 		"processors",
 		"archived",
-		"newFeatureId",
 	]) {
 		expect(keys).toContain(expected);
 	}
 	expect(keys).not.toContain("eventNames");
+	// Dead since internal_id: a changed featureId is the rename.
+	expect(keys).not.toContain("newFeatureId");
 	// Spec order across the allOf branches, not alphabetical.
 	expect(keys.indexOf("name")).toBeLessThan(keys.indexOf("featureId"));
 	expect(keys.indexOf("featureId")).toBeLessThan(keys.indexOf("processors"));

--- a/packages/atmn-generator/test/fuzz.test.ts
+++ b/packages/atmn-generator/test/fuzz.test.ts
@@ -1,0 +1,108 @@
+/**
+ * What the fuzz coverage tools produce. The first block is synthetic so the
+ * numbers are exact and legible; the second reads the REAL spec, since a test
+ * against an invented schema can pass while the real shape differs.
+ */
+
+import { expect, test } from "bun:test";
+import type { JsonSchema } from "../src/casing/schemaKeyCasing";
+import type { CoverageReport } from "../src/fuzz/coverageReport";
+import {
+	coverageReport,
+	formatCoverageReport,
+} from "../src/fuzz/coverageReport";
+import { documentPaths } from "../src/fuzz/documentPaths";
+import { schemaPaths } from "../src/fuzz/schemaPaths";
+import { OVERLAY } from "../src/overlay/overlay";
+import { catalogUpdateSchema, loadSpec } from "../src/spec/loadSpec";
+
+const EMPTY_OVERLAY = { collections: {}, exposeInternal: [] };
+
+const syntheticSchema: JsonSchema = {
+	type: "object",
+	properties: {
+		things: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					id: { type: "string" },
+					status: { type: "string", enum: ["active", "archived"] },
+				},
+			},
+		},
+	},
+};
+
+test("a synthetic schema: three paths, one enum, a document touching two", () => {
+	const schema = schemaPaths({
+		schema: syntheticSchema,
+		root: {},
+		overlay: EMPTY_OVERLAY,
+	});
+	expect([...schema.keys()].sort()).toEqual([
+		"things",
+		"things.id",
+		"things.status",
+	]);
+	expect([...(schema.get("things.status") ?? [])]).toEqual([
+		"active",
+		"archived",
+	]);
+
+	const document = documentPaths({ document: { things: [{ id: "abc" }] } });
+	const report = coverageReport({ schema, document, collection: "things" });
+
+	expect(report.total).toBe(3);
+	expect(report.touched).toBe(2);
+	expect(report.percent).toBe(67);
+	expect(report.untouched).toEqual(["things.status"]);
+	expect(report.unusedEnumValues).toEqual([
+		"things.status = active",
+		"things.status = archived",
+	]);
+
+	expect(formatCoverageReport({ report, collection: "things" })).toStartWith(
+		"things: 2/3 paths touched (67%)",
+	);
+});
+
+test("formatCoverageReport caps each section at 40 lines with a +N more tail", () => {
+	const untouched = Array.from(
+		{ length: 45 },
+		(_, index) => `things.field${index}`,
+	);
+	const report: CoverageReport = {
+		total: 45,
+		touched: 0,
+		percent: 0,
+		untouched,
+		unusedEnumValues: [],
+	};
+
+	const lines = formatCoverageReport({ report, collection: "things" }).split(
+		"\n",
+	);
+	expect(
+		lines.filter((line) => line.startsWith("    things.field")).length,
+	).toBe(40);
+	expect(lines.at(-1)).toBe("    +5 more");
+});
+
+const spec = loadSpec();
+const root = spec as unknown as JsonSchema;
+const realSchema = schemaPaths({
+	schema: catalogUpdateSchema({ spec }),
+	root,
+	overlay: OVERLAY,
+});
+
+test("the real spec: plans exposes tierBehavior but hides versioning and priceId", () => {
+	expect(
+		[...(realSchema.get("plans.items.price.tierBehavior") ?? [])].sort(),
+	).toEqual(["graduated", "volume"]);
+	// Overlay-hidden: the server derives it from the rows, so a config can't set it.
+	expect(realSchema.has("plans.versioning")).toBe(false);
+	// x-internal: a server-owned id, never a fixture field.
+	expect(realSchema.has("plans.items.priceId")).toBe(false);
+});

--- a/packages/atmn-generator/test/lintRuntime.test.ts
+++ b/packages/atmn-generator/test/lintRuntime.test.ts
@@ -255,6 +255,81 @@ test("exists checks a present collection and skips an absent one", () => {
 	expect(messagesWith({ rules, entry, document: {} })).toEqual([]);
 });
 
+test("valueWhen", () => {
+	const rules = [
+		{
+			kind: "valueWhen" as const,
+			when: "tierBehavior",
+			equals: "volume",
+			field: "billingMethod",
+			mustBe: "prepaid",
+			because: "Because.",
+		},
+	];
+	expect(messagesWith({ rules, entry: { tierBehavior: "graduated" } })).toEqual(
+		[],
+	);
+	expect(
+		messagesWith({
+			rules,
+			entry: { tierBehavior: "volume", billingMethod: "prepaid" },
+		}),
+	).toEqual([]);
+	expect(messagesWith({ rules, entry: { tierBehavior: "volume" } })).toEqual(
+		[],
+	);
+	expect(
+		messagesWith({
+			rules,
+			entry: { tierBehavior: "volume", billingMethod: "usage_based" },
+		}),
+	).toEqual([
+		'billingMethod must be "prepaid" when tierBehavior is "volume". Because.',
+	]);
+});
+
+test("targetHas checks a present collection, skips an absent one or an unmatched row", () => {
+	const rules = [
+		{
+			kind: "targetHas" as const,
+			when: "featureOverride",
+			field: "featureId",
+			in: "features",
+			matching: "featureId",
+			target: "type",
+			equals: "credit_system",
+			because: "Because.",
+		},
+	];
+	const entry = { featureId: "seats", featureOverride: {} };
+	expect(messagesWith({ rules, entry: { featureId: "seats" } })).toEqual([]);
+	expect(
+		messagesWith({
+			rules,
+			entry,
+			document: { features: [{ featureId: "seats", type: "credit_system" }] },
+		}),
+	).toEqual([]);
+	// Omitted means "not mine": the exists rule owns unmatched references.
+	expect(messagesWith({ rules, entry, document: {} })).toEqual([]);
+	expect(
+		messagesWith({
+			rules,
+			entry,
+			document: { features: [{ featureId: "other", type: "metered" }] },
+		}),
+	).toEqual([]);
+	expect(
+		messagesWith({
+			rules,
+			entry,
+			document: { features: [{ featureId: "seats", type: "metered" }] },
+		}),
+	).toEqual([
+		'featureOverride needs features "seats" to have type "credit_system" — got "metered". Because.',
+	]);
+});
+
 test("compare", () => {
 	const rules = [
 		{

--- a/packages/atmn-nightly/src/actions/push.ts
+++ b/packages/atmn-nightly/src/actions/push.ts
@@ -8,6 +8,7 @@ import {
 	renderPreview,
 } from "../render/renderPreview";
 import { findRepoLayout } from "../repo/findRepoRoot";
+import { backfillInternalIds } from "./push/backfillInternalIds";
 
 export type PushResult = {
 	configPath: string;
@@ -65,6 +66,7 @@ export const runPush = async ({
 
 	const applied = (await client.update(wire as Record<string, unknown>)) as {
 		migrations?: { id?: string }[];
+		results?: Record<string, unknown>;
 	};
 
 	const migrationIds = (applied.migrations ?? [])
@@ -72,6 +74,16 @@ export const runPush = async ({
 		.filter((id): id is string => typeof id === "string");
 
 	write("\nApplied.\n");
+
+	const { backfilled } = backfillInternalIds({
+		results: applied.results ?? {},
+		configPath,
+	});
+	if (backfilled.length > 0) {
+		write(
+			`Wrote internalId into ${backfilled.length} fixture${backfilled.length === 1 ? "" : "s"}.\n`,
+		);
+	}
 
 	return { configPath, preview, applied, migrationIds };
 };

--- a/packages/atmn-nightly/src/actions/push/backfillInternalIds.ts
+++ b/packages/atmn-nightly/src/actions/push/backfillInternalIds.ts
@@ -1,0 +1,66 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { COLLECTIONS } from "../../generated/emit";
+import { insertFirstProperty } from "../../surgery/insertFirstProperty";
+import { listSourceFiles } from "../pull/listSourceFiles";
+import { locateFixture } from "../pull/locateFixture";
+
+type AppliedRow = { id?: string; internalId?: string | null; action?: string };
+
+const HAS_INTERNAL_ID = /\binternalId\s*:/;
+
+/**
+ * After apply, each created row's minted id is written into its fixture, so
+ * the next push addresses the row by identity and a changed public id is a
+ * rename rather than a delete and a create.
+ */
+export const backfillInternalIds = ({
+	results,
+	configPath,
+}: {
+	results: Record<string, unknown>;
+	configPath: string;
+}): { backfilled: string[] } => {
+	const files = new Map<string, string>();
+	files.set(configPath, readFileSync(configPath, "utf8"));
+	for (const file of listSourceFiles({ directory: dirname(configPath) })) {
+		if (!files.has(file)) files.set(file, readFileSync(file, "utf8"));
+	}
+	const originals = new Map(files);
+	const backfilled: string[] = [];
+
+	for (const [collection, spec] of Object.entries(COLLECTIONS)) {
+		const rows = results[collection];
+		if (!Array.isArray(rows)) continue;
+		for (const row of rows as AppliedRow[]) {
+			if (row.action !== "create") continue;
+			if (typeof row.id !== "string" || typeof row.internalId !== "string")
+				continue;
+			const located = locateFixture({
+				configPath,
+				files,
+				builder: spec.builder,
+				idField: spec.idField,
+				id: row.id,
+			});
+			// Not a plain literal: the row still matches by public id next push.
+			if (located === null || HAS_INTERNAL_ID.test(located.node.text()))
+				continue;
+			const updated = insertFirstProperty({
+				source: located.source,
+				builder: spec.builder,
+				idField: spec.idField,
+				id: row.id,
+				property: `internalId: ${JSON.stringify(row.internalId)}`,
+			});
+			if (updated === null) continue;
+			files.set(located.file, updated);
+			backfilled.push(row.id);
+		}
+	}
+
+	for (const [file, source] of files) {
+		if (source !== originals.get(file)) writeFileSync(file, source, "utf8");
+	}
+	return { backfilled };
+};

--- a/packages/atmn-nightly/src/generated/client.ts
+++ b/packages/atmn-nightly/src/generated/client.ts
@@ -71,6 +71,8 @@ const post = async ({
 export type PreviewUpdateCatalogResponse = {
 	plans: Array<{
 		planId: string;
+		/** Stable id of this row; null when the row is minted by this update. */
+		internalId: string | null;
 		/** Present only when this row's public plan id changes. */
 		newPlanId?: string;
 		version: number;
@@ -1423,6 +1425,8 @@ export type PreviewUpdateCatalogResponse = {
 		/** Other existing versions of this plan. Each may carry `license_parents` for links that still point at that version. Omitted when there are none, or when more than one entry in this update targets the same plan (`all_versions` is unavailable then). */
 		siblingVersions?: Array<{
 			planId: string;
+			/** Stable id of this row; null when the row is minted by this update. */
+			internalId: string | null;
 			/** Present only when this row's public plan id changes. */
 			newPlanId?: string;
 			version: number;
@@ -2319,6 +2323,8 @@ export type PreviewUpdateCatalogResponse = {
 			/** Parents whose planLicense still points at this sibling version. Omitted when none do, or when this version is itself a direct `plans[]` entry. */
 			licenseParents?: Array<{
 				planId: string;
+				/** Stable id of this row; null when the row is minted by this update. */
+				internalId: string | null;
 				/** Present only when this row's public plan id changes. */
 				newPlanId?: string;
 				version: number;
@@ -2696,6 +2702,8 @@ export type PreviewUpdateCatalogResponse = {
 				/** Other existing versions of this parent that offer the child. Omitted when only the latest version is linked. */
 				siblingVersions?: Array<{
 					planId: string;
+					/** Stable id of this row; null when the row is minted by this update. */
+					internalId: string | null;
 					/** Present only when this row's public plan id changes. */
 					newPlanId?: string;
 					version: number;
@@ -2780,6 +2788,8 @@ export type PreviewUpdateCatalogResponse = {
 			/** Variant rows anchored to this sibling version. Only present on `all_versions` edits, where each sibling receives its own follow diff. */
 			variants?: Array<{
 				planId: string;
+				/** Stable id of this row; null when the row is minted by this update. */
+				internalId: string | null;
 				/** Present only when this row's public plan id changes. */
 				newPlanId?: string;
 				version: number;
@@ -3155,6 +3165,8 @@ export type PreviewUpdateCatalogResponse = {
 				/** Other existing versions of this variant that could receive the base edit. Each version reports whether it is unchanged, propagated, or explicit. */
 				siblingVersions?: Array<{
 					planId: string;
+					/** Stable id of this row; null when the row is minted by this update. */
+					internalId: string | null;
 					/** Present only when this row's public plan id changes. */
 					newPlanId?: string;
 					version: number;
@@ -3247,6 +3259,8 @@ export type PreviewUpdateCatalogResponse = {
 		/** Parents whose planLicense currently points at this version row, and how each resolves against this entry's change. Omitted when none do. */
 		licenseParents?: Array<{
 			planId: string;
+			/** Stable id of this row; null when the row is minted by this update. */
+			internalId: string | null;
 			/** Present only when this row's public plan id changes. */
 			newPlanId?: string;
 			version: number;
@@ -4157,6 +4171,8 @@ export type PreviewUpdateCatalogResponse = {
 			/** Other existing versions of this parent that offer the child. Omitted when only the latest version is linked. */
 			siblingVersions?: Array<{
 				planId: string;
+				/** Stable id of this row; null when the row is minted by this update. */
+				internalId: string | null;
 				/** Present only when this row's public plan id changes. */
 				newPlanId?: string;
 				version: number;
@@ -4524,6 +4540,8 @@ export type PreviewUpdateCatalogResponse = {
 		/** Variants of this plan and how each resolved against this entry's change. Omitted when the plan has none. */
 		variants?: Array<{
 			planId: string;
+			/** Stable id of this row; null when the row is minted by this update. */
+			internalId: string | null;
 			/** Present only when this row's public plan id changes. */
 			newPlanId?: string;
 			version: number;
@@ -5432,6 +5450,8 @@ export type PreviewUpdateCatalogResponse = {
 			/** Other existing versions of this variant that could receive the base edit. Each version reports whether it is unchanged, propagated, or explicit. */
 			siblingVersions?: Array<{
 				planId: string;
+				/** Stable id of this row; null when the row is minted by this update. */
+				internalId: string | null;
 				/** Present only when this row's public plan id changes. */
 				newPlanId?: string;
 				version: number;
@@ -5971,6 +5991,8 @@ export type PreviewUpdateCatalogResponse = {
 	}>;
 	features: Array<{
 		featureId: string;
+		/** Stable id of the row this preview is about; on create, the id the row will receive. */
+		internalId: string | null;
 		name?: string;
 		/** What would happen to this resource: created, updated, deleted (or archived — see will_archive), explicitly skipped, or unchanged. For plans this is per plan_id, not per version — minting a new version of a live plan is `update`, and `create` means the plan_id had no live version. */
 		action: "create" | "update" | "delete" | "skip" | "none";
@@ -7193,11 +7215,15 @@ export type UpdateCatalogResponse = {
 	results: {
 		plans: Array<{
 			id: string;
+			/** Stable id of the row this result is about (features today). */
+			internalId?: string | null;
 			/** What was actually applied, including 'skip' and 'none'. */
 			action: "create" | "update" | "delete" | "skip" | "none";
 		}>;
 		features: Array<{
 			id: string;
+			/** Stable id of the row this result is about (features today). */
+			internalId?: string | null;
 			/** What was actually applied, including 'skip' and 'none'. */
 			action: "create" | "update" | "delete" | "skip" | "none";
 		}>;

--- a/packages/atmn-nightly/src/generated/emit.ts
+++ b/packages/atmn-nightly/src/generated/emit.ts
@@ -18,6 +18,7 @@ export const COLLECTIONS: Readonly<Record<string, CollectionSpec>> = {
 			"defaultMarkup",
 			"providerMarkups",
 			"featureId",
+			"internalId",
 			"newFeatureId",
 			"archived",
 			"processors",

--- a/packages/atmn-nightly/src/generated/emit.ts
+++ b/packages/atmn-nightly/src/generated/emit.ts
@@ -19,7 +19,6 @@ export const COLLECTIONS: Readonly<Record<string, CollectionSpec>> = {
 			"providerMarkups",
 			"featureId",
 			"internalId",
-			"newFeatureId",
 			"archived",
 			"processors",
 		],

--- a/packages/atmn-nightly/src/generated/features.ts
+++ b/packages/atmn-nightly/src/generated/features.ts
@@ -60,8 +60,6 @@ export type Feature = {
 } & {
 	/** Address an existing feature by its stable id. Omit when creating — the server generates one. A differing feature_id alongside it is a rename. */
 	internalId?: string;
-	/** Rename the feature to this id. */
-	newFeatureId?: string;
 	/** Archive or unarchive the feature. Omit to leave archived state unchanged. */
 	archived?: boolean;
 	/** Processor mappings for this feature. Omit keeps the current Stripe product and meter. */

--- a/packages/atmn-nightly/src/generated/features.ts
+++ b/packages/atmn-nightly/src/generated/features.ts
@@ -58,6 +58,8 @@ export type Feature = {
 	/** The ID of the feature to create. */
 	featureId: string;
 } & {
+	/** Address an existing feature by its stable id. Omit when creating — the server generates one. A differing feature_id alongside it is a rename. */
+	internalId?: string;
 	/** Rename the feature to this id. */
 	newFeatureId?: string;
 	/** Archive or unarchive the feature. Omit to leave archived state unchanged. */

--- a/packages/atmn-nightly/src/generated/lintRules.ts
+++ b/packages/atmn-nightly/src/generated/lintRules.ts
@@ -14,6 +14,9 @@ export const LINT_RULES: LintRules = {
 			defaultMarkup: {
 				minimum: -100,
 			},
+			internalId: {
+				minLength: 1,
+			},
 		},
 		rules: [
 			{

--- a/packages/atmn-nightly/src/generated/lintRules.ts
+++ b/packages/atmn-nightly/src/generated/lintRules.ts
@@ -257,6 +257,17 @@ export const LINT_RULES: LintRules = {
 				matching: "featureId",
 				because: "A plan item meters a feature this config does not declare.",
 			},
+			{
+				kind: "targetHas",
+				when: "featureOverride",
+				field: "featureId",
+				in: "features",
+				matching: "featureId",
+				target: "type",
+				equals: "credit_system",
+				because:
+					"featureOverride is only honoured on classic credit-system features.",
+			},
 		],
 	},
 	"plans.items.featureOverride.creditSchema": {
@@ -298,6 +309,7 @@ export const LINT_RULES: LintRules = {
 		},
 	},
 	"plans.items.price": {
+		label: "price",
 		required: ["billingMethod", "interval"],
 		fields: {
 			tierBehavior: {
@@ -310,6 +322,16 @@ export const LINT_RULES: LintRules = {
 				enum: ["prepaid", "usage_based"],
 			},
 		},
+		rules: [
+			{
+				kind: "valueWhen",
+				when: "tierBehavior",
+				equals: "volume",
+				field: "billingMethod",
+				mustBe: "prepaid",
+				because: "Volume tiers are prepaid-only.",
+			},
+		],
 	},
 	"plans.items.price.additionalCurrencies": {
 		required: ["amount", "currency"],

--- a/packages/atmn-nightly/src/generated/lintRuntime.ts
+++ b/packages/atmn-nightly/src/generated/lintRuntime.ts
@@ -90,6 +90,27 @@ export type LintRule =
 			readonly op: "<" | "<=" | ">" | ">=";
 			readonly than: string;
 			readonly because: string;
+	  }
+	| {
+			/** `field` must equal `mustBe` when `when` is `equals`. */
+			readonly kind: "valueWhen";
+			readonly when: string;
+			readonly equals: string;
+			readonly field: string;
+			readonly mustBe: string;
+			readonly because: string;
+	  }
+	| {
+			/** `field` names a row of top-level collection `in` by `matching`;
+			 * that row's `target` must equal `equals`. Skipped when `when` is unset. */
+			readonly kind: "targetHas";
+			readonly when: string;
+			readonly field: string;
+			readonly in: string;
+			readonly matching: string;
+			readonly target: string;
+			readonly equals: string;
+			readonly because: string;
 	  };
 
 /** The part of a node's rules that an anyOf/oneOf branch can override. */
@@ -373,6 +394,27 @@ const entryRuleFailures = ({
 				: [
 						`${rule.field} must be ${words} ${rule.than} — got ${a} and ${b}. ${rule.because}`,
 					];
+		}
+		case "valueWhen": {
+			if (entry[rule.when] !== rule.equals) return [];
+			const value = entry[rule.field];
+			if (value === undefined || value === rule.mustBe) return [];
+			return [
+				`${rule.field} must be ${show(rule.mustBe)} when ${rule.when} is ${show(rule.equals)}. ${rule.because}`,
+			];
+		}
+		case "targetHas": {
+			if (entry[rule.when] === undefined) return [];
+			const target = document[rule.in];
+			if (!Array.isArray(target)) return [];
+			const row = target.find(
+				(candidate) =>
+					isEntry(candidate) && candidate[rule.matching] === entry[rule.field],
+			);
+			if (!row || row[rule.target] === rule.equals) return [];
+			return [
+				`${rule.when} needs ${rule.in} ${show(entry[rule.field])} to have ${rule.target} ${show(rule.equals)} — got ${show(row[rule.target])}. ${rule.because}`,
+			];
 		}
 		case "unique":
 			return [];

--- a/packages/atmn-nightly/test/backfill.test.ts
+++ b/packages/atmn-nightly/test/backfill.test.ts
@@ -1,0 +1,82 @@
+/**
+ * After a push applies, the minted internal ids land in the fixtures that
+ * created them — the config-side half of addressing rows by identity.
+ */
+
+import { expect, test } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { runPush } from "../src/actions/push";
+
+const dir = `${import.meta.dir}/.tmp/backfill`;
+
+const config = [
+	'import { feature } from "../../../src/generated/features";',
+	'import { atmn } from "../../../src/generated/wire";',
+	'import { seats } from "./features";',
+	"",
+	"export default atmn({",
+	"\tfeatures: [",
+	"\t\tseats,",
+	'\t\tfeature({ featureId: "messages", name: "Messages", type: "metered", consumable: true }),',
+	"\t],",
+	"});",
+	"",
+].join("\n");
+
+const featuresFile = [
+	'import { feature } from "../../../src/generated/features";',
+	"",
+	"export const seats = feature({",
+	'\tfeatureId: "seats",',
+	'\tname: "Seats",',
+	'\ttype: "boolean",',
+	"});",
+	"",
+].join("\n");
+
+const clientReturning = (results: Record<string, unknown>) => ({
+	previewUpdate: async () => ({
+		features: [
+			{ featureId: "seats", action: "create" },
+			{ featureId: "messages", action: "create" },
+		],
+		plans: [],
+	}),
+	update: async () => ({ results, migrations: [] }),
+	get: async () => ({ features: [], plans: [] }),
+});
+
+test("a push writes the minted internalId into each created fixture, once", async () => {
+	rmSync(dir, { recursive: true, force: true });
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(`${dir}/autumn.config.ts`, config, "utf8");
+	writeFileSync(`${dir}/features.ts`, featuresFile, "utf8");
+	const client = clientReturning({
+		features: [
+			{ id: "seats", internalId: "fe_seats", action: "create" },
+			{ id: "messages", internalId: "fe_messages", action: "create" },
+		],
+		plans: [],
+	});
+	const printed: string[] = [];
+	// biome-ignore lint/suspicious/noExplicitAny: a fake client
+	await runPush({
+		client: client as any,
+		cwd: dir,
+		write: (text) => printed.push(text),
+	});
+
+	expect(readFileSync(`${dir}/features.ts`, "utf8")).toContain(
+		'feature({\n\tinternalId: "fe_seats",\n\tfeatureId: "seats",',
+	);
+	expect(readFileSync(`${dir}/autumn.config.ts`, "utf8")).toContain(
+		'feature({ internalId: "fe_messages", featureId: "messages",',
+	);
+	expect(printed.join("")).toContain("Wrote internalId into 2 fixtures.");
+
+	// A second apply reporting the same creates must not write a second id.
+	const before = readFileSync(`${dir}/features.ts`, "utf8");
+	// biome-ignore lint/suspicious/noExplicitAny: a fake client
+	await runPush({ client: client as any, cwd: dir, write: () => {} });
+	expect(readFileSync(`${dir}/features.ts`, "utf8")).toBe(before);
+});

--- a/packages/atmn-nightly/test/plans.test.ts
+++ b/packages/atmn-nightly/test/plans.test.ts
@@ -89,3 +89,81 @@ test("with features omitted, item references are not checked: absent means not m
 		atmn({ plans: [plan({ planId: "pro", items: [{ featureId: "ghost" }] })] }),
 	).not.toThrow();
 });
+
+test("a volume-tiered item price must be prepaid", () => {
+	const issues = issuesOf(() =>
+		atmn({
+			features: [
+				feature({
+					featureId: "api",
+					name: "API calls",
+					type: "metered",
+					consumable: true,
+				}),
+			],
+			plans: [
+				plan({
+					planId: "pro",
+					items: [
+						{
+							featureId: "api",
+							price: {
+								billingMethod: "usage_based",
+								tierBehavior: "volume",
+								tiers: [{ to: "inf", amount: 1 }],
+								interval: "month",
+							},
+						},
+					],
+				}),
+			],
+		}),
+	);
+	expect(issues).toEqual([
+		{
+			path: 'plan "pro" › item "api" › price',
+			message:
+				'billingMethod must be "prepaid" when tierBehavior is "volume". Volume tiers are prepaid-only.',
+		},
+	]);
+});
+
+test("featureOverride is only honoured on classic credit-system features", () => {
+	const items = [
+		{ featureId: "credits", featureOverride: { creditSchema: [] } },
+	];
+
+	const withMetered = issuesOf(() =>
+		atmn({
+			features: [
+				feature({
+					featureId: "credits",
+					name: "Credits",
+					type: "metered",
+					consumable: true,
+				}),
+			],
+			plans: [plan({ planId: "pro", items })],
+		}),
+	);
+	expect(withMetered).toEqual([
+		{
+			path: 'plan "pro" › item "credits"',
+			message:
+				'featureOverride needs features "credits" to have type "credit_system" — got "metered". featureOverride is only honoured on classic credit-system features.',
+		},
+	]);
+
+	expect(() =>
+		atmn({
+			features: [
+				feature({
+					featureId: "credits",
+					name: "Credits",
+					type: "credit_system",
+				}),
+			],
+			plans: [plan({ planId: "pro", items })],
+		}),
+	).not.toThrow();
+});

--- a/packages/openapi/openapi-internal.yml
+++ b/packages/openapi/openapi-internal.yml
@@ -53212,6 +53212,12 @@ paths:
                           - feature_id
                       - type: object
                         properties:
+                          internal_id:
+                            type: string
+                            minLength: 1
+                            description: Address an existing feature by its stable id. Omit when creating —
+                              the server generates one. A differing feature_id
+                              alongside it is a rename.
                           new_feature_id:
                             type: string
                             description: Rename the feature to this id.
@@ -55600,6 +55606,11 @@ paths:
                       properties:
                         plan_id:
                           type: string
+                        internal_id:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                          description: Stable id of this row; null when the row is minted by this update.
                         new_plan_id:
                           type: string
                           description: Present only when this row's public plan id changes.
@@ -59002,6 +59013,11 @@ paths:
                             properties:
                               plan_id:
                                 type: string
+                              internal_id:
+                                anyOf:
+                                  - type: string
+                                  - type: "null"
+                                description: Stable id of this row; null when the row is minted by this update.
                               new_plan_id:
                                 type: string
                                 description: Present only when this row's public plan id changes.
@@ -61225,6 +61241,11 @@ paths:
                                   properties:
                                     plan_id:
                                       type: string
+                                    internal_id:
+                                      anyOf:
+                                        - type: string
+                                        - type: "null"
+                                      description: Stable id of this row; null when the row is minted by this update.
                                     new_plan_id:
                                       type: string
                                       description: Present only when this row's public plan id changes.
@@ -62192,6 +62213,11 @@ paths:
                                         properties:
                                           plan_id:
                                             type: string
+                                          internal_id:
+                                            anyOf:
+                                              - type: string
+                                              - type: "null"
+                                            description: Stable id of this row; null when the row is minted by this update.
                                           new_plan_id:
                                             type: string
                                             description: Present only when this row's public plan id changes.
@@ -62338,6 +62364,7 @@ paths:
                                             description: How this parent version treated the child edit.
                                         required:
                                           - plan_id
+                                          - internal_id
                                           - version
                                           - version_slug
                                           - active
@@ -62347,6 +62374,7 @@ paths:
                                         linked.
                                   required:
                                     - plan_id
+                                    - internal_id
                                     - version
                                     - version_slug
                                     - active
@@ -62362,6 +62390,11 @@ paths:
                                   properties:
                                     plan_id:
                                       type: string
+                                    internal_id:
+                                      anyOf:
+                                        - type: string
+                                        - type: "null"
+                                      description: Stable id of this row; null when the row is minted by this update.
                                     new_plan_id:
                                       type: string
                                       description: Present only when this row's public plan id changes.
@@ -63325,6 +63358,11 @@ paths:
                                         properties:
                                           plan_id:
                                             type: string
+                                          internal_id:
+                                            anyOf:
+                                              - type: string
+                                              - type: "null"
+                                            description: Stable id of this row; null when the row is minted by this update.
                                           new_plan_id:
                                             type: string
                                             description: Present only when this row's public plan id changes.
@@ -63471,6 +63509,7 @@ paths:
                                             description: How this variant version treated the base edit.
                                         required:
                                           - plan_id
+                                          - internal_id
                                           - version
                                           - version_slug
                                           - active
@@ -63494,6 +63533,7 @@ paths:
                                         the id is free.
                                   required:
                                     - plan_id
+                                    - internal_id
                                     - version
                                     - version_slug
                                     - active
@@ -63503,6 +63543,7 @@ paths:
                                   receives its own follow diff.
                             required:
                               - plan_id
+                              - internal_id
                               - version
                               - version_slug
                               - active
@@ -63519,6 +63560,11 @@ paths:
                             properties:
                               plan_id:
                                 type: string
+                              internal_id:
+                                anyOf:
+                                  - type: string
+                                  - type: "null"
+                                description: Stable id of this row; null when the row is minted by this update.
                               new_plan_id:
                                 type: string
                                 description: Present only when this row's public plan id changes.
@@ -65791,6 +65837,11 @@ paths:
                                   properties:
                                     plan_id:
                                       type: string
+                                    internal_id:
+                                      anyOf:
+                                        - type: string
+                                        - type: "null"
+                                      description: Stable id of this row; null when the row is minted by this update.
                                     new_plan_id:
                                       type: string
                                       description: Present only when this row's public plan id changes.
@@ -66711,6 +66762,7 @@ paths:
                                       description: How this parent version treated the child edit.
                                   required:
                                     - plan_id
+                                    - internal_id
                                     - version
                                     - version_slug
                                     - active
@@ -66720,6 +66772,7 @@ paths:
                                   linked.
                             required:
                               - plan_id
+                              - internal_id
                               - version
                               - version_slug
                               - active
@@ -66735,6 +66788,11 @@ paths:
                             properties:
                               plan_id:
                                 type: string
+                              internal_id:
+                                anyOf:
+                                  - type: string
+                                  - type: "null"
+                                description: Stable id of this row; null when the row is minted by this update.
                               new_plan_id:
                                 type: string
                                 description: Present only when this row's public plan id changes.
@@ -69004,6 +69062,11 @@ paths:
                                   properties:
                                     plan_id:
                                       type: string
+                                    internal_id:
+                                      anyOf:
+                                        - type: string
+                                        - type: "null"
+                                      description: Stable id of this row; null when the row is minted by this update.
                                     new_plan_id:
                                       type: string
                                       description: Present only when this row's public plan id changes.
@@ -69923,6 +69986,7 @@ paths:
                                       description: How this variant version treated the base edit.
                                   required:
                                     - plan_id
+                                    - internal_id
                                     - version
                                     - version_slug
                                     - active
@@ -69946,6 +70010,7 @@ paths:
                                   the id is free.
                             required:
                               - plan_id
+                              - internal_id
                               - version
                               - version_slug
                               - active
@@ -70322,6 +70387,7 @@ paths:
                             free.
                       required:
                         - plan_id
+                        - internal_id
                         - version
                         - version_slug
                         - active
@@ -70335,6 +70401,12 @@ paths:
                       properties:
                         feature_id:
                           type: string
+                        internal_id:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                          description: Stable id of the row this preview is about; on create, the id the
+                            row will receive.
                         name:
                           type: string
                         action:
@@ -70498,6 +70570,7 @@ paths:
                             nothing changed or the feature is new.
                       required:
                         - feature_id
+                        - internal_id
                         - action
                         - state
                         - previous_attributes
@@ -72953,6 +73026,12 @@ paths:
                           - feature_id
                       - type: object
                         properties:
+                          internal_id:
+                            type: string
+                            minLength: 1
+                            description: Address an existing feature by its stable id. Omit when creating —
+                              the server generates one. A differing feature_id
+                              alongside it is a rename.
                           new_feature_id:
                             type: string
                             description: Rename the feature to this id.
@@ -75546,6 +75625,11 @@ paths:
                           properties:
                             id:
                               type: string
+                            internal_id:
+                              anyOf:
+                                - type: string
+                                - type: "null"
+                              description: Stable id of the row this result is about (features today).
                             action:
                               enum:
                                 - create
@@ -75565,6 +75649,11 @@ paths:
                           properties:
                             id:
                               type: string
+                            internal_id:
+                              anyOf:
+                                - type: string
+                                - type: "null"
+                              description: Stable id of the row this result is about (features today).
                             action:
                               enum:
                                 - create

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeInsertFeaturesPlan/computeInsertFeaturesPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeInsertFeaturesPlan/computeInsertFeaturesPlan.ts
@@ -43,7 +43,9 @@ export const computeInsertFeaturesPlan = ({
 
 	const entries = sortFeaturesForInsert(
 		(params.features ?? []).filter(
-			(featureParams) => !originalById.has(featureParams.feature_id),
+			(featureParams) =>
+				featureParams.internal_id === undefined &&
+				!originalById.has(featureParams.feature_id),
 		),
 	);
 
@@ -51,8 +53,9 @@ export const computeInsertFeaturesPlan = ({
 	let workingFeatures = [...projected.features];
 
 	for (const featureParams of entries) {
+		const { internal_id: _statedInternalId, ...apiFeature } = featureParams;
 		const dbFeature = featureV1ToDbFeature({
-			apiFeature: { id: featureParams.feature_id, ...featureParams },
+			apiFeature: { id: featureParams.feature_id, ...apiFeature },
 		});
 		const parsedFeature = validateFeature({
 			data: dbFeature,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveFeaturesPlan/resolveAbsenteeFeatureIds.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveFeaturesPlan/resolveAbsenteeFeatureIds.ts
@@ -1,14 +1,25 @@
 import { ErrCode, RecaseError, type UpdateCatalogParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { resolveCurrentFeature } from "../../utils/featureUpdateUtils/resolveCurrentFeature";
 
 /** Every feature id the payload speaks for — stated, removed, or skipped. */
 const statedFeatureIds = ({
+	ctx,
 	params,
 }: {
+	ctx: AutumnContext;
 	params: UpdateCatalogParams;
 }): Set<string> =>
 	new Set([
-		...(params.features ?? []).map((entry) => entry.feature_id),
+		...(params.features ?? []).flatMap((entry) => {
+			// A row addressed by internal_id is spoken for under its CURRENT id
+			// too, or renaming it would propose deleting the id it is leaving.
+			const current =
+				entry.internal_id === undefined
+					? null
+					: resolveCurrentFeature({ features: ctx.features, entry });
+			return current ? [entry.feature_id, current.id] : [entry.feature_id];
+		}),
 		...params.remove_features.map((entry) => entry.feature_id),
 		...params.skip_feature_ids,
 	]);
@@ -37,7 +48,7 @@ export const resolveAbsenteeFeatureIds = ({
 	// rule the legacy path already follows for rewards and referral programs.
 	if (params.features === undefined) return [];
 
-	const stated = statedFeatureIds({ params });
+	const stated = statedFeatureIds({ ctx, params });
 	return ctx.features
 		.filter((feature) => !stated.has(feature.id) && !feature.archived)
 		.map((feature) => feature.id);

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/features/buildFeaturesPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/features/buildFeaturesPreview.ts
@@ -27,6 +27,8 @@ export const buildFeaturesPreview = ({
 			});
 			return {
 				feature_id: feature.id,
+				// Minted per computation: a preview's id would not be the applied one.
+				internal_id: null,
 				name: feature.name,
 				action: "create" as const,
 				state: {
@@ -50,6 +52,7 @@ export const buildFeaturesPreview = ({
 			});
 			return {
 				feature_id: updateFeaturePlan.next.id,
+				internal_id: updateFeaturePlan.current.internal_id,
 				name: updateFeaturePlan.next.name,
 				action: updateFeaturePlan.previousAttributes
 					? ("update" as const)
@@ -71,6 +74,7 @@ export const buildFeaturesPreview = ({
 			});
 			return {
 				feature_id: removeFeaturePlan.featureId,
+				internal_id: removeFeaturePlan.current?.internal_id ?? null,
 				name: removeFeaturePlan.current?.name,
 				action: "delete" as const,
 				state: {

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity.ts
@@ -3,6 +3,7 @@ export const defaultVersionSlug = ({ version }: { version: number }) =>
 
 type IdentityProduct = {
 	id: string;
+	internal_id?: string | null;
 	version_slug?: string | null;
 	active: boolean;
 };
@@ -39,6 +40,7 @@ export const catalogRowIdentity = ({
 	next: IdentityProduct;
 }): {
 	plan_id: string;
+	internal_id: string | null;
 	version: number;
 	version_slug: string;
 	active: boolean;
@@ -52,6 +54,8 @@ export const catalogRowIdentity = ({
 
 	return {
 		plan_id: planId,
+		// A minted row's id is per computation; only an existing row's is stable.
+		internal_id: current?.internal_id ?? null,
 		version,
 		version_slug: versionSlug,
 		active: next.active,

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/resolveCurrentFeature.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/resolveCurrentFeature.ts
@@ -1,0 +1,37 @@
+import {
+	ErrCode,
+	type Feature,
+	RecaseError,
+	type UpdateCatalogFeatureParams,
+} from "@autumn/shared";
+
+/**
+ * The row a features[] entry addresses: by `internal_id` when stated (so a
+ * differing `feature_id` is a rename), else by `feature_id`. An unknown
+ * internal_id is a caller bug — minting under it would silently disconnect the
+ * config from the row it meant to address.
+ */
+export const resolveCurrentFeature = ({
+	features,
+	entry,
+}: {
+	features: Feature[];
+	entry: Pick<UpdateCatalogFeatureParams, "feature_id" | "internal_id">;
+}): Feature | null => {
+	if (entry.internal_id !== undefined) {
+		const byInternalId = features.find(
+			(candidate) => candidate.internal_id === entry.internal_id,
+		);
+		if (!byInternalId) {
+			throw new RecaseError({
+				code: ErrCode.InvalidRequest,
+				message: `No feature exists for internal_id ${entry.internal_id}`,
+				statusCode: 400,
+			});
+		}
+		return byInternalId;
+	}
+	return (
+		features.find((candidate) => candidate.id === entry.feature_id) ?? null
+	);
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/resolveFeatureUpdateEntry.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/resolveFeatureUpdateEntry.ts
@@ -3,6 +3,7 @@ import {
 	featureV1ToDbFeature,
 	type UpdateCatalogFeatureParams,
 } from "@autumn/shared";
+import { resolveCurrentFeature } from "./resolveCurrentFeature";
 
 /** A features[] entry matched to the feature it updates, resolved to its desired row. */
 export const resolveFeatureUpdateEntry = ({
@@ -12,13 +13,13 @@ export const resolveFeatureUpdateEntry = ({
 	features: Feature[];
 	entry: UpdateCatalogFeatureParams;
 }): { current: Feature; next: Feature } | null => {
-	const current = features.find(
-		(candidate) => candidate.id === entry.feature_id,
-	);
+	const current = resolveCurrentFeature({ features, entry });
 	if (!current) return null;
 
-	// Strip catalog-only fields so featureV1ToDbFeature doesn't see them.
-	const { new_feature_id, archived, ...createParams } = entry;
+	// Strip catalog-only fields so featureV1ToDbFeature doesn't see them. With
+	// internal_id matching, feature_id itself is the desired id — a rename when
+	// it differs from the row's current id.
+	const { new_feature_id, archived, internal_id, ...createParams } = entry;
 	const next = featureV1ToDbFeature({
 		apiFeature: {
 			id: new_feature_id ?? entry.feature_id,

--- a/server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts
+++ b/server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts
@@ -297,16 +297,19 @@ export const executeUpdateCatalogPlan = async ({
 		features: [
 			...updateCatalogPlan.insertFeatures.map((feature) => ({
 				id: feature.id,
+				internal_id: feature.internal_id,
 				action: "create" as const,
 			})),
 			...updateCatalogPlan.updateFeatures.map((updateFeaturePlan) => ({
 				id: updateFeaturePlan.next.id,
+				internal_id: updateFeaturePlan.current.internal_id,
 				action: updateFeaturePlan.previousAttributes
 					? ("update" as const)
 					: ("none" as const),
 			})),
 			...updateCatalogPlan.removeFeatures.map((removeFeaturePlan) => ({
 				id: removeFeaturePlan.featureId,
+				internal_id: removeFeaturePlan.current?.internal_id ?? null,
 				action: "delete" as const,
 			})),
 		],

--- a/server/tests/integration/atmn/push-migration-drafts.test.ts
+++ b/server/tests/integration/atmn/push-migration-drafts.test.ts
@@ -1,0 +1,129 @@
+/**
+ * atmn push — an in-place plan change drafts a migration for whoever is on it.
+ *
+ * Every push carries request-level `migration: { draft: true }` (a constant,
+ * not a decision — see plans/atmn-v3/02_flow.md). The server decides which
+ * rows actually warrant a draft: an in-place change to a plan with customers
+ * on it gets one, a plan with nobody on it doesn't.
+ *
+ * Contract:
+ *   M1  an in-place price change on a customered plan drafts a migration —
+ *       preview carries it, the applied result names it, and the row
+ *       persists as an undrafted (non-archived) migration
+ *   M2  the same change on a plan with no customers drafts nothing
+ */
+
+import { expect, test } from "bun:test";
+import {
+	atmnConfigSource,
+	initAtmnScenario,
+} from "@tests/utils/atmnUtils/initAtmnScenario.js";
+import { s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+import { runPush } from "../../../../packages/atmn-nightly/src/actions/push";
+import { createClient } from "../../../../packages/atmn-nightly/src/generated/client";
+import { seedVersionableCustomer } from "../catalog-v2/plans/migrations/utils/seedVersionableCustomer.js";
+import { uniqueTestId } from "../catalog-v2/utils/uniqueTestId.js";
+
+/** A feature plus a paid `pro` plan, one item, base price parameterized. */
+const catalogConfig = ({
+	featureId,
+	planId,
+	amount,
+}: {
+	featureId: string;
+	planId: string;
+	amount: number;
+}) => `{
+	features: [
+		feature({ featureId: "${featureId}", name: "Messages", type: "metered", consumable: true }),
+	],
+	plans: [
+		{
+			planId: "${planId}",
+			name: "Pro",
+			price: { amount: ${amount}, interval: "month" },
+			items: [{ featureId: "${featureId}", included: 100, reset: { interval: "month" } }],
+			createInStripe: false,
+		},
+	],
+}`;
+
+test.concurrent(
+	`${chalk.yellowBright("atmn push: an in-place price change drafts a migration for a customered plan")}`,
+	async () => {
+		const featureId = uniqueTestId("atmn_mig_msgs");
+		const planId = uniqueTestId("atmn_mig_pro");
+
+		const scenario = await initAtmnScenario({
+			setup: [
+				s.platform.create({ userEmail: `${uniqueTestId("atmn")}@autumn.test` }),
+			],
+			config: catalogConfig({ featureId, planId, amount: 20 }),
+		});
+
+		try {
+			await scenario.push();
+			await seedVersionableCustomer({ ctx: scenario.ctx, planId, version: 1 });
+
+			scenario.writeConfig(
+				atmnConfigSource({
+					body: catalogConfig({ featureId, planId, amount: 25 }),
+				}),
+			);
+
+			// Called directly (not through scenario.push) to read the preview's
+			// migrations array, which the scenario harness doesn't surface.
+			const client = createClient({
+				secretKey: scenario.ctx.orgSecretKey,
+				baseUrl: scenario.baseUrl,
+			});
+			const result = await runPush({ client, cwd: scenario.cwd });
+
+			expect(result.preview.migrations ?? []).not.toHaveLength(0);
+			expect(result.migrationIds).not.toHaveLength(0);
+
+			const [migration] = await migrationRepo.get({
+				ctx: scenario.ctx,
+				id: result.migrationIds[0],
+			});
+			expect(migration).toBeDefined();
+			// A migration row has no explicit status column — `archived: false` is
+			// what a freshly persisted draft looks like before anyone runs it.
+			expect(migration.archived).toBe(false);
+		} finally {
+			scenario.cleanup();
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("atmn push: the same in-place price change drafts nothing for a plan with no customers")}`,
+	async () => {
+		const featureId = uniqueTestId("atmn_mig_quiet_msgs");
+		const planId = uniqueTestId("atmn_mig_quiet_pro");
+
+		const scenario = await initAtmnScenario({
+			setup: [
+				s.platform.create({ userEmail: `${uniqueTestId("atmn")}@autumn.test` }),
+			],
+			config: catalogConfig({ featureId, planId, amount: 20 }),
+		});
+
+		try {
+			await scenario.push();
+
+			scenario.writeConfig(
+				atmnConfigSource({
+					body: catalogConfig({ featureId, planId, amount: 25 }),
+				}),
+			);
+			const applied = await scenario.push();
+
+			expect(applied.migrationIds).toHaveLength(0);
+		} finally {
+			scenario.cleanup();
+		}
+	},
+);

--- a/server/tests/integration/atmn/push-plans.test.ts
+++ b/server/tests/integration/atmn/push-plans.test.ts
@@ -1,0 +1,365 @@
+/**
+ * atmn push — plans, their items, versions, and licenses land in the catalog.
+ *
+ * Companion to push-features: same config-in / catalog-out contract, extended
+ * to plans. Assertions read the DB (ProductService.listFull) or the catalogV2
+ * get client, never the CLI's rendered text.
+ *
+ * Contract:
+ *   P1  a config with one feature and two plans (a free default plan with an
+ *       included-usage item, and a paid monthly plan with a flat price, a
+ *       prepaid seat item with a price, and a 14-day free trial) creates both
+ *       plans with those items and the trial; re-pushing the same config is a
+ *       no-op (preview has no create/update/delete rows)
+ *   P2  pushing `pro` v1, then a config with `pro` v2 in `plans` (price
+ *       changed) and the v1 row in `planVersions`, leaves two versions of
+ *       `pro` — v2 active, v1 inactive; a third push adding `pro` v3 as a
+ *       draft (`active: false` in `plans`) alongside v2 leaves three
+ *       versions, v2 still active
+ *   P3  pushing `seat` and `enterprise` where `enterprise` licenses `seat`
+ *       with `included: 25` links the two plans with that included count
+ */
+
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+import { initAtmnScenario } from "@tests/utils/atmnUtils/initAtmnScenario.js";
+import { s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+// Relative rather than a package import, for the same reason initAtmnScenario
+// imports runPush that way: the package publishes only its bin.
+import {
+	type AutumnClient,
+	createClient,
+} from "../../../../packages/atmn-nightly/src/generated/client";
+import { uniqueTestId } from "../catalog-v2/utils/uniqueTestId.js";
+
+const CLI_PACKAGE_DIR = join(
+	import.meta.dir,
+	"../../../../packages/atmn-nightly",
+);
+
+/**
+ * initAtmnScenario's default source only imports `feature` — these tests also
+ * need the `plan` builder, so this extends it inline rather than widening the
+ * shared helper for one file's needs.
+ */
+const atmnConfigSourceWithPlans = ({ body }: { body: string }): string =>
+	`import { feature } from "${CLI_PACKAGE_DIR}/src/generated/features";
+import { plan } from "${CLI_PACKAGE_DIR}/src/generated/plans";
+import { atmn } from "${CLI_PACKAGE_DIR}/src/generated/wire";
+
+export default atmn(${body});
+`;
+
+const APPLIED_PLAN_ACTIONS = new Set(["create", "update", "delete"]);
+
+/** Rows with a real action — the same filter runPush's renderer applies. */
+const changedRows = (
+	rows: Array<{ action?: string }> | undefined,
+): Array<{ action?: string }> =>
+	(rows ?? []).filter(
+		(row) => row.action !== undefined && APPLIED_PLAN_ACTIONS.has(row.action),
+	);
+
+type CatalogPlanRow = {
+	id: string;
+	price: { amount: number; interval: string } | null;
+	items: Array<{
+		featureId: string;
+		included: number;
+		price?: { amount?: number; billingMethod?: string } | null;
+	}>;
+	freeTrial?: { durationLength: number; durationType: string } | null;
+	licenses?: Array<{ licensePlanId: string; included: number }>;
+};
+
+const liveCatalogPlans = async ({
+	client,
+}: {
+	client: AutumnClient;
+}): Promise<CatalogPlanRow[]> => {
+	const catalog = (await client.get({})) as unknown as {
+		plans: CatalogPlanRow[];
+	};
+	return catalog.plans;
+};
+
+/** Every live version row for a plan_id, oldest first — catalogV2.get only
+ * ever returns the active one, so versioning needs the DB directly. */
+const livePlanVersions = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}): Promise<Array<{ version: number; active: boolean }>> => {
+	const products = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: [planId],
+		returnAll: true,
+	});
+	return products
+		.map((product) => ({ version: product.version, active: product.active }))
+		.sort((a, b) => a.version - b.version);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("atmn push: plans, their items, and a free trial land in the catalog")}`,
+	async () => {
+		const seats = uniqueTestId("atmn_seats");
+		const freePlan = uniqueTestId("atmn_free");
+		const proPlan = uniqueTestId("atmn_pro");
+
+		const scenario = await initAtmnScenario({
+			setup: [
+				s.platform.create({ userEmail: `${uniqueTestId("atmn")}@autumn.test` }),
+			],
+			config: "{}",
+		});
+		scenario.writeConfig(
+			atmnConfigSourceWithPlans({
+				body: `{
+	features: [
+		feature({ featureId: "${seats}", name: "Seats", type: "metered", consumable: false }),
+	],
+	plans: [
+		plan({
+			planId: "${freePlan}",
+			name: "Free",
+			autoEnable: true,
+			items: [{ featureId: "${seats}", included: 1 }],
+		}),
+		plan({
+			planId: "${proPlan}",
+			name: "Pro",
+			price: { amount: 49, interval: "month" },
+			items: [
+				{
+					featureId: "${seats}",
+					included: 1,
+					price: {
+						amount: 10,
+						interval: "month",
+						billingUnits: 1,
+						billingMethod: "prepaid",
+					},
+				},
+			],
+			freeTrial: { durationLength: 14, durationType: "day" },
+		}),
+	],
+}`,
+			}),
+		);
+		const client = createClient({
+			secretKey: scenario.ctx.orgSecretKey,
+			baseUrl: scenario.baseUrl,
+		});
+
+		try {
+			await scenario.push();
+
+			const plans = await liveCatalogPlans({ client });
+			const free = plans.find((row) => row.id === freePlan);
+			const pro = plans.find((row) => row.id === proPlan);
+
+			expect(free?.price).toBeNull();
+			const freeItem = free?.items[0];
+			expect(freeItem).toEqual(
+				expect.objectContaining({ featureId: seats, included: 1 }),
+			);
+			expect(freeItem?.price).toBeNull();
+
+			expect(pro?.price).toEqual(
+				expect.objectContaining({ amount: 49, interval: "month" }),
+			);
+			const proItem = pro?.items[0];
+			expect(proItem).toEqual(
+				expect.objectContaining({ featureId: seats, included: 1 }),
+			);
+			expect(proItem?.price).toEqual(
+				expect.objectContaining({ amount: 10, billingMethod: "prepaid" }),
+			);
+			expect(pro?.freeTrial).toEqual(
+				expect.objectContaining({ durationLength: 14, durationType: "day" }),
+			);
+
+			// Re-pushing the unchanged config previews nothing to create, update,
+			// or delete — read off the structured preview, never rendered text.
+			const wire = await scenario.wireFromConfig();
+			const preview = (await client.previewUpdate(wire)) as unknown as {
+				features?: Array<{ action?: string }>;
+				plans?: Array<{ action?: string }>;
+			};
+			expect(changedRows(preview.features)).toEqual([]);
+			expect(changedRows(preview.plans)).toEqual([]);
+		} finally {
+			scenario.cleanup();
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("atmn push: minting a plan version keeps history rows, then adds a draft")}`,
+	async () => {
+		const pro = uniqueTestId("atmn_pro");
+
+		const scenario = await initAtmnScenario({
+			setup: [
+				s.platform.create({ userEmail: `${uniqueTestId("atmn")}@autumn.test` }),
+			],
+			config: "{}",
+		});
+		const client = createClient({
+			secretKey: scenario.ctx.orgSecretKey,
+			baseUrl: scenario.baseUrl,
+		});
+
+		try {
+			scenario.writeConfig(
+				atmnConfigSourceWithPlans({
+					body: `{
+	plans: [
+		plan({
+			planId: "${pro}",
+			name: "Pro",
+			price: { amount: 10, interval: "month" },
+		}),
+	],
+}`,
+				}),
+			);
+			await scenario.push();
+			expect(
+				await livePlanVersions({ ctx: scenario.ctx, planId: pro }),
+			).toEqual([{ version: 1, active: true }]);
+
+			// v2 mints under a new slug with a changed price; v1 is restated in
+			// planVersions, which stamps it inactive.
+			scenario.writeConfig(
+				atmnConfigSourceWithPlans({
+					body: `{
+	plans: [
+		plan({
+			planId: "${pro}",
+			name: "Pro",
+			versionSlug: "v2",
+			price: { amount: 20, interval: "month" },
+		}),
+	],
+	planVersions: [
+		plan({
+			planId: "${pro}",
+			name: "Pro",
+			versionSlug: "v1",
+			price: { amount: 10, interval: "month" },
+		}),
+	],
+}`,
+				}),
+			);
+			await scenario.push();
+			expect(
+				await livePlanVersions({ ctx: scenario.ctx, planId: pro }),
+			).toEqual([
+				{ version: 1, active: false },
+				{ version: 2, active: true },
+			]);
+			const afterV2 = await liveCatalogPlans({ client });
+			expect(afterV2.find((row) => row.id === pro)?.price).toEqual(
+				expect.objectContaining({ amount: 20 }),
+			);
+
+			// A third push mints v3 as an explicit draft alongside the still-active v2.
+			scenario.writeConfig(
+				atmnConfigSourceWithPlans({
+					body: `{
+	plans: [
+		plan({
+			planId: "${pro}",
+			name: "Pro",
+			versionSlug: "v2",
+			price: { amount: 20, interval: "month" },
+		}),
+		plan({
+			planId: "${pro}",
+			name: "Pro",
+			versionSlug: "v3",
+			active: false,
+			price: { amount: 30, interval: "month" },
+		}),
+	],
+}`,
+				}),
+			);
+			await scenario.push();
+			expect(
+				await livePlanVersions({ ctx: scenario.ctx, planId: pro }),
+			).toEqual([
+				{ version: 1, active: false },
+				{ version: 2, active: true },
+				{ version: 3, active: false },
+			]);
+			const afterV3 = await liveCatalogPlans({ client });
+			expect(afterV3.find((row) => row.id === pro)?.price).toEqual(
+				expect.objectContaining({ amount: 20 }),
+			);
+		} finally {
+			scenario.cleanup();
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("atmn push: a plan's licenses link to the license plan with the config's included count")}`,
+	async () => {
+		const seatPlan = uniqueTestId("atmn_seat");
+		const enterprisePlan = uniqueTestId("atmn_enterprise");
+
+		const scenario = await initAtmnScenario({
+			setup: [
+				s.platform.create({ userEmail: `${uniqueTestId("atmn")}@autumn.test` }),
+			],
+			config: "{}",
+		});
+		scenario.writeConfig(
+			atmnConfigSourceWithPlans({
+				body: `{
+	plans: [
+		plan({
+			planId: "${seatPlan}",
+			name: "Seat",
+			price: { amount: 15, interval: "month" },
+		}),
+		plan({
+			planId: "${enterprisePlan}",
+			name: "Enterprise",
+			price: { amount: 12000, interval: "year" },
+			licenses: [{ licensePlanId: "${seatPlan}", included: 25 }],
+		}),
+	],
+}`,
+			}),
+		);
+		const client = createClient({
+			secretKey: scenario.ctx.orgSecretKey,
+			baseUrl: scenario.baseUrl,
+		});
+
+		try {
+			await scenario.push();
+
+			const plans = await liveCatalogPlans({ client });
+			const enterprise = plans.find((row) => row.id === enterprisePlan);
+			expect(enterprise?.licenses).toEqual([
+				expect.objectContaining({ licensePlanId: seatPlan, included: 25 }),
+			]);
+		} finally {
+			scenario.cleanup();
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/features/update/update-feature-internal-id.test.ts
+++ b/server/tests/integration/catalog-v2/features/update/update-feature-internal-id.test.ts
@@ -1,0 +1,133 @@
+/**
+ * catalogV2.update / preview_update — addressing a feature by internal_id.
+ *
+ * Contract:
+ *   I1  create → preview has no id yet (null); the applied result carries the
+ *       DB row's, and a later preview of the existing row carries the same
+ *   I2  internal_id + a different feature_id is a rename: old id gone, new id
+ *       present, same internal_id, reported as "update" with the old id in
+ *       previous_attributes
+ *   I3  internal_id + the same feature_id is a no-op ("none")
+ *   I4  an unknown internal_id is refused, naming the id
+ */
+
+import { expect, test } from "bun:test";
+import { FeatureType } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import {
+	deleteDbFeatures,
+	expectDbFeaturesAbsent,
+	expectDbFeaturesCorrect,
+} from "../../utils/expectCatalogFeatures.js";
+import {
+	expectCatalogPreviewCorrect,
+	expectCatalogResultsCorrect,
+} from "../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+
+const consumableFeature = (featureId: string) => ({
+	feature_id: featureId,
+	name: "CatalogV2 Internal Id",
+	type: FeatureType.Metered,
+	consumable: true,
+});
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 internal_id: rows are addressed by their stable id, and a differing feature_id renames")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const oldId = uniqueTestId("cv2_iid_old");
+		const newId = uniqueTestId("cv2_iid_new");
+		const featureIds = [oldId, newId];
+		await deleteDbFeatures({ ctx, featureIds });
+
+		const dbRow = async (id: string) =>
+			(
+				await FeatureService.list({
+					db: ctx.db,
+					orgId: ctx.org.id,
+					env: ctx.env,
+				})
+			).find((candidate) => candidate.id === id);
+
+		try {
+			// I1: the id is known at preview time and stable through apply
+			const preview = await autumnV2_3.catalogV2.previewUpdate({
+				features: [consumableFeature(oldId)],
+			});
+			const previewRow = preview.features.find(
+				(row) => row.feature_id === oldId,
+			);
+			expect(previewRow?.action).toBe("create");
+			// A create has no stable id until it is applied.
+			expect(previewRow?.internal_id).toBeNull();
+
+			const applied = await autumnV2_3.catalogV2.update({
+				features: [consumableFeature(oldId)],
+			});
+			const created = await dbRow(oldId);
+			const internalId = created?.internal_id;
+			expect(typeof internalId).toBe("string");
+			expect(
+				applied.results.features.find((row) => row.id === oldId)?.internal_id,
+			).toBe(internalId);
+
+			// An existing row's id is stable in preview too.
+			const unchangedPreview = await autumnV2_3.catalogV2.previewUpdate({
+				features: [consumableFeature(oldId)],
+			});
+			expect(
+				unchangedPreview.features.find((row) => row.feature_id === oldId)
+					?.internal_id,
+			).toBe(internalId);
+
+			// I2: same row, new public id
+			const renamed = { ...consumableFeature(newId), internal_id: internalId };
+			expectCatalogPreviewCorrect({
+				preview: await autumnV2_3.catalogV2.previewUpdate({
+					features: [renamed],
+				}),
+				features: [
+					{
+						featureId: newId,
+						action: "update",
+						hasCustomerEntitlements: false,
+						previousAttributes: { id: oldId },
+					},
+				],
+			});
+			expectCatalogResultsCorrect({
+				response: await autumnV2_3.catalogV2.update({ features: [renamed] }),
+				features: [{ id: newId, action: "update" }],
+			});
+			await expectDbFeaturesCorrect({
+				ctx,
+				expected: [{ id: newId, type: FeatureType.Metered }],
+			});
+			await expectDbFeaturesAbsent({ ctx, featureIds: [oldId] });
+			expect((await dbRow(newId))?.internal_id).toBe(internalId);
+
+			// I3: same row, same id → nothing to do
+			expectCatalogResultsCorrect({
+				response: await autumnV2_3.catalogV2.update({ features: [renamed] }),
+				features: [{ id: newId, action: "none" }],
+			});
+
+			// I4: an id nothing owns is a caller bug, not a create
+			await expectAutumnError({
+				errMessage: "fe_does_not_exist",
+				func: () =>
+					autumnV2_3.catalogV2.previewUpdate({
+						features: [
+							{ ...consumableFeature(newId), internal_id: "fe_does_not_exist" },
+						],
+					}),
+			});
+		} finally {
+			await deleteDbFeatures({ ctx, featureIds });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/utils/expectCatalogUpdate.ts
+++ b/server/tests/integration/catalog-v2/utils/expectCatalogUpdate.ts
@@ -161,7 +161,10 @@ export const expectCatalogPreviewCorrect = ({
 			const entry = preview.plans.find(
 				(candidate) => candidate.plan_id === expected.planId,
 			);
-			expect(entry, `missing preview entry for ${expected.planId}`).toBeDefined();
+			expect(
+				entry,
+				`missing preview entry for ${expected.planId}`,
+			).toBeDefined();
 			expect(entry?.action).toBe(expected.action);
 			if (expected.version !== undefined) {
 				expect(entry?.version).toBe(expected.version);
@@ -206,7 +209,10 @@ export const expectCatalogResultsCorrect = ({
 	returnedPlanIds?: string[];
 }) => {
 	if (features !== undefined) {
-		expect(response.results.features).toEqual(features);
+		// Identity and action only: result rows also carry internal_id.
+		expect(
+			response.results.features.map(({ id, action }) => ({ id, action })),
+		).toEqual(features);
 	}
 	if (plans !== undefined) {
 		for (const expected of plans) {

--- a/server/tests/unit/catalogV2/features/resolveAbsenteeFeatureIds.test.ts
+++ b/server/tests/unit/catalogV2/features/resolveAbsenteeFeatureIds.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Addressing a feature by internal_id. Pure functions, so the subtle line —
+ * a renamed row is still spoken for under the id it is leaving — is proven
+ * without a shared org.
+ *
+ * Contract:
+ *   A1  a rename by internal_id does not propose deleting the old id
+ *   A2  a row nobody mentions is still proposed
+ *   A3  an unknown internal_id is refused, naming the id
+ */
+
+import { expect, test } from "bun:test";
+import type { Feature, UpdateCatalogParams } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { resolveAbsenteeFeatureIds } from "@/internal/catalogV2/actions/updateCatalog/compute/computeRemoveFeaturesPlan/resolveAbsenteeFeatureIds";
+import { resolveCurrentFeature } from "@/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/resolveCurrentFeature";
+
+const feature = ({ id, internalId }: { id: string; internalId: string }) =>
+	({ id, internal_id: internalId, archived: false }) as unknown as Feature;
+
+const ctxWith = (features: Feature[]) =>
+	({ features }) as unknown as AutumnContext;
+
+const fullState = (
+	features: UpdateCatalogParams["features"],
+): UpdateCatalogParams =>
+	({
+		skip_deletions: false,
+		features,
+		remove_features: [],
+		skip_feature_ids: [],
+	}) as unknown as UpdateCatalogParams;
+
+test("A1 a rename by internal_id keeps the old id spoken for", () => {
+	const absent = resolveAbsenteeFeatureIds({
+		ctx: ctxWith([feature({ id: "old", internalId: "fe_1" })]),
+		params: fullState([
+			{ feature_id: "new", internal_id: "fe_1", name: "New", type: "boolean" },
+		] as never),
+	});
+	expect(absent).toEqual([]);
+});
+
+test("A2 a row nobody mentions is proposed for removal", () => {
+	const absent = resolveAbsenteeFeatureIds({
+		ctx: ctxWith([
+			feature({ id: "kept", internalId: "fe_1" }),
+			feature({ id: "forgotten", internalId: "fe_2" }),
+		]),
+		params: fullState([
+			{
+				feature_id: "kept",
+				internal_id: "fe_1",
+				name: "Kept",
+				type: "boolean",
+			},
+		] as never),
+	});
+	expect(absent).toEqual(["forgotten"]);
+});
+
+test("A3 an unknown internal_id is refused with the id in the message", () => {
+	expect(() =>
+		resolveCurrentFeature({
+			features: [feature({ id: "seats", internalId: "fe_1" })],
+			entry: { feature_id: "seats", internal_id: "fe_nope" },
+		}),
+	).toThrow(/fe_nope/);
+	expect(
+		resolveCurrentFeature({
+			features: [feature({ id: "seats", internalId: "fe_1" })],
+			entry: { feature_id: "renamed", internal_id: "fe_1" },
+		})?.id,
+	).toBe("seats");
+});

--- a/server/tests/unit/catalogV2/planUpdate/catalogVersionIdentity.test.ts
+++ b/server/tests/unit/catalogV2/planUpdate/catalogVersionIdentity.test.ts
@@ -144,6 +144,7 @@ describe("catalogRowIdentity", () => {
 			}),
 		).toEqual({
 			plan_id: "pro",
+			internal_id: null,
 			version: 2,
 			version_slug: "v2",
 			active: false,
@@ -160,6 +161,7 @@ describe("catalogRowIdentity", () => {
 			}),
 		).toEqual({
 			plan_id: "pro",
+			internal_id: null,
 			version: 2,
 			version_slug: "v2",
 			new_version_slug: "summer",
@@ -177,6 +179,7 @@ describe("catalogRowIdentity", () => {
 			}),
 		).toEqual({
 			plan_id: "pro",
+			internal_id: null,
 			version: 1,
 			version_slug: "abc",
 			new_version_slug: "newSlug",
@@ -208,6 +211,7 @@ describe("catalogRowIdentity", () => {
 			}),
 		).toEqual({
 			plan_id: "pro",
+			internal_id: null,
 			version: 1,
 			version_slug: "v1",
 			new_plan_id: "pro_2",

--- a/shared/api/catalogV2/components/catalogFeatureUpdatePreview/catalogFeatureUpdatePreview.ts
+++ b/shared/api/catalogV2/components/catalogFeatureUpdatePreview/catalogFeatureUpdatePreview.ts
@@ -13,6 +13,11 @@ export const CatalogFeatureUpdatePreviewReasonSchema = z.object({
 
 export const CatalogFeatureUpdatePreviewSchema = z.object({
 	feature_id: z.string(),
+	internal_id: z.string().nullable().meta({
+		description:
+			"Stable id of the row this preview is about. Null on create — the applied result carries the id the row received.",
+		internal: true,
+	}),
 	name: z.string().optional(),
 	action: CatalogActionSchema,
 	state: z.object({

--- a/shared/api/catalogV2/planUpdate/preview/catalogCorePreview.ts
+++ b/shared/api/catalogV2/planUpdate/preview/catalogCorePreview.ts
@@ -17,6 +17,11 @@ export const CatalogPreviewStateSchema = z.object({
 /** Shared kernel for a plan row in catalog preview (direct, sibling, or license parent). */
 export const CatalogCorePreviewSchema = z.object({
 	plan_id: z.string(),
+	internal_id: z.string().nullable().meta({
+		description:
+			"Stable id of this row. Null when the row is minted by this update — the applied result carries the id it received.",
+		internal: true,
+	}),
 	new_plan_id: z.string().optional().meta({
 		description: "Present only when this row's public plan id changes.",
 	}),

--- a/shared/api/catalogV2/updateCatalogParams.ts
+++ b/shared/api/catalogV2/updateCatalogParams.ts
@@ -8,6 +8,11 @@ import { UpdateCatalogPlanParamsSchema } from "./planUpdate/params/catalogPlanPa
 export const UpdateCatalogFeatureParamsSchema = z.intersection(
 	CreateFeatureV2ParamsSchema,
 	z.object({
+		internal_id: z.string().nonempty().optional().meta({
+			description:
+				"Address an existing feature by its stable id. Omit when creating — the server generates one. A differing feature_id alongside it is a rename.",
+			internal: true,
+		}),
 		new_feature_id: z.string().optional().meta({
 			description: "Rename the feature to this id.",
 		}),

--- a/shared/api/catalogV2/updateCatalogResponse.ts
+++ b/shared/api/catalogV2/updateCatalogResponse.ts
@@ -6,6 +6,10 @@ import { CatalogMigrationSchema } from "./components/catalogMigration.js";
 
 const CatalogAppliedResultSchema = z.object({
 	id: z.string(),
+	internal_id: z.string().nullable().optional().meta({
+		description: "Stable id of the row this result is about (features today).",
+		internal: true,
+	}),
 	action: CatalogActionSchema.meta({
 		description: "What was actually applied, including 'skip' and 'none'.",
 	}),
@@ -19,13 +23,10 @@ export const UpdateCatalogResponseSchema = z.object({
 		plans: z.array(CatalogAppliedResultSchema),
 		features: z.array(CatalogAppliedResultSchema),
 	}),
-	migrations: z
-		.array(CatalogMigrationSchema)
-		.optional()
-		.meta({
-			description:
-				"Migration drafts created for in-place / all_versions plan updates that requested `migration.draft`.",
-		}),
+	migrations: z.array(CatalogMigrationSchema).optional().meta({
+		description:
+			"Migration drafts created for in-place / all_versions plan updates that requested `migration.draft`.",
+	}),
 });
 
 export type UpdateCatalogResponse = z.infer<typeof UpdateCatalogResponseSchema>;


### PR DESCRIPTION
Features gain a nullable `internal_id` in `catalogV2.update` params, matched first when stated so a differing `feature_id` alongside it is a rename; an unknown id is a 400 rather than a create. The absentee sweep keeps a renamed row spoken for under the id it is leaving. Preview rows and applied results carry `internal_id` for features and plans (null on create in preview; the applied result carries the minted id). Marked `internal: true`, so it stays out of the public spec while the CLI's spec keeps it. Also two atmn e2e tests: plans/versions/licenses through push, and migration drafts from an in-place price change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a nullable `internal_id` to catalog features so configs can address rows by a stable id, returns it in previews and results, and backfills minted ids into CLI fixtures after push. Also adds CLI lint rules for volume-tiered prices and `featureOverride` targets.

- A differing `feature_id` alongside an `internal_id` is a rename (retiring `new_feature_id`); an unknown id is a 400 rather than a create.
- The absentee sweep keeps a renamed row spoken for under the id it is leaving.
- Preview rows carry `internal_id` (null on create); applied results carry the minted id.
- New lint rules: volume-tiered item prices must be `prepaid`, and `featureOverride` is only valid on credit-system features.
- `internal_id` and the new lint rules are marked `internal: true`, staying out of the public spec while the CLI's generated spec keeps them.
- `bun run fuzz` reports how much of the catalog schema a config's fixture exercises, per top-level collection.
- e2e tests cover plans, items, free trials, versioning, and licenses through push (including re-push idempotency), plus migration drafts from an in-place price change.
- Known limitation: duplicate `internal_id` values in one update can race and update the same row concurrently, and rename dependency discovery may miss credit-system references to the old public id.

<sup>Written for commit 9d23a0edae0703c288f3164f1029f08189866278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds stable internal IDs for catalog features and exposes stable identities in preview and applied update results.
- **[API changes]** Features can be addressed by `internal_id`, with a differing public feature ID interpreted as a rename.
- **[Improvements, API changes]** Preview and applied-result rows now include internal IDs, and the CLI writes newly minted feature IDs back into source fixtures.
- **[Improvements]** Adds catalog-schema coverage reporting, new configuration lint checks, and broader push and migration tests.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because duplicate stable targets can race and stable-ID renames can leave credit-system references pointing to an obsolete feature ID.

Two previously reported failures remain: multiple entries may concurrently update the same feature row, and rename dependency discovery still omits credit-system references associated with the feature's old public ID.

**Files Needing Attention:** server/src/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/resolveCurrentFeature.ts; server/src/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/resolveFeatureUpdateEntry.ts; server/src/internal/catalogV2/actions/updateCatalog/compute/paramsToTouchedFeatures.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/resolveCurrentFeature.ts | Adds stable-ID feature resolution, but the previously reported duplicate-target behavior remains. |
| server/src/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/resolveFeatureUpdateEntry.ts | Converts stable-ID matches into updates or renames, while the previously reported credit-reference issue remains. |
| packages/atmn-nightly/src/actions/push/backfillInternalIds.ts | Writes minted internal feature IDs into matching source fixtures after a successful push. |
| shared/api/catalogV2/updateCatalogParams.ts | Adds the internal feature identifier to the internal catalog update contract. |
| server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts | Includes stable feature identifiers in applied catalog results. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Catalog config feature] --> B{internal_id supplied?}
  B -- No --> C[Match by feature_id or create]
  B -- Yes --> D[Match existing stable row]
  D --> E{feature_id changed?}
  E -- No --> F[Update existing feature]
  E -- Yes --> G[Rename existing feature]
  C --> H[Preview and apply results]
  F --> H
  G --> H
  H --> I[CLI backfills minted internalId]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: 🐛 resolve the fuzz config path aga..."](https://github.com/useautumn/autumn/commit/9d23a0edae0703c288f3164f1029f08189866278) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60061424)</sub>

<!-- /greptile_comment -->