### PR TITLE
fix: let one-off plans transfer to a scope that already holds one

### DIFF
--- a/server/src/internal/customers/handlers/handleTransferProduct/transferRelatedCustomerProducts.ts
+++ b/server/src/internal/customers/handlers/handleTransferProduct/transferRelatedCustomerProducts.ts
@@ -69,13 +69,18 @@ export const findExistingTransferTargetProduct = ({
 	fullCustomer,
 	toEntity,
 	product,
+	isOneOff,
 	transferringCustomerProducts,
 }: {
 	fullCustomer: FullCustomer;
 	toEntity: Entity | null;
 	product: TransferProduct;
+	/** One-off plans stack, so the target already holding one is not a collision. */
+	isOneOff: boolean;
 	transferringCustomerProducts: FullCusProduct[];
 }) => {
+	if (isOneOff) return undefined;
+
 	const transferringScheduledStates = new Set(
 		transferringCustomerProducts.map((cusProduct) =>
 			isCustomerProductScheduled(cusProduct),

--- a/server/src/internal/customers/handlers/handleTransferProductV2.ts
+++ b/server/src/internal/customers/handlers/handleTransferProductV2.ts
@@ -3,6 +3,8 @@ import {
 	AttachScenario,
 	CusProductAlreadyExistsError,
 	CusProductNotFoundError,
+	customerProductToEffectivePrices,
+	isOneOffProduct,
 	RecaseError,
 	Scopes,
 } from "@autumn/shared";
@@ -123,6 +125,11 @@ export const handleTransferProductV2 = createRoute({
 			fullCustomer: customer,
 			toEntity,
 			product,
+			isOneOff: isOneOffProduct({
+				prices: customerProductToEffectivePrices({
+					customerProduct: cusProduct,
+				}),
+			}),
 			transferringCustomerProducts: getTransferCustomerProducts({
 				fullCustomer: customer,
 				fromEntity,

--- a/server/tests/unit/customers/transfer-related-customer-products.test.ts
+++ b/server/tests/unit/customers/transfer-related-customer-products.test.ts
@@ -171,6 +171,7 @@ describe("transfer target collision", () => {
 			} as FullCustomer,
 			toEntity: targetEntity,
 			product,
+			isOneOff: false,
 			transferringCustomerProducts: [scheduledSource],
 		});
 
@@ -184,6 +185,7 @@ describe("transfer target collision", () => {
 			} as FullCustomer,
 			toEntity: targetEntity,
 			product,
+			isOneOff: false,
 			transferringCustomerProducts: [scheduledSource],
 		});
 
@@ -199,6 +201,7 @@ describe("transfer target collision", () => {
 			} as FullCustomer,
 			toEntity: targetEntity,
 			product,
+			isOneOff: false,
 			transferringCustomerProducts: [activeSource],
 		});
 


### PR DESCRIPTION
## Problem

Reported by athenahq: transferring their `credits_add-on_one_time` add-on from an entity to the customer fails with `Customer <id> already has plan credits_add-on_one_time` — even though it is a one-time plan that can be bought many times.

`findExistingTransferTargetProduct` treats any add-on the destination already holds as a collision, matching on `product_id` alone. It never asks whether the plan is one-off:

```
attach  credits_add-on_one_time  ->  setupAttachTransitionContext
                                     is_add_on || one-off ? bail early -> no conflict -> OK

transfer credits_add-on_one_time ->  matchesTransferProduct
                                     is_add_on ? match on product_id ALONE   <-- never checks one-off
                                     -> findExistingTransferTargetProduct hits -> 409
```

So attach and transfer disagree: the plan can be purchased repeatedly but never moved between an entity and the customer. Because one-off plans never expire, a single prior purchase blocks that add-on from ever being transferred to that scope again.

Production confirms stacking is legal — athenahq customer `cus_2xzWcJ9XdZ0O31Nyz81codt0esD` holds two active copies of `credits_add-on_one_time` at customer level.

## Fix

`findExistingTransferTargetProduct` takes an `isOneOff` flag and skips the collision check when set. The handler derives it from the effective prices on the customer product being moved, so transfer now agrees with attach.

## Scope

Deliberately limited to one-off plans. Attach is looser still — it exempts *every* add-on from its transition lookup, so recurring add-ons like `credits_add-on` also stack there but will keep colliding on transfer. Whether recurring add-ons should stack on transfer is a separate call and not made here.

## Testing

`bun ts` and the existing `transfer-related-customer-products` unit tests pass. The three existing `findExistingTransferTargetProduct` call sites gained an explicit `isOneOff: false` since the parameter is required.

Not verified against the original failing request — the Axiom token was expired, so this rests on the code path plus production DB state. Worth re-running athenahq's transfer once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes transferring one-off add-ons to a customer that already holds the same plan. Previously the transfer endpoint rejected any add-on the destination already held without checking whether the plan was one-off, so a one-time add-on could be bought repeatedly but never moved between an entity and a customer.

- One-off plans now skip the collision check, matching attach behavior.
- Recurring add-ons still collide on transfer as before.

<sup>Written for commit 42aa8b85f279f554b2fa4885074ef4e01cf959a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns product transfers with one-off purchase behavior by allowing one-off plans to move into a scope that already holds the plan.
- **Bug fixes:** Detects whether the transferred customer product is one-off and skips the target collision for stackable one-off purchases.
- **API changes:** Adds a required `isOneOff` argument to the internal transfer-collision helper.
- **Improvements:** Updates existing recurring-plan collision tests for the new helper contract, though the new one-off branch itself remains untested.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking concern that the newly fixed one-off transfer scenario lacks a regression test.

The implementation limits the collision bypass to products classified as one-off, but the focused tests exercise only the unchanged recurring behavior, leaving the repaired scenario vulnerable to an unnoticed regression.

**Files Needing Attention:** server/tests/unit/customers/transfer-related-customer-products.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/handlers/handleTransferProduct/transferRelatedCustomerProducts.ts | Adds a required one-off flag and bypasses target collision detection for stackable one-off products. |
| server/src/internal/customers/handlers/handleTransferProductV2.ts | Classifies the transferred customer product from its effective prices and passes the result into collision detection. |
| server/tests/unit/customers/transfer-related-customer-products.test.ts | Updates recurring collision cases for the new argument but does not test the newly introduced one-off bypass. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Transfer requested] --> B[Resolve effective prices]
    B --> C{One-off product?}
    C -->|Yes| D[Allow stacking at target scope]
    C -->|No| E[Check target for collision]
    E -->|Collision| F[Return already-exists error]
    E -->|No collision| G[Transfer product]
    D --> G
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/tests/unit/customers/transfer-related-customer-products.test.ts:174
**One-off bypass remains untested**

These updated cases all pass `isOneOff: false`, so they do not exercise the new collision bypass. Add a case where the destination already holds the one-off plan and assert that the transfer is allowed, preventing the original failure from returning unnoticed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: let one-off plans transfer to a sco..."](https://github.com/useautumn/autumn/commit/42aa8b85f279f554b2fa4885074ef4e01cf959a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60363262)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->