### PR TITLE
test(server): dimensioned usage survives a plan transition

### DIFF
--- a/server/tests/integration/balances/track/basic/track-credit-dimensions-transition.test.ts
+++ b/server/tests/integration/balances/track/basic/track-credit-dimensions-transition.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Contract: per-dimension usage survives a plan transition. Attribution is keyed
+ * `<feature>::<dimension>`, so an upgrade that carries consumable usage must
+ * carry every dimension's position — not merge them, and not lose one.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5, FeatureConfigOverride } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const GRANT = 1_000;
+
+const dimensionedAction1: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				large: { match: { size: "large" }, credit_amount: 16 },
+				xl: { match: { size: "xl" }, credit_amount: 20 },
+			},
+		},
+	],
+};
+
+const creditItem = (includedUsage: number) => {
+	const item = items.consumable({
+		featureId: TestFeature.Credits,
+		includedUsage,
+	});
+	return {
+		...item,
+		config: { ...item.config, feature_override: dimensionedAction1 },
+	};
+};
+
+test.concurrent(
+	`${chalk.yellowBright("track-credit-dimensions-transition: usage in several dimensions carries across an upgrade")}`,
+	async () => {
+		const customerId = "dimensions-transition";
+		const starter = products.base({
+			id: "dimensions-transition-starter",
+			items: [creditItem(GRANT)],
+		});
+		const upgraded = products.pro({
+			id: "dimensions-transition-pro",
+			items: [creditItem(GRANT * 2)],
+		});
+
+		const { autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [starter, upgraded] }),
+			],
+			actions: [
+				s.billing.attach({ productId: starter.id }),
+				// Two dimensions, so the carry has more than one attribution key.
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 2,
+					properties: { size: "large" },
+					timeout: 2_000,
+				}),
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 1,
+					properties: { size: "xl" },
+					timeout: 2_000,
+				}),
+			],
+		});
+
+		// 2 x 16 + 1 x 20 = 52 consumed before the upgrade.
+		const before = await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(before.balances?.[TestFeature.Credits]).toMatchObject({
+			usage: 52,
+		});
+
+		await autumnV2_3.billing.attach({
+			customer_id: customerId,
+			plan_id: upgraded.id,
+			carry_over_usages: {
+				enabled: true,
+				feature_ids: [TestFeature.Credits],
+			},
+		});
+
+		// carry_over_usages moves both dimension positions onto the new plan.
+		const after = await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(after.balances?.[TestFeature.Credits]).toMatchObject({
+			usage: 52,
+			remaining: GRANT * 2 - 52,
+		});
+
+		// Pricing still resolves per dimension on the new plan.
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 1,
+			properties: { size: "xl" },
+		});
+		await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+		const afterTrack = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		expect(afterTrack.balances?.[TestFeature.Credits]).toMatchObject({
+			usage: 72,
+		});
+	},
+);


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an integration test proving dimensioned consumable usage survives a plan transition, so upgrades using `carry_over_usages` preserve every dimension's position instead of merging or dropping one.

The test records usage in two dimensions on a starter plan, upgrades to a pro plan with `carry_over_usages`, and verifies the carried usage and remaining balance match. It then tracks another event on the new plan and confirms per-dimension pricing still resolves correctly.

<sup>Written for commit aa292df34388ae2dd1b34c9c13113ace04c0d2ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

