### PR TITLE
feat: API 2.4 — skip customer-level entity aggregations and cap list pages at 200

### DIFF
--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -35,6 +35,7 @@ import { triggerBatchResetCustomerEntitlements } from "./actions/resetCustomerEn
 import { CusSearchService } from "./CusSearchService.js";
 import { getCursorPaginatedFullCusQuery } from "./cursorPaginatedFullCusQuery.js";
 import { getApiCustomerBase } from "./cusUtils/apiCusUtils/getApiCustomerBase.js";
+import { shouldAggregateEntityData } from "./cusUtils/customerEntityData.js";
 import {
 	getPaginatedFullCusQuery,
 	parseDashboardIntervalFilter,
@@ -145,6 +146,9 @@ export class CusBatchService {
 			plans,
 			processors,
 			cusProductLimit,
+			aggregateEntityData: shouldAggregateEntityData({
+				apiVersion: ctx.apiVersion,
+			}),
 		});
 		const tSqlStart = performance.now();
 		const results = await ctx.db.execute(sqlQuery);
@@ -245,6 +249,9 @@ export class CusBatchService {
 			createdAtRangeFilter: created_at_range,
 			cusProductLimit,
 			sortOrder: query.sort_order,
+			aggregateEntityData: shouldAggregateEntityData({
+				apiVersion: ctx.apiVersion,
+			}),
 		});
 
 		const tSqlStart = performance.now();

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -57,6 +57,8 @@ export type CursorPaginatedFullCusQueryArgs = {
 	 * preview cap, so displayed balances sum every live row. */
 	balanceFeatureInternalIds?: string[];
 	sortOrder?: SortOrder;
+	/** V2_4+ customer-level reads exclude entity-scoped rows entirely. */
+	aggregateEntityData?: boolean;
 };
 
 /**
@@ -108,8 +110,14 @@ export const getCursorPaginatedFullCusQuery = ({
 	withProductsPage = false,
 	balanceFeatureInternalIds,
 	sortOrder = "desc",
+	aggregateEntityData = true,
 }: CursorPaginatedFullCusQueryArgs) => {
 	const cpStatusFilter = cpStatusInClause(inStatuses);
+
+	const customerLevelOnly = (alias: string) =>
+		aggregateEntityData
+			? sql``
+			: sql`AND ${sql.raw(alias)}.internal_entity_id IS NULL`;
 
 	const holdsBalanceFeatureExpr = balanceFeatureInternalIds?.length
 		? sql`EXISTS (
@@ -267,7 +275,7 @@ export const getCursorPaginatedFullCusQuery = ({
 			FROM cr
 			JOIN customer_products cp ON cp.internal_customer_id = cr.internal_id
 			JOIN products prod ON prod.internal_id = cp.internal_product_id
-			WHERE cp.customer_license_link_id IS NULL ${cpStatusFilter}
+			WHERE cp.customer_license_link_id IS NULL ${cpStatusFilter} ${customerLevelOnly("cp")}
 		),
 		cps_ranked AS MATERIALIZED (
 			SELECT
@@ -323,6 +331,7 @@ export const getCursorPaginatedFullCusQuery = ({
 					AND ce.pooled_contribution_id IS NULL
 					AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
 					AND ${looseEntitlementIsLiveSql()}
+					${customerLevelOnly("ce")}
 				ORDER BY ce.id DESC
 				LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
 			) ce ON true

--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.ts
@@ -14,6 +14,10 @@ import { z } from "zod/v4";
 import type { RequestContext } from "@/honoUtils/HonoEnv.js";
 import { invoicesToResponse } from "../../../invoices/invoiceUtils.js";
 import { getCusProcessors } from "../cusResponseUtils/getCusProcessors.js";
+import {
+	fullCustomerWithoutEntityData,
+	shouldAggregateEntityData,
+} from "../customerEntityData.js";
 import { getApiCustomerLicenses } from "../getApiCustomerV2/getApiCustomerLicense/getApiCustomerLicenses.js";
 import { getApiSubscriptions } from "./getApiSubscription/getApiSubscriptions.js";
 
@@ -31,9 +35,15 @@ export const getApiCustomerBase = async ({
 	fullCus: FullCustomer;
 	withAutumnId?: boolean;
 }): Promise<{ apiCustomer: ApiCustomerV5; legacyData: CustomerLegacyData }> => {
+	const fullCustomer =
+		!fullCus.entity &&
+		!shouldAggregateEntityData({ apiVersion: ctx.apiVersion })
+			? fullCustomerWithoutEntityData({ fullCustomer: fullCus })
+			: fullCus;
+
 	const { balances: apiBalances, flags: apiFlags } = await getApiBalances({
 		ctx,
-		fullCus,
+		fullCus: fullCustomer,
 	});
 
 	const subscriptionsScopedCtx = scopeExpandForCtx({
@@ -47,10 +57,10 @@ export const getApiCustomerBase = async ({
 		legacyData: cusProductLegacyData,
 	} = await getApiSubscriptions({
 		ctx: subscriptionsScopedCtx,
-		fullCus,
+		fullCus: fullCustomer,
 	});
 	const usageLimits = fullSubjectToApiUsageLimits({
-		fullSubject: fullCustomerToFullSubject({ fullCustomer: fullCus }),
+		fullSubject: fullCustomerToFullSubject({ fullCustomer }),
 		features: ctx.features,
 		inStatuses: orgToInStatuses({ org: ctx.org }),
 	});
@@ -74,7 +84,7 @@ export const getApiCustomerBase = async ({
 		purchases: apiPurchases,
 		licenses: getApiCustomerLicenses({
 			ctx,
-			customerProducts: fullCus.customer_products,
+			customerProducts: fullCustomer.customer_products,
 		}),
 		balances: apiBalances,
 		flags: apiFlags,
@@ -94,8 +104,8 @@ export const getApiCustomerBase = async ({
 			: undefined,
 
 		processors: getCusProcessors({
-			customer: fullCus,
-			customer_products: fullCus.customer_products,
+			customer: fullCustomer,
+			customer_products: fullCustomer.customer_products,
 		}),
 
 		invoices:

--- a/server/src/internal/customers/cusUtils/customerEntityData.ts
+++ b/server/src/internal/customers/cusUtils/customerEntityData.ts
@@ -9,12 +9,16 @@ import {
 export const shouldAggregateEntityData = ({
 	apiVersion,
 }: {
-	apiVersion: ApiVersionClass;
-}): boolean =>
-	backwardsChangeActive({
+	/** Omit for callers that are not tied to a request's API version. */
+	apiVersion?: ApiVersionClass;
+}): boolean => {
+	if (!apiVersion) return true;
+
+	return backwardsChangeActive({
 		apiVersion,
 		versionChange: V2_3_CustomerEntityData,
 	});
+};
 
 /** FullSubject carries entity rows as pre-computed aggregates, never as products. */
 export const subjectWithoutEntityData = ({

--- a/server/src/internal/customers/cusUtils/customerEntityData.ts
+++ b/server/src/internal/customers/cusUtils/customerEntityData.ts
@@ -1,0 +1,51 @@
+import {
+	type ApiVersionClass,
+	backwardsChangeActive,
+	type FullCustomer,
+	type FullSubject,
+	V2_3_CustomerEntityData,
+} from "@autumn/shared";
+
+export const shouldAggregateEntityData = ({
+	apiVersion,
+}: {
+	apiVersion: ApiVersionClass;
+}): boolean =>
+	backwardsChangeActive({
+		apiVersion,
+		versionChange: V2_3_CustomerEntityData,
+	});
+
+/** FullSubject carries entity rows as pre-computed aggregates, never as products. */
+export const subjectWithoutEntityData = ({
+	fullSubject,
+}: {
+	fullSubject: FullSubject;
+}): FullSubject => ({
+	...fullSubject,
+	aggregated_customer_products: undefined,
+	aggregated_customer_entitlements: undefined,
+	aggregated_subject_flags: undefined,
+});
+
+const isEntityScoped = (row: { internal_entity_id?: string | null }): boolean =>
+	!!row.internal_entity_id;
+
+/** FullCustomer list rows carry entity products inline, so they are dropped. */
+export const fullCustomerWithoutEntityData = ({
+	fullCustomer,
+}: {
+	fullCustomer: FullCustomer;
+}): FullCustomer => ({
+	...fullCustomer,
+	customer_products: fullCustomer.customer_products.filter(
+		(customerProduct) => !isEntityScoped(customerProduct),
+	),
+	extra_customer_entitlements: fullCustomer.extra_customer_entitlements?.filter(
+		(customerEntitlement) => !isEntityScoped(customerEntitlement),
+	),
+	pooled_customer_entitlements:
+		fullCustomer.pooled_customer_entitlements?.filter(
+			(customerEntitlement) => !isEntityScoped(customerEntitlement),
+		),
+});

--- a/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiCustomerV2.ts
+++ b/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiCustomerV2.ts
@@ -8,6 +8,10 @@ import {
 } from "@autumn/shared";
 import type { RequestContext } from "@/honoUtils/HonoEnv.js";
 import { getApiCustomerExpandV2 } from "../apiCusUtils/getApiCustomerExpandV2.js";
+import {
+	shouldAggregateEntityData,
+	subjectWithoutEntityData,
+} from "../customerEntityData.js";
 import { getApiCustomerBaseV2 } from "./getApiCustomerBaseV2.js";
 
 /**
@@ -22,16 +26,22 @@ export const getApiCustomerV2 = async ({
 	fullSubject: FullSubject;
 	withAutumnId?: boolean;
 }): Promise<ApiCustomerV5> => {
+	const subjectToUse =
+		fullSubject.subjectType === "customer" &&
+		!shouldAggregateEntityData({ apiVersion: ctx.apiVersion })
+			? subjectWithoutEntityData({ fullSubject })
+			: fullSubject;
+
 	const { apiCustomer: baseCustomer, legacyData } = await getApiCustomerBaseV2({
 		ctx,
-		fullSubject,
+		fullSubject: subjectToUse,
 		withAutumnId,
 	});
 
 	const billingControls = mergePlanBillingControlsForResponse({
 		billingControls: baseCustomer.billing_controls,
-		planCustomerProducts: fullSubject.customer_products,
-		fullSubject,
+		planCustomerProducts: subjectToUse.customer_products,
+		fullSubject: subjectToUse,
 		features: ctx.features,
 	});
 
@@ -47,7 +57,7 @@ export const getApiCustomerV2 = async ({
 
 	const apiCustomerExpand = await getApiCustomerExpandV2({
 		ctx,
-		fullSubject,
+		fullSubject: subjectToUse,
 		autoTopupsConfig: billingControls.auto_topups,
 	});
 

--- a/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiSubject.ts
+++ b/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiSubject.ts
@@ -1,20 +1,8 @@
 import type { ApiCustomerV5, ApiEntityV2, FullSubject } from "@autumn/shared";
 import type { RequestContext } from "@/honoUtils/HonoEnv.js";
 import { getApiEntityBaseV2 } from "@/internal/entities/entityUtils/getApiEntityV2/getApiEntityBaseV2.js";
+import { subjectWithoutEntityData } from "../customerEntityData.js";
 import { getApiCustomerBaseV2 } from "./getApiCustomerBaseV2.js";
-
-const stripAggregations = ({
-	fullSubject,
-}: {
-	fullSubject: FullSubject;
-}): FullSubject => {
-	return {
-		...fullSubject,
-		aggregated_customer_products: undefined,
-		aggregated_customer_entitlements: undefined,
-		aggregated_subject_flags: undefined,
-	};
-};
 
 export const getApiSubject = async ({
 	ctx,
@@ -35,9 +23,7 @@ export const getApiSubject = async ({
 
 	const subjectToUse = includeAggregations
 		? fullSubject
-		: stripAggregations({
-				fullSubject,
-			});
+		: subjectWithoutEntityData({ fullSubject });
 
 	const { apiCustomer } = await getApiCustomerBaseV2({
 		ctx,

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -720,6 +720,7 @@ export const getPaginatedFullCusQuery = ({
 	processors,
 	search,
 	cusProductLimit,
+	aggregateEntityData = true,
 }: {
 	orgId: string;
 	env: AppEnv;
@@ -737,7 +738,14 @@ export const getPaginatedFullCusQuery = ({
 	processors?: ListCustomersV2Params["processors"];
 	search?: string;
 	cusProductLimit: number;
+	/** V2_4+ customer-level reads exclude entity-scoped rows entirely. */
+	aggregateEntityData?: boolean;
 }) => {
+	const customerLevelOnly = (alias: string) =>
+		aggregateEntityData
+			? sql``
+			: sql`AND ${sql.raw(alias)}.internal_entity_id IS NULL`;
+
 	const withStatusFilter = () => {
 		return inStatuses?.length
 			? sql`AND cp.status = ANY(ARRAY[${sql.join(
@@ -780,6 +788,7 @@ export const getPaginatedFullCusQuery = ({
 		AND ce.pooled_contribution_id IS NULL
         AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
         AND ${looseEntitlementIsLiveSql()}
+        ${customerLevelOnly("ce")}
       ORDER BY ce.id DESC
 	  LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
     ) ce ON true
@@ -839,6 +848,7 @@ export const getPaginatedFullCusQuery = ({
         FROM customer_products cp
         WHERE cp.internal_customer_id = cr.internal_id
         AND cp.customer_license_link_id IS NULL
+        ${customerLevelOnly("cp")}
         ${withStatusFilter()}
         ORDER BY (SELECT p.is_add_on FROM products p WHERE p.internal_id = cp.internal_product_id) ASC, cp.created_at DESC
         LIMIT ${cusProductLimit}

--- a/server/src/internal/customers/handlers/handleListCustomersV2.ts
+++ b/server/src/internal/customers/handlers/handleListCustomersV2.ts
@@ -4,8 +4,8 @@ import {
 	type BaseApiCustomerV5,
 	type CursorPaginatedResponse,
 	ErrCode,
-	type ListCustomersV2Params,
 	ListCustomersV2_3ParamsSchema,
+	type ListCustomersV2Params,
 	ListCustomersV2ParamsSchema,
 	type PagePaginatedResponse,
 	PaginationType,
@@ -84,6 +84,7 @@ export const handleListCustomersV2 = createRoute({
 				orgId: ctx.org.id,
 				orgSlug: ctx.org.slug,
 				type: PaginationType.ListCustomers,
+				apiVersion: ctx.apiVersion,
 			});
 			if (body.limit > maxLimit) {
 				throw new RecaseError({

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
@@ -22,6 +22,7 @@ import { lazyResetSubjectEntitlements } from "../../actions/resetCustomerEntitle
 import { lazyResetSubjectUsageWindows } from "../../actions/resetUsageWindows/lazyResetSubjectUsageWindows.js";
 import { markReplicaSourced } from "../../cache/fullSubject/subjectProvenance.js";
 import { RELEVANT_STATUSES } from "../../cusProducts/CusProductService.js";
+import { shouldAggregateEntityData } from "../../cusUtils/customerEntityData.js";
 import {
 	type FullSubjectGateLane,
 	isFullSubjectGateRejection,
@@ -90,6 +91,9 @@ const runRoutedHydration = async ({
 							entityId,
 							inStatuses,
 							allowMissingEntity,
+							aggregateEntityData: shouldAggregateEntityData({
+								apiVersion: ctx.apiVersion,
+							}),
 						}),
 					});
 

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectQuery.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectQuery.ts
@@ -160,6 +160,7 @@ export const getFullSubjectQuery = ({
 	},
 	inStatuses = RELEVANT_STATUSES,
 	allowMissingEntity = false,
+	aggregateEntityData = true,
 }: {
 	orgId: string;
 	env: AppEnv;
@@ -174,6 +175,8 @@ export const getFullSubjectQuery = ({
 	// customer-scoped row even if the entity does not exist. No-op when
 	// customerId is absent (entity-only lookup has no customer anchor).
 	allowMissingEntity?: boolean;
+	/** Entity aggregation scales with the customer's entity count; V2_4+ drops it. */
+	aggregateEntityData?: boolean;
 }) => {
 	const page = pagination.page ?? 50;
 	const offset = pagination.offset ?? 0;
@@ -222,6 +225,6 @@ export const getFullSubjectQuery = ({
 		leadingCtes,
 		inStatuses,
 		includeInvoices: !entityId,
-		includeEntityAggregations: !entityId,
+		includeEntityAggregations: !entityId && aggregateEntityData,
 	});
 };

--- a/server/src/internal/entities/handlers/handleListEntitiesV2.ts
+++ b/server/src/internal/entities/handlers/handleListEntitiesV2.ts
@@ -191,6 +191,7 @@ export const handleListEntitiesV2 = createRoute({
 				orgId: ctx.org.id,
 				orgSlug: ctx.org.slug,
 				type: PaginationType.ListEntities,
+				apiVersion: ctx.apiVersion,
 			});
 			if (body.limit > maxLimit) {
 				throw new RecaseError({

--- a/server/src/internal/misc/edgeConfig/orgLimitsStore.ts
+++ b/server/src/internal/misc/edgeConfig/orgLimitsStore.ts
@@ -1,8 +1,12 @@
 import {
+	ApiVersion,
+	type ApiVersionClass,
 	ErrCode,
 	PAGINATION_CONFIGS,
 	type PaginationType,
 	RecaseError,
+	V2_4_CAPPED_PAGINATION_TYPES,
+	V2_4_MAX_PAGINATION_LIMIT,
 } from "@autumn/shared";
 import { ADMIN_ORG_LIMITS_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
 import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
@@ -52,20 +56,35 @@ export const getOrgEntitiesLimit = ({
 	return orgConfig?.maxEntities ?? DEFAULT_ENTITIES_LIMIT;
 };
 
+const defaultMaxLimit = ({
+	type,
+	apiVersion,
+}: {
+	type: PaginationType;
+	apiVersion?: ApiVersionClass;
+}): number =>
+	apiVersion?.gte(ApiVersion.V2_4) &&
+	V2_4_CAPPED_PAGINATION_TYPES.includes(type)
+		? V2_4_MAX_PAGINATION_LIMIT
+		: PAGINATION_CONFIGS[type].maxLimit;
+
 export const getOrgPaginationMaxLimit = ({
 	orgId,
 	orgSlug,
 	type,
+	apiVersion,
 }: {
 	orgId?: string;
 	orgSlug?: string;
 	type: PaginationType;
+	/** Omit for internal callers that are not tied to a request's API version. */
+	apiVersion?: ApiVersionClass;
 }): number => {
 	const orgs = store.get().orgs;
 	const orgConfig =
 		(orgId ? orgs[orgId] : undefined) ?? (orgSlug ? orgs[orgSlug] : undefined);
 	const override = orgConfig?.pagination?.[type]?.maxLimit;
-	return override ?? PAGINATION_CONFIGS[type].maxLimit;
+	return override ?? defaultMaxLimit({ type, apiVersion });
 };
 
 export const assertWithinOrgPaginationLimit = ({

--- a/server/tests/integration/crud/customers/api-v2-4-entity-data-contract.test.ts
+++ b/server/tests/integration/crud/customers/api-v2-4-entity-data-contract.test.ts
@@ -1,0 +1,300 @@
+/**
+ * API v2.4: customer-level reads drop entity-level subscriptions and balances.
+ *
+ * V2.3 still aggregates. Entity-scoped reads and check are unchanged.
+ * skip_cache rebuilds prove the FullSubject SQL gate, not only the response strip.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5, ApiEntityV2 } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+const CUSTOMER_GRANT = 100;
+const ENTITY_GRANT = 500;
+
+const setupScenario = async ({ customerId }: { customerId: string }) => {
+	const customerPlan = products.base({
+		id: `v24-cus-plan-${customerId}`,
+		items: [items.monthlyMessages({ includedUsage: CUSTOMER_GRANT })],
+	});
+
+	const entityPlan = products.pro({
+		id: `v24-ent-plan-${customerId}`,
+		items: [items.monthlyWords({ includedUsage: ENTITY_GRANT })],
+	});
+
+	const scenario = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false, paymentMethod: "success" }),
+			s.products({ list: [customerPlan, entityPlan] }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+		],
+		actions: [
+			s.attach({ productId: customerPlan.id }),
+			s.attach({ productId: entityPlan.id, entityIndex: 0 }),
+		],
+	});
+
+	return { ...scenario, customerPlan, entityPlan };
+};
+
+const readCustomerEveryWay = async ({
+	autumn,
+	customerId,
+}: {
+	autumn: AutumnInt;
+	customerId: string;
+}): Promise<[string, ApiCustomerV5 | undefined][]> => {
+	const rpcGet = (await autumn.post("/customers.get", {
+		customer_id: customerId,
+	})) as ApiCustomerV5;
+
+	const legacyGet = await autumn.customers.get<ApiCustomerV5>(customerId);
+
+	const cursorPage = (await autumn.customers.listV2({
+		search: customerId,
+		limit: 10,
+	})) as { list: ApiCustomerV5[] };
+
+	const offsetPage = (await autumn.customers.list({ limit: 100 })) as {
+		list: ApiCustomerV5[];
+	};
+
+	const getOrCreate = (await autumn.customers.create({
+		id: customerId,
+	})) as ApiCustomerV5;
+
+	return [
+		["POST /customers.get", rpcGet],
+		["GET /v1/customers/:id", legacyGet],
+		[
+			"POST /customers/list (cursor)",
+			cursorPage.list.find((customer) => customer.id === customerId),
+		],
+		[
+			"GET /v1/customers (offset)",
+			offsetPage.list.find((customer) => customer.id === customerId),
+		],
+		["POST /customers (get_or_create)", getOrCreate],
+	];
+};
+
+const grantedFor = ({
+	customer,
+	featureId,
+}: {
+	customer: ApiCustomerV5 | undefined;
+	featureId: string;
+}): number => customer?.balances[featureId]?.granted ?? 0;
+
+const hasPlan = ({
+	customer,
+	planId,
+}: {
+	customer: ApiCustomerV5 | undefined;
+	planId: string;
+}): boolean =>
+	!!customer?.subscriptions.some(
+		(subscription) => subscription.plan_id === planId,
+	);
+
+test.concurrent(
+	`${chalk.yellowBright("api v2.4 contract: every customer-level read path excludes entity data and keeps customer data")}`,
+	async () => {
+		const customerId = "v24-contract-read-paths";
+		const { autumnV2_4, customerPlan, entityPlan } = await setupScenario({
+			customerId,
+		});
+
+		const reads = await readCustomerEveryWay({
+			autumn: autumnV2_4,
+			customerId,
+		});
+
+		for (const [label, customer] of reads) {
+			expect(customer, `${label}: customer missing`).toBeDefined();
+			expect(
+				hasPlan({ customer, planId: entityPlan.id }),
+				`${label}: entity plan must be excluded`,
+			).toBe(false);
+			expect(
+				grantedFor({ customer, featureId: TestFeature.Words }),
+				`${label}: entity grant must be excluded`,
+			).toBe(0);
+			expect(
+				hasPlan({ customer, planId: customerPlan.id }),
+				`${label}: customer plan must be reported`,
+			).toBe(true);
+			expect(
+				grantedFor({ customer, featureId: TestFeature.Messages }),
+				`${label}: customer grant must be reported`,
+			).toBe(CUSTOMER_GRANT);
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("api v2.4 contract: V2_3 and below still aggregate entity data onto the customer")}`,
+	async () => {
+		const customerId = "v24-contract-v23-unchanged";
+		const { autumnV2_3, customerPlan, entityPlan } = await setupScenario({
+			customerId,
+		});
+
+		const reads = await readCustomerEveryWay({
+			autumn: autumnV2_3,
+			customerId,
+		});
+
+		for (const [label, customer] of reads) {
+			expect(customer, `${label}: customer missing`).toBeDefined();
+			expect(
+				hasPlan({ customer, planId: entityPlan.id }),
+				`${label}: v2.3 keeps the entity plan`,
+			).toBe(true);
+			expect(
+				grantedFor({ customer, featureId: TestFeature.Words }),
+				`${label}: v2.3 keeps the entity grant`,
+			).toBe(ENTITY_GRANT);
+			expect(
+				hasPlan({ customer, planId: customerPlan.id }),
+				`${label}: v2.3 keeps the customer plan`,
+			).toBe(true);
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("api v2.4 contract: entity-scoped reads still report the entity's own plan")}`,
+	async () => {
+		const customerId = "v24-contract-entity-reads";
+		const { autumnV2_4, entities, entityPlan } = await setupScenario({
+			customerId,
+		});
+
+		const entity = await autumnV2_4.entities.get<ApiEntityV2>(
+			customerId,
+			entities[0].id,
+		);
+		expect(
+			entity.subscriptions?.some((sub) => sub.plan_id === entityPlan.id),
+			"entities.get: entity keeps its own plan",
+		).toBe(true);
+		expect(
+			entity.balances?.[TestFeature.Words]?.granted,
+			"entities.get: entity keeps its own grant",
+		).toBe(ENTITY_GRANT);
+
+		const listed = await autumnV2_4.entitiesV2.list<{ list: ApiEntityV2[] }>({
+			customer_id: customerId,
+		});
+		const listedEntity = listed.list.find((row) => row.id === entities[0].id);
+		expect(
+			listedEntity?.subscriptions?.some((sub) => sub.plan_id === entityPlan.id),
+			"entities.list: entity keeps its own plan",
+		).toBe(true);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("api v2.4 contract: cached read and cold rebuild agree, and check still evaluates customer balances")}`,
+	async () => {
+		const customerId = "v24-contract-cache-parity";
+		const { autumnV2_4, customerPlan, entityPlan } = await setupScenario({
+			customerId,
+		});
+
+		const cached = await autumnV2_4.customers.get<ApiCustomerV5>(customerId);
+		const rebuilt = await autumnV2_4.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+
+		for (const [label, customer] of [
+			["cached", cached],
+			["cold rebuild", rebuilt],
+		] as const) {
+			expect(
+				hasPlan({ customer, planId: entityPlan.id }),
+				`${label}: entity plan excluded`,
+			).toBe(false);
+			expect(
+				grantedFor({ customer, featureId: TestFeature.Messages }),
+				`${label}: customer grant intact`,
+			).toBe(CUSTOMER_GRANT);
+			expect(
+				hasPlan({ customer, planId: customerPlan.id }),
+				`${label}: customer plan intact`,
+			).toBe(true);
+		}
+
+		const checkRes = (await autumnV2_4.check({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		})) as { allowed: boolean };
+		expect(checkRes.allowed, "check: customer balance still allowed").toBe(
+			true,
+		);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("api v2.4 contract: customers.get excludes entity-scoped standalone balances")}`,
+	async () => {
+		const customerId = "v24-contract-standalone-entity";
+		const customerGrant = 100;
+		const entityGrant = 300;
+
+		const { autumnV2_4, entities } = await setupScenario({ customerId });
+
+		await autumnV2_4.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Storage,
+			included_grant: customerGrant,
+		});
+
+		await autumnV2_4.balances.create({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Storage,
+			included_grant: entityGrant,
+		});
+
+		const cached = await autumnV2_4.customers.get<ApiCustomerV5>(customerId);
+		const rebuilt = await autumnV2_4.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+
+		for (const [label, customer] of [
+			["cached", cached],
+			["cold rebuild", rebuilt],
+		] as const) {
+			expect(
+				grantedFor({ customer, featureId: TestFeature.Storage }),
+				`${label}: entity-scoped standalone grant must be excluded`,
+			).toBe(customerGrant);
+
+			const entityScopedItem = customer.balances[
+				TestFeature.Storage
+			]?.breakdown?.find((item) => item.included_grant === entityGrant);
+			expect(
+				entityScopedItem,
+				`${label}: entity standalone breakdown row must be absent`,
+			).toBeUndefined();
+		}
+
+		const entity = await autumnV2_4.entities.get<ApiEntityV2>(
+			customerId,
+			entities[0].id,
+		);
+		expect(
+			entity.balances?.[TestFeature.Storage]?.granted,
+			"entities.get: entity keeps its own standalone grant",
+		).toBe(entityGrant + customerGrant);
+	},
+);

--- a/server/tests/integration/crud/customers/api-v2-4-pagination-limit.test.ts
+++ b/server/tests/integration/crud/customers/api-v2-4-pagination-limit.test.ts
@@ -1,0 +1,106 @@
+/**
+ * API v2.4 caps customers.list and entities.list at 200.
+ *
+ * limit <= 200 succeeds; limit > 200 is InvalidRequest naming the max.
+ * V2.3 still accepts 201.
+ */
+
+import { expect, test } from "bun:test";
+import { ErrCode, V2_4_MAX_PAGINATION_LIMIT } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+const OVER_LIMIT = V2_4_MAX_PAGINATION_LIMIT + 1;
+
+const listCustomers = ({
+	autumn,
+	limit,
+}: {
+	autumn: AutumnInt;
+	limit: number;
+}) => autumn.customers.listV2({ limit });
+
+const listEntities = ({
+	autumn,
+	customerId,
+	limit,
+}: {
+	autumn: AutumnInt;
+	customerId: string;
+	limit: number;
+}) =>
+	autumn.entitiesV2.list({
+		customer_id: customerId,
+		limit,
+	});
+
+test.concurrent(
+	`${chalk.yellowBright("api v2.4 pagination: customers.list caps limit at 200, V2_3 unchanged")}`,
+	async () => {
+		const customerId = "v24-limit-customers";
+		const { autumnV2_3, autumnV2_4 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		const atLimit = (await listCustomers({
+			autumn: autumnV2_4,
+			limit: V2_4_MAX_PAGINATION_LIMIT,
+		})) as { list: unknown[] };
+		expect(
+			atLimit.list,
+			"v2.4 customers.list at 200 should succeed",
+		).toBeArray();
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: `max of ${V2_4_MAX_PAGINATION_LIMIT}`,
+			func: () => listCustomers({ autumn: autumnV2_4, limit: OVER_LIMIT }),
+		});
+
+		const v23 = (await listCustomers({
+			autumn: autumnV2_3,
+			limit: OVER_LIMIT,
+		})) as { list: unknown[] };
+		expect(v23.list, "v2.3 customers.list at 201 should succeed").toBeArray();
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("api v2.4 pagination: entities.list caps limit at 200, V2_3 unchanged")}`,
+	async () => {
+		const customerId = "v24-limit-entities";
+		const { autumnV2_3, autumnV2_4 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		const atLimit = (await listEntities({
+			autumn: autumnV2_4,
+			customerId,
+			limit: V2_4_MAX_PAGINATION_LIMIT,
+		})) as { list: unknown[] };
+		expect(
+			atLimit.list,
+			"v2.4 entities.list at 200 should succeed",
+		).toBeArray();
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: `max of ${V2_4_MAX_PAGINATION_LIMIT}`,
+			func: () =>
+				listEntities({ autumn: autumnV2_4, customerId, limit: OVER_LIMIT }),
+		});
+
+		const v23 = (await listEntities({
+			autumn: autumnV2_3,
+			customerId,
+			limit: OVER_LIMIT,
+		})) as { list: unknown[] };
+		expect(v23.list, "v2.3 entities.list at 201 should succeed").toBeArray();
+	},
+);

--- a/server/tests/unit/customers/should-aggregate-entity-data.test.ts
+++ b/server/tests/unit/customers/should-aggregate-entity-data.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { ApiVersion, ApiVersionClass } from "@autumn/shared";
+import { shouldAggregateEntityData } from "@/internal/customers/cusUtils/customerEntityData.js";
+
+describe("shouldAggregateEntityData", () => {
+	test("is on for V2.3 and earlier", () => {
+		expect(
+			shouldAggregateEntityData({
+				apiVersion: new ApiVersionClass(ApiVersion.V2_3),
+			}),
+		).toBe(true);
+		expect(
+			shouldAggregateEntityData({
+				apiVersion: new ApiVersionClass(ApiVersion.V2_2),
+			}),
+		).toBe(true);
+	});
+
+	test("is off for V2.4", () => {
+		expect(
+			shouldAggregateEntityData({
+				apiVersion: new ApiVersionClass(ApiVersion.V2_4),
+			}),
+		).toBe(false);
+	});
+});

--- a/server/tests/unit/customers/should-aggregate-entity-data.test.ts
+++ b/server/tests/unit/customers/should-aggregate-entity-data.test.ts
@@ -23,4 +23,8 @@ describe("shouldAggregateEntityData", () => {
 			}),
 		).toBe(false);
 	});
+
+	test("keeps aggregating when apiVersion is missing", () => {
+		expect(shouldAggregateEntityData({})).toBe(true);
+	});
 });

--- a/server/tests/unit/misc/org-pagination-max-limit-v2-4.test.ts
+++ b/server/tests/unit/misc/org-pagination-max-limit-v2-4.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import {
+	ApiVersion,
+	ApiVersionClass,
+	PaginationType,
+	V2_4_MAX_PAGINATION_LIMIT,
+} from "@autumn/shared";
+import { getOrgPaginationMaxLimit } from "@/internal/misc/edgeConfig/orgLimitsStore.js";
+
+describe("getOrgPaginationMaxLimit V2.4 default", () => {
+	test("caps customers and entities lists at 200 for V2.4", () => {
+		const apiVersion = new ApiVersionClass(ApiVersion.V2_4);
+		expect(
+			getOrgPaginationMaxLimit({
+				type: PaginationType.ListCustomers,
+				apiVersion,
+			}),
+		).toBe(V2_4_MAX_PAGINATION_LIMIT);
+		expect(
+			getOrgPaginationMaxLimit({
+				type: PaginationType.ListEntities,
+				apiVersion,
+			}),
+		).toBe(V2_4_MAX_PAGINATION_LIMIT);
+	});
+
+	test("leaves V2.3 and other list types unchanged", () => {
+		const v23 = new ApiVersionClass(ApiVersion.V2_3);
+		expect(
+			getOrgPaginationMaxLimit({
+				type: PaginationType.ListCustomers,
+				apiVersion: v23,
+			}),
+		).toBe(1000);
+		expect(
+			getOrgPaginationMaxLimit({
+				type: PaginationType.ListEntities,
+				apiVersion: v23,
+			}),
+		).toBe(5000);
+		expect(
+			getOrgPaginationMaxLimit({
+				type: PaginationType.ListInvoices,
+				apiVersion: new ApiVersionClass(ApiVersion.V2_4),
+			}),
+		).toBe(1000);
+	});
+});

--- a/server/tests/utils/testInitUtils/initScenario.ts
+++ b/server/tests/utils/testInitUtils/initScenario.ts
@@ -1095,6 +1095,7 @@ type InitScenarioImplementationResult = {
 	autumnV2_1: AutumnInt;
 	autumnV2_2: AutumnInt;
 	autumnV2_3: AutumnInt;
+	autumnV2_4: AutumnInt;
 	testClockId: string | undefined;
 	testClockIds: Record<string, string>;
 	customer: Awaited<ReturnType<typeof initCustomerV3>>["customer"] | null;
@@ -1124,6 +1125,7 @@ export async function initScenario(params: {
 	autumnV2_1: AutumnInt;
 	autumnV2_2: AutumnInt;
 	autumnV2_3: AutumnInt;
+	autumnV2_4: AutumnInt;
 	testClockId: string | undefined;
 	testClockIds: Record<string, string>;
 	customer: Awaited<ReturnType<typeof initCustomerV3>>["customer"];
@@ -1153,6 +1155,7 @@ export async function initScenario(params: {
 	autumnV2_1: AutumnInt;
 	autumnV2_2: AutumnInt;
 	autumnV2_3: AutumnInt;
+	autumnV2_4: AutumnInt;
 	testClockId: undefined;
 	testClockIds: Record<string, string>;
 	customer: null;
@@ -1444,6 +1447,10 @@ export async function initScenario({
 	});
 	const autumnV2_3 = new AutumnInt({
 		version: ApiVersion.V2_3,
+		secretKey: ctx.orgSecretKey,
+	});
+	const autumnV2_4 = new AutumnInt({
+		version: ApiVersion.V2_4,
 		secretKey: ctx.orgSecretKey,
 	});
 
@@ -1907,6 +1914,7 @@ export async function initScenario({
 		autumnV2_1,
 		autumnV2_2,
 		autumnV2_3,
+		autumnV2_4,
 		testClockId,
 		testClockIds,
 		customer,

--- a/shared/api/common/paginationConfigs.ts
+++ b/shared/api/common/paginationConfigs.ts
@@ -18,6 +18,14 @@ export type PaginationConfig = {
 	maxLimit: number;
 };
 
+/** V2_4 default page ceiling for customer and entity lists. Per-org overrides still win. */
+export const V2_4_MAX_PAGINATION_LIMIT = 200;
+
+export const V2_4_CAPPED_PAGINATION_TYPES: PaginationType[] = [
+	PaginationType.ListCustomers,
+	PaginationType.ListEntities,
+];
+
 export const PAGINATION_CONFIGS: Record<PaginationType, PaginationConfig> = {
 	[PaginationType.ListCustomers]: {
 		defaultLimit: PaginationDefaults.DefaultLimit,

--- a/shared/api/customers/changes/V2.3_CustomerEntityData.ts
+++ b/shared/api/customers/changes/V2.3_CustomerEntityData.ts
@@ -1,0 +1,23 @@
+import { ApiVersion } from "@api/versionUtils/ApiVersion";
+import {
+	AffectedResource,
+	defineVersionChange,
+} from "@api/versionUtils/versionChangeUtils/VersionChange";
+import { z } from "zod/v4";
+
+const NoOpSchema = z.any();
+
+/** Side-effect only: <= V2.3 customer reads fold in entity-level data. */
+export const V2_3_CustomerEntityData = defineVersionChange({
+	name: "V2_3_CustomerEntityData",
+	newVersion: ApiVersion.V2_4,
+	oldVersion: ApiVersion.V2_3,
+	description: [
+		"Customer object aggregated entity-level subscriptions and balances before V2_4",
+	],
+	affectedResources: [AffectedResource.Customer],
+	newSchema: NoOpSchema,
+	oldSchema: NoOpSchema,
+	hasSideEffects: true,
+	transformResponse: ({ input }) => input,
+});

--- a/shared/api/versionUtils/ApiVersion.ts
+++ b/shared/api/versionUtils/ApiVersion.ts
@@ -4,6 +4,7 @@
  * Internally we use SemVer for comparison (e.g., "1.1.0")
  */
 export enum ApiVersion {
+	V2_4 = "2.4.0",
 	V2_3 = "2.3.0",
 	V2_2 = "2.2.0",
 	V2_1 = "2.1.0",
@@ -19,4 +20,4 @@ export type ApiVersionString = `${ApiVersion}`;
 
 export const API_VERSIONS = Object.values(ApiVersion);
 
-export const LATEST_VERSION = ApiVersion.V2_3;
+export const LATEST_VERSION = ApiVersion.V2_4;

--- a/shared/api/versionUtils/convertVersionUtils.ts
+++ b/shared/api/versionUtils/convertVersionUtils.ts
@@ -138,6 +138,7 @@ export function createdAtToVersion({
 }: {
 	createdAt?: number;
 }): ApiVersionClass {
+	const v2_4 = new Date("2026-09-04T00:00:00Z").getTime();
 	const v2_3 = new Date("2026-05-13T00:00:00Z").getTime();
 	const v2_2 = new Date("2026-03-18T00:00:00Z").getTime();
 
@@ -147,7 +148,9 @@ export function createdAtToVersion({
 
 	let version: ApiVersion;
 
-	if (!createdAt || createdAt >= v2_3) {
+	if (!createdAt || createdAt >= v2_4) {
+		version = ApiVersion.V2_4;
+	} else if (createdAt >= v2_3) {
 		version = ApiVersion.V2_3;
 	} else if (createdAt >= v2_2) {
 		version = ApiVersion.V2_2;

--- a/shared/api/versionUtils/versionChangeUtils/versionChangeRegistry.ts
+++ b/shared/api/versionUtils/versionChangeUtils/versionChangeRegistry.ts
@@ -26,6 +26,7 @@ import { V1_2_InvoiceChange } from "@api/others/apiInvoice/changes/V1.2_InvoiceC
 
 import { V2_0_CustomerChange } from "@api/customers/changes/V2.0_CustomerChange";
 import { V2_2_PlanInheritedBillingControls } from "@api/customers/changes/V2.2_PlanInheritedBillingControls";
+import { V2_3_CustomerEntityData } from "@api/customers/changes/V2.3_CustomerEntityData";
 import { V1_2_ProductChanges } from "@api/products/changes/V1.2_ProductChanges";
 import { V2_0_PlanChanges } from "@api/products/changes/V2.0_PlanChanges";
 import { V2_1_PlanChanges } from "@api/products/changes/V2.1_PlanChanges";
@@ -45,6 +46,10 @@ import { V2_0_AggregateEventsChange } from "../../events/aggregate/changes/V2.0_
 import { ApiVersion } from "../ApiVersion";
 import type { VersionChangeConstructor } from "./VersionChange";
 import { VersionChangeRegistryClass } from "./VersionChangeRegistryClass";
+
+export const V2_4_CHANGES: VersionChangeConstructor[] = [
+	V2_3_CustomerEntityData, // Side effect: <= V2.3 aggregates entity-level data onto the Customer
+];
 
 export const V2_3_CHANGES: VersionChangeConstructor[] = [
 	V2_2_PlanInheritedBillingControls, // Strips plan-inherited billing controls + source tags for <= V2.2
@@ -106,6 +111,10 @@ export const V0_1_CHANGES: VersionChangeConstructor[] = [];
 
 export function registerAllVersionChanges() {
 	VersionChangeRegistryClass.register({
+		version: ApiVersion.V2_4,
+		changes: V2_4_CHANGES,
+	});
+	VersionChangeRegistryClass.register({
 		version: ApiVersion.V2_3,
 		changes: V2_3_CHANGES,
 	});
@@ -147,4 +156,8 @@ export function registerAllVersionChanges() {
 // Auto-register on import
 registerAllVersionChanges();
 
-export { V0_2_InvoicesAlwaysExpanded, V1_2_CheckQueryChange };
+export {
+	V0_2_InvoicesAlwaysExpanded,
+	V1_2_CheckQueryChange,
+	V2_3_CustomerEntityData,
+};

--- a/shared/api/versionUtils/versionRegistry.ts
+++ b/shared/api/versionUtils/versionRegistry.ts
@@ -14,6 +14,12 @@ export interface VersionMetadata {
  * SemVer ↔ CalVer mappings and metadata
  */
 export const VERSION_REGISTRY: Record<ApiVersion, VersionMetadata> = {
+	[ApiVersion.V2_4]: {
+		semver: ApiVersion.V2_4,
+		calver: "2026-09-04",
+		releasedAt: new Date("2026-09-04").getTime(),
+		description: "Customer object no longer returns entity-level data",
+	},
 	[ApiVersion.V2_3]: {
 		semver: ApiVersion.V2_3,
 		calver: "2026-05-13",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Port of the two API 2.4 behaviors from #2663, without the drained-standalone-balance / usage-tracking work that landed with that branch.

## What changes

**1. Customer-level FullSubject no longer retrieves entity aggregations (V2.4+)**

Up to V2.3 a customer-level read folded in the subscriptions and balances attached to that customer's entities. On the FullSubject path that meant an aggregation whose cost scales with entity count.

From V2.4, customer-level reads report only what is attached to the customer itself. Entity data is read through the entities endpoints. Entity-scoped reads (`entity_id` in the request) are unchanged.

Gated by `shouldAggregateEntityData()`, backed by a side-effect version change (`V2_3_CustomerEntityData`):

- **Hydration:** `getFullSubjectQuery` skips the entity-aggregate CTEs. Both list queries exclude entity-scoped `customer_products` and loose entitlements.
- **Response builders:** a V2.4 request can still hit a FullSubject written by a V2.3 request, so `getApiCustomerV2` strips aggregates and `getApiCustomerBase` drops entity-scoped products.

Dashboard list (`getDashboardCursorPage`) keeps the default and still shows entity data.

**2. Smaller list page size (V2.4+)**

`customers.list` and `entities.list` cap `limit` at **200** (was 1000 and 5000). Implemented as a version-aware default in `getOrgPaginationMaxLimit`, so a per-org override still wins.

## Not in this PR

#2663 also included drained standalone-balance filtering and related track/usage tests. That work is already on `dev` (or is out of scope here). This branch only introduces the two V2.4 behaviors above.

## Tests

- Unit: `shouldAggregateEntityData` and the version-aware page cap (4/4)
- Integration: `api-v2-4-entity-data-contract.test.ts` (5) and `api-v2-4-pagination-limit.test.ts` (2) — **7/7 passed**
- Inverted the “entity plan excluded” assertion once; it failed `Expected: true, Received: false` as intended, then was restored

## Mixed-version cache note

The FullSubject cache key is left unversioned (same call as #2663). A V2.4 write leaves an aggregation-free blob that a V2.3 read will under-report from; the reverse direction is covered by the response gate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f10a8dc2-4c8d-4eff-ab76-65fe0ed27335?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f10a8dc2-4c8d-4eff-ab76-65fe0ed27335&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports two API 2.4 behaviors: customer-level reads no longer fold in entity-level subscriptions and balances, and `customers.list` / `entities.list` page sizes are capped at 200.

- V2.3 and earlier keep aggregating entity data onto customer reads; entity-scoped reads are unchanged.
- Response builders strip entity aggregates so a V2.4 request reading a V2.3-cached subject still reports correctly.
- The FullSubject cache key is unversioned, so a V2.4 write leaves an aggregation-free blob that a V2.3 read will under-report from.
- The page cap is version-aware; per-org overrides still win, and V2.3 keeps the previous 1000/5000 limits.
- Callers without an API version (workers, some fixtures) default to aggregating, so `shouldAggregateEntityData` no longer throws on `apiVersion.lte`.

<sup>Written for commit 04c7c3a67c88601d5880d09d0e475af0e2ffb313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR introduces API 2.4 behavior for customer data aggregation and list pagination while preserving earlier API behavior.
- **[API changes, Improvements]** Customer-level API 2.4 reads omit subscriptions, entitlements, flags, and balances belonging to entities; entity-scoped reads remain unchanged.
- **[API changes, Improvements]** API 2.4 customer and entity list requests use a default maximum page size of 200, while organization-specific overrides still take precedence.
- **[API changes]** API 2.4 becomes the latest version and is assigned to organizations created on or after September 4, 2026.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/repos/getFullSubject/getFullSubjectQuery.ts | Gates customer-level entity aggregation during FullSubject hydration according to the request API version. |
| server/src/internal/customers/cusUtils/customerEntityData.ts | Centralizes the API-version decision and helpers that remove entity-level data from customer responses. |
| server/src/internal/customers/cusUtils/getApiCustomerV2/getApiCustomerV2.ts | Ensures API 2.4 customer responses strip entity aggregates even when reading data hydrated by an earlier API version. |
| server/src/internal/misc/edgeConfig/orgLimitsStore.ts | Applies the API 2.4 page ceiling to customer and entity lists while retaining organization overrides. |
| shared/api/versionUtils/convertVersionUtils.ts | Maps organizations created on or after the API 2.4 release date to the new version. |
| shared/api/versionUtils/versionChangeUtils/versionChangeRegistry.ts | Registers the customer entity-data behavior as the API 2.4 side-effect change. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Request[Customer or entity request] --> Version{API version}
    Version -->|V2.3 or earlier| Aggregate[Include customer and entity-level data]
    Version -->|V2.4 or later| Scope{Requested subject}
    Scope -->|Customer| CustomerOnly[Return customer-level data only]
    Scope -->|Entity| EntityData[Return entity-scoped data]
    Request --> List{List request?}
    List -->|V2.4 customers or entities| Cap[Apply default maximum limit of 200]
    List -->|Earlier version| LegacyCap[Apply previous default limit]
    Cap --> Override{Organization override?}
    Override -->|Yes| OrgLimit[Use organization limit]
    Override -->|No| DefaultLimit[Use limit 200]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): default entity aggregation on ..."](https://github.com/useautumn/autumn/commit/04c7c3a67c88601d5880d09d0e475af0e2ffb313) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60343389)</sub>

<!-- /greptile_comment -->