### PR TITLE
Retire unused catalog prices and entitlements instead of deleting

### DIFF
--- a/server/src/internal/catalogV2/execute/executeUpsertProducts/applyEntitlementPricesPlan.ts
+++ b/server/src/internal/catalogV2/execute/executeUpsertProducts/applyEntitlementPricesPlan.ts
@@ -39,31 +39,16 @@ export const applyEntitlementPricesPlan = async ({
 		});
 	}
 
-	for (const entitlement of plan.entitlements.retired) {
-		await EntitlementService.update({
-			db: ctx.db,
-			id: entitlement.id,
-			updates: { is_custom: true },
-		});
-	}
-	for (const price of plan.prices.retired) {
-		await PriceService.update({
-			db: ctx.db,
-			id: price.id,
-			update: { is_custom: true },
-		});
-	}
-
-	if (plan.prices.deleted.length > 0) {
-		await PriceService.deleteInIds({
-			db: ctx.db,
-			ids: plan.prices.deleted.map((price) => price.id),
-		});
-	}
-	if (plan.entitlements.deleted.length > 0) {
-		await EntitlementService.deleteInIds({
-			db: ctx.db,
-			ids: plan.entitlements.deleted.map((entitlement) => entitlement.id),
-		});
-	}
+	await PriceService.retireInIds({
+		db: ctx.db,
+		ids: [...plan.prices.retired, ...plan.prices.deleted].map(
+			(price) => price.id,
+		),
+	});
+	await EntitlementService.retireInIds({
+		db: ctx.db,
+		ids: [...plan.entitlements.retired, ...plan.entitlements.deleted].map(
+			(entitlement) => entitlement.id,
+		),
+	});
 };

--- a/server/src/internal/product/actions/inPlaceUpdateUtils.ts
+++ b/server/src/internal/product/actions/inPlaceUpdateUtils.ts
@@ -145,12 +145,8 @@ const backfillExistingItemIds = ({
 	});
 };
 
-/**
- * Retire (vs mutate/delete) a catalog ent/price so existing customers that
- * reference it keep their definition. Referenced rows flip to is_custom:true
- * (hidden from the catalog, FK still valid); unreferenced rows are deleted.
- */
-const retireOrDeleteRows = async ({
+/** Leave unused catalog rows in place as is_custom so deferred FKs stay valid. */
+const retireCatalogRows = async ({
 	db,
 	entitlementIds,
 	priceIds,
@@ -159,59 +155,13 @@ const retireOrDeleteRows = async ({
 	entitlementIds: string[];
 	priceIds: string[];
 }) => {
-	const [customerEnts, customerPrices, licenseEnts, licensePrices] =
-		await Promise.all([
-			CusEntService.getReferencedEntitlementIds({ db, entitlementIds }),
-			CusPriceService.getReferencedPriceIds({ db, priceIds }),
-			licenseItemRepo.listReferencedEntitlementIds({ db, entitlementIds }),
-			licenseItemRepo.listReferencedPriceIds({ db, priceIds }),
-		]);
-	const referencedEnts = new Set([...customerEnts, ...licenseEnts]);
-	const referencedPrices = new Set([...customerPrices, ...licensePrices]);
-	const priceRows = await PriceService.getInIds({ db, ids: priceIds });
-	const entitlementsReferencedByRetainedPrices = new Set(
-		priceRows.flatMap((price) =>
-			referencedPrices.has(price.id) && price.entitlement_id
-				? [price.entitlement_id]
-				: [],
-		),
-	);
-
-	for (const priceId of priceIds) {
-		if (referencedPrices.has(priceId)) {
-			await PriceService.update({
-				db,
-				id: priceId,
-				update: { is_custom: true },
-			});
-		} else {
-			await PriceService.deleteInIds({ db, ids: [priceId] });
-		}
-	}
-
-	for (const entitlementId of entitlementIds) {
-		if (
-			referencedEnts.has(entitlementId) ||
-			entitlementsReferencedByRetainedPrices.has(entitlementId)
-		) {
-			await EntitlementService.update({
-				db,
-				id: entitlementId,
-				updates: { is_custom: true },
-			});
-		} else {
-			await EntitlementService.deleteInIds({ db, ids: [entitlementId] });
-		}
-	}
+	await PriceService.retireInIds({ db, ids: priceIds });
+	await EntitlementService.retireInIds({ db, ids: entitlementIds });
 };
 
 /**
- * Resolve an in-place edit (disable_version + customers) against the current
- * catalog. Carries forward unchanged ids, retires the rows behind UPDATE/DELETE
- * (is_custom flip when referenced, else delete) so existing customers are
- * untouched, and returns the items to insert plus the catalog prices/ents with
- * the retired rows removed — handed to `handleNewProductItems` so it does not
- * re-delete them.
+ * Carry unchanged item ids forward and retire replaced catalog rows (is_custom).
+ * Existing customer/license FKs keep pointing at the retired definition.
  */
 export const resolveInPlaceEdit = async ({
 	db,
@@ -253,7 +203,7 @@ export const resolveInPlaceEdit = async ({
 		if (currentItem.price_id) retiredPriceIds.push(currentItem.price_id);
 	}
 
-	await retireOrDeleteRows({
+	await retireCatalogRows({
 		db,
 		entitlementIds: retiredEntitlementIds,
 		priceIds: retiredPriceIds,

--- a/server/src/internal/products/actions/computeEntitlementPricesPlan/buildEntitlementPricesPlan/buildEntitlementPricesPlanUtils.ts
+++ b/server/src/internal/products/actions/computeEntitlementPricesPlan/buildEntitlementPricesPlan/buildEntitlementPricesPlanUtils.ts
@@ -1,7 +1,7 @@
-import {
-	type EntitlementPrice,
-	type EntitlementWithFeature,
-	type Price,
+import type {
+	EntitlementPrice,
+	EntitlementWithFeature,
+	Price,
 } from "@autumn/shared";
 import { generateId } from "@/utils/genUtils";
 import type { EntitlementPricesPlanMode } from "../types/computeEntitlementPricesPlanParams";
@@ -17,7 +17,7 @@ export const leaveBucketForMode = ({
 	mode: EntitlementPricesPlanMode;
 }): keyof Pick<RowBuckets<unknown>, "deleted" | "retired"> | null => {
 	if (mode.type === "version" || mode.type === "custom") return null;
-	return mode.protectReferencedRows ? "retired" : "deleted";
+	return "retired";
 };
 
 /** Push both halves of an EP into the same bucket. */

--- a/server/src/internal/products/actions/computeEntitlementPricesPlan/types/entitlementPricesPlan.ts
+++ b/server/src/internal/products/actions/computeEntitlementPricesPlan/types/entitlementPricesPlan.ts
@@ -7,9 +7,9 @@ export type RowBuckets<Row> = {
 	updated: Row[];
 	/** Untouched — id carried forward. */
 	same: Row[];
-	/** Hard-delete candidates — only when not protecting referenced rows. */
+	/** Unused — execute retires these the same as `retired`. */
 	deleted: Row[];
-	/** Leave catalog; execute may is_custom or hard-delete by refs. */
+	/** Leave catalog; execute stamps is_custom and never deletes. */
 	retired: Row[];
 };
 

--- a/server/src/internal/products/entitlements/EntitlementService.ts
+++ b/server/src/internal/products/entitlements/EntitlementService.ts
@@ -109,6 +109,14 @@ export class EntitlementService {
 		await db.delete(entitlements).where(inArray(entitlements.id, ids));
 	}
 
+	static async retireInIds({ db, ids }: { db: DrizzleCli; ids: string[] }) {
+		if (ids.length === 0) return;
+		await db
+			.update(entitlements)
+			.set({ is_custom: true })
+			.where(inArray(entitlements.id, ids));
+	}
+
 	static async hasEntityFeatureId({
 		db,
 		orgId,

--- a/server/src/internal/products/prices/PriceService.ts
+++ b/server/src/internal/products/prices/PriceService.ts
@@ -83,6 +83,14 @@ export class PriceService {
 		await db.delete(prices).where(inArray(prices.id, ids));
 	}
 
+	static async retireInIds({ db, ids }: { db: DrizzleCli; ids: string[] }) {
+		if (ids.length === 0) return;
+		await db
+			.update(prices)
+			.set({ is_custom: true })
+			.where(inArray(prices.id, ids));
+	}
+
 	static async getByStripeId({
 		db,
 		stripePriceId,

--- a/server/src/internal/products/product-items/productItemUtils/handleNewProductItems.ts
+++ b/server/src/internal/products/product-items/productItemUtils/handleNewProductItems.ts
@@ -9,17 +9,14 @@ import {
 	type Price,
 	type Product,
 	type ProductItem,
-	prices,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@server/db/initDrizzle.js";
 import type { Logger } from "@server/external/logtail/logtailUtils.js";
 import { FeatureService } from "@server/internal/features/FeatureService.js";
-import { licenseItemRepo } from "@server/internal/licenses/repos/licenseItemRepo.js";
 import { EntitlementService } from "@server/internal/products/entitlements/EntitlementService.js";
 import { PriceService } from "@server/internal/products/prices/PriceService.js";
 import { itemToPriceAndEnt } from "@server/internal/products/product-items/productItemUtils/itemToPriceAndEnt.js";
 import { validateProductItems } from "@server/internal/products/product-items/validateProductItems.js";
-import { inArray } from "drizzle-orm";
 
 const updateDbPricesAndEnts = async ({
 	db,
@@ -63,79 +60,14 @@ const updateDbPricesAndEnts = async ({
 		}),
 	]);
 
-	await deletePricesKeepingLicenseReferenced({
+	await PriceService.retireInIds({
 		db,
-		deletedPriceIds: deletedPrices.map((price) => price.id),
+		ids: deletedPrices.map((price) => price.id),
 	});
-	await deleteEntsKeepingReferenced({ db, deletedEnts });
-};
-
-/** Base rows still referenced by a license link are relabeled is_custom and
- * kept (grandfathered content), matching the customer-reference behavior. */
-const deletePricesKeepingLicenseReferenced = async ({
-	db,
-	deletedPriceIds,
-}: {
-	db: DrizzleCli;
-	deletedPriceIds: string[];
-}) => {
-	if (deletedPriceIds.length === 0) return;
-	const referenced = await licenseItemRepo.listReferencedPriceIds({
+	await EntitlementService.retireInIds({
 		db,
-		priceIds: deletedPriceIds,
+		ids: deletedEnts.map((entitlement) => entitlement.id),
 	});
-
-	const toRelabel = deletedPriceIds.filter((id) => referenced.has(id));
-	const toDelete = deletedPriceIds.filter((id) => !referenced.has(id));
-	if (toRelabel.length > 0) {
-		await db
-			.update(prices)
-			.set({ is_custom: true })
-			.where(inArray(prices.id, toRelabel));
-	}
-	if (toDelete.length > 0) {
-		await PriceService.deleteInIds({ db, ids: toDelete });
-	}
-};
-
-/** Deleted entitlements that a custom price or a license link still points at
- * are relabeled is_custom (kept as standalone rows) rather than deleted. */
-const deleteEntsKeepingReferenced = async ({
-	db,
-	deletedEnts,
-}: {
-	db: DrizzleCli;
-	deletedEnts: Entitlement[];
-}) => {
-	if (deletedEnts.length === 0) return;
-	const deletedEntIds = deletedEnts.map((ent) => ent.id);
-	const [customPrices, licenseReferencedEntIds] = await Promise.all([
-		PriceService.getCustomInEntIds({ db, entitlementIds: deletedEntIds }),
-		licenseItemRepo.listReferencedEntitlementIds({
-			db,
-			entitlementIds: deletedEntIds,
-		}),
-	]);
-
-	if (customPrices.length === 0 && licenseReferencedEntIds.size === 0) {
-		await EntitlementService.deleteInIds({ db, ids: deletedEntIds });
-		return;
-	}
-
-	await Promise.all(
-		deletedEnts.map((ent) => {
-			const referenced =
-				customPrices.some((price) => price.entitlement_id === ent.id) ||
-				licenseReferencedEntIds.has(ent.id);
-			return referenced
-				? EntitlementService.update({
-						db,
-						id: ent.id,
-						updates: { is_custom: true },
-					})
-				: EntitlementService.deleteInIds({ db, ids: [ent.id] });
-		}),
-	);
 };
 
 const handleCustomProductItems = ({

--- a/server/tests/_groups/temp.ts
+++ b/server/tests/_groups/temp.ts
@@ -1,7 +1,10 @@
 import type { TestGroup } from "./types";
 
 /** Scratch group for tw leftovers. Keep empty on trunk. */
-const activeTempPaths: string[] = [];
+const activeTempPaths: string[] = [
+	"integration/crud/plans/update/in-place/in-place-isolation.test.ts",
+	"integration/crud/plans/update/update-plan-allocated-v1-compat.test.ts",
+];
 
 export const temp: TestGroup = {
 	name: "temp",

--- a/server/tests/integration/catalog-v2/plans/update/update-plan-rows.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/update-plan-rows.test.ts
@@ -1,7 +1,6 @@
 /**
  * catalogV2.update — claim / row carry-over (definition-exact → same row ids;
- * any change mints new rows; old deleted without customers, or retired +
- * is_custom with customers).
+ * any change mints new rows; old rows are always retired with is_custom).
  *
  * Customer refs are DB-seeded: the local Stripe Connect account is currently
  * unreachable from s.customer / attach, which would otherwise fail before the
@@ -135,7 +134,7 @@ const messagesItem = (included: number) => ({
 });
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 rows: base price change keeps feature rows; old base deleted (no customers)")}`,
+	`${chalk.yellowBright("catalogV2 rows: base price change keeps feature rows; old base retired (no customers)")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const planId = uniqueTestId("cv2_row_base");
@@ -169,7 +168,7 @@ test.concurrent(
 					stableEnts: true,
 					stableFeaturePrices: true,
 					mintedBase: { amount: 40 },
-					deletedPrices: [before.basePriceId!],
+					retiredPrices: [before.basePriceId!],
 				},
 			});
 		} finally {
@@ -179,7 +178,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 rows: remove item deletes removed rows; remaining stable (no customers)")}`,
+	`${chalk.yellowBright("catalogV2 rows: remove item retires removed rows; remaining stable (no customers)")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const planId = uniqueTestId("cv2_row_rm");
@@ -206,7 +205,7 @@ test.concurrent(
 				expected: {
 					stableEnts: [TestFeature.Messages],
 					absentFeatures: [TestFeature.Dashboard],
-					deletedEnts: [before.ents[TestFeature.Dashboard].id],
+					retiredEnts: [before.ents[TestFeature.Dashboard].id],
 				},
 			});
 		} finally {
@@ -216,7 +215,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 rows: included bump mints new ent; old deleted (no customers)")}`,
+	`${chalk.yellowBright("catalogV2 rows: included bump mints new ent; old retired (no customers)")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const planId = uniqueTestId("cv2_row_incl");
@@ -238,7 +237,7 @@ test.concurrent(
 				before,
 				expected: {
 					mintedEnts: [{ featureId: TestFeature.Messages, allowance: 250 }],
-					deletedEnts: [before.ents[TestFeature.Messages].id],
+					retiredEnts: [before.ents[TestFeature.Messages].id],
 				},
 			});
 		} finally {

--- a/server/tests/integration/crud/plans/update/in-place/in-place-isolation.test.ts
+++ b/server/tests/integration/crud/plans/update/in-place/in-place-isolation.test.ts
@@ -265,7 +265,7 @@ test(`${chalk.yellowBright("in-place isolation: an entity-scoped customer on ano
 // carry normal customer_entitlements, so the reference check retires (not
 // deletes) any ent they hold — the same guarantee the other cases prove.
 
-test(`${chalk.yellowBright("in-place isolation: no-customer plan mutates in place (no retired rows)")}`, async () => {
+test(`${chalk.yellowBright("in-place isolation: no-customer plan retires replaced rows")}`, async () => {
 	const owner = "iso-nocus-owner";
 	const pro = products.pro({
 		id: "iso_nocus",
@@ -281,7 +281,7 @@ test(`${chalk.yellowBright("in-place isolation: no-customer plan mutates in plac
 		actions: [],
 	});
 
-	// No customers on the plan -> mutate in place, no is_custom:true rows left.
+	// Replaced catalog rows stay as is_custom so deferred FKs stay valid.
 	await rpcFor(ctx).plans.update<ApiPlanV1, RpcInput>(pro.id, {
 		disable_version: true,
 		price: monthPrice,
@@ -307,5 +307,6 @@ test(`${chalk.yellowBright("in-place isolation: no-customer plan mutates in plac
 				eq(entitlements.is_custom, true),
 			),
 		);
-	expect(customEnts).toHaveLength(0);
+	expect(customEnts).toHaveLength(1);
+	expect(customEnts[0]?.allowance).toBe(100);
 });

--- a/server/tests/unit/products/apply-entitlement-prices-plan-retire.test.ts
+++ b/server/tests/unit/products/apply-entitlement-prices-plan-retire.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Catalog leftover rows are retired (is_custom), never hard-deleted.
+ *
+ * Red (current):  plan.prices.deleted / entitlements.deleted call deleteInIds
+ * Green (after):  both buckets go to retireInIds; deleteInIds is not called
+ */
+
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import type { Entitlement, Price } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { applyEntitlementPricesPlan } from "@/internal/catalogV2/execute/executeUpsertProducts/applyEntitlementPricesPlan.js";
+import { emptyEntitlementPricesPlan } from "@/internal/products/actions/computeEntitlementPricesPlan/types/entitlementPricesPlan.js";
+import { EntitlementService } from "@/internal/products/entitlements/EntitlementService.js";
+import { PriceService } from "@/internal/products/prices/PriceService.js";
+
+afterEach(() => {
+	mock.restore();
+});
+
+test("applyEntitlementPricesPlan retires leftover catalog rows and never deletes", async () => {
+	const retirePrices = spyOn(PriceService, "retireInIds").mockResolvedValue(
+		undefined,
+	);
+	const retireEnts = spyOn(EntitlementService, "retireInIds").mockResolvedValue(
+		undefined,
+	);
+	const deletePrices = spyOn(PriceService, "deleteInIds").mockResolvedValue(
+		undefined,
+	);
+	const deleteEnts = spyOn(EntitlementService, "deleteInIds").mockResolvedValue(
+		undefined,
+	);
+
+	const plan = emptyEntitlementPricesPlan();
+	plan.prices.deleted = [{ id: "pr_deleted" } as Price];
+	plan.prices.retired = [{ id: "pr_retired" } as Price];
+	plan.entitlements.deleted = [{ id: "ent_deleted" } as Entitlement];
+	plan.entitlements.retired = [{ id: "ent_retired" } as Entitlement];
+
+	await applyEntitlementPricesPlan({
+		ctx: { db: {} } as AutumnContext,
+		upsert: { entitlementPricesPlan: plan } as never,
+	});
+
+	expect(retirePrices).toHaveBeenCalledWith({
+		db: {},
+		ids: ["pr_retired", "pr_deleted"],
+	});
+	expect(retireEnts).toHaveBeenCalledWith({
+		db: {},
+		ids: ["ent_retired", "ent_deleted"],
+	});
+	expect(deletePrices).not.toHaveBeenCalled();
+	expect(deleteEnts).not.toHaveBeenCalled();
+});

--- a/server/tests/unit/products/computeEntitlementPricesPlan/computeEntitlementPricesPlan.test.ts
+++ b/server/tests/unit/products/computeEntitlementPricesPlan/computeEntitlementPricesPlan.test.ts
@@ -18,6 +18,7 @@ import {
 	computeEntitlementPricesPlan,
 	type EntitlementPricesPlan,
 } from "@/internal/products/actions/computeEntitlementPricesPlan";
+import { leaveBucketForMode } from "@/internal/products/actions/computeEntitlementPricesPlan/buildEntitlementPricesPlan/buildEntitlementPricesPlanUtils";
 
 const messagesFeature = features.create({
 	id: "messages",
@@ -173,7 +174,7 @@ describe("computeEntitlementPricesPlan", () => {
 		expect(plan.entitlements.same[0].id).toBe("ent_messages");
 	});
 
-	test("3a. PUT amount edit (no protect) → delete old + mint new", () => {
+	test("3a. PUT amount edit (no protect) → retire old + mint new", () => {
 		const currentEnt = entitlements.buildWithFeature({
 			id: "ent_messages",
 			internal_feature_id: messagesFeature.internal_id,
@@ -213,10 +214,10 @@ describe("computeEntitlementPricesPlan", () => {
 			},
 		});
 
-		expect(plan.prices.deleted.map((price) => price.id)).toEqual([
+		expect(plan.prices.retired.map((price) => price.id)).toEqual([
 			"pr_messages",
 		]);
-		expect(plan.entitlements.deleted.map((ent) => ent.id)).toEqual([
+		expect(plan.entitlements.retired.map((ent) => ent.id)).toEqual([
 			"ent_messages",
 		]);
 		expect(plan.prices.new).toHaveLength(1);
@@ -319,7 +320,7 @@ describe("computeEntitlementPricesPlan", () => {
 		});
 
 		expect(plan.prices.same).toEqual([]);
-		expect(plan.prices.deleted.map((price) => price.id).sort()).toEqual([
+		expect(plan.prices.retired.map((price) => price.id).sort()).toEqual([
 			"pr_base",
 			"pr_messages",
 		]);
@@ -339,7 +340,7 @@ describe("computeEntitlementPricesPlan", () => {
 		]);
 	});
 
-	test("4. PUT remove feature → deleted / retired", () => {
+	test("4. PUT remove feature → retired", () => {
 		const currentEnt = entitlements.buildWithFeature({
 			id: "ent_messages",
 			internal_feature_id: messagesFeature.internal_id,
@@ -361,7 +362,7 @@ describe("computeEntitlementPricesPlan", () => {
 				},
 			},
 		});
-		expect(deletedPlan.entitlements.deleted.map((ent) => ent.id)).toEqual([
+		expect(deletedPlan.entitlements.retired.map((ent) => ent.id)).toEqual([
 			"ent_messages",
 		]);
 
@@ -419,7 +420,7 @@ describe("computeEntitlementPricesPlan", () => {
 			},
 		});
 
-		expect(plan.entitlements.deleted.map((ent) => ent.id)).toEqual([
+		expect(plan.entitlements.retired.map((ent) => ent.id)).toEqual([
 			"ent_messages",
 		]);
 		expect(plan.entitlements.new).toHaveLength(1);
@@ -444,7 +445,7 @@ describe("computeEntitlementPricesPlan", () => {
 				currentRows: { prices: [currentBase], entitlements: [] },
 			},
 		});
-		expect(amountEdit.prices.deleted.map((price) => price.id)).toEqual([
+		expect(amountEdit.prices.retired.map((price) => price.id)).toEqual([
 			"pr_base",
 		]);
 		expect(amountEdit.prices.new).toHaveLength(1);
@@ -459,7 +460,7 @@ describe("computeEntitlementPricesPlan", () => {
 				currentRows: { prices: [currentBase], entitlements: [] },
 			},
 		});
-		expect(removeBase.prices.deleted.map((price) => price.id)).toEqual([
+		expect(removeBase.prices.retired.map((price) => price.id)).toEqual([
 			"pr_base",
 		]);
 	});
@@ -637,7 +638,7 @@ describe("computeEntitlementPricesPlan", () => {
 			"ent_messages",
 		]);
 		expect(plan.prices.same.map((price) => price.id)).toEqual(["pr_messages"]);
-		expect(plan.prices.deleted.map((price) => price.id)).toEqual(["pr_base"]);
+		expect(plan.prices.retired.map((price) => price.id)).toEqual(["pr_base"]);
 		expect(plan.prices.new).toHaveLength(1);
 		expect(plan.entitlements.deleted).toEqual([]);
 	});
@@ -673,10 +674,10 @@ describe("computeEntitlementPricesPlan", () => {
 		});
 
 		expect(plan.prices.same.map((price) => price.id)).toEqual(["pr_base"]);
-		expect(plan.prices.deleted.map((price) => price.id)).toEqual([
+		expect(plan.prices.retired.map((price) => price.id)).toEqual([
 			"pr_messages",
 		]);
-		expect(plan.entitlements.deleted.map((ent) => ent.id)).toEqual([
+		expect(plan.entitlements.retired.map((ent) => ent.id)).toEqual([
 			"ent_messages",
 		]);
 		expect(plan.entitlements.new).toHaveLength(1);
@@ -717,6 +718,19 @@ describe("computeEntitlementPricesPlan", () => {
 			},
 		});
 		expect(plan.entitlements.new).toHaveLength(1);
+	});
+
+	test("update mode always retires leftover rows", () => {
+		expect(
+			leaveBucketForMode({
+				mode: { type: "update", protectReferencedRows: false },
+			}),
+		).toBe("retired");
+		expect(
+			leaveBucketForMode({
+				mode: { type: "update", protectReferencedRows: true },
+			}),
+		).toBe("retired");
 	});
 
 	test("items (PUT) cannot combine with add_items (PATCH)", () => {

--- a/server/tests/unit/products/handle-new-product-items-retire.test.ts
+++ b/server/tests/unit/products/handle-new-product-items-retire.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Leftover catalog prices and entitlements are retired together, never deleted.
+ *
+ * Red (current): leftover rows call deleteInIds (breaks deferred checkout FKs)
+ * Green (after): both leftover prices and ents go to retireInIds
+ */
+
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import type { Entitlement, Price, Product } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import { EntitlementService } from "@/internal/products/entitlements/EntitlementService.js";
+import { PriceService } from "@/internal/products/prices/PriceService.js";
+import { handleNewProductItems } from "@/internal/products/product-items/productItemUtils/handleNewProductItems.js";
+
+afterEach(() => {
+	mock.restore();
+});
+
+test("handleNewProductItems retires leftover prices and entitlements and never deletes", async () => {
+	const retirePrices = spyOn(PriceService, "retireInIds").mockResolvedValue(
+		undefined,
+	);
+	const retireEnts = spyOn(EntitlementService, "retireInIds").mockResolvedValue(
+		undefined,
+	);
+	const deletePrices = spyOn(PriceService, "deleteInIds").mockResolvedValue(
+		undefined,
+	);
+	const deleteEnts = spyOn(EntitlementService, "deleteInIds").mockResolvedValue(
+		undefined,
+	);
+
+	await handleNewProductItems({
+		db: {} as DrizzleCli,
+		curPrices: [{ id: "pr_old" } as Price],
+		curEnts: [{ id: "ent_old" } as Entitlement],
+		newItems: [],
+		features: [],
+		product: {
+			org_id: "org_test",
+			internal_id: "prod_test",
+			env: "sandbox",
+		} as Product,
+		logger: { info() {}, error() {}, warn() {} } as Logger,
+		isCustom: false,
+		saveToDb: true,
+		multiCurrencyEnabled: false,
+	});
+
+	expect(retirePrices).toHaveBeenCalledWith({
+		db: {},
+		ids: ["pr_old"],
+	});
+	expect(retireEnts).toHaveBeenCalledWith({
+		db: {},
+		ids: ["ent_old"],
+	});
+	expect(deletePrices).not.toHaveBeenCalled();
+	expect(deleteEnts).not.toHaveBeenCalled();
+});

--- a/server/tests/unit/products/product-items-have-customer-references.test.ts
+++ b/server/tests/unit/products/product-items-have-customer-references.test.ts
@@ -105,6 +105,11 @@ test("product item references: reloads current rows under the product lock", asy
 			};
 		},
 		delete: () => ({ where: async () => undefined }),
+		update: () => ({
+			set: () => ({
+				where: async () => undefined,
+			}),
+		}),
 		query: { prices: { findMany: async () => [] } },
 	} as unknown as DrizzleCli;
 	const db = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Catalog leftover prices **and** entitlements are now always retired (`is_custom: true`). Neither row is hard-deleted on plan/item edits.

A deferred checkout snapshot can still insert `customer_prices` / `customer_entitlements` against those ids after the catalog changes. Retiring the paired entitlement avoids the reverse foreign key: a retired price still holds `entitlement_id`.

## What changed

- Update-mode leftover rows always go to `retired` (even with no customer/license refs)
- `applyEntitlementPricesPlan`, `handleNewProductItems`, and in-place item edits call `retireInIds` for leftover prices and entitlements
- `deleted` buckets, if present, are retired the same way — execute never calls `deleteInIds`
- V1 in-place isolation now expects a no-customer allowance edit to leave the old entitlement as `is_custom`

## Out of scope

- License `sweepUnreferencedCustomRows` (replace-set GC only)
- Product `ON DELETE CASCADE`
- Webhook error classification / SQS replay policy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10bf6c7e-1932-4f63-8e8f-63b80285c6b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10bf6c7e-1932-4f63-8e8f-63b80285c6b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires unused catalog prices and entitlements instead of hard-deleting them, so deferred checkout snapshots can still insert `customer_prices` and `customer_entitlements` against the old ids.

**Changes**
- Update-mode leftover rows always become `is_custom: true`, even with no customer or license references.
- `applyEntitlementPricesPlan`, `handleNewProductItems`, and in-place item edits retire prices together with their paired entitlements.
- Rows in `deleted` buckets are retired the same way; these paths no longer call `deleteInIds`.

**Out of scope**
- License `sweepUnreferencedCustomRows`, product `ON DELETE CASCADE`, and webhook error classification are unchanged.

<sup>Written for commit 3ad4beba227b071741b420b2772d68ec74ff296b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves replaced catalog prices and entitlements as retired rows so deferred checkout records can continue referencing them.
- **[Bug fixes]** Retires leftover price and entitlement rows instead of deleting them.
- **[Improvements]** Applies the same retirement behavior across catalog V2 execution, legacy in-place edits, and product-item replacement.
- **[Improvements]** Adds unit and integration coverage for retirement with and without existing references.
</details>


<h3>Confidence Score: 4/5</h3>

The production changes appear safe to merge, with only the non-blocking temporary test-group cleanup remaining.

Catalog loaders exclude retired rows, relevant schemas permit historical rows to coexist, and the update paths preserve deferred references while creating fresh active definitions; however, two integration tests remain enabled in the scratch group.

**Files Needing Attention:** server/tests/_groups/temp.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/execute/executeUpsertProducts/applyEntitlementPricesPlan.ts | Retires rows from both leftover buckets instead of invoking hard deletion. |
| server/src/internal/product/actions/inPlaceUpdateUtils.ts | Simplifies in-place isolation by unconditionally retiring replaced catalog rows while minting fresh active rows. |
| server/src/internal/products/product-items/productItemUtils/handleNewProductItems.ts | Replaces reference-aware deletion with paired price and entitlement retirement. |
| server/src/internal/products/actions/computeEntitlementPricesPlan/buildEntitlementPricesPlan/buildEntitlementPricesPlanUtils.ts | Routes all update-mode leftovers to the retired bucket. |
| server/tests/_groups/temp.ts | Leaves two integration tests in a scratch group that is documented as empty on trunk. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Plan or item edit] --> B[Create replacement rows]
  B --> C[Mark replaced prices as is_custom]
  C --> D[Mark replaced entitlements as is_custom]
  D --> E[Active catalog reads exclude retired rows]
  D --> F[Deferred checkout references remain valid]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/tests/_groups/temp.ts:4-7
**Scratch test group remains populated**

These integration tests remain registered in `activeTempPaths` even though this scratch group is documented as empty on trunk, causing later temporary test runs to include unrelated cases.

```suggestion
const activeTempPaths: string[] = [];
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(catalog): expect replaced no-custom..."](https://github.com/useautumn/autumn/commit/3ad4beba227b071741b420b2772d68ec74ff296b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60442862)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->