### PR TITLE
Shorten T3 Chat customer story link label

### DIFF
--- a/apps/website/app/constant.tsx
+++ b/apps/website/app/constant.tsx
@@ -1445,7 +1445,7 @@ export const customerStoriesData: CustomerStory[] = [
 		slug: "t3-chat",
 		name: "T3.chat",
 		href: "/blog/working-with-t3-chat-on-a-new-way-of-pricing",
-		linkLabel: "Consumer psychology is important in AI pricing",
+		linkLabel: "Consumer psychology in AI pricing",
 		logo: "/images/logos/T3_svg.svg",
 		iconLogo: "/images/logos/icons/t3-chat.svg",
 		logoClassName: "scale-65",


### PR DESCRIPTION
Trims the T3 Chat link label on the landing page customer story panel.

**Before:** `CONSUMER PSYCHOLOGY IS IMPORTANT IN AI PRICING`
**After:** `CONSUMER PSYCHOLOGY IN AI PRICING`

One-line change to `customerStoriesData` in `constant.tsx`. No component changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortens the T3 Chat customer story link label on the landing page from "Consumer psychology is important in AI pricing" to "Consumer psychology in AI pricing" so the button reads more cleanly. This is a one-line change to `customerStoriesData` in `apps/website/app/constant.tsx`; no component changes.

<sup>Written for commit 1677b6858b9a132038d5e5fff721e00d215407eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

