### PR TITLE
test(server): dimension coverage for transitions, entity locks and pooled tiers

### DIFF
--- a/server/tests/integration/balances/check/check-credit-dimensions-entities.test.ts
+++ b/server/tests/integration/balances/check/check-credit-dimensions-entities.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Contract: check, lock and finalize all price by the event's properties when
+ * the balance is entity-scoped. The reservation is taken from the entity's own
+ * balance at the dimensioned rate, and finalize reprices against the same
+ * properties the check locked with.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiEntityV2, FeatureConfigOverride } from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const GRANT = 1_000;
+
+const dimensionedAction1: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				large: { match: { size: "large" }, credit_amount: 16 },
+			},
+			multipliers: {
+				spot: { match: { lifecycle: "spot" }, factor: 0.5 },
+			},
+		},
+	],
+};
+
+const setupEntityCredits = async ({ customerId }: { customerId: string }) => {
+	const creditItem = items.consumable({
+		featureId: TestFeature.Credits,
+		includedUsage: GRANT,
+		entityFeatureId: TestFeature.Users,
+	});
+	const product = products.pro({
+		id: customerId,
+		items: [
+			items.freeUsers({ includedUsage: 3 }),
+			{
+				...creditItem,
+				config: { ...creditItem.config, feature_override: dimensionedAction1 },
+			},
+		],
+	});
+
+	return initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.products({ list: [product] }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+		],
+		actions: [s.billing.attach({ productId: product.id })],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("check-credit-dimensions-entities: an entity check converts at the matched dimension")}`,
+	async () => {
+		const customerId = "check-dimensions-entities";
+		const { autumnV2_3, entities } = await setupEntityCredits({ customerId });
+
+		const large = await autumnV2_3.check({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Action1,
+			required_balance: 10,
+			properties: { size: "large" },
+		});
+		expect(large).toMatchObject({ allowed: true, required_balance: 160 });
+
+		const spot = await autumnV2_3.check({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Action1,
+			required_balance: 10,
+			properties: { size: "large", lifecycle: "spot" },
+		});
+		expect(spot).toMatchObject({ allowed: true, required_balance: 80 });
+	},
+	{ timeout: 120_000 },
+);
+
+test.concurrent(
+	`${chalk.yellowBright("check-credit-dimensions-entities: a locked entity check finalizes at the same properties")}`,
+	async () => {
+		const customerId = "check-dimensions-entities-lock";
+		const { autumnV2_2, autumnV2_3, entities } = await setupEntityCredits({
+			customerId,
+		});
+		const lockId = `${customerId}-lock`;
+
+		const check = await autumnV2_3.check({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Action1,
+			required_balance: 10,
+			properties: { size: "large" },
+			lock: { enabled: true, lock_id: lockId },
+		});
+		expect(check.allowed).toBe(true);
+
+		// The reservation comes off this entity's balance, not the customer's.
+		const reserved = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entities[0].id,
+		);
+		expectBalanceCorrect({
+			customer: reserved,
+			featureId: TestFeature.Credits,
+			granted: GRANT,
+			remaining: GRANT - 160,
+			usage: 160,
+		});
+
+		await autumnV2_3.balances.finalize({
+			lock_id: lockId,
+			action: "confirm",
+			override_value: 5,
+		});
+
+		// Repriced at the locked properties: 5 x 16 = 80.
+		const finalized = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entities[0].id,
+		);
+		expectBalanceCorrect({
+			customer: finalized,
+			featureId: TestFeature.Credits,
+			granted: GRANT,
+			remaining: GRANT - 80,
+			usage: 80,
+		});
+	},
+	{ timeout: 120_000 },
+);

--- a/server/tests/integration/balances/track/basic/track-credit-dimensions-transition.test.ts
+++ b/server/tests/integration/balances/track/basic/track-credit-dimensions-transition.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Contract: per-dimension usage survives a plan transition. Attribution is keyed
+ * `<feature>::<dimension>`, so an upgrade that carries consumable usage must
+ * carry every dimension's position — not merge them, and not lose one.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5, FeatureConfigOverride } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const GRANT = 1_000;
+
+const dimensionedAction1: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				large: { match: { size: "large" }, credit_amount: 16 },
+				xl: { match: { size: "xl" }, credit_amount: 20 },
+			},
+		},
+	],
+};
+
+const creditItem = (includedUsage: number) => {
+	const item = items.consumable({
+		featureId: TestFeature.Credits,
+		includedUsage,
+	});
+	return {
+		...item,
+		config: { ...item.config, feature_override: dimensionedAction1 },
+	};
+};
+
+test.concurrent(
+	`${chalk.yellowBright("track-credit-dimensions-transition: usage in several dimensions carries across an upgrade")}`,
+	async () => {
+		const customerId = "dimensions-transition";
+		const starter = products.base({
+			id: "dimensions-transition-starter",
+			items: [creditItem(GRANT)],
+		});
+		const upgraded = products.pro({
+			id: "dimensions-transition-pro",
+			items: [creditItem(GRANT * 2)],
+		});
+
+		const { autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [starter, upgraded] }),
+			],
+			actions: [
+				s.billing.attach({ productId: starter.id }),
+				// Two dimensions, so the carry has more than one attribution key.
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 2,
+					properties: { size: "large" },
+					timeout: 2_000,
+				}),
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 1,
+					properties: { size: "xl" },
+					timeout: 2_000,
+				}),
+			],
+		});
+
+		// 2 x 16 + 1 x 20 = 52 consumed before the upgrade.
+		const before = await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(before.balances?.[TestFeature.Credits]).toMatchObject({
+			usage: 52,
+		});
+
+		await autumnV2_3.billing.attach({
+			customer_id: customerId,
+			plan_id: upgraded.id,
+			carry_over_usages: {
+				enabled: true,
+				feature_ids: [TestFeature.Credits],
+			},
+		});
+
+		// carry_over_usages moves both dimension positions onto the new plan.
+		const after = await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(after.balances?.[TestFeature.Credits]).toMatchObject({
+			usage: 52,
+			remaining: GRANT * 2 - 52,
+		});
+
+		// Pricing still resolves per dimension on the new plan.
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 1,
+			properties: { size: "xl" },
+		});
+		await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+		const afterTrack = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		expect(afterTrack.balances?.[TestFeature.Credits]).toMatchObject({
+			usage: 72,
+		});
+	},
+);

--- a/server/tests/integration/billing/pooled-balances/track-pooled-credit-dimensions-graduated.test.ts
+++ b/server/tests/integration/billing/pooled-balances/track-pooled-credit-dimensions-graduated.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Contract: a graduated dimension climbs its own ladder against a pooled
+ * balance. Tier progress is tracked per dimension, so usage from two entities
+ * sharing the pool advances the same ladder rather than each starting at tier 1.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5, FeatureConfigOverride } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const GRANT = 1_000;
+
+const graduatedDimension: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				xl: {
+					match: { size: "xl" },
+					tier_behavior: "graduated" as const,
+					tiers: [
+						{ to: 5, credit_amount: 10 },
+						{ to: "inf" as const, credit_amount: 4 },
+					],
+				},
+			},
+		},
+	],
+};
+
+test.concurrent(
+	`${chalk.yellowBright("pooled graduated dimension: both entities advance one shared ladder")}`,
+	async () => {
+		const customerId = "pooled-graduated-dimensions";
+		const creditItem = items.monthlyCredits({ includedUsage: GRANT });
+		const product = products.base({
+			id: "pooled-graduated-dimensions",
+			items: [
+				{
+					...creditItem,
+					pooled: true,
+					config: {
+						...creditItem.config,
+						feature_override: graduatedDimension,
+					},
+				},
+			],
+		});
+
+		const { autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [product] }),
+			],
+			actions: [
+				s.billing.attach({ productId: product.id, entityIndex: 0 }),
+				// 3 units from one entity, 4 from the other: 7 total up one ladder,
+				// so 5 @ 10 then 2 @ 4 = 58 — not two ladders of 3 and 4.
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 3,
+					entityIndex: 0,
+					properties: { size: "xl" },
+					timeout: 2_000,
+				}),
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 4,
+					entityIndex: 1,
+					properties: { size: "xl" },
+					timeout: 2_000,
+				}),
+			],
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(customer.balances?.[TestFeature.Credits]).toMatchObject({
+			usage: 58,
+		});
+	},
+	{ timeout: 120_000 },
+);


### PR DESCRIPTION
Continues #3286, which covered the balance *shapes* dimensions run against
(entity-scoped, pooled, license seats, and all three combined). This adds the
lifecycle and runtime paths that move usage around.

- **Plan transition** — usage in two dimensions carried across an upgrade with
  `carry_over_usages`. Attribution is keyed `<feature>::<dimension>`, and the
  carry path throws on duplicate attribution positions, so this proves both
  dimensions survive rather than merging or being dropped. Pricing still
  resolves per dimension on the new plan.
- **Entity check / lock / finalize** — an entity-scoped check converts at the
  matched dimension (10 units → 160, or 80 with a multiplier), the reservation
  comes off that entity's own balance, and finalize reprices at the properties
  the check locked with.
- **Graduated dimension on a pooled balance** — 3 units from one entity and 4
  from another advance *one* shared ladder (5 @ 10, then 2 @ 4 = 58), rather
  than each entity starting again at tier 1.

## Not covered

Invoice-level billing of dimensioned usage on a *licensed seat*. The seat's
credits are entity-scoped, so the renewal invoice needs a different assertion
shape than the customer-level invoice test uses — worth its own follow-up rather
than a half-working test here. Customer-level dimensioned invoicing is already
covered by `invoice-created-credit-dimensions`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds integration coverage for dimensioned credit lifecycle and runtime behavior, extending existing balance-shape tests to ensure attribution and pricing remain correct as usage moves. This is test-only and does not change production behavior.

**Coverage**

- Verifies `carry_over_usages` preserves separate dimension positions and applies new-plan rates.
- Verifies entity checks reserve from the entity balance and finalize using the locked properties.
- Verifies pooled graduated usage advances one shared ladder across entities.
- Leaves invoice-level billing for dimensioned licensed-seat usage to a separate follow-up.

<sup>Written for commit 7862011ec12df432bd2500c82ecab28986652840. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

