### PR TITLE
test(balances): usage alert basis edge cases and free-tier daily cap end to end

### DIFF
--- a/server/tests/integration/balances/track/limit-reached/limit-reached-plan.test.ts
+++ b/server/tests/integration/balances/track/limit-reached/limit-reached-plan.test.ts
@@ -17,16 +17,7 @@ import { products } from "@tests/utils/fixtures/products.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
-
-type BalancesLimitReachedPayload = {
-	type: string;
-	data: {
-		customer_id: string;
-		feature_id: string;
-		limit_type: string;
-		entity_id?: string;
-	};
-};
+import type { LimitReachedWebhookPayload } from "../../utils/limit-reached-utils/limitReachedWebhookUtils.js";
 
 let webhook: WebhookTestSetup;
 let playToken: string;
@@ -85,7 +76,7 @@ test.concurrent(
 			value: 60,
 		});
 
-		const result = await waitForWebhook<BalancesLimitReachedPayload>({
+		const result = await waitForWebhook<LimitReachedWebhookPayload>({
 			token: playToken,
 			predicate: (payload) =>
 				payload.type === "balances.limit_reached" &&
@@ -144,7 +135,7 @@ test.concurrent(
 			value: 120,
 		});
 
-		const result = await waitForWebhook<BalancesLimitReachedPayload>({
+		const result = await waitForWebhook<LimitReachedWebhookPayload>({
 			token: playToken,
 			predicate: (payload) =>
 				payload.type === "balances.limit_reached" &&
@@ -200,7 +191,7 @@ test.concurrent(
 			value: 6,
 		});
 
-		const result = await waitForWebhook<BalancesLimitReachedPayload>({
+		const result = await waitForWebhook<LimitReachedWebhookPayload>({
 			token: playToken,
 			predicate: (payload) =>
 				payload.type === "balances.limit_reached" &&
@@ -214,5 +205,10 @@ test.concurrent(
 		expect(data.customer_id).toBe(customerId);
 		expect(data.feature_id).toBe(TestFeature.Messages);
 		expect(data.limit_type).toBe("usage_limit");
+		expect(data.usage_limit).toMatchObject({
+			limit: 5,
+			usage: 5,
+			remaining: 0,
+		});
 	},
 );

--- a/server/tests/integration/balances/track/usage-alerts/usage-alert-free-tier-daily-cap.test.ts
+++ b/server/tests/integration/balances/track/usage-alerts/usage-alert-free-tier-daily-cap.test.ts
@@ -14,6 +14,7 @@ import {
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
@@ -168,19 +169,16 @@ test(`${chalk.yellowBright("free-tier-cap1: 80, 100 and 200 emails fire in order
 	expect(await canSendOneMore(customerId)).toBe(false);
 
 	await track(customerId, 1);
-	await expectNoUsageAlert({
-		token: playToken,
-		customerId,
-		threshold: 80,
-		timeoutMs: 2000,
-	});
-	expect(
-		await countUsageAlertWebhooks({
-			token: playToken,
-			customerId,
-			threshold: 200,
-		}),
-	).toBe(1);
+	await timeout(3000);
+	for (const threshold of ALERT_THRESHOLDS) {
+		expect(
+			await countUsageAlertWebhooks({
+				token: playToken,
+				customerId,
+				threshold,
+			}),
+		).toBe(1);
+	}
 });
 
 test(`${chalk.yellowBright("free-tier-cap2: one batch of 150 fires 80 and 100 together, not 200")}`, async () => {
@@ -271,7 +269,7 @@ test(`${chalk.yellowBright("free-tier-cap4: an uncapped plan silences the alerts
 
 	await autumnV2_3.billing.attach({
 		customer_id: customerId,
-		product_id: uncapped.id,
+		plan_id: uncapped.id,
 		redirect_mode: "if_required",
 	});
 	await track(customerId, 100);
@@ -285,7 +283,7 @@ test(`${chalk.yellowBright("free-tier-cap4: an uncapped plan silences the alerts
 
 	await autumnV2_3.billing.attach({
 		customer_id: customerId,
-		product_id: capped.id,
+		plan_id: capped.id,
 		redirect_mode: "if_required",
 	});
 	await track(customerId, 80);

--- a/server/tests/integration/balances/track/usage-alerts/usage-alert-free-tier-daily-cap.test.ts
+++ b/server/tests/integration/balances/track/usage-alerts/usage-alert-free-tier-daily-cap.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Mirrors the free-tier setup this feature was built for: the plan carries a
+ * 200/day cap and three plan-level usage_limit alerts at 80, 100 and 200.
+ * Every customer on the plan inherits both; nothing is configured per customer.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { ApiVersion, ms, ResetInterval } from "@autumn/shared";
+import {
+	getTestSvixAppId,
+	setupWebhookTest,
+	type WebhookTestSetup,
+} from "@tests/integration/utils/svixWebhookTestUtils.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import {
+	countLimitReachedWebhooks,
+	waitForLimitReached,
+} from "../../utils/limit-reached-utils/limitReachedWebhookUtils.js";
+import {
+	countUsageAlertWebhooks,
+	expectNoUsageAlert,
+	listUsageAlertWebhooks,
+	waitForNextMinuteBucket,
+	waitForUsageAlert,
+	waitForUsageAlertCount,
+} from "../../utils/usage-alert-utils/usageAlertWebhookUtils.js";
+import { setCustomerUsageLimit } from "../../utils/usage-limit-utils/customerUsageLimitUtils.js";
+import { expectUsageLimitWindowContains } from "../../utils/usage-limit-utils/expectUsageLimitWindowContains.js";
+import { expireUsageWindowForReset } from "../../utils/usage-limit-utils/expireUsageWindowForReset.js";
+
+const autumnV2_3 = new AutumnInt({ version: ApiVersion.V2_3 });
+
+const DAILY_CAP = 200;
+const ALERT_THRESHOLDS = [80, 100, 200] as const;
+
+let webhook: WebhookTestSetup;
+let playToken: string;
+
+beforeAll(async () => {
+	const appId = getTestSvixAppId({ svixConfig: ctx.org.svix_config });
+	webhook = await setupWebhookTest({
+		appId,
+		filterTypes: ["balances.usage_alert_triggered", "balances.limit_reached"],
+	});
+	playToken = webhook.playToken;
+});
+
+afterAll(async () => {
+	await webhook?.cleanup();
+});
+
+const freePlan = (id: string) =>
+	products.base({
+		id,
+		items: [items.monthlyMessages({ includedUsage: 10000 })],
+		billingControls: {
+			usage_limits: [
+				{
+					feature_id: TestFeature.Messages,
+					limit: DAILY_CAP,
+					interval: ResetInterval.Day,
+					anchor: "utc",
+				},
+			],
+			usage_alerts: ALERT_THRESHOLDS.map((threshold) => ({
+				feature_id: TestFeature.Messages,
+				basis: "usage_limit",
+				threshold_type: "usage",
+				threshold,
+				enabled: true,
+			})),
+		},
+	});
+
+const uncappedPlan = (id: string) =>
+	products.base({
+		id,
+		items: [items.monthlyMessages({ includedUsage: 10000 })],
+	});
+
+const track = (customerId: string, value: number) =>
+	autumnV2_3.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value,
+	});
+
+const expectAlertAtUsage = async ({
+	customerId,
+	threshold,
+	usage,
+	limit = DAILY_CAP,
+}: {
+	customerId: string;
+	threshold: number;
+	usage: number;
+	limit?: number;
+}) => {
+	const data = await waitForUsageAlert({
+		token: playToken,
+		customerId,
+		threshold,
+		basis: "usage_limit",
+	});
+	expect(data.usage_alert.threshold_type).toBe("usage");
+	expect(data.usage_limit).toMatchObject({
+		limit,
+		usage,
+		remaining: limit - usage,
+		interval: "day",
+	});
+	return data;
+};
+
+const canSendOneMore = async (customerId: string) => {
+	const check = await autumnV2_3.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		required_balance: 1,
+	});
+	return check.allowed;
+};
+
+test(`${chalk.yellowBright("free-tier-cap1: 80, 100 and 200 emails fire in order, 200 also blocks")}`, async () => {
+	const customerId = "free-tier-cap-1";
+	const plan = freePlan("free-tier-cap-plan-1");
+	await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.billing.attach({ productId: plan.id })],
+	});
+
+	const trackedAt = Date.now();
+	await track(customerId, 80);
+	const first = await expectAlertAtUsage({
+		customerId,
+		threshold: 80,
+		usage: 80,
+	});
+	expectUsageLimitWindowContains({
+		usageLimit: first.usage_limit,
+		at: trackedAt,
+		intervalMs: ms.days(1),
+	});
+	expect(await canSendOneMore(customerId)).toBe(true);
+
+	await track(customerId, 20);
+	await expectAlertAtUsage({ customerId, threshold: 100, usage: 100 });
+
+	await track(customerId, 100);
+	await expectAlertAtUsage({ customerId, threshold: 200, usage: 200 });
+	const blocked = await waitForLimitReached({
+		token: playToken,
+		customerId,
+		limitType: "usage_limit",
+	});
+	expect(blocked?.payload.data.usage_limit).toMatchObject({
+		limit: DAILY_CAP,
+		usage: DAILY_CAP,
+		remaining: 0,
+	});
+	expect(await canSendOneMore(customerId)).toBe(false);
+
+	await track(customerId, 1);
+	await expectNoUsageAlert({
+		token: playToken,
+		customerId,
+		threshold: 80,
+		timeoutMs: 2000,
+	});
+	expect(
+		await countUsageAlertWebhooks({
+			token: playToken,
+			customerId,
+			threshold: 200,
+		}),
+	).toBe(1);
+});
+
+test(`${chalk.yellowBright("free-tier-cap2: one batch of 150 fires 80 and 100 together, not 200")}`, async () => {
+	const customerId = "free-tier-cap-2";
+	const plan = freePlan("free-tier-cap-plan-2");
+	await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.billing.attach({ productId: plan.id })],
+	});
+
+	await track(customerId, 150);
+	await expectAlertAtUsage({ customerId, threshold: 80, usage: 150 });
+	await expectAlertAtUsage({ customerId, threshold: 100, usage: 150 });
+	await expectNoUsageAlert({ token: playToken, customerId, threshold: 200 });
+});
+
+test(`${chalk.yellowBright("free-tier-cap3: the next day re-arms every threshold with a new window")}`, async () => {
+	const customerId = "free-tier-cap-3";
+	const plan = freePlan("free-tier-cap-plan-3");
+	await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.billing.attach({ productId: plan.id })],
+	});
+
+	await track(customerId, 200);
+	const yesterday = await expectAlertAtUsage({
+		customerId,
+		threshold: 200,
+		usage: 200,
+	});
+	expect(await canSendOneMore(customerId)).toBe(false);
+
+	await expireUsageWindowForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(await canSendOneMore(customerId)).toBe(true);
+
+	await waitForNextMinuteBucket();
+	await track(customerId, 80);
+	await waitForUsageAlertCount({
+		token: playToken,
+		customerId,
+		threshold: 80,
+		count: 2,
+	});
+	const today = (
+		await listUsageAlertWebhooks({
+			token: playToken,
+			customerId,
+			threshold: 80,
+		})
+	).find((alert) => alert.usage_limit?.usage === 80);
+	expect(today?.usage_limit?.remaining).toBe(DAILY_CAP - 80);
+	expect(yesterday.usage_limit?.usage).toBe(DAILY_CAP);
+
+	await track(customerId, 120);
+	await waitForUsageAlertCount({
+		token: playToken,
+		customerId,
+		threshold: 200,
+		count: 2,
+	});
+	expect(
+		await countLimitReachedWebhooks({
+			token: playToken,
+			customerId,
+			limitType: "usage_limit",
+		}),
+	).toBe(2);
+});
+
+test(`${chalk.yellowBright("free-tier-cap4: an uncapped plan silences the alerts; the capped plan brings them back")}`, async () => {
+	const customerId = "free-tier-cap-4";
+	const capped = freePlan("free-tier-cap-plan-4");
+	const uncapped = uncappedPlan("free-tier-uncapped-plan-4");
+	await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.products({ list: [capped, uncapped] }),
+		],
+		actions: [s.billing.attach({ productId: capped.id })],
+	});
+
+	await autumnV2_3.billing.attach({
+		customer_id: customerId,
+		product_id: uncapped.id,
+		redirect_mode: "if_required",
+	});
+	await track(customerId, 100);
+	await expectNoUsageAlert({ token: playToken, customerId, threshold: 80 });
+	await expectNoUsageAlert({
+		token: playToken,
+		customerId,
+		threshold: 100,
+		timeoutMs: 2000,
+	});
+
+	await autumnV2_3.billing.attach({
+		customer_id: customerId,
+		product_id: capped.id,
+		redirect_mode: "if_required",
+	});
+	await track(customerId, 80);
+	await expectAlertAtUsage({ customerId, threshold: 80, usage: 80 });
+});
+
+test(`${chalk.yellowBright("free-tier-cap5: a customer cap of 500 overrides the plan cap for the plan alerts")}`, async () => {
+	const customerId = "free-tier-cap-5";
+	const plan = freePlan("free-tier-cap-plan-5");
+	await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.billing.attach({ productId: plan.id })],
+	});
+	await setCustomerUsageLimit({
+		autumn: autumnV2_3,
+		customerId,
+		featureId: TestFeature.Messages,
+		limit: 500,
+		interval: ResetInterval.Day,
+		anchor: "utc",
+	});
+
+	await track(customerId, 200);
+	await expectAlertAtUsage({
+		customerId,
+		threshold: 80,
+		usage: 200,
+		limit: 500,
+	});
+	await expectAlertAtUsage({
+		customerId,
+		threshold: 100,
+		usage: 200,
+		limit: 500,
+	});
+	await expectAlertAtUsage({
+		customerId,
+		threshold: 200,
+		usage: 200,
+		limit: 500,
+	});
+	expect(await canSendOneMore(customerId)).toBe(true);
+});
+
+test(`${chalk.yellowBright("free-tier-cap6: a batch past the cap is clamped, fires 200 and limit_reached from one request")}`, async () => {
+	const customerId = "free-tier-cap-6";
+	const plan = freePlan("free-tier-cap-plan-6");
+	await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.billing.attach({ productId: plan.id })],
+	});
+
+	await track(customerId, 190);
+	await expectAlertAtUsage({ customerId, threshold: 100, usage: 190 });
+
+	await track(customerId, 50);
+	await expectAlertAtUsage({ customerId, threshold: 200, usage: 200 });
+	const blocked = await waitForLimitReached({
+		token: playToken,
+		customerId,
+		limitType: "usage_limit",
+	});
+	expect(blocked?.payload.data.usage_limit?.usage).toBe(DAILY_CAP);
+	expect(await canSendOneMore(customerId)).toBe(false);
+});
+
+test(`${chalk.yellowBright("free-tier-cap7: a customer cap of 100 lowers the denominator and the 200 alert can never fire")}`, async () => {
+	const customerId = "free-tier-cap-7";
+	const plan = freePlan("free-tier-cap-plan-7");
+	await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.billing.attach({ productId: plan.id })],
+	});
+	await setCustomerUsageLimit({
+		autumn: autumnV2_3,
+		customerId,
+		featureId: TestFeature.Messages,
+		limit: 100,
+		interval: ResetInterval.Day,
+		anchor: "utc",
+	});
+
+	await track(customerId, 80);
+	await expectAlertAtUsage({
+		customerId,
+		threshold: 80,
+		usage: 80,
+		limit: 100,
+	});
+
+	await track(customerId, 150);
+	await expectAlertAtUsage({
+		customerId,
+		threshold: 100,
+		usage: 100,
+		limit: 100,
+	});
+	await expectNoUsageAlert({ token: playToken, customerId, threshold: 200 });
+	expect(await canSendOneMore(customerId)).toBe(false);
+});

--- a/server/tests/integration/balances/track/usage-alerts/usage-alert-usage-limit-edge-cases.test.ts
+++ b/server/tests/integration/balances/track/usage-alerts/usage-alert-usage-limit-edge-cases.test.ts
@@ -1,8 +1,10 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import {
 	ApiVersion,
+	type CustomerBillingControls,
 	type EntityBillingControls,
 	ResetInterval,
+	usageLimitFilterKey,
 } from "@autumn/shared";
 import {
 	getTestSvixAppId,
@@ -13,10 +15,12 @@ import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { waitForLimitReached } from "../../utils/limit-reached-utils/limitReachedWebhookUtils.js";
 import { setCustomerUsageAlerts } from "../../utils/usage-alert-utils/customerUsageAlertUtils.js";
 import {
 	expectNoUsageAlert,
@@ -36,7 +40,7 @@ beforeAll(async () => {
 	const appId = getTestSvixAppId({ svixConfig: ctx.org.svix_config });
 	webhook = await setupWebhookTest({
 		appId,
-		filterTypes: ["balances.usage_alert_triggered"],
+		filterTypes: ["balances.usage_alert_triggered", "balances.limit_reached"],
 	});
 	playToken = webhook.playToken;
 });
@@ -48,16 +52,68 @@ afterAll(async () => {
 const usageLimitAlert = ({
 	threshold,
 	thresholdType = "usage_percentage",
+	filter,
 }: {
 	threshold: number;
 	thresholdType?: "usage" | "usage_percentage" | "remaining";
+	filter?: { properties: Record<string, string> };
 }) => ({
 	feature_id: TestFeature.Messages,
 	basis: "usage_limit" as const,
 	threshold,
 	threshold_type: thresholdType,
 	enabled: true,
+	...(filter && { filter }),
 });
+
+const dailyCap = ({
+	limit,
+	filter,
+	enabled = true,
+}: {
+	limit: number;
+	filter?: { properties: Record<string, string> };
+	enabled?: boolean;
+}) => ({
+	feature_id: TestFeature.Messages,
+	limit,
+	interval: ResetInterval.Day,
+	anchor: "utc" as const,
+	enabled,
+	...(filter && { filter }),
+});
+
+const setCustomerBillingControls = async ({
+	customerId,
+	billingControls,
+}: {
+	customerId: string;
+	billingControls: CustomerBillingControls;
+}) => {
+	await timeout(2000);
+	await autumnV2_3.customers.update(customerId, {
+		billing_controls: billingControls,
+	});
+	await timeout(3000);
+};
+
+const setupUncappedCustomer = async ({
+	customerId,
+	planId,
+}: {
+	customerId: string;
+	planId: string;
+}) => {
+	const plan = products.base({
+		id: planId,
+		items: [items.monthlyMessages({ includedUsage: 10000 })],
+	});
+	await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.billing.attach({ productId: plan.id })],
+	});
+};
 
 const setupCappedCustomer = async ({
 	customerId,
@@ -252,5 +308,139 @@ test(`${chalk.yellowBright("ul-edge4: entity alerts dedupe on the full identity 
 				{ ...usageLimitAlert({ threshold: 80 }), basis: "balance" as const },
 			],
 		} as EntityBillingControls,
+	});
+});
+
+test(`${chalk.yellowBright("ul-edge5: a broad and a narrow filtered cap both count one event and alert independently")}`, async () => {
+	const customerId = "ul-edge-filter-superset-1";
+	await setupUncappedCustomer({
+		customerId,
+		planId: "ul-edge-filter-superset",
+	});
+	const broad = { properties: { region: "eu" } };
+	const narrow = { properties: { region: "eu", apiKeyId: "key-a" } };
+	await setCustomerBillingControls({
+		customerId,
+		billingControls: {
+			usage_limits: [
+				dailyCap({ limit: 100, filter: broad }),
+				dailyCap({ limit: 100, filter: narrow }),
+			],
+			usage_alerts: [
+				usageLimitAlert({ threshold: 80, filter: broad }),
+				usageLimitAlert({ threshold: 80, filter: narrow }),
+			],
+		} as CustomerBillingControls,
+	});
+
+	await autumnV2_3.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 80,
+		properties: { region: "eu", apiKeyId: "key-a", extra: "ignored" },
+	});
+	const broadFire = await waitForUsageAlert({
+		token: playToken,
+		customerId,
+		threshold: 80,
+		filterKey: usageLimitFilterKey(broad),
+	});
+	const narrowFire = await waitForUsageAlert({
+		token: playToken,
+		customerId,
+		threshold: 80,
+		filterKey: usageLimitFilterKey(narrow),
+	});
+	expect(broadFire.usage_limit?.usage).toBe(80);
+	expect(narrowFire.usage_limit?.usage).toBe(80);
+
+	await autumnV2_3.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 20,
+		properties: { region: "eu", apiKeyId: "key-a" },
+	});
+	const blocked = await waitForLimitReached({
+		token: playToken,
+		customerId,
+		limitType: "usage_limit",
+	});
+	expect(blocked?.payload.data.usage_limit?.usage).toBe(100);
+	expect(blocked?.payload.data.filter).toBeDefined();
+});
+
+test(`${chalk.yellowBright("ul-edge6: boolean filter values canonicalise the same way on the cap, the alert and the event")}`, async () => {
+	const customerId = "ul-edge-boolean-filter-1";
+	await setupUncappedCustomer({ customerId, planId: "ul-edge-boolean-filter" });
+	const booleanFilter = { properties: { internal: true } } as unknown as {
+		properties: Record<string, string>;
+	};
+	await setCustomerBillingControls({
+		customerId,
+		billingControls: {
+			usage_limits: [dailyCap({ limit: 100, filter: booleanFilter })],
+			usage_alerts: [
+				usageLimitAlert({
+					threshold: 80,
+					filter: { properties: { internal: "true" } },
+				}),
+			],
+		} as CustomerBillingControls,
+	});
+
+	await autumnV2_3.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 80,
+		properties: { internal: true },
+	});
+	const data = await waitForUsageAlert({
+		token: playToken,
+		customerId,
+		threshold: 80,
+		filterKey: "internal=true",
+	});
+	expect(data.usage_limit?.usage).toBe(80);
+});
+
+test(`${chalk.yellowBright("ul-edge7: disabling a filtered cap silences only the alert that points at it")}`, async () => {
+	const customerId = "ul-edge-filtered-cap-disabled-1";
+	await setupUncappedCustomer({
+		customerId,
+		planId: "ul-edge-filtered-cap-disabled",
+	});
+	const keyA = { properties: { apiKeyId: "key-a" } };
+	await setCustomerBillingControls({
+		customerId,
+		billingControls: {
+			usage_limits: [
+				dailyCap({ limit: 100 }),
+				dailyCap({ limit: 50, filter: keyA, enabled: false }),
+			],
+			usage_alerts: [
+				usageLimitAlert({ threshold: 80 }),
+				usageLimitAlert({ threshold: 80, filter: keyA }),
+			],
+		} as CustomerBillingControls,
+	});
+
+	await autumnV2_3.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 80,
+		properties: keyA.properties,
+	});
+	const unfiltered = await waitForUsageAlert({
+		token: playToken,
+		customerId,
+		threshold: 80,
+		filterKey: "",
+	});
+	expect(unfiltered.usage_limit?.limit).toBe(100);
+	await expectNoUsageAlert({
+		token: playToken,
+		customerId,
+		threshold: 80,
+		filterKey: usageLimitFilterKey(keyA),
 	});
 });

--- a/server/tests/integration/balances/track/usage-alerts/usage-alert-usage-limit-edge-cases.test.ts
+++ b/server/tests/integration/balances/track/usage-alerts/usage-alert-usage-limit-edge-cases.test.ts
@@ -1,0 +1,256 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import {
+	ApiVersion,
+	type EntityBillingControls,
+	ResetInterval,
+} from "@autumn/shared";
+import {
+	getTestSvixAppId,
+	setupWebhookTest,
+	type WebhookTestSetup,
+} from "@tests/integration/utils/svixWebhookTestUtils.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { setCustomerUsageAlerts } from "../../utils/usage-alert-utils/customerUsageAlertUtils.js";
+import {
+	expectNoUsageAlert,
+	waitForNextMinuteBucket,
+	waitForUsageAlert,
+} from "../../utils/usage-alert-utils/usageAlertWebhookUtils.js";
+import { setCustomerUsageLimit } from "../../utils/usage-limit-utils/customerUsageLimitUtils.js";
+import { setEntityUsageLimit } from "../../utils/usage-limit-utils/entityUsageLimitUtils.js";
+import { expireUsageWindowForReset } from "../../utils/usage-limit-utils/expireUsageWindowForReset.js";
+
+const autumnV2_3 = new AutumnInt({ version: ApiVersion.V2_3 });
+
+let webhook: WebhookTestSetup;
+let playToken: string;
+
+beforeAll(async () => {
+	const appId = getTestSvixAppId({ svixConfig: ctx.org.svix_config });
+	webhook = await setupWebhookTest({
+		appId,
+		filterTypes: ["balances.usage_alert_triggered"],
+	});
+	playToken = webhook.playToken;
+});
+
+afterAll(async () => {
+	await webhook?.cleanup();
+});
+
+const usageLimitAlert = ({
+	threshold,
+	thresholdType = "usage_percentage",
+}: {
+	threshold: number;
+	thresholdType?: "usage" | "usage_percentage" | "remaining";
+}) => ({
+	feature_id: TestFeature.Messages,
+	basis: "usage_limit" as const,
+	threshold,
+	threshold_type: thresholdType,
+	enabled: true,
+});
+
+const setupCappedCustomer = async ({
+	customerId,
+	planId,
+	limit = 200,
+}: {
+	customerId: string;
+	planId: string;
+	limit?: number;
+}) => {
+	const plan = products.base({
+		id: planId,
+		items: [items.monthlyMessages({ includedUsage: 10000 })],
+	});
+	await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.billing.attach({ productId: plan.id })],
+	});
+	await setCustomerUsageLimit({
+		autumn: autumnV2_3,
+		customerId,
+		featureId: TestFeature.Messages,
+		limit,
+		interval: ResetInterval.Day,
+		anchor: "utc",
+	});
+};
+
+const track = ({
+	customerId,
+	value,
+	entityId,
+}: {
+	customerId: string;
+	value: number;
+	entityId?: string;
+}) =>
+	autumnV2_3.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value,
+		...(entityId && { entity_id: entityId }),
+	});
+
+test(`${chalk.yellowBright("ul-edge1: a rollover mid-track never fires a remaining alert from yesterday's usage")}`, async () => {
+	const customerId = "ul-edge-rollover-remaining-1";
+	await setupCappedCustomer({
+		customerId,
+		planId: "ul-edge-rollover-remaining",
+	});
+	await setCustomerUsageAlerts({
+		autumn: autumnV2_3,
+		customerId,
+		usageAlerts: [
+			usageLimitAlert({ threshold: 5, thresholdType: "remaining" }),
+		],
+	});
+
+	await track({ customerId, value: 190 });
+	await expectNoUsageAlert({ token: playToken, customerId, threshold: 5 });
+
+	await expireUsageWindowForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	await waitForNextMinuteBucket();
+	await track({ customerId, value: 1 });
+	await expectNoUsageAlert({ token: playToken, customerId, threshold: 5 });
+});
+
+test(`${chalk.yellowBright("ul-edge2: a usage_limit percentage above 100 can never fire because the cap clamps usage")}`, async () => {
+	const customerId = "ul-edge-over-100-1";
+	await setupCappedCustomer({ customerId, planId: "ul-edge-over-100" });
+	await setCustomerUsageAlerts({
+		autumn: autumnV2_3,
+		customerId,
+		usageAlerts: [
+			usageLimitAlert({ threshold: 150 }),
+			usageLimitAlert({ threshold: 100 }),
+		],
+	});
+
+	await track({ customerId, value: 400 });
+	const capped = await waitForUsageAlert({
+		token: playToken,
+		customerId,
+		threshold: 100,
+	});
+	expect(capped.usage_limit?.usage).toBe(200);
+	await expectNoUsageAlert({ token: playToken, customerId, threshold: 150 });
+});
+
+test(`${chalk.yellowBright("ul-edge3: an entity alert on its own cap ignores a sibling entity's tracks")}`, async () => {
+	const customerId = "ul-edge-sibling-entity-1";
+	const plan = products.base({
+		id: "ul-edge-sibling-entity",
+		items: [
+			items.monthlyMessages({
+				includedUsage: 10000,
+				entityFeatureId: TestFeature.Users,
+			}),
+		],
+	});
+	const { entities } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.products({ list: [plan] }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+		],
+		actions: [s.billing.attach({ productId: plan.id })],
+	});
+	const [alerted, sibling] = entities;
+	await setEntityUsageLimit({
+		autumn: autumnV2_3,
+		customerId,
+		entityId: alerted.id,
+		featureId: TestFeature.Messages,
+		limit: 200,
+		interval: ResetInterval.Day,
+	});
+	await autumnV2_3.entities.update(customerId, alerted.id, {
+		billing_controls: {
+			usage_alerts: [usageLimitAlert({ threshold: 80 })],
+		} as EntityBillingControls,
+	});
+
+	await track({ customerId, value: 160, entityId: sibling.id });
+	await expectNoUsageAlert({
+		token: playToken,
+		customerId,
+		threshold: 80,
+		entityId: alerted.id,
+	});
+
+	await track({ customerId, value: 160, entityId: alerted.id });
+	const data = await waitForUsageAlert({
+		token: playToken,
+		customerId,
+		threshold: 80,
+		entityId: alerted.id,
+	});
+	expect(data.usage_limit?.usage).toBe(160);
+});
+
+test(`${chalk.yellowBright("ul-edge4: entity alerts dedupe on the full identity like customer alerts")}`, async () => {
+	const customerId = "ul-edge-entity-dedup-1";
+	const { entities } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.products({
+				list: [
+					products.base({
+						id: "ul-edge-entity-dedup",
+						items: [items.monthlyMessages({ includedUsage: 10000 })],
+					}),
+				],
+			}),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+		],
+		actions: [s.billing.attach({ productId: "ul-edge-entity-dedup" })],
+	});
+	const entityId = entities[0].id;
+	await setEntityUsageLimit({
+		autumn: autumnV2_3,
+		customerId,
+		entityId,
+		featureId: TestFeature.Messages,
+		limit: 200,
+		interval: ResetInterval.Day,
+	});
+
+	await expectAutumnError({
+		errMessage: "Only one usage alert entry",
+		func: () =>
+			autumnV2_3.entities.update(customerId, entityId, {
+				billing_controls: {
+					usage_alerts: [
+						usageLimitAlert({ threshold: 80 }),
+						usageLimitAlert({ threshold: 80 }),
+					],
+				} as EntityBillingControls,
+			}),
+	});
+	await autumnV2_3.entities.update(customerId, entityId, {
+		billing_controls: {
+			usage_alerts: [
+				usageLimitAlert({ threshold: 80 }),
+				{ ...usageLimitAlert({ threshold: 80 }), basis: "balance" as const },
+			],
+		} as EntityBillingControls,
+	});
+});

--- a/server/tests/integration/balances/utils/limit-reached-utils/limitReachedWebhookUtils.ts
+++ b/server/tests/integration/balances/utils/limit-reached-utils/limitReachedWebhookUtils.ts
@@ -1,5 +1,9 @@
 import type { BalancesLimitReached } from "@autumn/shared";
-import { waitForWebhook } from "@tests/integration/utils/svixWebhookTestUtils.js";
+import {
+	getPlayHistory,
+	parseEventBody,
+	waitForWebhook,
+} from "@tests/integration/utils/svixWebhookTestUtils.js";
 
 export const LIMIT_REACHED_EVENT_TYPE = "balances.limit_reached";
 
@@ -27,3 +31,28 @@ export const waitForLimitReached = ({
 			payload.data?.limit_type === limitType,
 		timeoutMs,
 	});
+
+export const countLimitReachedWebhooks = async ({
+	token,
+	customerId,
+	limitType,
+}: {
+	token: string;
+	customerId: string;
+	limitType: string;
+}) => {
+	const history = await getPlayHistory({ token });
+	let count = 0;
+	for (const event of history.data) {
+		try {
+			const payload = parseEventBody<LimitReachedWebhookPayload>(event);
+			if (
+				payload.type === LIMIT_REACHED_EVENT_TYPE &&
+				payload.data?.customer_id === customerId &&
+				payload.data?.limit_type === limitType
+			)
+				count++;
+		} catch {}
+	}
+	return count;
+};

--- a/server/tests/integration/balances/utils/usage-alert-utils/usageAlertWebhookUtils.ts
+++ b/server/tests/integration/balances/utils/usage-alert-utils/usageAlertWebhookUtils.ts
@@ -97,20 +97,25 @@ export const expectNoUsageAlert = async ({
 	).toBeNull();
 };
 
-export const countUsageAlertWebhooks = async ({
+export const listUsageAlertWebhooks = async ({
 	token,
 	...match
 }: UsageAlertMatch & { token: string }) => {
 	const matches = matchesUsageAlert(match);
 	const history = await getPlayHistory({ token });
-	let count = 0;
+	const payloads: UsageAlertWebhookPayload["data"][] = [];
 	for (const event of history.data) {
 		try {
-			if (matches(parseEventBody<UsageAlertWebhookPayload>(event))) count++;
+			const payload = parseEventBody<UsageAlertWebhookPayload>(event);
+			if (matches(payload)) payloads.push(payload.data);
 		} catch {}
 	}
-	return count;
+	return payloads;
 };
+
+export const countUsageAlertWebhooks = async (
+	params: UsageAlertMatch & { token: string },
+) => (await listUsageAlertWebhooks(params)).length;
 
 export const waitForUsageAlertCount = async ({
 	token,

--- a/server/tests/setup-integration-tests.ts
+++ b/server/tests/setup-integration-tests.ts
@@ -141,6 +141,22 @@ if (process.env.TESTS_ORG && !process.env.UNIT_TESTS) {
 	);
 	await Promise.all([primeRedisMonitor(), primeRedisV2Monitor()]);
 
+	// Cache clears fan out to the instances the edge config names; without it
+	// the test process only clears "main" while the server may read elsewhere.
+	await import("@/internal/misc/miscRedisConfig/miscRedisConfigStore.js");
+	const { startAllEdgeConfigPolling } = await import(
+		"@/internal/misc/edgeConfig/edgeConfigRegistry.js"
+	);
+	const { logger } = await import("@/external/logtail/logtailUtils.js");
+	await startAllEdgeConfigPolling({ logger });
+	const { getMiscRedisTargets } = await import(
+		"@/external/redis/miscCache/resolveMiscRedis.js"
+	);
+	const { waitForRedisReady } = await import("@/external/redis/initRedis.js");
+	for (const target of getMiscRedisTargets()) {
+		await waitForRedisReady(target.redis, target.instanceName);
+	}
+
 	if (!testContext.org.config.multi_currency) {
 		const { db } = await import("@/db/initDrizzle.js");
 		const { OrgService } = await import("@/internal/orgs/OrgService.js");

--- a/server/tests/unit/balances/usageAlerts/buildUsageAlertIdempotencyKey.test.ts
+++ b/server/tests/unit/balances/usageAlerts/buildUsageAlertIdempotencyKey.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import type { DbUsageAlert, Feature } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { buildUsageAlertIdempotencyKey } from "@/internal/balances/usageAlerts/check/send/buildUsageAlertIdempotencyKey.js";
+
+const ctx = {
+	org: { id: "org_1" },
+	env: "sandbox",
+	timestamp: 1_800_000_000_000,
+} as unknown as AutumnContext;
+
+const feature = { id: "messages" } as Feature;
+
+const keyFor = ({
+	alert,
+	periodStartAt = null,
+}: {
+	alert: Partial<DbUsageAlert>;
+	periodStartAt?: number | null;
+}) =>
+	buildUsageAlertIdempotencyKey({
+		ctx,
+		customerId: "cus_1",
+		scope: "customer",
+		feature,
+		alert: {
+			feature_id: "messages",
+			threshold: 80,
+			threshold_type: "usage_percentage",
+			enabled: true,
+			...alert,
+		} as DbUsageAlert,
+		periodStartAt,
+	});
+
+describe("buildUsageAlertIdempotencyKey", () => {
+	test("a missing basis keys like balance", () => {
+		expect(keyFor({ alert: {} })).toBe(keyFor({ alert: { basis: "balance" } }));
+	});
+
+	test("basis, filter and window start each make a distinct key", () => {
+		const base = keyFor({ alert: { basis: "usage_limit" } });
+		expect(keyFor({ alert: { basis: "included" } })).not.toBe(base);
+		expect(
+			keyFor({
+				alert: { basis: "usage_limit", filter: { properties: { key: "a" } } },
+			}),
+		).not.toBe(base);
+		expect(
+			keyFor({ alert: { basis: "usage_limit" }, periodStartAt: 1 }),
+		).not.toBe(base);
+	});
+
+	test("filter order does not change the key", () => {
+		const left = keyFor({
+			alert: {
+				basis: "usage_limit",
+				filter: { properties: { a: "1", b: "2" } },
+			},
+		});
+		const right = keyFor({
+			alert: {
+				basis: "usage_limit",
+				filter: { properties: { b: "2", a: "1" } },
+			},
+		});
+		expect(left).toBe(right);
+	});
+});


### PR DESCRIPTION
Integration tests only. Closes the gaps between the usage-alert basis spec and the existing suites, and mirrors the free-tier daily-cap setup this feature was built for.

## Free-tier daily cap (`usage-alert-free-tier-daily-cap.test.ts`)
Plan-level 200/day cap with plan-level `usage_limit` alerts at 80, 100 and 200:
- alerts fire in order with the `usage_limit` block; 200 also emits `limit_reached` and blocks the next track
- one batch of 150 fires 80 and 100 together, not 200
- the next UTC day re-arms every alert and `limit_reached`
- a batch past the cap is clamped and fires 200 plus `limit_reached` from one request
- an uncapped plan silences the alerts; switching back restores them
- customer override caps of 500 and 100 change the denominator (and 200 can never fire under 100)

## Edge cases (`usage-alert-usage-limit-edge-cases.test.ts`)
- rollover mid-track never fires a remaining alert from yesterday's usage
- a usage_limit percentage above 100 never fires because the cap clamps usage
- an entity alert on its own cap ignores a sibling entity's tracks
- entity alerts dedupe on the full identity
- broad and narrow filtered caps both count one event and alert independently; `limit_reached` names the tightest
- boolean filter values canonicalise the same on cap, alert and event
- disabling a filtered cap silences only the alert pointing at it

## Also
- `limit-reached-plan3` now asserts the `usage_limit` block for a plan-level cap
- unit tests for `buildUsageAlertIdempotencyKey`
- shared `limitReachedWebhookUtils` and `listUsageAlertWebhooks` test helpers
- test preload loads the misc-cache edge config so cache clears reach the instance the server reads; without it the org-level alert suites fail locally against a running server





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This test-only PR expands coverage for usage-alert basis behavior, daily caps, webhook payloads, and idempotency keys.
- [Improvements] Adds end-to-end coverage for free-tier daily caps, alert thresholds, resets, overrides, and plan switching.
- [Improvements] Adds edge-case coverage for rollover, entity scoping, filtered caps, boolean filter normalization, and disabled limits.
- [Improvements] Introduces shared webhook history helpers and strengthens the plan-level limit-reached payload assertion.
- [Improvements] Initializes edge-config-backed miscellaneous Redis targets during integration-test setup.
- [Improvements] Adds unit coverage for usage-alert idempotency-key inputs and filter ordering.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/tests/integration/balances/track/usage-alerts/usage-alert-free-tier-daily-cap.test.ts | Adds comprehensive integration scenarios for inherited daily caps, alert thresholds, resets, overrides, and plan switching. |
| server/tests/integration/balances/track/usage-alerts/usage-alert-usage-limit-edge-cases.test.ts | Adds integration coverage for usage-limit alert rollover, entity identity, filtering, and disabled-cap behavior. |
| server/tests/integration/balances/utils/limit-reached-utils/limitReachedWebhookUtils.ts | Adds a shared helper for counting matching limit-reached webhook deliveries. |
| server/tests/integration/balances/utils/usage-alert-utils/usageAlertWebhookUtils.ts | Refactors webhook counting through a reusable listing helper. |
| server/tests/setup-integration-tests.ts | Loads edge configuration and waits for configured miscellaneous Redis targets before integration tests. |
| server/tests/unit/balances/usageAlerts/buildUsageAlertIdempotencyKey.test.ts | Verifies that basis, filter, and period identity affect alert idempotency keys while filter property order does not. |

<sub>Reviews (3): Last reviewed commit: ["test(balances): free-tier suite counts f..."](https://github.com/useautumn/autumn/commit/48cc8c1abb20c11eb50c184180073c54d94d9ba3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60085602)</sub>

<!-- /greptile_comment -->