### PR TITLE
Firecrawl blog internal links, story button, and T3 label

### DIFF
--- a/apps/website/app/constant.tsx
+++ b/apps/website/app/constant.tsx
@@ -1447,7 +1447,7 @@ export const customerStoriesData: CustomerStory[] = [
 		slug: "t3-chat",
 		name: "T3.chat",
 		href: "/blog/working-with-t3-chat-on-a-new-way-of-pricing",
-		linkLabel: "Consumer psychology is important in AI pricing",
+		linkLabel: "Consumer psychology in AI pricing",
 		logo: "/images/logos/T3_svg.svg",
 		iconLogo: "/images/logos/icons/t3-chat.svg",
 		logoClassName: "scale-65",

--- a/apps/website/app/constant.tsx
+++ b/apps/website/app/constant.tsx
@@ -1394,6 +1394,8 @@ export const customerStoriesData: CustomerStory[] = [
 	{
 		slug: "firecrawl",
 		name: "Firecrawl",
+		href: "/blog/how-firecrawl-runs-pricing-experiments-every-week",
+		linkLabel: "Weekly pricing experiments at Firecrawl",
 		logo: "/images/logos/Firecrawl.svg.svg",
 		iconLogo: "/images/logos/icons/firecrawl.svg",
 		logoClassName: "scale-95 -translate-y-0.5",

--- a/apps/website/content/blog/how-firecrawl-runs-pricing-experiments-every-week.mdx
+++ b/apps/website/content/blog/how-firecrawl-runs-pricing-experiments-every-week.mdx
@@ -8,7 +8,7 @@ image: "/images/blog/how-firecrawl-runs-pricing-experiments-every-week.png"
 featured: true
 ---
 
-[Firecrawl](https://firecrawl.dev) is one of our favorite products at Autumn. It is the context API for searching, scraping, and interacting with the web at scale. It's open source with over 175K GitHub stars, used heavily inside coding agents through their MCP server and CLI, and it bills billions of credits per month.
+[Firecrawl](https://firecrawl.dev) is one of our favorite products at Autumn. It is the context API for searching, scraping, and interacting with the web at scale. It's open source with over 175K GitHub stars, used heavily inside coding agents through their MCP server and CLI, and it bills [billions of credits](/blog/ai-billing-infrastructure) per month.
 
 They're scaling incredibly quickly as agents have taken off. At peak they send Autumn more than 5,000 requests every second.
 
@@ -29,13 +29,13 @@ Micah was a few weeks into a big billing rework because their existing engine wa
 	role="Head of Support Engineering, Firecrawl"
 >
 
-Our in-house billing system had been around for a while and hadn't received enough attention. Its logic was scattered across the codebase, so complexity built up over time. The SQL function handling balances, expirations, and rollovers alone had grown to more than 800 lines.
+Our in-house billing system had been around for a while and hadn't received enough attention. Its logic was [scattered across the codebase](/blog/stop-rebuilding-billing), so complexity built up over time. The SQL function handling balances, expirations, and rollovers alone had grown to more than 800 lines.
 
 </TestimonialQuote>
 
 Since billing problems usually ended up in a support ticket, most of the work fell on him and his team. When we first met, he was fairly blunt that he didn't think we were a fit. His view was that Autumn suited new companies that hadn't built a complicated billing system yet, and that migrating would cost more than finishing the refactor he'd already started.
 
-However, after we chatted it was clear that billing was going to be an ongoing problem as they continued to scale. Pricing changes, new products, multi-team structures and spend control for enterprises were things we could provide out of the box, freeing up time for product work. Autumn forward-deployed an engineer to work with them for the migration, and after just a few weeks, they went live on April 1st.
+However, after we chatted it was clear that billing was going to be an ongoing problem as they continued to scale. Pricing changes, new products, [multi-team structures](/blog/how-mintlify-is-scaling-sales-led-gtm) and spend control for enterprises were things we could provide out of the box, freeing up time for product work. Autumn forward-deployed an engineer to work with them for the migration, and after just a few weeks, they went live on April 1st.
 
 ### Updating pricing every week
 
@@ -61,7 +61,7 @@ The lift to run an experiment is reduced 10x. Through this process, the Firecraw
 
 ### Smart upgrades vs. auto top-ups
 
-Most credit products handle "I ran out" with a one time top up. The economics of it aren't ideal, because top ups are priced at a premium per credit, so the heaviest users end up paying the most per unit. For the company it's lumpy revenue that rarely converts into expanding subscription revenue.
+Most credit products handle "I ran out" with a [one time top up](/blog/usage-billing-bad). The economics of it aren't ideal, because top ups are priced at a premium per credit, so the heaviest users end up paying the most per unit. For the company it's lumpy revenue that rarely converts into expanding subscription revenue.
 
 Someone on Micah's team suggested doing it differently, and they built what they call "smart upgrades." When a user hits their ceiling, instead of selling them another pack, Firecrawl moves them to the next subscription tier and charges the prorated difference. Autumn sends the alert when credits run out, the upgrade is attempted, overage credits are allowed while the payment processes, and the new credits are granted once it clears.
 


### PR DESCRIPTION
Follow-up to #3265. Three changes that missed that merge, plus the T3 label tweak, consolidated here.

## 1. Internal links in the Firecrawl post

| Phrase | Links to |
|---|---|
| "billions of credits" | `/blog/ai-billing-infrastructure` |
| "scattered across the codebase" | `/blog/stop-rebuilding-billing` |
| "multi-team structures" | `/blog/how-mintlify-is-scaling-sales-led-gtm` |
| "one time top up" | `/blog/usage-billing-bad` |

## 2. Firecrawl customer story button

Adds `href` + `linkLabel` to the Firecrawl entry in `customerStoriesData`, so the
landing page panel renders a link to the case study, matching Mintlify and T3 Chat.
No component changes needed — `story-panel.tsx` already falls back to a plain div
when `href` is absent.

## 3. T3 Chat label

`CONSUMER PSYCHOLOGY IS IMPORTANT IN AI PRICING` → `CONSUMER PSYCHOLOGY IN AI PRICING`

## Notes

- Supersedes #3278, which contained only change 3
- All six blog slugs referenced across both files verified to resolve to real `.mdx` posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds internal links to related posts in the Firecrawl case study, links the Firecrawl customer story to its blog post, and shortens the T3 Chat link label.

The Firecrawl entry in `customerStoriesData` now has `href` and `linkLabel`, so the landing page panel renders a story link instead of a plain div. The T3 Chat label changed from "Consumer psychology is important in AI pricing" to "Consumer psychology in AI pricing".

<sup>Written for commit 6a792441bb088b262df95573863c727c60a7fc2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

