### PR TITLE
feat(create-schedule): support license-backed plans

### DIFF
--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -192,7 +192,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 		(params.plans ?? []).map(async (plan) => {
 			const scopedFullCustomer = await getScopedFullCustomer(plan.entity_id);
 
-			const { fullProduct, customPrices, customEnts } =
+			const { fullProduct, customPrices, customEnts, insertPlanLicenses } =
 				await setupAttachProductContext({
 					ctx,
 					params: {
@@ -225,6 +225,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 				customPrices: customPrices ?? [],
 				customEnts: customEnts ?? [],
 				featureQuantities,
+				insertPlanLicenses,
 				fullCustomer: scopedFullCustomer,
 				currentCustomerProduct,
 				scheduledCustomerProduct,

--- a/server/src/internal/billing/v2/actions/createSchedule/compute/computeCreateSchedulePlan.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/compute/computeCreateSchedulePlan.ts
@@ -64,6 +64,13 @@ export const computeCreateSchedulePlan = ({
 		...scheduled.insertCustomerProducts,
 	];
 
+	const insertPlanLicenses = [
+		...billingContext.productContexts,
+		...billingContext.scheduledPhaseContexts.flatMap(
+			(phase) => phase.productContexts,
+		),
+	].flatMap((productContext) => productContext.insertPlanLicenses ?? []);
+
 	const { allLineItems, updateCustomerEntitlements } = buildAutumnLineItems({
 		ctx,
 		newCustomerProducts: immediateCustomerProducts,
@@ -110,6 +117,9 @@ export const computeCreateSchedulePlan = ({
 			...oneOffPrepaidCarryOvers.entitlements,
 		],
 		customFreeTrial: billingContext.trialContext?.customFreeTrial,
+		insertPlanLicenses: insertPlanLicenses.length
+			? insertPlanLicenses
+			: undefined,
 		lineItems: allLineItems,
 		updateCustomerEntitlements,
 		insertCustomerEntitlements: oneOffPrepaidCarryOvers.customerEntitlements,

--- a/server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts
@@ -7,7 +7,7 @@ import {
 } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { handleUnsupportedLicenseActionErrors } from "@/internal/billing/v2/common/errors/handleUnsupportedLicenseActionErrors";
+import { handleUnsupportedOutgoingLicenseErrors } from "@/internal/billing/v2/common/errors/handleUnsupportedLicenseActionErrors";
 import { handleStripeBillingPlanErrors } from "@/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors";
 import {
 	getDeleteCustomerProducts,
@@ -47,7 +47,6 @@ export const handleCreateScheduleErrors = async ({
 };
 
 export const handleCreateScheduleComputeErrors = ({
-	billingContext,
 	autumnBillingPlan,
 }: {
 	billingContext: CreateScheduleBillingContext;
@@ -57,14 +56,8 @@ export const handleCreateScheduleComputeErrors = ({
 		...getExpiredUpdatedCustomerProducts({ autumnBillingPlan }),
 		...getDeleteCustomerProducts({ autumnBillingPlan }),
 	];
-	handleUnsupportedLicenseActionErrors({
+	handleUnsupportedOutgoingLicenseErrors({
 		actionLabel: "billing.create_schedule",
-		fullProducts: [
-			...billingContext.fullProducts,
-			...billingContext.scheduledPhaseContexts.flatMap((phase) =>
-				phase.productContexts.map(({ fullProduct }) => fullProduct),
-			),
-		],
 		customerProducts: outgoingCustomerProducts,
 	});
 };

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupScheduledProductsContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupScheduledProductsContext.ts
@@ -34,6 +34,7 @@ export const setupScheduledProductsContext = async ({
 						fullProduct,
 						customPrices = [],
 						customEnts: customEntitlements = [],
+						insertPlanLicenses,
 					} = await setupAttachProductContext({
 						ctx,
 						params: plan,
@@ -55,6 +56,7 @@ export const setupScheduledProductsContext = async ({
 						customPrices,
 						customEntitlements,
 						featureQuantities,
+						insertPlanLicenses,
 						externalId: plan.subscription_id,
 						entity: computeScopeForScheduledProduct({
 							fullProduct,

--- a/server/src/internal/billing/v2/common/errors/handleUnsupportedLicenseActionErrors.ts
+++ b/server/src/internal/billing/v2/common/errors/handleUnsupportedLicenseActionErrors.ts
@@ -5,6 +5,28 @@ import {
 	RecaseError,
 } from "@autumn/shared";
 
+const throwUnsupportedLicenseAction = (actionLabel: string) => {
+	throw new RecaseError({
+		message: `${actionLabel} does not support license-backed plans yet.`,
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+	});
+};
+
+/** Rejects moving a customer off a plan whose license pools they still hold. */
+export const handleUnsupportedOutgoingLicenseErrors = ({
+	actionLabel,
+	customerProducts,
+}: {
+	actionLabel: string;
+	customerProducts: (FullCusProduct | undefined | null)[];
+}) => {
+	const holdsLicensePools = customerProducts.some(
+		(customerProduct) => customerProduct?.customer_licenses?.length,
+	);
+	if (holdsLicensePools) throwUnsupportedLicenseAction(actionLabel);
+};
+
 /** Hard block for actions with no license support: any incoming plan
  * offering licenses, or any outgoing plan holding pools, rejects. */
 export const handleUnsupportedLicenseActionErrors = ({
@@ -16,17 +38,10 @@ export const handleUnsupportedLicenseActionErrors = ({
 	fullProducts: (FullProduct | undefined)[];
 	customerProducts: (FullCusProduct | undefined | null)[];
 }) => {
-	const hasIncomingLicenses = fullProducts.some(
+	const offersLicenses = fullProducts.some(
 		(product) => product?.licenses?.length,
 	);
-	const hasOutgoingLicenses = customerProducts.some(
-		(customerProduct) => customerProduct?.customer_licenses?.length,
-	);
-	if (!hasIncomingLicenses && !hasOutgoingLicenses) return;
+	if (offersLicenses) throwUnsupportedLicenseAction(actionLabel);
 
-	throw new RecaseError({
-		message: `${actionLabel} does not support license-backed plans yet.`,
-		code: ErrCode.InvalidRequest,
-		statusCode: 400,
-	});
+	handleUnsupportedOutgoingLicenseErrors({ actionLabel, customerProducts });
 };

--- a/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
@@ -221,10 +221,12 @@ export const executeAutumnBillingPlan = async ({
 		});
 	}
 
-	if (
-		(autumnBillingPlan.customerLicenseUpdates?.length ?? 0) > 0 &&
-		autumnBillingPlan.customerId
-	) {
+	const mayTouchLicenses =
+		(autumnBillingPlan.customerLicenseUpdates?.length ?? 0) > 0 ||
+		(autumnBillingPlan.insertPlanLicenses?.length ?? 0) > 0 ||
+		(autumnBillingPlan.insertCustomerProducts?.length ?? 0) > 0;
+
+	if (mayTouchLicenses && autumnBillingPlan.customerId) {
 		await reconcileLicenseStateForCustomer({
 			ctx,
 			idOrInternalId: autumnBillingPlan.customerId,

--- a/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
@@ -224,7 +224,10 @@ export const executeAutumnBillingPlan = async ({
 	const mayTouchLicenses =
 		(autumnBillingPlan.customerLicenseUpdates?.length ?? 0) > 0 ||
 		(autumnBillingPlan.insertPlanLicenses?.length ?? 0) > 0 ||
-		(autumnBillingPlan.insertCustomerProducts?.length ?? 0) > 0;
+		(autumnBillingPlan.insertCustomerProducts?.some(
+			(customerProduct) => (customerProduct.customer_licenses?.length ?? 0) > 0,
+		) ??
+			false);
 
 	if (mayTouchLicenses && autumnBillingPlan.customerId) {
 		await reconcileLicenseStateForCustomer({

--- a/server/tests/integration/licenses/billing/create-schedule/create-schedule-license-plan.test.ts
+++ b/server/tests/integration/licenses/billing/create-schedule/create-schedule-license-plan.test.ts
@@ -1,0 +1,176 @@
+/**
+ * TDD test for scheduling a license-backed plan via billing.create_schedule.
+ *
+ * Reported as: the dashboard's Create Schedule sheet never shows a plan's
+ * licences, while the Attach Plan sheet does. The UI gate is downstream of a
+ * backend that rejected licence-backed plans on this action outright.
+ *
+ * Red-failure mode (before fix):
+ *  - handleUnsupportedLicenseActionErrors threw 400 "billing.create_schedule
+ *    does not support license-backed plans yet." for any phase plan with licences
+ *  - createScheduleParamsV0 additionally .strict()-omitted customize.upsert_licenses,
+ *    so a per-phase licence customization failed schema validation
+ *
+ * Green-success criteria (after fix):
+ *  - a future phase can schedule a licence-backed plan, and the scheduled
+ *    product owns a licence pool granting the catalog seat allowance
+ *  - customize.upsert_licenses is accepted per phase and the scheduled pool
+ *    is anchored to the customized licence definition, not the catalog one
+ */
+import { test } from "bun:test";
+import { BillingInterval, ms } from "@autumn/shared";
+import { expectLicenseDefinitionCorrect } from "@tests/integration/licenses/utils/expectLicenseDefinitionCorrect";
+import { expectScheduledLicensePools } from "@tests/integration/licenses/utils/expectScheduledLicensePools";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+const CATALOG_SEAT_PRICE = 20;
+const CUSTOM_SEAT_PRICE = 40;
+const CATALOG_MESSAGES = 100;
+const CUSTOM_MESSAGES = 500;
+const INCLUDED_SEATS = 2;
+
+const buildLicensePlans = ({ prefix }: { prefix: string }) => {
+	const parent = products.base({
+		id: `${prefix}-parent`,
+		items: [items.dashboard()],
+	});
+	const seat = products.base({
+		id: `${prefix}-seat`,
+		items: [
+			items.monthlyPrice({ price: CATALOG_SEAT_PRICE }),
+			items.monthlyMessages({ includedUsage: CATALOG_MESSAGES }),
+		],
+		group: `${prefix}-seat-licenses`,
+	});
+
+	return { parent, seat };
+};
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule-license: schedules a license-backed plan in a future phase")}`,
+	async () => {
+		const customerId = "create-schedule-license-plan";
+		const starter = products.base({
+			id: "csl-starter",
+			items: [items.monthlyPrice({ price: 10 })],
+		});
+		const { parent: enterprise, seat } = buildLicensePlans({ prefix: "csl" });
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [starter, enterprise, seat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: enterprise.id,
+					licenseProductId: seat.id,
+					included: INCLUDED_SEATS,
+				}),
+			],
+		});
+
+		await autumnV2_3.billing.createSchedule({
+			customer_id: customerId,
+			phases: [
+				{ starts_at: Date.now(), plans: [{ plan_id: starter.id }] },
+				{
+					starts_at: Date.now() + ms.months(1),
+					plans: [{ plan_id: enterprise.id }],
+				},
+			],
+		});
+
+		await expectScheduledLicensePools({
+			ctx,
+			customerId,
+			parentPlanId: enterprise.id,
+			licenses: [{ licensePlanId: seat.id, granted: INCLUDED_SEATS }],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule-license: accepts customize.upsert_licenses on a scheduled phase")}`,
+	async () => {
+		const customerId = "create-schedule-license-customize";
+		const starter = products.base({
+			id: "cslc-starter",
+			items: [items.monthlyPrice({ price: 10 })],
+		});
+		const { parent: enterprise, seat } = buildLicensePlans({ prefix: "cslc" });
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [starter, enterprise, seat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: enterprise.id,
+					licenseProductId: seat.id,
+					included: INCLUDED_SEATS,
+				}),
+			],
+		});
+
+		await autumnV2_3.billing.createSchedule({
+			customer_id: customerId,
+			phases: [
+				{ starts_at: Date.now(), plans: [{ plan_id: starter.id }] },
+				{
+					starts_at: Date.now() + ms.months(1),
+					plans: [
+						{
+							plan_id: enterprise.id,
+							customize: {
+								upsert_licenses: [
+									{
+										license_plan_id: seat.id,
+										customize: {
+											price: {
+												amount: CUSTOM_SEAT_PRICE,
+												interval: BillingInterval.Month,
+											},
+											remove_items: [{ feature_id: TestFeature.Messages }],
+											add_items: [
+												itemsV2.monthlyMessages({ included: CUSTOM_MESSAGES }),
+											],
+										},
+									},
+								],
+							},
+						},
+					],
+				},
+			],
+		});
+
+		await expectScheduledLicensePools({
+			ctx,
+			customerId,
+			parentPlanId: enterprise.id,
+			licenses: [{ licensePlanId: seat.id, granted: INCLUDED_SEATS }],
+		});
+
+		await expectLicenseDefinitionCorrect({
+			ctx,
+			customerId,
+			parentPlanId: enterprise.id,
+			isCustom: true,
+			isCustomized: true,
+			basePrice: {
+				amount: CUSTOM_SEAT_PRICE,
+				interval: BillingInterval.Month,
+				isCustom: true,
+			},
+		});
+	},
+);

--- a/server/tests/integration/licenses/utils/expectScheduledLicensePools.ts
+++ b/server/tests/integration/licenses/utils/expectScheduledLicensePools.ts
@@ -1,0 +1,100 @@
+import { expect } from "bun:test";
+import {
+	customerLicenses,
+	customerProducts,
+	products as productsTable,
+} from "@autumn/shared";
+import type { initScenario } from "@tests/utils/testInitUtils/initScenario";
+import { and, eq } from "drizzle-orm";
+
+type Ctx = Awaited<ReturnType<typeof initScenario>>["ctx"];
+
+type ScheduledLicensePoolExpectation = {
+	licensePlanId: string;
+	granted: number;
+	paidQuantity?: number;
+};
+
+const getScheduledLicensePools = async ({
+	ctx,
+	customerId,
+	parentPlanId,
+}: {
+	ctx: Ctx;
+	customerId: string;
+	parentPlanId: string;
+}) => {
+	const licenseProducts = ctx.db
+		.select({
+			internalId: productsTable.internal_id,
+			planId: productsTable.id,
+		})
+		.from(productsTable)
+		.as("license_products");
+
+	return await ctx.db
+		.select({
+			licensePlanId: licenseProducts.planId,
+			granted: customerLicenses.granted,
+			paidQuantity: customerLicenses.paid_quantity,
+			parentStatus: customerProducts.status,
+		})
+		.from(customerLicenses)
+		.innerJoin(
+			customerProducts,
+			eq(customerProducts.id, customerLicenses.parent_customer_product_id),
+		)
+		.innerJoin(
+			licenseProducts,
+			eq(
+				licenseProducts.internalId,
+				customerLicenses.license_internal_product_id,
+			),
+		)
+		.where(
+			and(
+				eq(customerProducts.customer_id, customerId),
+				eq(customerProducts.product_id, parentPlanId),
+			),
+		);
+};
+
+/**
+ * Asserts the license pools hanging off a scheduled parent product. Scheduled
+ * products are absent from the customer API until activation, so the pools are
+ * read straight from the DB.
+ */
+export const expectScheduledLicensePools = async ({
+	ctx,
+	customerId,
+	parentPlanId,
+	licenses,
+}: {
+	ctx: Ctx;
+	customerId: string;
+	parentPlanId: string;
+	licenses: ScheduledLicensePoolExpectation[];
+}) => {
+	const pools = await getScheduledLicensePools({
+		ctx,
+		customerId,
+		parentPlanId,
+	});
+
+	expect(pools.length).toBe(licenses.length);
+
+	for (const expectation of licenses) {
+		const match = pools.find(
+			(pool) => pool.licensePlanId === expectation.licensePlanId,
+		);
+
+		expect(
+			match,
+			`Missing scheduled license pool ${expectation.licensePlanId}: ${JSON.stringify(pools)}`,
+		).toBeDefined();
+		expect(match?.granted).toBe(expectation.granted);
+		if (expectation.paidQuantity !== undefined) {
+			expect(match?.paidQuantity).toBe(expectation.paidQuantity);
+		}
+	}
+};

--- a/server/tests/scenarios/licenses/license-create-schedule-scenario.test.ts
+++ b/server/tests/scenarios/licenses/license-create-schedule-scenario.test.ts
@@ -1,0 +1,54 @@
+import { test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+/**
+ * Customer "license-create-schedule" for dashboard testing of Create Schedule
+ * against a license-backed plan:
+ *
+ *   starter    attached now, cheap monthly base price
+ *   enterprise $250/mo parent plan, linked to team-seat (included: 2)
+ *   3 entities available to assign seats to
+ *
+ * In the dashboard: open the customer, Attach Plan ▸ Create Schedule, and put
+ * enterprise in a future phase. Before the fix this 400s with "billing.create_schedule
+ * does not support license-backed plans yet"; after it, the phase schedules and
+ * the scheduled product owns a 2-seat pool.
+ */
+test(`${chalk.yellowBright("scenario: create schedule with a license-backed plan")}`, async () => {
+	const starter = products.base({
+		id: "schedule-starter",
+		items: [items.monthlyPrice({ price: 20 })],
+	});
+	const enterprise = products.base({
+		id: "schedule-enterprise",
+		items: [items.monthlyPrice({ price: 250 }), items.dashboard()],
+	});
+	const teamSeat = products.base({
+		id: "team-seat",
+		items: [
+			items.monthlyPrice({ price: 30 }),
+			items.monthlyMessages({ includedUsage: 500 }),
+		],
+	});
+
+	await initScenario({
+		customerId: "license-create-schedule",
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.entities({ count: 3, featureId: TestFeature.Users }),
+			s.products({ list: [starter, enterprise, teamSeat] }),
+		],
+		actions: [
+			s.licenses.link({
+				parentProductId: enterprise.id,
+				licenseProductId: teamSeat.id,
+				included: 2,
+			}),
+			s.billing.attach({ productId: starter.id }),
+		],
+	});
+});

--- a/shared/api/billing/createSchedule/createScheduleParamsV0.ts
+++ b/shared/api/billing/createSchedule/createScheduleParamsV0.ts
@@ -22,14 +22,11 @@ export enum StartingAfterDuration {
 const CreateScheduleCustomizePlanSchema = refineCustomizePlanV1Schema(
 	CustomizePlanV1BaseSchema.omit({
 		free_trial: true,
-		upsert_licenses: true,
-		remove_licenses: true,
 		update_items: true,
 	}).strict(),
 	{
 		includeFreeTrial: false,
 		includeUpdateItems: false,
-		includeLicenses: false,
 	},
 );
 

--- a/shared/models/billingModels/context/createScheduleBillingContext.ts
+++ b/shared/models/billingModels/context/createScheduleBillingContext.ts
@@ -2,6 +2,7 @@ import type {
 	Entitlement,
 	Entity,
 	FeatureOptions,
+	InsertPlanLicenseSpec,
 	Price,
 } from "@autumn/shared";
 import type {
@@ -16,6 +17,7 @@ export interface ScheduledProductContext {
 	customPrices: Price[];
 	customEntitlements: Entitlement[];
 	featureQuantities: FeatureOptions[];
+	insertPlanLicenses?: InsertPlanLicenseSpec[];
 	/** User-provided subscription ID for this scheduled product. */
 	externalId?: string;
 	/**

--- a/shared/models/billingModels/context/multiAttachBillingContext.ts
+++ b/shared/models/billingModels/context/multiAttachBillingContext.ts
@@ -3,6 +3,7 @@ import type {
 	FeatureOptions,
 	FullCusProduct,
 	FullCustomer,
+	InsertPlanLicenseSpec,
 	Price,
 } from "@autumn/shared";
 import type { FullProduct } from "../../productModels/productModels";
@@ -14,6 +15,7 @@ export interface MultiAttachProductContext {
 	customPrices: Price[];
 	customEnts: Entitlement[];
 	featureQuantities: FeatureOptions[];
+	insertPlanLicenses?: InsertPlanLicenseSpec[];
 	fullCustomer: FullCustomer;
 	/** The existing active product in the same group and scope. */
 	currentCustomerProduct?: FullCusProduct;

--- a/vite/src/components/forms/create-schedule/createScheduleFormSchema.ts
+++ b/vite/src/components/forms/create-schedule/createScheduleFormSchema.ts
@@ -1,10 +1,15 @@
-import { BillingBehaviorSchema, type ProductItem } from "@autumn/shared";
+import {
+	BillingBehaviorSchema,
+	type CustomizePlanLicense,
+	type ProductItem,
+} from "@autumn/shared";
 import { z } from "zod/v4";
 
 export const SchedulePlanSchema = z.object({
 	productId: z.string().min(1),
 	prepaidOptions: z.record(z.string(), z.number().nonnegative()),
 	items: z.custom<ProductItem[]>().nullable(),
+	addLicenses: z.custom<CustomizePlanLicense[]>().nullable(),
 	isCustom: z.boolean(),
 	version: z.number().positive().optional(),
 	// Only meaningful on the first phase — later phases inherit its scope.
@@ -17,6 +22,7 @@ export const EMPTY_SCHEDULE_PLAN: SchedulePlan = {
 	productId: "",
 	prepaidOptions: {},
 	items: null,
+	addLicenses: null,
 	isCustom: false,
 	version: undefined,
 	// null is customer-level: a plan picks its own scope, the sheet has none.

--- a/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
@@ -41,6 +41,19 @@ export function buildCreateScheduleRequestBody({
 	if (getCreateSchedulePhaseTimingError({ phases, nowMs: now })) return null;
 	const hasPersistedSchedule = hasPersistedCreateSchedule({ phases });
 
+	const toApiPlan = (plan: SchedulePlan) =>
+		buildBillingPlan({
+			productId: plan.productId,
+			prepaidOptions: plan.prepaidOptions,
+			items: plan.items,
+			addLicenses: plan.addLicenses,
+			version: plan.version,
+			isCustom: plan.isCustom,
+			entityId: plan.entityId ?? null,
+			product: products.find((product) => product.id === plan.productId),
+			features,
+		});
+
 	const apiPhases = phases.map((phase, index) => {
 		let startsAt = phase.startsAt;
 		if (index === 0) {
@@ -56,22 +69,7 @@ export function buildCreateScheduleRequestBody({
 		if (startsAt === null) return null;
 
 		const plans = phase.plans.flatMap((plan) =>
-			plan.productId
-				? [
-						buildBillingPlan({
-							productId: plan.productId,
-							prepaidOptions: plan.prepaidOptions,
-							items: plan.items,
-							version: plan.version,
-							isCustom: plan.isCustom,
-							entityId: plan.entityId ?? null,
-							product: products.find(
-								(product) => product.id === plan.productId,
-							),
-							features,
-						}),
-					]
-				: [],
+			plan.productId ? [toApiPlan(plan)] : [],
 		);
 
 		if (plans.length === 0) return null;
@@ -97,20 +95,7 @@ export function buildCreateScheduleRequestBody({
 	}));
 
 	const apiUnscheduledPlans = unscheduledPlans.flatMap((plan) =>
-		plan.productId
-			? [
-					buildBillingPlan({
-						productId: plan.productId,
-						prepaidOptions: plan.prepaidOptions,
-						items: plan.items,
-						version: plan.version,
-						isCustom: plan.isCustom,
-						entityId: plan.entityId ?? null,
-						product: products.find((product) => product.id === plan.productId),
-						features,
-					}),
-				]
-			: [],
+		plan.productId ? [toApiPlan(plan)] : [],
 	);
 
 	const body: Record<string, unknown> = {

--- a/vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.ts
+++ b/vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.ts
@@ -1,4 +1,8 @@
-import type { BillingBehavior, ProductItem } from "@autumn/shared";
+import type {
+	BillingBehavior,
+	CustomizePlanLicense,
+	ProductItem,
+} from "@autumn/shared";
 import { addMonths, addYears } from "date-fns";
 import {
 	type FieldReaders,
@@ -24,6 +28,14 @@ const PLAN_FIELD_READERS: FieldReaders<SchedulePlan> = {
 	version: readNumber("version"),
 };
 
+const upsertLicensesFrom = (plan: Record<string, unknown>) => {
+	const customize = requestRecord(plan.customize);
+	const upsertLicenses = customize?.upsert_licenses;
+	return Array.isArray(upsertLicenses)
+		? (upsertLicenses as CustomizePlanLicense[])
+		: null;
+};
+
 const planFrom = (value: unknown): SchedulePlan | undefined => {
 	const plan = requestRecord(value);
 	if (!plan || typeof plan.plan_id !== "string") return undefined;
@@ -32,6 +44,7 @@ const planFrom = (value: unknown): SchedulePlan | undefined => {
 		entityId: overrides.entityId ?? null,
 		isCustom: Array.isArray(plan.items),
 		items: overrides.items ?? null,
+		addLicenses: upsertLicensesFrom(plan),
 		prepaidOptions:
 			readQuantities("feature_quantities", "feature_id")(plan) ?? {},
 		productId: plan.plan_id,

--- a/vite/src/components/forms/shared/utils/buildPlanCustomize.ts
+++ b/vite/src/components/forms/shared/utils/buildPlanCustomize.ts
@@ -1,6 +1,7 @@
 import type {
 	ApiPlanItemV1,
 	CreatePlanItemParamsV1,
+	CustomizePlanLicense,
 	Feature,
 	MultiAttachParamsV0,
 	ProductItem,
@@ -114,6 +115,7 @@ export function buildBillingPlan({
 	productId,
 	prepaidOptions,
 	items,
+	addLicenses,
 	version,
 	isCustom,
 	entityId,
@@ -124,6 +126,7 @@ export function buildBillingPlan({
 	productId: string;
 	prepaidOptions: Record<string, number | undefined>;
 	items: ProductItem[] | null;
+	addLicenses?: CustomizePlanLicense[] | null;
 	version?: number;
 	isCustom: boolean;
 	entityId?: string | null;
@@ -135,9 +138,13 @@ export function buildBillingPlan({
 		prepaidOptions,
 		product,
 	});
-	const customize = isCustom
+	const itemCustomize = isCustom
 		? buildCustomize({ items, features, includeEmptyItems })
 		: undefined;
+	const customize =
+		addLicenses && addLicenses.length > 0
+			? { ...(itemCustomize ?? {}), upsert_licenses: addLicenses }
+			: itemCustomize;
 
 	return {
 		plan_id: productId,

--- a/vite/src/views/customers2/components/sheets/CreateScheduleSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/CreateScheduleSheet.tsx
@@ -1,4 +1,5 @@
 import type {
+	CustomizePlanLicense,
 	FrontendProduct,
 	FullCustomer,
 	FullCustomerSchedule,
@@ -311,7 +312,10 @@ function CreateScheduleSheetBody() {
 		});
 	}, [editingPlanValue, products]);
 
-	const handleInlineSave = (draftProduct: FrontendProduct) => {
+	const handleInlineSave = (
+		draftProduct: FrontendProduct,
+		addLicenses?: CustomizePlanLicense[],
+	) => {
 		if (!(editingPlanValue && planEditorProduct)) return setEditingPlan(null);
 
 		const patch = getSupportedPlanFormPatchFromDraftProduct({
@@ -326,6 +330,7 @@ function CreateScheduleSheetBody() {
 					isCustom: true,
 				}),
 				...("version" in patch && { version: patch.version }),
+				...(addLicenses !== undefined && { addLicenses }),
 			},
 		});
 	};
@@ -348,6 +353,8 @@ function CreateScheduleSheetBody() {
 					onSave={handleInlineSave}
 					onCancel={() => setEditingPlan(null)}
 					isOpen={!!editingPlan}
+					enableLicenseEditing
+					initialAddLicenses={editingPlanValue?.addLicenses}
 				/>
 			)}
 		</>


### PR DESCRIPTION
## Problem

Scheduling a licence-backed plan was impossible, and the dashboard gave no hint why.

Reported in #autumn-stackone: *"How come I can't see the licence when I'm doing a phased schedule?"* The Attach Plan sheet renders a plan's licence card; the Create Schedule sheet renders only the seat price line, with no editable licence.

The UI gap sat on top of a backend that rejected these plans outright, at two independent layers:

- `createScheduleParamsV0` `.strict()`-omitted `upsert_licenses` / `remove_licenses`, so a per-phase licence customization failed schema validation.
- `handleUnsupportedLicenseActionErrors` threw `400 billing.create_schedule does not support license-backed plans yet.` for **any** plan carrying licences — no `customize` needed, just a catalog licence link.

Two further layers silently dropped licence data even once those passed:

- `setupScheduledProductsContext` and `setupImmediateMultiProductBillingContext` destructured `setupAttachProductContext`'s result without `insertPlanLicenses`, and neither `ScheduledProductContext` nor `MultiAttachProductContext` had a field to carry it. This is also the seat-price discrepancy: `insertPlanLicenses` carries the licence's customized base price, so the schedule path fell back to the catalog price.
- `executeAutumnBillingPlan` gated licence reconciliation on `customerLicenseUpdates`, which create_schedule never produces.

## Changes

**Backend**
- Allow `upsert_licenses` / `remove_licenses` through the schedule customize schema.
- Split `handleUnsupportedOutgoingLicenseErrors` out of the combined guard — transferring an existing pool off a plan stays unsupported, offering licences no longer is.
- Thread `insertPlanLicenses` through both scheduled and immediate phase contexts into the billing plan.
- Widen the reconcile trigger to newly inserted products; `reconcileLicenseStateForCustomer` self-guards on `customerTouchesLicenses` and is idempotent.

**Dashboard**
- `addLicenses` per schedule plan (schedules have plans per phase, unlike attach's single form-level value) through the form schema, request body, and persisted-schedule round trip.
- `buildBillingPlan` folds `addLicenses` into `customize.upsert_licenses` in one place, so multi-attach picks it up too.
- Extracted `toApiPlan` in `useCreateScheduleRequestBody`, collapsing two identical 11-line `buildBillingPlan` blocks.

## Testing

New `create-schedule-license-plan.test.ts` — written failing first, against the two real errors above:

```
before  ✗ billing.create_schedule does not support license-backed plans yet.
        ✗ phases.1.plans.0.customize: Unrecognized key: "upsert_licenses"
after   ✓ 2 pass
```

Covers scheduling a licensed plan in a future phase (pool granted with the catalog seat allowance) and `customize.upsert_licenses` per phase (pool anchored to the customized definition at the custom price). New `expectScheduledLicensePools` helper reads pools from the DB, since scheduled products are absent from the customer API until activation.

Also: licence attach suite 10/10, `scheduleFormFromRequestBody` 8/8, vite `tsc --noEmit` clean.

`license-create-schedule-scenario.test.ts` seeds a customer for dashboard testing.

## Notes

The `create-schedule` integration folder is flaky on local infra (`service_unavailable`, Postgres `57P01`) — dev fails 3 and this branch 2, with different test names each run. Re-run individually they pass. Worth a CI eye rather than treating as caused by this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scheduling license-backed plans in `create_schedule` used to fail with a 400 ("billing.create_schedule does not support license-backed plans yet."), and the dashboard's Create Schedule sheet never showed a plan's license card. License-backed plans now schedule in future phases, per-phase `customize.upsert_licenses` is honored, and the sheet lets you edit each phase plan's licenses.

**Bug Fixes**
- Allow `upsert_licenses` / `remove_licenses` through the schedule customize schema.
- Narrow the guard so only outgoing plans still holding license pools are rejected; incoming license-backed plans are accepted.
- Thread `insertPlanLicenses` through both scheduled and immediate phase contexts into the billing plan.
- Run license reconciliation only when the plan inserts license updates or customer products that carry license pools.

**New Features**
- Add per-plan license editing in the Create Schedule sheet, carried through the form schema, request body, and persisted-schedule round trip.
- `buildBillingPlan` folds `addLicenses` into `customize.upsert_licenses`, so multi-attach ignores behavior changes.

The `create-schedule` integration folder is flaky on local infra (`service_unavailable`, Postgres `57P01`); failing tests pass when run individually. Known gap: loading a persisted schedule reads only `upsert_licenses`, so a `remove_licenses` customization is silently dropped when the form is resubmitted.

<sup>Written for commit 12c7ef31b79822ab3818d333cd9c725ffae83e01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR enables license-backed plans in scheduled billing phases and adds per-phase license editing to the dashboard.
- **Bug fixes · API changes:** Accept license upserts and removals in create-schedule customization and carry inserted license definitions through billing contexts.
- **Bug fixes:** Reconcile license state when plans or customer products introduce license pools.
- **Improvements · API changes:** Add per-plan license editing and preserve license upserts when schedule request bodies pass through the dashboard form.
- **Improvements:** Add integration coverage and database assertions for scheduled license pools.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because editing and resaving a schedule can silently discard requested license removals.

A valid schedule containing `customize.remove_licenses` is loaded through a conversion that preserves only license upserts, while the form model and serializer provide no path to retain the removal operation.

**Files Needing Attention:** vite/src/components/forms/create-schedule/utils/scheduleFormFromRequestBody.ts, vite/src/components/forms/create-schedule/createScheduleFormSchema.ts, vite/src/components/forms/shared/utils/buildPlanCustomize.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/billing/createSchedule/createScheduleParamsV0.ts | Expands create-schedule customization validation to accept license operations. |
| server/src/internal/billing/v2/actions/createSchedule/compute/computeCreateSchedulePlan.ts | Collects inserted license definitions from immediate and scheduled product contexts into the billing plan. |
| server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts | Runs license reconciliation when the billing plan inserts license-related records. |
| vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts | Centralizes conversion of schedule form plans into API billing plans. |
| vite/src/views/customers2/components/sheets/CreateScheduleSheet.tsx | Enables per-plan license editing in the Create Schedule sheet. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Schedule form plan] --> B[Build API customization]
    B --> C[Create-schedule validation]
    C --> D[Scheduled product context]
    D --> E[Billing plan]
    E --> F[Insert license pools]
    F --> G[Reconcile customer license state]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(licenses): only reconcile when an in..."](https://github.com/useautumn/autumn/commit/12c7ef31b79822ab3818d333cd9c725ffae83e01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60508703)</sub>

<!-- /greptile_comment -->