### PR TITLE
fix(stripe): enqueue webhook replay when a sync-ack webhook would 500

### DIFF
--- a/server/src/external/stripe/webhookMiddlewares/stripeWebhookAckMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeWebhookAckMiddleware.ts
@@ -1,6 +1,7 @@
 import { context, SpanStatusCode, trace } from "@opentelemetry/api";
 import type { Context, Next } from "hono";
 import { enqueueStripeWebhookReplay } from "../webhookReplay/enqueueStripeWebhookReplay.js";
+import { stripeWebhookErrorWouldRedeliver } from "../webhookReplay/stripeWebhookErrorWouldRedeliver.js";
 import { classifyStripeWebhookAckMode } from "./classifyStripeWebhookAckMode.js";
 import type { StripeWebhookHonoEnv } from "./stripeWebhookContext.js";
 
@@ -31,6 +32,15 @@ export const stripeWebhookAckMiddleware = async (
 	const idempotency = ctx.webhookIdempotency;
 
 	if (ackMode === "sync") {
+		const queueSyncFailure = (error: unknown) => {
+			if (!stripeWebhookErrorWouldRedeliver({ error })) return;
+			return enqueueStripeWebhookReplay({
+				ctx,
+				failureReason:
+					error instanceof Error ? error.message : String(error),
+			});
+		};
+
 		try {
 			await next();
 		} catch (error) {
@@ -38,6 +48,7 @@ export const stripeWebhookAckMiddleware = async (
 				error,
 			});
 			await idempotency?.release();
+			await queueSyncFailure(error);
 			return c.json(
 				{ message: "Webhook processing failed, Stripe will retry" },
 				500,
@@ -48,6 +59,7 @@ export const stripeWebhookAckMiddleware = async (
 		// the response), so failure must be detected here, not via catch.
 		if (c.error) {
 			await idempotency?.release();
+			await queueSyncFailure(c.error);
 			return;
 		}
 

--- a/server/src/external/stripe/webhookReplay/runStripeWebhookReplay.ts
+++ b/server/src/external/stripe/webhookReplay/runStripeWebhookReplay.ts
@@ -13,6 +13,7 @@ import {
 import { syncStripeEventToSyncDb } from "../webhookMiddlewares/stripeSyncMiddleware.js";
 import { attachStripeEventCustomer } from "../webhookMiddlewares/stripeToAutumnCustomerMiddleware.js";
 import type { StripeWebhookContext } from "../webhookMiddlewares/stripeWebhookContext.js";
+import { STRIPE_WEBHOOK_REPLAY_MAX_ATTEMPTS } from "./stripeWebhookErrorWouldRedeliver.js";
 
 export type StripeWebhookReplayPayload = {
 	orgId: string;
@@ -38,9 +39,11 @@ export class StripeWebhookReplayInFlightError extends Error {
 export const runStripeWebhookReplay = async ({
 	ctx,
 	payload,
+	receiveCount = 1,
 }: {
 	ctx: AutumnContext;
 	payload: StripeWebhookReplayPayload;
+	receiveCount?: number;
 }) => {
 	const { stripeEvent } = payload;
 	const { logger } = ctx;
@@ -69,6 +72,7 @@ export const runStripeWebhookReplay = async ({
 	}
 
 	if (claim === "in_flight") {
+		if (receiveCount >= STRIPE_WEBHOOK_REPLAY_MAX_ATTEMPTS) return;
 		throw new StripeWebhookReplayInFlightError(stripeEvent.id);
 	}
 
@@ -80,6 +84,7 @@ export const runStripeWebhookReplay = async ({
 		await runStripeWebhookHandlers({ ctx: routedCtx });
 	} catch (error) {
 		if (claim === "claimed") await releaseStripeWebhookEvent({ eventKey });
+		if (receiveCount >= STRIPE_WEBHOOK_REPLAY_MAX_ATTEMPTS) return;
 		throw error;
 	}
 

--- a/server/src/external/stripe/webhookReplay/stripeWebhookErrorWouldRedeliver.ts
+++ b/server/src/external/stripe/webhookReplay/stripeWebhookErrorWouldRedeliver.ts
@@ -1,0 +1,24 @@
+import { RecaseError } from "@autumn/shared";
+import Stripe from "stripe";
+import { handleWebhookErrorSkip } from "@/utils/routerUtils/webhookErrorSkip.js";
+
+export const STRIPE_WEBHOOK_REPLAY_MAX_ATTEMPTS = 30;
+
+/** True when the HTTP webhook path would 500 Stripe (so it retries). */
+export const stripeWebhookErrorWouldRedeliver = ({
+	error,
+}: {
+	error: unknown;
+}): boolean => {
+	if (handleWebhookErrorSkip({ error })) return false;
+	if (error instanceof Stripe.errors.StripeError) return false;
+	if (
+		process.env.NODE_ENV === "development" &&
+		error instanceof Error &&
+		error.message.includes("No stripe account linked to organization")
+	) {
+		return false;
+	}
+	if (error instanceof RecaseError) return error.statusCode >= 500;
+	return true;
+};

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -102,6 +102,9 @@ const JOB_OVERRIDES: Partial<Record<JobName, JobOverride>> = {
 	[JobName.AutoTopUp]: {
 		visibilityTimeoutSeconds: seconds.minutes(2),
 	},
+	[JobName.StripeWebhookReplay]: {
+		visibilityTimeoutSeconds: seconds.minutes(1),
+	},
 };
 
 const getJobOverride = (jobName: string): JobOverride | undefined =>

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -11,6 +11,7 @@ import {
 	runStripeWebhookReplay,
 	StripeWebhookReplayInFlightError,
 } from "@/external/stripe/webhookReplay/runStripeWebhookReplay.js";
+import { stripeWebhookErrorWouldRedeliver } from "@/external/stripe/webhookReplay/stripeWebhookErrorWouldRedeliver.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { runActionHandlerTask } from "@/internal/analytics/runActionHandlerTask.js";
 import { autoTopup } from "@/internal/balances/autoTopUp/autoTopup.js";
@@ -104,8 +105,7 @@ export const shouldRetrySqsJobError = ({
 		case JobName.StripeWebhookReplay:
 			return (
 				error instanceof StripeWebhookReplayInFlightError ||
-				isTransientDbError({ error }) ||
-				isTransientRedisError({ error })
+				stripeWebhookErrorWouldRedeliver({ error })
 			);
 		default:
 			return false;
@@ -236,6 +236,7 @@ export const processMessage = async ({
 			await runStripeWebhookReplay({
 				ctx,
 				payload: job.data,
+				receiveCount: Number.isFinite(receiveCount) ? receiveCount : 1,
 			});
 			return;
 		}

--- a/server/tests/integration/stripe/webhookAck/stripe-webhook-sync-replay-idempotency.test.ts
+++ b/server/tests/integration/stripe/webhookAck/stripe-webhook-sync-replay-idempotency.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Worker replay and Stripe HTTP share the Redis claim. First success wins:
+ * the other path must not run the handler again.
+ *
+ * Contract:
+ *   - Worker completes → Stripe redelivery 200 {duplicate:true}, handler once
+ *   - Stripe completes → worker no-ops, handler once
+ *   - Stripe in-flight → worker throws InFlightError (no handler); after
+ *     Stripe succeeds, both a worker retry and a Stripe retry skip
+ *   - Worker in-flight → Stripe HTTP 500 in_flight (no handler); after
+ *     worker succeeds, Stripe retry 200 {duplicate:true}
+ *
+ * Lives in integration because it uses the real Redis claim the route and
+ * runStripeWebhookReplay both call.
+ */
+
+import { afterAll, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { AppEnv } from "@autumn/shared";
+import chalk from "chalk";
+import { Hono } from "hono";
+import type Stripe from "stripe";
+import { getMiscRedis } from "@/external/redis/initRedis";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { mockModuleWithRestore } from "../../../unit/utils/mockModuleWithRestore.js";
+
+const originalReplayQueueUrl = process.env.STRIPE_WEBHOOK_SQS_QUEUE_URL;
+process.env.STRIPE_WEBHOOK_SQS_QUEUE_URL = "";
+
+const processCounts = new Map<string, number>();
+const workerHold = new Map<string, Promise<void>>();
+
+const bumpProcess = (eventId: string) => {
+	processCounts.set(eventId, (processCounts.get(eventId) ?? 0) + 1);
+};
+
+await mockModuleWithRestore("@/external/connect/createStripeCli.js", () => ({
+	createStripeCli: () => ({}),
+}));
+
+await mockModuleWithRestore(
+	"@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js",
+	() => ({ deleteCachedFullCustomer: async () => {} }),
+);
+
+await mockModuleWithRestore(
+	"@/external/stripe/runStripeWebhookHandlers.js",
+	() => ({
+		runStripeWebhookHandlers: async ({ ctx }: { ctx: AutumnContext }) => {
+			const eventId = (ctx as AutumnContext & { stripeEvent: Stripe.Event })
+				.stripeEvent.id;
+			const hold = workerHold.get(eventId);
+			if (hold) await hold;
+			bumpProcess(eventId);
+		},
+	}),
+);
+
+await mockModuleWithRestore(
+	"@/external/stripe/webhookMiddlewares/stripeSyncMiddleware.js",
+	() => ({ syncStripeEventToSyncDb: () => {} }),
+);
+
+await mockModuleWithRestore(
+	"@/external/stripe/webhookMiddlewares/stripeToAutumnCustomerMiddleware.js",
+	() => ({
+		attachStripeEventCustomer: async ({ ctx }: { ctx: AutumnContext }) => ctx,
+	}),
+);
+
+const { runStripeWebhookReplay, StripeWebhookReplayInFlightError } =
+	await import(
+		// @ts-expect-error - Bun cache-busting query isolates module mocks.
+		"@/external/stripe/webhookReplay/runStripeWebhookReplay.js?syncReplayIdempotency"
+	);
+
+const { stripeIdempotencyMiddleware } = await import(
+	"@/external/stripe/webhookMiddlewares/stripeIdempotencyMiddleware.js"
+);
+const { stripeWebhookAckMiddleware } = await import(
+	"@/external/stripe/webhookMiddlewares/stripeWebhookAckMiddleware.js"
+);
+
+const REDIS_READY_TIMEOUT_MS = 10_000;
+const POLL_INTERVAL_MS = 100;
+const CONDITION_TIMEOUT_MS = 5000;
+
+const waitForRedisReady = async () => {
+	const deadline = Date.now() + REDIS_READY_TIMEOUT_MS;
+	while (getMiscRedis().status !== "ready") {
+		if (Date.now() > deadline) {
+			throw new Error(
+				`Redis never became ready (status: ${getMiscRedis().status})`,
+			);
+		}
+		await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+	}
+};
+
+const waitForCondition = async ({
+	condition,
+	description,
+}: {
+	condition: () => Promise<boolean>;
+	description: string;
+}) => {
+	const deadline = Date.now() + CONDITION_TIMEOUT_MS;
+	while (!(await condition())) {
+		if (Date.now() > deadline) {
+			throw new Error(`Timed out waiting for: ${description}`);
+		}
+		await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+	}
+};
+
+const buildCheckoutEvent = (eventId: string): Stripe.Event =>
+	({
+		id: eventId,
+		type: "checkout.session.completed",
+		data: { object: {} },
+		request: null,
+	}) as unknown as Stripe.Event;
+
+const redisKeyFor = ({ orgId, eventId }: { orgId: string; eventId: string }) =>
+	`stripe:webhook:${orgId}:sandbox:${eventId}`;
+
+const createWebhookApp = ({
+	orgId,
+	event,
+	handler,
+}: {
+	orgId: string;
+	event: Stripe.Event;
+	handler: () => Response | Promise<Response>;
+}) => {
+	const app = new Hono();
+
+	app.use("*", async (c, next) => {
+		(c as never as { set: (key: string, value: unknown) => void }).set("ctx", {
+			org: { id: orgId },
+			env: AppEnv.Sandbox,
+			stripeEvent: event,
+			logger: { error: () => {}, warn: () => {}, info: () => {} },
+		});
+		await next();
+	});
+
+	app.post(
+		"/webhook",
+		stripeIdempotencyMiddleware as never,
+		stripeWebhookAckMiddleware as never,
+		handler as never,
+	);
+
+	return app;
+};
+
+const workerCtx = ({ orgId }: { orgId: string }) =>
+	({
+		org: { id: orgId },
+		env: AppEnv.Sandbox,
+		logger: { info: () => {}, error: () => {}, warn: () => {} },
+	}) as unknown as AutumnContext;
+
+const replay = ({
+	orgId,
+	event,
+}: {
+	orgId: string;
+	event: Stripe.Event;
+}) =>
+	runStripeWebhookReplay({
+		ctx: workerCtx({ orgId }),
+		payload: {
+			orgId,
+			env: AppEnv.Sandbox,
+			stripeEvent: event,
+			failedAt: Date.now(),
+			failureReason: "test",
+		},
+	});
+
+test.concurrent(
+	`${chalk.yellowBright("webhookAck: worker success then Stripe retry 200s without reprocessing")}`,
+	async () => {
+		await waitForRedisReady();
+		const orgId = `org_replay_${randomUUID()}`;
+		const eventId = `evt_${randomUUID()}`;
+		const event = buildCheckoutEvent(eventId);
+
+		const app = createWebhookApp({
+			orgId,
+			event,
+			handler: () => {
+				bumpProcess(eventId);
+				return new Response(JSON.stringify({ success: true }), { status: 200 });
+			},
+		});
+
+		await replay({ orgId, event });
+		expect(processCounts.get(eventId)).toBe(1);
+		expect(await getMiscRedis().get(redisKeyFor({ orgId, eventId }))).toBe(
+			"completed",
+		);
+
+		const stripeRetry = await app.request("/webhook", { method: "POST" });
+		expect(stripeRetry.status).toBe(200);
+		expect(await stripeRetry.json()).toEqual({
+			received: true,
+			duplicate: true,
+		});
+		expect(processCounts.get(eventId)).toBe(1);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("webhookAck: Stripe success then worker skip without reprocessing")}`,
+	async () => {
+		await waitForRedisReady();
+		const orgId = `org_replay_${randomUUID()}`;
+		const eventId = `evt_${randomUUID()}`;
+		const event = buildCheckoutEvent(eventId);
+
+		const app = createWebhookApp({
+			orgId,
+			event,
+			handler: () => {
+				bumpProcess(eventId);
+				return new Response(JSON.stringify({ success: true }), { status: 200 });
+			},
+		});
+
+		const first = await app.request("/webhook", { method: "POST" });
+		expect(first.status).toBe(200);
+		expect(processCounts.get(eventId)).toBe(1);
+
+		await replay({ orgId, event });
+		expect(processCounts.get(eventId)).toBe(1);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("webhookAck: Stripe in-flight blocks the worker; after success neither reprocesses")}`,
+	async () => {
+		await waitForRedisReady();
+		const orgId = `org_replay_${randomUUID()}`;
+		const eventId = `evt_${randomUUID()}`;
+		const event = buildCheckoutEvent(eventId);
+		let resolveProcessing!: () => void;
+		const processing = new Promise<void>((resolve) => {
+			resolveProcessing = resolve;
+		});
+
+		const app = createWebhookApp({
+			orgId,
+			event,
+			handler: async () => {
+				await processing;
+				bumpProcess(eventId);
+				return new Response(JSON.stringify({ success: true }), { status: 200 });
+			},
+		});
+
+		const stripeDelivery = app.request("/webhook", { method: "POST" });
+		await waitForCondition({
+			condition: async () =>
+				(await getMiscRedis().get(redisKeyFor({ orgId, eventId }))) ===
+				"processing",
+			description: "Stripe delivery to acquire the processing lock",
+		});
+
+		await expect(replay({ orgId, event })).rejects.toBeInstanceOf(
+			StripeWebhookReplayInFlightError,
+		);
+		expect(processCounts.get(eventId) ?? 0).toBe(0);
+
+		resolveProcessing();
+		expect((await stripeDelivery).status).toBe(200);
+		expect(processCounts.get(eventId)).toBe(1);
+
+		await replay({ orgId, event });
+		const stripeRetry = await app.request("/webhook", { method: "POST" });
+		expect(stripeRetry.status).toBe(200);
+		expect(await stripeRetry.json()).toEqual({
+			received: true,
+			duplicate: true,
+		});
+		expect(processCounts.get(eventId)).toBe(1);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("webhookAck: worker in-flight 500s Stripe; after success Stripe retry does not reprocess")}`,
+	async () => {
+		await waitForRedisReady();
+		const orgId = `org_replay_${randomUUID()}`;
+		const eventId = `evt_${randomUUID()}`;
+		const event = buildCheckoutEvent(eventId);
+		let resolveProcessing!: () => void;
+		workerHold.set(
+			eventId,
+			new Promise<void>((resolve) => {
+				resolveProcessing = resolve;
+			}),
+		);
+
+		const app = createWebhookApp({
+			orgId,
+			event,
+			handler: () => {
+				bumpProcess(eventId);
+				return new Response(JSON.stringify({ success: true }), { status: 200 });
+			},
+		});
+
+		const workerRun = replay({ orgId, event });
+		await waitForCondition({
+			condition: async () =>
+				(await getMiscRedis().get(redisKeyFor({ orgId, eventId }))) ===
+				"processing",
+			description: "worker to acquire the processing lock",
+		});
+
+		const inFlight = await app.request("/webhook", { method: "POST" });
+		expect(inFlight.status).toBe(500);
+		expect(await inFlight.json()).toEqual({
+			received: false,
+			in_flight: true,
+		});
+		expect(processCounts.get(eventId) ?? 0).toBe(0);
+
+		resolveProcessing();
+		await workerRun;
+		expect(processCounts.get(eventId)).toBe(1);
+
+		const stripeRetry = await app.request("/webhook", { method: "POST" });
+		expect(stripeRetry.status).toBe(200);
+		expect(await stripeRetry.json()).toEqual({
+			received: true,
+			duplicate: true,
+		});
+		expect(processCounts.get(eventId)).toBe(1);
+	},
+);
+
+afterAll(() => {
+	process.env.STRIPE_WEBHOOK_SQS_QUEUE_URL = originalReplayQueueUrl;
+});

--- a/server/tests/unit/queue/processMessage.test.ts
+++ b/server/tests/unit/queue/processMessage.test.ts
@@ -56,4 +56,22 @@ describe("shouldRetrySqsJobError", () => {
 			}),
 		).toBe(false);
 	});
+
+	test("retries stripe webhook replay on handler errors that would 500 Stripe", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.StripeWebhookReplay,
+				error: new Error("duplicate key value violates unique constraint"),
+			}),
+		).toBe(true);
+	});
+
+	test("does not retry stripe webhook replay on errors that would not 500 Stripe", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.StripeWebhookReplay,
+				error: new Error("Not a valid URL"),
+			}),
+		).toBe(false);
+	});
 });

--- a/server/tests/unit/webhooks/stripe-webhook-replay-max-attempts.test.ts
+++ b/server/tests/unit/webhooks/stripe-webhook-replay-max-attempts.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, expect, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import type Stripe from "stripe";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const state = {
+	claim: "claimed" as "claimed" | "in_flight",
+	handlerError: null as Error | null,
+};
+
+await mockModuleWithRestore("@/external/connect/createStripeCli.js", () => ({
+	createStripeCli: () => ({}),
+}));
+
+await mockModuleWithRestore(
+	"@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js",
+	() => ({ deleteCachedFullCustomer: async () => {} }),
+);
+
+await mockModuleWithRestore(
+	"@/external/stripe/runStripeWebhookHandlers.js",
+	() => ({
+		runStripeWebhookHandlers: async () => {
+			if (state.handlerError) throw state.handlerError;
+		},
+	}),
+);
+
+await mockModuleWithRestore(
+	"@/external/stripe/webhookMiddlewares/stripeIdempotencyMiddleware.js",
+	() => ({
+		buildStripeWebhookEventKey: () => "stripe_webhook_event:test",
+		claimStripeWebhookEvent: async () => state.claim,
+		completeStripeWebhookEvent: async () => {},
+		releaseStripeWebhookEvent: async () => {},
+	}),
+);
+
+await mockModuleWithRestore(
+	"@/external/stripe/webhookMiddlewares/stripeSyncMiddleware.js",
+	() => ({ syncStripeEventToSyncDb: () => {} }),
+);
+
+await mockModuleWithRestore(
+	"@/external/stripe/webhookMiddlewares/stripeToAutumnCustomerMiddleware.js",
+	() => ({
+		attachStripeEventCustomer: async ({ ctx }: { ctx: AutumnContext }) => ctx,
+	}),
+);
+
+const { runStripeWebhookReplay } = await import(
+	// @ts-expect-error - Bun cache-busting query isolates module mocks.
+	"@/external/stripe/webhookReplay/runStripeWebhookReplay.js?maxAttempts"
+);
+
+const replay = ({ receiveCount }: { receiveCount: number }) =>
+	runStripeWebhookReplay({
+		ctx: {
+			id: "request_123",
+			org: { id: "org_123" },
+			env: AppEnv.Sandbox,
+			logger: { info: () => {} },
+		} as unknown as AutumnContext,
+		payload: {
+			orgId: "org_123",
+			env: AppEnv.Sandbox,
+			stripeEvent: {
+				id: "evt_123",
+				type: "checkout.session.completed",
+			} as Stripe.Event,
+			failedAt: Date.now(),
+			failureReason: "test",
+		},
+		receiveCount,
+	});
+
+beforeEach(() => {
+	state.claim = "claimed";
+	state.handlerError = new Error("duplicate key value violates unique constraint");
+});
+
+test("rethrows handler errors before the attempt cap", async () => {
+	await expect(replay({ receiveCount: 29 })).rejects.toThrow("duplicate key");
+});
+
+test("ACKs a still-failing replay at the attempt cap", async () => {
+	await expect(replay({ receiveCount: 30 })).resolves.toBeUndefined();
+});

--- a/server/tests/unit/webhooks/stripe-webhook-sync-ack-replay.test.ts
+++ b/server/tests/unit/webhooks/stripe-webhook-sync-ack-replay.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Sync-ack failures that would 500 Stripe enqueue the in-house replay job.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type Stripe from "stripe";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const enqueueCalls: Array<{ failureReason: string }> = [];
+
+await mockModuleWithRestore(
+	"@/external/stripe/webhookReplay/enqueueStripeWebhookReplay.js",
+	() => ({
+		enqueueStripeWebhookReplay: async ({
+			failureReason,
+		}: {
+			failureReason: string;
+		}) => {
+			enqueueCalls.push({ failureReason });
+			return true;
+		},
+	}),
+);
+
+const { stripeWebhookAckMiddleware } = await import(
+	// @ts-expect-error - Bun cache-busting query isolates module mocks.
+	"@/external/stripe/webhookMiddlewares/stripeWebhookAckMiddleware.js?syncAckReplay"
+);
+
+const checkoutCompleted = {
+	id: "evt_checkout_test",
+	type: "checkout.session.completed",
+	data: { object: {} },
+	request: null,
+} as unknown as Stripe.Event;
+
+const createApp = ({
+	handler,
+}: {
+	handler: () => Response | Promise<Response>;
+}) => {
+	const app = new Hono();
+	const hookCalls = { completed: 0, released: 0 };
+
+	app.use("*", async (c, next) => {
+		(c as never as { set: (key: string, value: unknown) => void }).set("ctx", {
+			logger: { error: () => {}, warn: () => {}, info: () => {} },
+			stripeEvent: checkoutCompleted,
+			webhookAckMode: "sync",
+			webhookIdempotency: {
+				markCompleted: async () => {
+					hookCalls.completed++;
+				},
+				release: async () => {
+					hookCalls.released++;
+				},
+			},
+		});
+		await next();
+	});
+
+	app.post("/webhook", stripeWebhookAckMiddleware as never, handler as never);
+	return { app, hookCalls };
+};
+
+beforeEach(() => {
+	enqueueCalls.length = 0;
+});
+
+describe("sync webhook failure enqueues replay", () => {
+	test("enqueues, releases, and 500s on a handler error Stripe would retry", async () => {
+		const { app, hookCalls } = createApp({
+			handler: () => {
+				throw new Error("db connection reset");
+			},
+		});
+
+		const response = await app.request("/webhook", { method: "POST" });
+
+		expect(response.status).toBe(500);
+		expect(hookCalls.released).toBe(1);
+		expect(hookCalls.completed).toBe(0);
+		expect(enqueueCalls).toEqual([{ failureReason: "db connection reset" }]);
+	});
+
+	test("does not enqueue skipped webhook errors", async () => {
+		const { app, hookCalls } = createApp({
+			handler: () => {
+				throw new Error("Not a valid URL");
+			},
+		});
+
+		const response = await app.request("/webhook", { method: "POST" });
+
+		expect(response.status).toBe(500);
+		expect(hookCalls.released).toBe(1);
+		expect(enqueueCalls).toEqual([]);
+	});
+});

--- a/server/tests/unit/webhooks/stripeWebhookErrorWouldRedeliver.test.ts
+++ b/server/tests/unit/webhooks/stripeWebhookErrorWouldRedeliver.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { RecaseError } from "@autumn/shared";
+import Stripe from "stripe";
+import { stripeWebhookErrorWouldRedeliver } from "@/external/stripe/webhookReplay/stripeWebhookErrorWouldRedeliver";
+
+describe("stripeWebhookErrorWouldRedeliver", () => {
+	test("redelivers unknown handler errors (HTTP 500)", () => {
+		expect(
+			stripeWebhookErrorWouldRedeliver({
+				error: new Error("duplicate key value violates unique constraint"),
+			}),
+		).toBe(true);
+	});
+
+	test("redelivers RecaseError only when status is 5xx", () => {
+		expect(
+			stripeWebhookErrorWouldRedeliver({
+				error: new RecaseError({ message: "bad request", statusCode: 400 }),
+			}),
+		).toBe(false);
+		expect(
+			stripeWebhookErrorWouldRedeliver({
+				error: new RecaseError({ message: "db down", statusCode: 500 }),
+			}),
+		).toBe(true);
+	});
+
+	test("does not redeliver Stripe API errors (HTTP 400)", () => {
+		expect(
+			stripeWebhookErrorWouldRedeliver({
+				error: new Stripe.errors.StripeInvalidRequestError({
+					message: "No such customer: cus_123",
+					type: "invalid_request_error",
+				}),
+			}),
+		).toBe(false);
+	});
+
+	test("does not redeliver skipped webhook errors (HTTP 200)", () => {
+		expect(
+			stripeWebhookErrorWouldRedeliver({
+				error: new Error("Not a valid URL"),
+			}),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

When a **sync-acked** Stripe webhook (checkout completed, etc.) fails with an error that would 500 Stripe, enqueue the existing `StripeWebhookReplay` job **and still return 500**. Stripe remains the backup retry. Checkout stays sync-acked.

## Why

Stripe’s first successful retry after a checkout 500 is typically the ~1h backoff slot. The in-house replay queue already exists and is on in prod for early-ack failures. Using it for sync 500s recovers the customer’s plan in ~60s instead of waiting on Stripe.

## Behavior

- Enqueue only when `stripeWebhookErrorWouldRedeliver` is true (unknown/5xx). Skip, Stripe API, and 4xx RecaseErrors are not queued.
- Worker retries the same 500-class errors, not only transient DB/Redis/`in_flight`.
- Replay visibility is **60s**. After **30** attempts the worker ACKs and stops.
- Early-ack enqueue, Redis lock, ack-mode classifier, and `defaultEnabled: false` are unchanged.

## Test plan

- [x] Unit: classifier (`stripeWebhookErrorWouldRedeliver`)
- [x] Unit: sync-ack middleware enqueues on 500-class errors, not on skip errors
- [x] Unit: `shouldRetrySqsJobError` for StripeWebhookReplay
- [x] Unit: replay worker ACKs at attempt 30
- [x] Unit: existing ack-mode / early-ack / replay-cache tests (51 pass)
- [x] Integration: worker vs Stripe HTTP share the Redis claim — first success wins, no double process (4 pass)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10bf6c7e-1932-4f63-8e8f-63b80285c6b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10bf6c7e-1932-4f63-8e8f-63b80285c6b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync-acked Stripe webhooks that would 500 Stripe now enqueue the in-house `StripeWebhookReplay` job, so customers recover in ~60s instead of waiting on Stripe's hour-scale retry. Stripe still gets the 500 and remains the backup retry; checkout stays sync-acked.

**Behavior**
- Enqueue only when `stripeWebhookErrorWouldRedeliver` is true (unknown errors and 5xx `RecaseError`s); skip errors, Stripe API errors, and 4xx `RecaseError`s are not queued.
- The replay worker now retries 500-class handler errors, not only transient DB/Redis errors.
- Replay visibility is 60s; the worker ACKs and stops after 30 attempts.
- Worker and Stripe HTTP share the Redis claim; first success wins and the other path skips without reprocessing.
- Early-ack enqueue, Redis lock, ack-mode classifier, and `defaultEnabled: false` are unchanged.

<sup>Written for commit 8aefcaed0437add410d1ed275a59eb3dae5ea2c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR accelerates recovery from failed synchronous Stripe webhooks by using the existing replay queue while retaining Stripe’s HTTP retry as a backup.

- **Bug fixes:** Enqueues replay jobs when synchronous webhook processing encounters an error that returns HTTP 500.
- **Improvements:** Reuses the webhook HTTP error classification to decide which replay failures should remain retryable.
- **Improvements:** Sets replay visibility to 60 seconds and acknowledges terminal failures after 30 deliveries.
- **Improvements:** Adds focused tests for enqueue classification, replay retry behavior, and the delivery cap.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The new replay enqueue, retry classification, visibility override, and bounded terminal acknowledgment are consistent with the explicitly documented behavior, while the existing enqueue and idempotency safeguards remain intact.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookMiddlewares/stripeWebhookAckMiddleware.ts | Enqueues the existing replay job for synchronous webhook failures classified as HTTP-500-equivalent while preserving the 500 response. |
| server/src/external/stripe/webhookReplay/stripeWebhookErrorWouldRedeliver.ts | Centralizes the policy for errors eligible for local replay and defines the 30-delivery cap. |
| server/src/external/stripe/webhookReplay/runStripeWebhookReplay.ts | Stops retrying in-flight or handler failures once the replay reaches its configured delivery limit. |
| server/src/queue/processMessage.ts | Passes the SQS receive count into replay processing and applies the shared error classifier to retry decisions. |
| server/src/queue/initWorkers.ts | Configures a one-minute visibility timeout for Stripe webhook replay jobs. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Webhook as Webhook middleware
    participant Queue as Replay queue
    participant Worker as Replay worker
    Stripe->>Webhook: Deliver sync-ack event
    Webhook->>Webhook: Process event
    alt Processing succeeds
        Webhook-->>Stripe: 2xx
    else Error would return 500
        Webhook->>Queue: Enqueue replay
        Webhook-->>Stripe: 500 for backup retry
        Queue->>Worker: Deliver after visibility delay
        Worker->>Worker: Reprocess with idempotency claim
        alt Processing succeeds
            Worker->>Queue: ACK
        else Retryable failure before attempt 30
            Worker-->>Queue: Leave for redelivery
        else Attempt 30 still fails
            Worker->>Queue: ACK and stop
        end
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(stripe): enqueue webhook replay when..."](https://github.com/useautumn/autumn/commit/b6fc9c014f269e74a25d435e3eca9b5d86d335b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60385418)</sub>

<!-- /greptile_comment -->