### PR TITLE
fix(stripe): do not SQS-replay webhook foreign-key failures

### DIFF
--- a/server/src/db/dbUtils.ts
+++ b/server/src/db/dbUtils.ts
@@ -36,6 +36,24 @@ const walkErrorChain = ({ error }: { error: unknown }): unknown[] => {
 	return chain;
 };
 
+const POSTGRES_FOREIGN_KEY_VIOLATION = "23503";
+
+/** Postgres 23503, including wrapped drivers that only keep the message. */
+export const isForeignKeyViolationError = ({
+	error,
+}: {
+	error: unknown;
+}): boolean => {
+	for (const candidate of walkErrorChain({ error })) {
+		if (getErrorCode({ error: candidate }) === POSTGRES_FOREIGN_KEY_VIOLATION) {
+			return true;
+		}
+		const message = getErrorMessage({ error: candidate });
+		if (message?.includes("violates foreign key constraint")) return true;
+	}
+	return false;
+};
+
 const messageLooksTransient = ({ message }: { message: string }): boolean => {
 	if (TRANSIENT_DB_ERROR_MESSAGES.has(message)) return true;
 	for (const known of TRANSIENT_DB_ERROR_MESSAGES) {

--- a/server/src/external/stripe/webhookMiddlewares/stripeWebhookAckMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeWebhookAckMiddleware.ts
@@ -1,7 +1,7 @@
 import { context, SpanStatusCode, trace } from "@opentelemetry/api";
 import type { Context, Next } from "hono";
 import { enqueueStripeWebhookReplay } from "../webhookReplay/enqueueStripeWebhookReplay.js";
-import { stripeWebhookErrorWouldRedeliver } from "../webhookReplay/stripeWebhookErrorWouldRedeliver.js";
+import { stripeWebhookErrorShouldQueueReplay } from "../webhookReplay/stripeWebhookErrorWouldRedeliver.js";
 import { classifyStripeWebhookAckMode } from "./classifyStripeWebhookAckMode.js";
 import type { StripeWebhookHonoEnv } from "./stripeWebhookContext.js";
 
@@ -33,11 +33,10 @@ export const stripeWebhookAckMiddleware = async (
 
 	if (ackMode === "sync") {
 		const queueSyncFailure = (error: unknown) => {
-			if (!stripeWebhookErrorWouldRedeliver({ error })) return;
+			if (!stripeWebhookErrorShouldQueueReplay({ error })) return;
 			return enqueueStripeWebhookReplay({
 				ctx,
-				failureReason:
-					error instanceof Error ? error.message : String(error),
+				failureReason: error instanceof Error ? error.message : String(error),
 			});
 		};
 

--- a/server/src/external/stripe/webhookReplay/stripeWebhookErrorWouldRedeliver.ts
+++ b/server/src/external/stripe/webhookReplay/stripeWebhookErrorWouldRedeliver.ts
@@ -1,5 +1,6 @@
 import { RecaseError } from "@autumn/shared";
 import Stripe from "stripe";
+import { isForeignKeyViolationError } from "@/db/dbUtils.js";
 import { handleWebhookErrorSkip } from "@/utils/routerUtils/webhookErrorSkip.js";
 
 export const STRIPE_WEBHOOK_REPLAY_MAX_ATTEMPTS = 30;
@@ -21,4 +22,14 @@ export const stripeWebhookErrorWouldRedeliver = ({
 	}
 	if (error instanceof RecaseError) return error.statusCode >= 500;
 	return true;
+};
+
+/** SQS replay is for transient 500s, not catalog FK poison pills. */
+export const stripeWebhookErrorShouldQueueReplay = ({
+	error,
+}: {
+	error: unknown;
+}): boolean => {
+	if (isForeignKeyViolationError({ error })) return false;
+	return stripeWebhookErrorWouldRedeliver({ error });
 };

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -11,7 +11,7 @@ import {
 	runStripeWebhookReplay,
 	StripeWebhookReplayInFlightError,
 } from "@/external/stripe/webhookReplay/runStripeWebhookReplay.js";
-import { stripeWebhookErrorWouldRedeliver } from "@/external/stripe/webhookReplay/stripeWebhookErrorWouldRedeliver.js";
+import { stripeWebhookErrorShouldQueueReplay } from "@/external/stripe/webhookReplay/stripeWebhookErrorWouldRedeliver.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { runActionHandlerTask } from "@/internal/analytics/runActionHandlerTask.js";
 import { autoTopup } from "@/internal/balances/autoTopUp/autoTopup.js";
@@ -105,7 +105,7 @@ export const shouldRetrySqsJobError = ({
 		case JobName.StripeWebhookReplay:
 			return (
 				error instanceof StripeWebhookReplayInFlightError ||
-				stripeWebhookErrorWouldRedeliver({ error })
+				stripeWebhookErrorShouldQueueReplay({ error })
 			);
 		default:
 			return false;

--- a/server/tests/unit/queue/processMessage.test.ts
+++ b/server/tests/unit/queue/processMessage.test.ts
@@ -66,6 +66,33 @@ describe("shouldRetrySqsJobError", () => {
 		).toBe(true);
 	});
 
+	test("does not retry stripe webhook replay on Postgres foreign-key violations", () => {
+		const foreignKeyError = Object.assign(
+			new Error(
+				'insert or update on table "customer_prices" violates foreign key constraint "customer_prices_price_id_fkey"',
+			),
+			{ code: "23503" },
+		);
+
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.StripeWebhookReplay,
+				error: foreignKeyError,
+			}),
+		).toBe(false);
+	});
+
+	test("does not retry stripe webhook replay on wrapped foreign-key violations", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.StripeWebhookReplay,
+				error: new Error(
+					'insert or update on table "customer_prices" violates foreign key constraint "customer_prices_price_id_fkey"',
+				),
+			}),
+		).toBe(false);
+	});
+
 	test("does not retry stripe webhook replay on errors that would not 500 Stripe", () => {
 		expect(
 			shouldRetrySqsJobError({

--- a/server/tests/unit/webhooks/stripe-webhook-sync-ack-replay.test.ts
+++ b/server/tests/unit/webhooks/stripe-webhook-sync-ack-replay.test.ts
@@ -1,5 +1,9 @@
 /**
- * Sync-ack failures that would 500 Stripe enqueue the in-house replay job.
+ * Sync-ack failures that would 500 Stripe enqueue the in-house replay job,
+ * except permanent Postgres foreign-key violations (those 500 Stripe only).
+ *
+ * Red (current):  a 23503 still lands on SQS and can DLQ after maxReceiveCount.
+ * Green (after):  23503 returns 500 and does not enqueue.
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
@@ -95,6 +99,26 @@ describe("sync webhook failure enqueues replay", () => {
 
 		expect(response.status).toBe(500);
 		expect(hookCalls.released).toBe(1);
+		expect(enqueueCalls).toEqual([]);
+	});
+
+	test("500s Stripe but does not enqueue a foreign-key violation", async () => {
+		const { app, hookCalls } = createApp({
+			handler: () => {
+				throw Object.assign(
+					new Error(
+						'insert or update on table "customer_prices" violates foreign key constraint "customer_prices_price_id_fkey"',
+					),
+					{ code: "23503" },
+				);
+			},
+		});
+
+		const response = await app.request("/webhook", { method: "POST" });
+
+		expect(response.status).toBe(500);
+		expect(hookCalls.released).toBe(1);
+		expect(hookCalls.completed).toBe(0);
 		expect(enqueueCalls).toEqual([]);
 	});
 });

--- a/server/tests/unit/webhooks/stripeWebhookErrorWouldRedeliver.test.ts
+++ b/server/tests/unit/webhooks/stripeWebhookErrorWouldRedeliver.test.ts
@@ -1,7 +1,25 @@
+/**
+ * HTTP 500 vs SQS replay are different: Stripe should still retry a missing
+ * catalog price, but the in-house queue must not.
+ *
+ * Red (current):  FK violations enqueue and SQS-retry like unknown 500s.
+ * Green (after):  wouldRedeliver stays true; shouldQueueReplay is false.
+ */
+
 import { describe, expect, test } from "bun:test";
 import { RecaseError } from "@autumn/shared";
 import Stripe from "stripe";
-import { stripeWebhookErrorWouldRedeliver } from "@/external/stripe/webhookReplay/stripeWebhookErrorWouldRedeliver";
+import {
+	stripeWebhookErrorShouldQueueReplay,
+	stripeWebhookErrorWouldRedeliver,
+} from "@/external/stripe/webhookReplay/stripeWebhookErrorWouldRedeliver";
+
+const foreignKeyError = Object.assign(
+	new Error(
+		'insert or update on table "customer_prices" violates foreign key constraint "customer_prices_price_id_fkey"',
+	),
+	{ code: "23503" },
+);
 
 describe("stripeWebhookErrorWouldRedeliver", () => {
 	test("redelivers unknown handler errors (HTTP 500)", () => {
@@ -10,6 +28,12 @@ describe("stripeWebhookErrorWouldRedeliver", () => {
 				error: new Error("duplicate key value violates unique constraint"),
 			}),
 		).toBe(true);
+	});
+
+	test("still 500s Stripe for foreign-key violations", () => {
+		expect(stripeWebhookErrorWouldRedeliver({ error: foreignKeyError })).toBe(
+			true,
+		);
 	});
 
 	test("redelivers RecaseError only when status is 5xx", () => {
@@ -39,6 +63,30 @@ describe("stripeWebhookErrorWouldRedeliver", () => {
 	test("does not redeliver skipped webhook errors (HTTP 200)", () => {
 		expect(
 			stripeWebhookErrorWouldRedeliver({
+				error: new Error("Not a valid URL"),
+			}),
+		).toBe(false);
+	});
+});
+
+describe("stripeWebhookErrorShouldQueueReplay", () => {
+	test("queues unknown handler errors that Stripe would retry", () => {
+		expect(
+			stripeWebhookErrorShouldQueueReplay({
+				error: new Error("db connection reset"),
+			}),
+		).toBe(true);
+	});
+
+	test("does not queue Postgres foreign-key violations", () => {
+		expect(
+			stripeWebhookErrorShouldQueueReplay({ error: foreignKeyError }),
+		).toBe(false);
+	});
+
+	test("does not queue skipped webhook errors", () => {
+		expect(
+			stripeWebhookErrorShouldQueueReplay({
 				error: new Error("Not a valid URL"),
 			}),
 		).toBe(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`tf-stripe-webhook-prod-dlq-messages-visible` fired because a sync-ack `checkout.session.completed` failed with Postgres `23503` (`customer_prices.price_id` missing from `prices`). After #3277, that 500 also enqueued `stripe-webhook-replay`. The worker treated the FK as retryable, hit SQS `maxReceiveCount=5` in ~5 minutes, and the message landed on the DLQ.

HTTP 500 to Stripe is still correct (Stripe can retry later if the catalog price returns). The in-house queue must not retry a poison pill.

## Change

```
- wouldRedeliver(error) → enqueue + SQS retry
+ wouldRedeliver(error) → HTTP 500 Stripe
+ shouldQueueReplay(error) → enqueue + SQS retry
+ shouldQueueReplay = wouldRedeliver && !isForeignKeyViolation (23503 / message)
```

- Sync-ack still returns 500 and releases the idempotency lock
- FK violations are not enqueued
- If one is already on the queue, the worker ACKs instead of retrying

The missing catalog price itself is unchanged. Stripe’s slower HTTP retry remains the backstop.

## Tests

- Classifier: FK still `wouldRedeliver`, not `shouldQueueReplay`
- Sync ack middleware: 500, no enqueue
- `shouldRetrySqsJobError`: FK (code or message) is not retried
- Existing unique-constraint / transient 500 replay cases still retry

`bun test` on `tests/unit/webhooks/` + `tests/unit/queue/processMessage.test.ts`: 89 pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10bf6c7e-1932-4f63-8e8f-63b80285c6b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10bf6c7e-1932-4f63-8e8f-63b80285c6b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops SQS replay of Stripe webhook failures caused by Postgres foreign-key violations, which previously hit `maxReceiveCount` and landed on the DLQ. Stripe still gets an HTTP 500 for these failures, so it can retry if the missing catalog price comes back.

- Detects foreign-key violations by Postgres code `23503` or message text, including wrapped driver errors.
- Sync-ack failures release the idempotency lock without enqueuing a replay job.
- Foreign-key violations already on the replay queue are ACKed instead of retried.
- Other transient 500s and unique-constraint failures keep the existing replay behavior.

<sup>Written for commit 9eae683790823976f17715243ded9a215ab31f31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

