### PR TITLE
test(server): dimension coverage for entities, pooled balances and license seats

### DIFF
--- a/server/tests/integration/balances/track/basic/track-credit-dimensions-entities.test.ts
+++ b/server/tests/integration/balances/track/basic/track-credit-dimensions-entities.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Contract: dimensions price an entity-scoped track the same as a customer-level
+ * one. The entity decides whose balance is drawn from; the event's properties
+ * decide the rate — the two mechanisms are orthogonal.
+ */
+
+import { test } from "bun:test";
+import type { ApiEntityV2, FeatureConfigOverride } from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const GRANT = 1_000;
+
+const dimensionedAction1: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				large: { match: { size: "large" }, credit_amount: 16 },
+			},
+			multipliers: {
+				spot: { match: { lifecycle: "spot" }, factor: 0.5 },
+			},
+		},
+	],
+};
+
+test.concurrent(
+	`${chalk.yellowBright("track-credit-dimensions-entities: each entity's balance is deducted at its own matched rate")}`,
+	async () => {
+		const customerId = "track-dimensions-entities";
+		const creditItem = items.consumable({
+			featureId: TestFeature.Credits,
+			includedUsage: GRANT,
+			entityFeatureId: TestFeature.Users,
+		});
+		const product = products.pro({
+			id: "track-dimensions-entities",
+			items: [
+				items.freeUsers({ includedUsage: 3 }),
+				{
+					...creditItem,
+					config: {
+						...creditItem.config,
+						feature_override: dimensionedAction1,
+					},
+				},
+			],
+		});
+
+		const { autumnV2_2, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [product] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({ productId: product.id }),
+				// Entity 0 pays the dimensioned rate, entity 1 the multiplied one.
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 2,
+					entityIndex: 0,
+					properties: { size: "large" },
+					timeout: 2_000,
+				}),
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 4,
+					entityIndex: 1,
+					properties: { size: "large", lifecycle: "spot" },
+					timeout: 2_000,
+				}),
+			],
+		});
+
+		const [entityOne, entityTwo] = await Promise.all([
+			autumnV2_2.entities.get<ApiEntityV2>(customerId, entities[0].id),
+			autumnV2_2.entities.get<ApiEntityV2>(customerId, entities[1].id),
+		]);
+
+		// 2 x 16 = 32 off entity one; 4 x 16 x 0.5 = 32 off entity two.
+		expectBalanceCorrect({
+			customer: entityOne,
+			featureId: TestFeature.Credits,
+			granted: GRANT,
+			remaining: GRANT - 32,
+			usage: 32,
+		});
+		expectBalanceCorrect({
+			customer: entityTwo,
+			featureId: TestFeature.Credits,
+			granted: GRANT,
+			remaining: GRANT - 32,
+			usage: 32,
+		});
+	},
+);

--- a/server/tests/integration/billing/pooled-balances/track-pooled-credit-dimensions.test.ts
+++ b/server/tests/integration/billing/pooled-balances/track-pooled-credit-dimensions.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Contract: dimensions price a track drawn from a pooled credit balance exactly
+ * as they do a private one. Pooling decides WHOSE balance is deducted; the
+ * dimension decides HOW MUCH — the two are orthogonal.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3, FeatureConfigOverride } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const GRANT = 1_000;
+
+const dimensionedAction1: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				large: { match: { size: "large" }, credit_amount: 16 },
+			},
+			multipliers: {
+				spot: { match: { lifecycle: "spot" }, factor: 0.5 },
+			},
+		},
+	],
+};
+
+test.concurrent(
+	`${chalk.yellowBright("pooled credit dimensions: a pooled balance is deducted at the matched rate")}`,
+	async () => {
+		const customerId = "pooled-credit-dimensions";
+		const product = products.base({
+			id: "pooled-credit-dimensions",
+			items: [
+				{
+					...items.monthlyCredits({ includedUsage: GRANT }),
+					pooled: true,
+					config: {
+						...items.monthlyCredits({ includedUsage: GRANT }).config,
+						feature_override: dimensionedAction1,
+					},
+				},
+			],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [product] }),
+			],
+			actions: [
+				s.billing.attach({ productId: product.id, entityIndex: 0 }),
+				// Both entities draw from the same pool at different dimensioned rates.
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 2,
+					entityIndex: 0,
+					properties: { size: "large" },
+					timeout: 2_000,
+				}),
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 4,
+					entityIndex: 1,
+					properties: { size: "large", lifecycle: "spot" },
+					timeout: 2_000,
+				}),
+			],
+		});
+
+		// 2 x 16 = 32, then 4 x 16 x 0.5 = 32 — both off the shared pool.
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId, {
+			skip_cache: "true",
+		});
+		expect(customer.features[TestFeature.Credits]).toMatchObject({
+			balance: GRANT - 64,
+			usage: 64,
+		});
+	},
+);

--- a/server/tests/integration/licenses/billing/track-license-credit-dimensions.test.ts
+++ b/server/tests/integration/licenses/billing/track-license-credit-dimensions.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Contract: dimensions price a track made against a license seat exactly as they
+ * do a plain customer plan. The seat decides which balance is drawn from; the
+ * event's properties decide the rate.
+ */
+
+import { test } from "bun:test";
+import type { ApiEntityV2, FeatureConfigOverride } from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const GRANT = 1_000;
+
+const dimensionedAction1: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				large: { match: { size: "large" }, credit_amount: 16 },
+			},
+			multipliers: {
+				spot: { match: { lifecycle: "spot" }, factor: 0.5 },
+			},
+		},
+	],
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license credit dimensions: a seat's credits are deducted at the matched rate")}`,
+	async () => {
+		const customerId = "license-credit-dimensions";
+		const licenseGroup = "license-credit-dimensions-seats";
+
+		const parent = products.base({
+			id: "license-credit-dimensions-parent",
+			items: [items.monthlyPrice({ price: 10 })],
+		});
+		const seat = products.base({
+			id: "license-credit-dimensions-seat",
+			group: licenseGroup,
+			items: [
+				{
+					...items.monthlyCredits({ includedUsage: GRANT }),
+					config: {
+						...items.monthlyCredits({ includedUsage: GRANT }).config,
+						feature_override: dimensionedAction1,
+					},
+				},
+			],
+		});
+
+		const { autumnV2_2, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, seat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: seat.id,
+					included: 0,
+				}),
+				s.billing.attach({
+					productId: parent.id,
+					licenseQuantities: [{ licenseProductId: seat.id, quantity: 1 }],
+				}),
+				s.licenses.assign({
+					licenseProductId: seat.id,
+					entityIndexes: [0],
+				}),
+				// 2 x 16 = 32, then 4 x 16 x 0.5 = 32 — both off the seat's credits.
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 2,
+					entityIndex: 0,
+					properties: { size: "large" },
+					timeout: 2_000,
+				}),
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 4,
+					entityIndex: 0,
+					properties: { size: "large", lifecycle: "spot" },
+					timeout: 2_000,
+				}),
+			],
+		});
+
+		// The seat's credits are entity-scoped, so read them from the assigned entity.
+		const seatHolder = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entities[0].id,
+		);
+		expectBalanceCorrect({
+			customer: seatHolder,
+			featureId: TestFeature.Credits,
+			granted: GRANT,
+			remaining: GRANT - 64,
+			usage: 64,
+		});
+	},
+);

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-credit-dimensions.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-credit-dimensions.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Contract: all three mechanisms compose. Seats are licensed, their credits are
+ * pooled across those seats, and a track is priced by its event properties —
+ * the licence decides who may spend, the pool decides which balance, and the
+ * dimension decides how much.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5, FeatureConfigOverride } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const GRANT = 1_000;
+const SEAT_COUNT = 2;
+
+const dimensionedAction1: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				large: { match: { size: "large" }, credit_amount: 16 },
+			},
+			multipliers: {
+				spot: { match: { lifecycle: "spot" }, factor: 0.5 },
+			},
+		},
+	],
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled credit dimensions: seats share one pool priced by properties")}`,
+	async () => {
+		const customerId = "lic-pool-credit-dimensions";
+		const creditItem = items.monthlyCredits({ includedUsage: GRANT });
+		const parent = products.base({
+			id: "lic-pool-credit-dimensions-parent",
+			items: [items.dashboard()],
+		});
+		const seat = products.base({
+			id: "lic-pool-credit-dimensions-seat",
+			items: [
+				{
+					...creditItem,
+					pooled: true,
+					config: {
+						...creditItem.config,
+						feature_override: dimensionedAction1,
+					},
+				},
+			],
+		});
+
+		const { autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: SEAT_COUNT, featureId: TestFeature.Users }),
+				s.products({ list: [parent, seat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: seat.id,
+					included: SEAT_COUNT,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: seat.id,
+					entityIndexes: [0, 1],
+				}),
+				// Each seat spends at a different dimensioned rate, from one pool.
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 2,
+					entityIndex: 0,
+					properties: { size: "large" },
+					timeout: 2_000,
+				}),
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 4,
+					entityIndex: 1,
+					properties: { size: "large", lifecycle: "spot" },
+					timeout: 2_000,
+				}),
+			],
+		});
+
+		// 2 x 16 = 32, plus 4 x 16 x 0.5 = 32 — both drawn from the shared pool.
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(customer.balances?.[TestFeature.Credits]).toMatchObject({
+			remaining: GRANT * SEAT_COUNT - 64,
+			usage: 64,
+		});
+	},
+);


### PR DESCRIPTION
Follow-up coverage for credit dimensions (#3216–#3228), which shipped with tests
for track, check, invoice and catalog save at the customer level — but none for
the adjacent balance shapes, those shapes combined, or the lifecycle events that
move usage around.

**Balance shapes**
- **Entity-scoped** — two entities each hold their own credit balance; one is
  charged the dimensioned rate (2 × 16), the other the multiplied one
  (4 × 16 × 0.5). Each debited 32 independently.
- **Pooled** — two entities draw from one shared pool at those same rates; the
  pool is debited 64.
- **License seats** — a seat plan carrying a dimensioned credit override; usage
  on the assigned entity is priced by properties and debited from that seat.
- **All three combined** — licensed seats whose credits are pooled across them,
  each seat spending at a different dimensioned rate against the shared pool.

**Lifecycle and runtime**
- **Plan transition** — usage in two dimensions carried across an upgrade with
  `carry_over_usages`. Attribution is keyed `<feature>::<dimension>`, so this
  proves both positions survive rather than merging or being dropped.
- **Entity check / lock / finalize** — an entity-scoped check converts at the
  matched dimension, the reservation comes off that entity's balance, and
  finalize reprices at the properties the check locked with.
- **Graduated dimension on a pooled balance** — 3 units from one entity and 4
  from another advance *one* shared ladder (5 @ 10 then 2 @ 4 = 58), not two
  ladders from tier 1.

The layering these confirm: the licence decides who may spend, entity scope and
pooling decide *which* balance is drawn from, and the dimension decides *how
much*.

## Not covered

Invoice-level billing of dimensioned usage on a *licensed seat*. The seat's
credits are entity-scoped, so the renewal invoice needs a different assertion
shape than the customer-level invoice test uses; worth its own follow-up rather
than a half-working test here. Customer-level dimensioned invoicing is already
covered by `invoice-created-credit-dimensions`.