### PR TITLE
fix(api): expose licenses on expanded Plan V1

### DIFF
--- a/shared/api/products/apiPlanV1.ts
+++ b/shared/api/products/apiPlanV1.ts
@@ -223,7 +223,6 @@ export const ApiPlanV1WithMeta = ApiPlanV1Schema.meta({
 /** ApiPlanV1 plus its license and variant edges. */
 export const ApiPlanExpandedV1Schema = ApiPlanV1Schema.extend({
 	licenses: z.array(ApiPlanLicenseV1Schema).optional().meta({
-		internal: true,
 		description:
 			"Plans offered as assignable licenses under this plan. Omitted when the plan has none.",
 	}),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Remove `internal: true` from `licenses` on `ApiPlanExpandedV1Schema`.

The field is already returned on expanded plan responses. This only unhides it from public OpenAPI / docs.

## Left alone

- `CreatePlanParamsV1.licenses` stays internal (write path).
- Nested `prepaid_only` / `customize` on `ApiPlanLicenseV1` stay internal.
- No OpenAPI YAML regen in this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10bf6c7e-1932-4f63-8e8f-63b80285c6b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10bf6c7e-1932-4f63-8e8f-63b80285c6b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes `licenses` on the expanded Plan V1 schema in public OpenAPI docs.

The field was already returned in expanded plan responses; this change removes `internal: true` so it appears in public API documentation. The write path (`CreatePlanParamsV1.licenses`) and nested `prepaid_only` / `customize` fields remain internal.

<sup>Written for commit 7dd4e4ea5f06a7bb32db638e44ff1e6e8425abac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

