### PR TITLE
test(server): a graduated dimension shares one ladder across a pool

### DIFF
--- a/server/tests/integration/billing/pooled-balances/track-pooled-credit-dimensions-graduated.test.ts
+++ b/server/tests/integration/billing/pooled-balances/track-pooled-credit-dimensions-graduated.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Contract: a graduated dimension climbs its own ladder against a pooled
+ * balance. Tier progress is tracked per dimension, so usage from two entities
+ * sharing the pool advances the same ladder rather than each starting at tier 1.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5, FeatureConfigOverride } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const GRANT = 1_000;
+
+const graduatedDimension: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				xl: {
+					match: { size: "xl" },
+					tier_behavior: "graduated" as const,
+					tiers: [
+						{ to: 5, credit_amount: 10 },
+						{ to: "inf" as const, credit_amount: 4 },
+					],
+				},
+			},
+		},
+	],
+};
+
+test.concurrent(
+	`${chalk.yellowBright("pooled graduated dimension: both entities advance one shared ladder")}`,
+	async () => {
+		const customerId = "pooled-graduated-dimensions";
+		const creditItem = items.monthlyCredits({ includedUsage: GRANT });
+		const product = products.base({
+			id: "pooled-graduated-dimensions",
+			items: [
+				{
+					...creditItem,
+					pooled: true,
+					config: {
+						...creditItem.config,
+						feature_override: graduatedDimension,
+					},
+				},
+			],
+		});
+
+		const { autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [product] }),
+			],
+			actions: [
+				s.billing.attach({ productId: product.id, entityIndex: 0 }),
+				// 3 units from one entity, 4 from the other: 7 total up one ladder,
+				// so 5 @ 10 then 2 @ 4 = 58 — not two ladders of 3 and 4.
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 3,
+					entityIndex: 0,
+					properties: { size: "xl" },
+					timeout: 2_000,
+				}),
+				s.track({
+					featureId: TestFeature.Action1,
+					value: 4,
+					entityIndex: 1,
+					properties: { size: "xl" },
+					timeout: 2_000,
+				}),
+			],
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(customer.balances?.[TestFeature.Credits]).toMatchObject({
+			usage: 58,
+		});
+	},
+	{ timeout: 120_000 },
+);


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a test-only integration test for graduated dimensions on pooled balances. It locks in the contract that usage from multiple entities sharing a pool advances one shared ladder: 7 total units are billed as 5 at the first tier and 2 at the second, not as separate ladders per entity.

<sup>Written for commit 0dd126f3f0d1a29e3ccedaf3d4d761539f36a168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

