### PR TITLE
Block overdue entitlements with plan overrides

### DIFF
--- a/scripts/seed/seedOverdueEntitlements.ts
+++ b/scripts/seed/seedOverdueEntitlements.ts
@@ -1,0 +1,58 @@
+import { organizations } from "@autumn/shared";
+import { initDrizzle } from "@server/db/initDrizzle.js";
+import { logger } from "@server/external/logtail/logtailUtils.js";
+import { waitForRedisReady } from "@server/external/redis/initRedis.js";
+import { getMiscRedisTargets } from "@server/external/redis/miscCache/resolveMiscRedis.js";
+import {
+	startAllEdgeConfigPolling,
+	stopAllEdgeConfigPolling,
+} from "@server/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { clearOrgCache } from "@server/internal/orgs/orgUtils/clearOrgCache.js";
+import { sql } from "drizzle-orm";
+
+const { db, client } = initDrizzle();
+const apply = process.argv.includes("--apply");
+const includePastDue = sql`COALESCE((${organizations.config}->>'include_past_due')::boolean, true)`;
+const needsSeed = sql`${organizations.config}->'block_overdue_entitlements'
+	IS DISTINCT FROM to_jsonb(NOT ${includePastDue})`;
+
+try {
+	if (apply) {
+		await startAllEdgeConfigPolling({ logger });
+		for (const target of getMiscRedisTargets()) {
+			await waitForRedisReady(target.redis, target.instanceName);
+		}
+
+		const updated = await db
+			.update(organizations)
+			.set({
+				config: sql`${organizations.config} || jsonb_build_object(
+					'include_past_due', ${includePastDue},
+					'block_overdue_entitlements', NOT ${includePastDue}
+				)`,
+			})
+			.where(needsSeed)
+			.returning({ id: organizations.id });
+
+		for (const org of updated) {
+			await clearOrgCache({ db, orgId: org.id });
+		}
+		console.log(
+			`Seeded overdue entitlement settings for ${updated.length} organizations.`,
+		);
+	} else {
+		const [result] = await db
+			.select({ count: sql<number>`count(*)::int` })
+			.from(organizations)
+			.where(needsSeed);
+		console.log(
+			`${result?.count ?? 0} organizations need seeding. Pass --apply to write.`,
+		);
+	}
+} finally {
+	stopAllEdgeConfigPolling();
+	if (apply) {
+		for (const target of getMiscRedisTargets()) target.redis.disconnect();
+	}
+	await client.end();
+}

--- a/server/src/internal/balances/check/checkTypes/CheckDataV2.ts
+++ b/server/src/internal/balances/check/checkTypes/CheckDataV2.ts
@@ -9,6 +9,7 @@ import type { CheckData } from "@/internal/api/check/checkTypes/CheckData.js";
 
 export interface CheckDataV2 extends CheckData {
 	fullSubject: FullSubject;
+	evaluationFullSubject: FullSubject;
 	evaluationApiSubject: ApiCustomerV5 | ApiEntityV2;
 	evaluationApiBalance?: ApiBalanceV1;
 	evaluationApiFlag?: ApiFlagV0;

--- a/server/src/internal/balances/check/getCheckDataV2.ts
+++ b/server/src/internal/balances/check/getCheckDataV2.ts
@@ -19,6 +19,7 @@ import { getApiSubject } from "@/internal/customers/cusUtils/getApiCustomerV2/ge
 import { triggerAutoTopUp } from "../autoTopUp/triggerAutoTopUp.js";
 import { buildEvaluationSubject } from "./buildEvaluationSubject.js";
 import type { CheckDataV2 } from "./checkTypes/CheckDataV2.js";
+import { getCheckSubject } from "./getCheckSubject.js";
 
 /** Deadline for check's cache-miss DB hydration — check's ~50ms latency SLO can't wait out the 15s pool clocks. */
 export const CHECK_DB_HYDRATION_BUDGET_MS = 2_000;
@@ -97,16 +98,17 @@ export const getCheckDataV2 = async ({
 		fullSubject,
 		includeAggregations: true,
 	});
+	const evaluationFullSubject = getCheckSubject({ ctx, fullSubject });
 	const evaluationApiSubject = await buildEvaluationSubject({
 		ctx,
-		fullSubject,
+		fullSubject: evaluationFullSubject,
 		entityId: entity_id,
 	});
 
 	// Candidates from the subject's effective schemas (feature_override aware),
 	// now that the entitlement rows are loaded.
 	const creditSystems = fullSubjectToCreditSystems({
-		fullSubject,
+		fullSubject: evaluationFullSubject,
 		featureId: feature_id,
 		features: ctx.features,
 	});
@@ -142,6 +144,7 @@ export const getCheckDataV2 = async ({
 		originalFeature: feature,
 		featureToUse,
 		fullSubject,
+		evaluationFullSubject,
 		evaluationApiSubject,
 		evaluationApiBalance: evaluationApiSubject.balances?.[featureToUse.id],
 		evaluationApiFlag: evaluationApiSubject.flags?.[featureToUse.id],

--- a/server/src/internal/balances/check/getCheckResponseV2.ts
+++ b/server/src/internal/balances/check/getCheckResponseV2.ts
@@ -36,7 +36,7 @@ export const getCheckResponseV2 = async ({
 		featureToUse.id !== originalFeature.id
 	) {
 		requiredBalance = getCreditRateRequiredBalance({
-			fullSubject: checkData.fullSubject,
+			fullSubject: checkData.evaluationFullSubject,
 			sourceFeature: originalFeature,
 			creditSystem: featureToUse,
 			amount: requiredBalance,

--- a/server/src/internal/balances/check/getCheckSubject.ts
+++ b/server/src/internal/balances/check/getCheckSubject.ts
@@ -1,0 +1,21 @@
+import { CusProductStatus, type FullSubject } from "@autumn/shared";
+import type { RequestContext } from "@/honoUtils/HonoEnv.js";
+
+export const getCheckSubject = ({
+	ctx,
+	fullSubject,
+}: {
+	ctx: RequestContext;
+	fullSubject: FullSubject;
+}): FullSubject => {
+	if (!ctx.org.config.block_overdue_entitlements) return fullSubject;
+
+	return {
+		...fullSubject,
+		customer_products: fullSubject.customer_products.filter(
+			(customerProduct) =>
+				customerProduct.product.config?.ignore_past_due ||
+				customerProduct.status !== CusProductStatus.PastDue,
+		),
+	};
+};

--- a/server/src/internal/balances/check/runCheckWithTrackV2.ts
+++ b/server/src/internal/balances/check/runCheckWithTrackV2.ts
@@ -20,35 +20,7 @@ import { buildLockScheduleName } from "@/internal/balances/utils/lock/buildLockS
 import { getCreditRateRequiredBalance } from "@/internal/features/creditSystemUtils.js";
 import { workflows } from "@/queue/workflows.js";
 import type { CheckDataV2 } from "./checkTypes/CheckDataV2.js";
-
-/**
- * Checks if the customer has any entitlement for the requested feature.
- * Returns false when apiBalance is undefined, indicating no customer_entitlement exists.
- */
-const customerHasEntitlementForFeature = (checkData: CheckDataV2): boolean => {
-	return checkData.apiBalance !== undefined;
-};
-
-/**
- * Builds a check response for when the customer has no entitlement for the feature.
- */
-const buildNoEntitlementResponse = ({
-	checkData,
-	requiredBalance,
-}: {
-	checkData: CheckDataV2;
-	requiredBalance: number;
-}) => {
-	return CheckResponseV3Schema.parse({
-		allowed: false,
-		customer_id: checkData.customerId || "",
-		entity_id: checkData.entityId,
-		required_balance: requiredBalance,
-		balance: null,
-		balances: undefined,
-		flag: checkData.apiFlag ?? null,
-	});
-};
+import { getCheckResponseV2 } from "./getCheckResponseV2.js";
 
 export const runCheckWithTrackV2 = async ({
 	ctx,
@@ -94,8 +66,16 @@ export const runCheckWithTrackV2 = async ({
 
 	// No entitlement means the Lua deduction script no-ops successfully,
 	// which would incorrectly surface as allowed: true.
-	if (!customerHasEntitlementForFeature(checkData) && requiredBalance > 0) {
-		return buildNoEntitlementResponse({ checkData, requiredBalance });
+	if (
+		!checkData.evaluationApiBalance &&
+		(requiredBalance > 0 || ctx.org.config.block_overdue_entitlements)
+	) {
+		return getCheckResponseV2({
+			ctx,
+			checkData,
+			requiredBalance,
+			properties: body.properties,
+		});
 	}
 
 	const { featureToUse, originalFeature } = checkData;
@@ -103,7 +83,7 @@ export const runCheckWithTrackV2 = async ({
 		featureToUse.type === FeatureType.CreditSystem &&
 		featureToUse.id !== originalFeature.id
 			? getCreditRateRequiredBalance({
-					fullSubject: checkData.fullSubject,
+					fullSubject: checkData.evaluationFullSubject,
 					sourceFeature: originalFeature,
 					creditSystem: featureToUse,
 					amount: requiredBalance,
@@ -118,7 +98,7 @@ export const runCheckWithTrackV2 = async ({
 		featureId: body.feature_id,
 		lock: body.lock,
 		value: requiredBalance,
-	});
+	}).map((deduction) => ({ ...deduction, enforceOverdueBlock: true }));
 
 	const trackBody: TrackParams = {
 		customer_id: body.customer_id,

--- a/server/src/internal/balances/utils/deductionV2/deductionToTrackResponseV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/deductionToTrackResponseV2.ts
@@ -9,6 +9,7 @@ import {
 } from "@autumn/shared";
 import { Decimal } from "decimal.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getCheckSubject } from "@/internal/balances/check/getCheckSubject.js";
 import { getApiSubject } from "@/internal/customers/cusUtils/getApiCustomerV2/getApiSubject.js";
 import type { DeductionUpdate } from "../types/deductionUpdate.js";
 import type { FeatureDeduction } from "../types/featureDeduction.js";
@@ -98,6 +99,9 @@ const getFeatureToUseForBalance = ({
 	featureDeduction: FeatureDeduction;
 	actualDeductions: Record<string, number>;
 }): string => {
+	if (featureDeduction.enforceOverdueBlock) {
+		fullSubject = getCheckSubject({ ctx, fullSubject });
+	}
 	const unlimitedFeature = findUnlimitedFeature({
 		ctx,
 		fullSubject,

--- a/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
@@ -10,6 +10,7 @@ import {
 	fullSubjectToUsageBasedCusEntsByFeatureId,
 	getMaxOverage,
 	getRelevantFeatures,
+	InsufficientBalanceError,
 	isAllocatedCustomerEntitlement,
 	isFreeCustomerEntitlement,
 	notNullish,
@@ -17,6 +18,7 @@ import {
 	usageLimitFilterMatchesProperties,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getCheckSubject } from "@/internal/balances/check/getCheckSubject.js";
 import { buildLockReceiptKey } from "@/internal/balances/utils/lock/buildLockReceiptKey.js";
 import { resolveUsageWindowLimits } from "@/internal/balances/utils/usageWindows/resolveUsageWindowLimits.js";
 import { generateId } from "@/utils/genUtils.js";
@@ -46,6 +48,9 @@ export const prepareFeatureDeductionV2 = ({
 	const { org, env } = ctx;
 	const { feature, lock, targetBalance } = deduction;
 	const { overageBehaviour = "cap", customerEntitlementFilters } = options;
+	if (deduction.enforceOverdueBlock) {
+		fullSubject = getCheckSubject({ ctx, fullSubject });
+	}
 
 	// Membership is per cusEnt (fundsFeatureId), not per catalog feature — a
 	// plan item's feature_override can add or remove the tracked feature from
@@ -59,6 +64,16 @@ export const prepareFeatureDeductionV2 = ({
 		inStatuses: orgToInStatuses({ org }),
 		customerEntitlementFilters,
 	});
+	if (
+		deduction.enforceOverdueBlock &&
+		ctx.org.config.block_overdue_entitlements &&
+		customerEntitlements.length === 0
+	) {
+		throw new InsufficientBalanceError({
+			featureId: feature.id,
+			value: deduction.deduction,
+		});
+	}
 
 	const isUnlimitedCusEnt = (ce: FullCusEntWithFullCusProduct): boolean =>
 		ce.entitlement.allowance_type === AllowanceType.Unlimited ||

--- a/server/src/internal/balances/utils/types/featureDeduction.ts
+++ b/server/src/internal/balances/utils/types/featureDeduction.ts
@@ -16,6 +16,7 @@ export type TokenDeduction = {
 export type FeatureDeduction = {
 	feature: Feature;
 	deduction: number;
+	enforceOverdueBlock?: boolean;
 	targetBalance?: number;
 	/** Present only for track_tokens deductions; standard deductions omit it. */
 	tokens?: TokenDeduction;

--- a/server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts
+++ b/server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts
@@ -61,6 +61,12 @@ export const handleUpdateOrgConfig = createRoute({
 			sentKeys.map((k) => [k, validated[k]]),
 		) as Partial<OrgConfig>;
 
+		if (updates.block_overdue_entitlements !== undefined) {
+			updates.include_past_due = !updates.block_overdue_entitlements;
+		} else if (updates.include_past_due !== undefined) {
+			updates.block_overdue_entitlements = !updates.include_past_due;
+		}
+
 		// One atomic UPDATE for both columns — a mixed request can never
 		// partially commit.
 		const [row] = await db

--- a/server/tests/integration/balances/check/check-overdue-entitlements.test.ts
+++ b/server/tests/integration/balances/check/check-overdue-entitlements.test.ts
@@ -1,0 +1,167 @@
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	type AttachParamsV1Input,
+	type CheckResponseV3,
+	CusProductStatus,
+	customerProducts,
+	organizations,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import { eq } from "drizzle-orm";
+import { CusService } from "@/internal/customers/CusService.js";
+import { invalidateCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
+import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache.js";
+
+test("overdue entitlements: visible balances, plan exemption, mixed deductions and payment recovery", async () => {
+	const overdue = products.base({
+		id: "overdue",
+		items: [items.monthlyMessages({ includedUsage: 100 }), items.dashboard()],
+	});
+	const enterprise = products.base({
+		id: "enterprise",
+		isAddOn: true,
+		items: [items.free({ featureId: TestFeature.Workflows, includedUsage: 7 })],
+	});
+	enterprise.config = { ignore_past_due: true };
+	const active = products.base({
+		id: "active",
+		isAddOn: true,
+		items: [items.monthlyMessages({ includedUsage: 5 })],
+	});
+	const {
+		ctx,
+		customerId,
+		autumnV2_4: autumn,
+	} = await initScenario({
+		customerId: "check-overdue-entitlements",
+		setup: [
+			s.customer({ testClock: false }),
+			s.products({ list: [overdue, enterprise, active] }),
+		],
+		actions: [
+			s.billing.attach({ productId: overdue.id }),
+			s.billing.attach({ productId: enterprise.id }),
+		],
+	});
+	const customer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const setStatus = async (status: CusProductStatus) => {
+		await ctx.db
+			.update(customerProducts)
+			.set({ status })
+			.where(eq(customerProducts.internal_customer_id, customer.internal_id));
+		await invalidateCachedFullSubject({
+			ctx,
+			customerId,
+			source: "testOverdueEntitlements",
+			flushBalances: true,
+		});
+	};
+	const checkMessages = ({ requiredBalance = 1, sendEvent = false } = {}) =>
+		autumn.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: requiredBalance,
+			send_event: sendEvent,
+		});
+
+	try {
+		await autumn.patch("/organization/config", {
+			block_overdue_entitlements: false,
+		});
+		await setStatus(CusProductStatus.PastDue);
+		expect(await checkMessages()).toMatchObject({
+			allowed: true,
+			balance: { remaining: 100 },
+		});
+		await autumn.patch("/organization/config", { include_past_due: false });
+		expect(await checkMessages()).toMatchObject({
+			allowed: false,
+			balance: { remaining: 100 },
+		});
+		expect(await checkMessages({ sendEvent: true })).toMatchObject({
+			allowed: false,
+			balance: { remaining: 100 },
+		});
+		expect(
+			await autumn.check<CheckResponseV3>({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				lock: { enabled: true, lock_id: "overdue-lock" },
+			}),
+		).toMatchObject({ allowed: false, balance: { remaining: 100 } });
+		expect(
+			await autumn.check<CheckResponseV3>({
+				customer_id: customerId,
+				feature_id: TestFeature.Dashboard,
+			}),
+		).toMatchObject({
+			allowed: false,
+			flag: { feature_id: TestFeature.Dashboard },
+		});
+		expect(
+			await autumn.check<CheckResponseV3>({
+				customer_id: customerId,
+				feature_id: TestFeature.Workflows,
+				send_event: true,
+			}),
+		).toMatchObject({ allowed: true, balance: { remaining: 6 } });
+
+		await autumn.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 2,
+		});
+		expect(await checkMessages()).toMatchObject({
+			allowed: false,
+			balance: { remaining: 98 },
+		});
+		expect(
+			(await autumn.customers.get<ApiCustomerV5>(customerId)).balances[
+				TestFeature.Messages
+			].remaining,
+		).toBe(98);
+
+		await invalidateCachedFullSubject({
+			ctx,
+			customerId,
+			source: "testOverdueEntitlements",
+			flushBalances: true,
+		});
+		await autumn.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: active.id,
+		});
+		expect(await checkMessages({ requiredBalance: 6 })).toMatchObject({
+			allowed: false,
+			balance: { remaining: 103 },
+		});
+		expect(
+			await checkMessages({ requiredBalance: 3, sendEvent: true }),
+		).toMatchObject({ allowed: true, balance: { remaining: 100 } });
+		expect(
+			await checkMessages({ requiredBalance: 3, sendEvent: true }),
+		).toMatchObject({ allowed: false, balance: { remaining: 100 } });
+		expect(await checkMessages({ requiredBalance: 2 })).toMatchObject({
+			allowed: true,
+		});
+
+		await setStatus(CusProductStatus.Active);
+		expect(await checkMessages({ requiredBalance: 100 })).toMatchObject({
+			allowed: true,
+			balance: { remaining: 100 },
+		});
+	} finally {
+		await ctx.db
+			.update(organizations)
+			.set({ config: ctx.org.config })
+			.where(eq(organizations.id, ctx.org.id));
+		await clearOrgCache({ db: ctx.db, orgId: ctx.org.id });
+	}
+});

--- a/server/tests/integration/org-config/update-org-config-handler.test.ts
+++ b/server/tests/integration/org-config/update-org-config-handler.test.ts
@@ -15,6 +15,48 @@ import { initScenario } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { eq } from "drizzle-orm";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache.js";
+
+test("org config handler: overdue flags stay inverted across old and new writes", async () => {
+	const { ctx } = await initScenario({ setup: [], actions: [] });
+	const { db, org } = ctx;
+	const autumn = new AutumnInt({ secretKey: ctx.orgSecretKey });
+	const cases: [Partial<OrgConfig>, boolean][] = [
+		[{ include_past_due: false }, true],
+		[{ include_past_due: true }, false],
+		[{ block_overdue_entitlements: true }, true],
+		[{ automatic_tax: true }, true],
+		[{ block_overdue_entitlements: false }, false],
+		[{ block_overdue_entitlements: true, include_past_due: true }, true],
+	];
+
+	try {
+		for (const [updates, blocked] of cases) {
+			const response = (await autumn.patch(
+				"/organization/config",
+				updates,
+			)) as {
+				config: OrgConfig;
+			};
+			const [persisted] = await db
+				.select({ config: organizations.config })
+				.from(organizations)
+				.where(eq(organizations.id, org.id));
+			for (const config of [response.config, persisted?.config]) {
+				expect(config).toMatchObject({
+					block_overdue_entitlements: blocked,
+					include_past_due: !blocked,
+				});
+			}
+		}
+	} finally {
+		await db
+			.update(organizations)
+			.set({ config: org.config })
+			.where(eq(organizations.id, org.id));
+		await clearOrgCache({ db, orgId: org.id });
+	}
+});
 
 test(`${chalk.yellowBright("org config handler: second save preserves first save")}`, async () => {
 	const { ctx } = await initScenario({ setup: [], actions: [] });

--- a/server/tests/integration/org-config/update-org-config.test.ts
+++ b/server/tests/integration/org-config/update-org-config.test.ts
@@ -46,6 +46,7 @@ test.concurrent(
 		expect(parsed.cancel_on_past_due).toBe(true);
 		expect(parsed.automatic_tax).toBe(true);
 		expect(parsed.include_past_due).toBe(true); // default
+		expect(parsed.block_overdue_entitlements).toBe(false);
 
 		// Restore
 		await db

--- a/server/tests/unit/balances/check-v2/overdue-entitlements.test.ts
+++ b/server/tests/unit/balances/check-v2/overdue-entitlements.test.ts
@@ -1,0 +1,350 @@
+import { expect, mock, test } from "bun:test";
+import {
+	ApiVersionClass,
+	CusProductStatus,
+	FeatureType,
+	type FullSubject,
+	fullCustomerToFullSubject,
+	InsufficientBalanceError,
+	LATEST_VERSION,
+	OrgConfigSchema,
+} from "@autumn/shared";
+import { contexts } from "@tests/utils/fixtures/db/contexts.js";
+import { customerEntitlements } from "@tests/utils/fixtures/db/customerEntitlements.js";
+import { customerProducts } from "@tests/utils/fixtures/db/customerProducts.js";
+import { customers } from "@tests/utils/fixtures/db/customers.js";
+import Redis from "ioredis";
+import { mockModuleWithRestore } from "../../utils/mockModuleWithRestore.js";
+
+let cachedSubject: FullSubject;
+const track = mock(async () => ({ customer_id: "cus_test", balance: null }));
+await mockModuleWithRestore(
+	"@/internal/balances/track/v3/runTrackV3.js",
+	() => ({ runTrackV3: track }),
+);
+await mockModuleWithRestore(
+	"@/internal/customers/cache/fullSubject/index.js",
+	() => ({
+		getOrSetCachedPartialFullSubject: async () => cachedSubject,
+	}),
+);
+await mockModuleWithRestore(
+	"@/internal/balances/autoTopUp/triggerAutoTopUp.js",
+	() => ({
+		triggerAutoTopUp: async () => {},
+	}),
+);
+
+const { getCheckDataV2 } = await import(
+	"@/internal/balances/check/getCheckDataV2.js"
+);
+const { getCheckResponseV2 } = await import(
+	"@/internal/balances/check/getCheckResponseV2.js"
+);
+const { runCheckWithTrackV2 } = await import(
+	"@/internal/balances/check/runCheckWithTrackV2.js"
+);
+const { prepareFeatureDeductionV2 } = await import(
+	"@/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.js"
+);
+const { executeRedisDeductionV2 } = await import(
+	"@/internal/balances/utils/deductionV2/executeRedisDeductionV2.js"
+);
+const { deductionToTrackResponseV2 } = await import(
+	"@/internal/balances/utils/deductionV2/deductionToTrackResponseV2.js"
+);
+
+const createPlan = ({
+	id = "overdue",
+	status = CusProductStatus.PastDue,
+	amount = 100,
+	ignorePastDue = false,
+	featureType = FeatureType.Metered,
+	unlimited = false,
+} = {}) => {
+	const entitlement = customerEntitlements.create({
+		id: `${id}_balance`,
+		customerProductId: id,
+		featureId: "messages",
+		featureName: "Messages",
+		featureType,
+		allowance: amount,
+		balance: amount,
+		usageAllowed: false,
+	});
+	entitlement.unlimited = unlimited;
+	const plan = customerProducts.create({
+		id,
+		productId: id,
+		status,
+		customerEntitlements: [entitlement],
+	});
+	plan.product.config.ignore_past_due = ignorePastDue;
+	return plan;
+};
+
+const setup = ({ blocked = true, plans = [createPlan()] } = {}) => {
+	cachedSubject = fullCustomerToFullSubject({
+		fullCustomer: customers.create({ customerProducts: plans }),
+	});
+	const feature = plans[0].customer_entitlements[0].entitlement.feature;
+	const ctx = contexts.create({ features: [feature] });
+	ctx.org.config = OrgConfigSchema.parse({
+		block_overdue_entitlements: blocked,
+		include_past_due: !blocked,
+	});
+	ctx.apiVersion = new ApiVersionClass(LATEST_VERSION);
+	ctx.expand = [];
+	ctx.timestamp = Date.now();
+	return { ctx, feature, fullSubject: cachedSubject };
+};
+
+test("overdue access: org default, status and plan exemption preserve normal limits", async () => {
+	for (const [blocked, status, ignorePastDue, allowed] of [
+		[false, CusProductStatus.PastDue, false, true],
+		[true, CusProductStatus.Active, false, true],
+		[true, CusProductStatus.PastDue, false, false],
+		[true, CusProductStatus.PastDue, true, true],
+	] as const) {
+		const { ctx } = setup({
+			blocked,
+			plans: [createPlan({ status, ignorePastDue })],
+		});
+		const checkData = await getCheckDataV2({
+			ctx,
+			body: { customer_id: "cus_test", feature_id: "messages" },
+			requiredBalance: 1,
+		});
+		const response = await getCheckResponseV2({
+			ctx,
+			checkData,
+			requiredBalance: 1,
+		});
+		expect(response).toMatchObject({ allowed, balance: { remaining: 100 } });
+		expect(
+			(await getCheckResponseV2({ ctx, checkData, requiredBalance: 101 }))
+				.allowed,
+		).toBe(false);
+	}
+});
+
+test("overdue access: blocked flags and unlimited grants remain visible without granting access", async () => {
+	for (const plan of [
+		createPlan({ featureType: FeatureType.Boolean }),
+		createPlan({ unlimited: true }),
+	]) {
+		const { ctx } = setup({ plans: [plan] });
+		const checkData = await getCheckDataV2({
+			ctx,
+			body: { customer_id: "cus_test", feature_id: "messages" },
+			requiredBalance: 1,
+		});
+		const response = await getCheckResponseV2({
+			ctx,
+			checkData,
+			requiredBalance: 1,
+		});
+		expect(response.allowed).toBe(false);
+		if (plan.customer_entitlements[0].unlimited)
+			expect(response.balance?.unlimited).toBe(true);
+		else expect(response.flag?.feature_id).toBe("messages");
+	}
+});
+
+test("overdue access: mixed grants evaluate and deduct only eligible balances; direct track keeps both", async () => {
+	const { ctx, feature, fullSubject } = setup({
+		plans: [
+			createPlan(),
+			createPlan({ id: "active", status: CusProductStatus.Active, amount: 5 }),
+		],
+	});
+	const checkData = await getCheckDataV2({
+		ctx,
+		body: { customer_id: "cus_test", feature_id: "messages" },
+		requiredBalance: 6,
+	});
+	expect(
+		await getCheckResponseV2({ ctx, checkData, requiredBalance: 6 }),
+	).toMatchObject({ allowed: false, balance: { remaining: 105 } });
+	expect(
+		(await getCheckResponseV2({ ctx, checkData, requiredBalance: 5 })).allowed,
+	).toBe(true);
+	const deduction = { feature, deduction: 3 };
+	const checked = prepareFeatureDeductionV2({
+		ctx,
+		fullSubject,
+		deduction: { ...deduction, enforceOverdueBlock: true },
+	});
+	expect(
+		checked.customerEntitlementDeductions.map(
+			(entry) => entry.customer_entitlement_id,
+		),
+	).toEqual(["active_balance"]);
+	const tracked = prepareFeatureDeductionV2({ ctx, fullSubject, deduction });
+	expect(tracked.customerEntitlementDeductions).toHaveLength(2);
+	expect(fullSubject.customer_products).toHaveLength(2);
+});
+
+test("overdue access: denied send-event and lock preserve the visible balance and cannot no-op successfully", async () => {
+	const { ctx, feature, fullSubject } = setup();
+	const checkData = await getCheckDataV2({
+		ctx,
+		body: { customer_id: "cus_test", feature_id: "messages" },
+		requiredBalance: 1,
+	});
+	for (const requiredBalance of [0, 1]) {
+		for (const mode of [
+			{ send_event: true },
+			{
+				lock: {
+					enabled: true as const,
+					lock_id: "lock_test",
+					hashed_key: "lock_test_hash",
+				},
+			},
+		]) {
+			const response = await runCheckWithTrackV2({
+				ctx,
+				checkData,
+				requiredBalance,
+				body: { customer_id: "cus_test", feature_id: "messages", ...mode },
+			});
+			expect(response).toMatchObject({
+				allowed: false,
+				balance: { remaining: 100 },
+			});
+		}
+	}
+	expect(() =>
+		prepareFeatureDeductionV2({
+			ctx,
+			fullSubject,
+			deduction: { feature, deduction: 1, enforceOverdueBlock: true },
+		}),
+	).toThrow(InsufficientBalanceError);
+	expect(
+		fullSubject.customer_products[0].customer_entitlements[0].balance,
+	).toBe(100);
+	expect(track).not.toHaveBeenCalled();
+});
+
+test("overdue access: credit fallback and tracked responses select eligible funding", async () => {
+	const activePlan = createPlan({
+		id: "active",
+		status: CusProductStatus.Active,
+		amount: 5,
+	});
+	const { ctx, feature, fullSubject } = setup({ plans: [activePlan] });
+	const creditEntitlement = customerEntitlements.create({
+		id: "credit_balance",
+		customerProductId: "credit_plan",
+		featureId: "credits",
+		featureName: "Credits",
+		featureType: FeatureType.CreditSystem,
+		allowance: 100,
+		balance: 100,
+		usageAllowed: false,
+		featureConfig: {
+			schema: [{ metered_feature_id: "messages", credit_amount: 5 }],
+		},
+	});
+	creditEntitlement.unlimited = true;
+	const creditPlan = customerProducts.create({
+		id: "credit_plan",
+		productId: "credit_plan",
+		status: CusProductStatus.PastDue,
+		customerEntitlements: [creditEntitlement],
+	});
+	fullSubject.customer_products.push(creditPlan);
+	ctx.features.push(creditEntitlement.entitlement.feature);
+	const body = { customer_id: "cus_test", feature_id: "messages" };
+	const blockedCreditCheck = await getCheckDataV2({
+		ctx,
+		body,
+		requiredBalance: 6,
+	});
+	expect(
+		(
+			await getCheckResponseV2({
+				ctx,
+				checkData: blockedCreditCheck,
+				requiredBalance: 6,
+			})
+		).allowed,
+	).toBe(false);
+	activePlan.customer_entitlements[0].balance = 2;
+	const response = await deductionToTrackResponseV2({
+		ctx,
+		fullSubject,
+		featureDeductions: [{ feature, deduction: 3, enforceOverdueBlock: true }],
+		updates: {
+			active_balance: {
+				balance: 2,
+				additional_balance: 0,
+				entities: {},
+				adjustment: 0,
+				deducted: 3,
+			},
+		},
+	});
+	expect(response.balance).toMatchObject({
+		feature_id: "messages",
+		remaining: 2,
+	});
+
+	activePlan.status = CusProductStatus.PastDue;
+	creditEntitlement.unlimited = false;
+	creditPlan.product.config.ignore_past_due = true;
+	const exemptCreditCheck = await getCheckDataV2({
+		ctx,
+		body,
+		requiredBalance: 4,
+	});
+	expect(
+		await getCheckResponseV2({
+			ctx,
+			checkData: exemptCreditCheck,
+			requiredBalance: 4,
+		}),
+	).toMatchObject({
+		allowed: true,
+		required_balance: 20,
+		balance: { feature_id: "credits", remaining: 100 },
+	});
+	const prepared = prepareFeatureDeductionV2({
+		ctx,
+		fullSubject,
+		deduction: { feature, deduction: 4, enforceOverdueBlock: true },
+	});
+	expect(prepared.customerEntitlementDeductions).toMatchObject([
+		{ customer_entitlement_id: "credit_balance", credit_cost: 5 },
+	]);
+});
+
+test("overdue access: subject refresh rechecks eligibility before retrying a deduction", async () => {
+	const { ctx, feature, fullSubject } = setup({
+		plans: [createPlan({ status: CusProductStatus.Active })],
+	});
+	fullSubject.subjectViewEpoch = 1;
+	const refreshedSubject = structuredClone(fullSubject);
+	refreshedSubject.subjectViewEpoch = 2;
+	refreshedSubject.customer_products[0].status = CusProductStatus.PastDue;
+	const deduct = mock(async () =>
+		JSON.stringify({ error: "SUBJECT_VIEW_CHANGED" }),
+	);
+	const redis = new Redis({ lazyConnect: true });
+	redis.status = "ready";
+	redis.deductFromSubjectBalances = deduct;
+	ctx.redisV2 = redis;
+	await expect(
+		executeRedisDeductionV2({
+			ctx,
+			fullSubject,
+			redisInstance: redis,
+			expectedSubjectViewEpoch: 1,
+			deductions: [{ feature, deduction: 1, enforceOverdueBlock: true }],
+			refreshFullSubject: async () => refreshedSubject,
+		}),
+	).rejects.toBeInstanceOf(InsufficientBalanceError);
+	expect(deduct).toHaveBeenCalledTimes(1);
+});

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -49,6 +49,7 @@ export const OrgConfigSchema = z.object({
 	reverse_deduction_order: z.boolean().default(false),
 
 	include_past_due: z.boolean().default(true),
+	block_overdue_entitlements: z.boolean().default(false),
 
 	sync_status: z.boolean().default(true),
 	merge_billing_cycles: z.boolean().default(true),

--- a/shared/models/productModels/productConfig/productConfig.ts
+++ b/shared/models/productModels/productConfig/productConfig.ts
@@ -4,7 +4,7 @@ import { z } from "zod/v4";
 export const ProductConfigSchema = z.object({
 	ignore_past_due: z.boolean().default(false).meta({
 		description:
-			"If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state.",
+			"If true, this plan's entitlements remain usable and reset on schedule while past due, overriding the organization's overdue entitlement block.",
 	}),
 });
 

--- a/shared/utils/orgUtils/convertOrgUtils.ts
+++ b/shared/utils/orgUtils/convertOrgUtils.ts
@@ -3,7 +3,7 @@ import { CusProductStatus } from "../../models/cusProductModels/cusProductEnums.
 import type { Organization } from "../../models/orgModels/orgTable.js";
 
 export const orgToInStatuses = ({ org }: { org: Organization }) => {
-	if (org.config.include_past_due) {
+	if (org.config.include_past_due || org.config.block_overdue_entitlements) {
 		return [CusProductStatus.Active, CusProductStatus.PastDue];
 	}
 	return [CusProductStatus.Active];

--- a/vite/src/views/products/plan/components/edit-plan-details/MoreSettingsSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/MoreSettingsSection.tsx
@@ -102,7 +102,7 @@ export const MoreSettingsSection = () => {
 
 					<ConfigRow
 						title="Ignore past due"
-						description="Exclude this plan from any auto-cancellation behavior"
+						description="Keep entitlements usable and resetting while overdue, and exclude this plan from auto-cancellation"
 						action={
 							<Switch
 								checked={!!product.config?.ignore_past_due}

--- a/vite/src/views/settings/sections/BillingSettingsSection.tsx
+++ b/vite/src/views/settings/sections/BillingSettingsSection.tsx
@@ -48,9 +48,10 @@ const BILLING_TOGGLES = [
 		description: "Deduct from newest balance first instead of oldest",
 	},
 	{
-		key: "include_past_due",
-		label: "Include past due",
-		description: "Include past-due subscriptions when checking entitlements",
+		key: "block_overdue_entitlements",
+		label: "Block overdue entitlements",
+		description:
+			"Block access while payment is past due, except for plans with Ignore past due enabled",
 	},
 	{
 		key: "invoice_memos",


### PR DESCRIPTION
When an organization blocks overdue entitlements, past-due grants remain visible but cannot satisfy feature checks or fund check deductions and locks. Plans with `ignore_past_due` retain access subject to normal limits; ordinary tracking continues recording usage.

- Wire the Billing settings toggle to `block_overdue_entitlements` and describe the override in the existing plan editor.
- Atomically keep the new flag inverse to `include_past_due` when either is updated. Add a rerunnable seed script that reads the old flag; default is dry-run, `--apply` writes.
- Reuse the existing evaluation and deduction paths, including credit selection and eligibility checks after cache refresh.

Validation: 10 backend unit tests, 2 focused HTTP integration tests, 25 existing frontend plan-save tests, server/scripts/frontend typechecks, and Knip pass. Seed dry-run, true/false/missing legacy values, and reruns verified on an isolated development database. React Doctor reports one existing component complexity warning.

Rollout: run `scripts/seed/seedOverdueEntitlements.ts` before deployment. Pause flag changes while old instances remain, or rerun the seed after rollout, because old handlers only write the old flag. Production seeding has not been run. Shared pooled balances retain existing behavior; this change covers grants owned by customer products. No Markdown or documentation files are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks overdue entitlements so past-due grants stay visible but can no longer satisfy feature checks, deductions, or locks. Plans with `ignore_past_due` keep access subject to normal limits, and tracking still records usage.

**Migration**
- Run `scripts/seed/seedOverdueEntitlements.ts` before deployment; it reads `include_past_due` and defaults to dry-run, with `--apply` to write.
- The new `block_overdue_entitlements` flag stays inverse to `include_past_due`, kept in sync by the org config handler and the plan editor.
- Re-run the seed after rollout if old instances may have written only the old flag.

<sup>Written for commit 29433b28ac2c94c2b6961c7a37b8c18b0fcca494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an organization setting that keeps past-due grants visible while preventing them from granting access or funding checked usage, with a per-plan override.

**Key changes**
- **[Improvements, API changes]** Adds `block_overdue_entitlements`, keeps it inverse to the legacy `include_past_due` setting, and exposes it in Billing settings.
- **[Improvements]** Filters ordinary past-due plans from check evaluation and checked deductions while preserving visible balances and `ignore_past_due` plans.
- **[Improvements]** Adds a dry-run-by-default seed script to migrate existing organization settings.
- **[Bug fixes]** Adds focused coverage for checks, event-backed checks, locks, credit fallback, cache refreshes, and organization configuration updates.
</details>


<h3>Confidence Score: 4/5</h3>

The PR should not merge until incremental lock-finalization deductions also honor the overdue-entitlement block.

Initial checks and reservations correctly exclude blocked past-due grants, but confirming an existing lock above its reserved value reconstructs an unmarked deduction and can charge those grants after the customer becomes past due.

**Files Needing Attention:** server/src/internal/balances/check/runCheckWithTrackV2.ts and server/src/internal/balances/utils/lockV2/buildFinalizeLockContextV2.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/check/getCheckSubject.ts | Introduces the filtered evaluation subject that removes non-exempt past-due customer products. |
| server/src/internal/balances/check/getCheckDataV2.ts | Uses the filtered subject for access evaluation and credit-system selection while retaining the complete subject for visible balances. |
| server/src/internal/balances/check/runCheckWithTrackV2.ts | Enforces overdue blocking for initial checked deductions, but the enforcement state does not reach later incremental lock-finalization deductions. |
| server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts | Filters blocked products from marked deductions and rejects deductions with no eligible entitlement. |
| server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts | Atomically maintains the inverse relationship between the new and legacy organization settings. |
| scripts/seed/seedOverdueEntitlements.ts | Adds a convergent, dry-run-by-default migration from the legacy organization flag. |
| vite/src/views/settings/sections/BillingSettingsSection.tsx | Replaces the legacy Billing toggle with the new overdue-entitlement policy control. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Check
    participant Subject
    participant Deduction
    participant LockFinalize as Lock finalization

    Client->>Check: Check feature
    Check->>Subject: Filter blocked past-due plans
    Subject-->>Check: Eligible evaluation subject
    Check->>Deduction: Deduct or reserve with overdue enforcement
    Deduction-->>Client: Allow or deny
    Client->>LockFinalize: Confirm with a larger final value
    LockFinalize->>Deduction: Deduct incremental amount
    Note over LockFinalize,Deduction: Incremental deduction currently loses overdue enforcement
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/balances/check/runCheckWithTrackV2.ts:101
**Lock finalization bypasses blocking**

The overdue-block marker is added only to deductions made during the initial check. For example, a customer can reserve 5 units while active, become past due, and then confirm the lock with a final value of 10. The extra 5 units are deducted from the blocked past-due grant because lock finalization rebuilds the deduction without this marker. Please preserve overdue enforcement for incremental lock-finalization deductions.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: block overdue entitlements with pl..."](https://github.com/useautumn/autumn/commit/29433b28ac2c94c2b6961c7a37b8c18b0fcca494) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61172066)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Event metering, balances, and insights](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/event-metering-and-insights.md)
- Knowledge Base — [Usage and billing API platform](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/api-platform.md)
- Knowledge Base — [Operational web applications and UI primitives](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/operational-web-applications.md)
</details>


<!-- /greptile_comment -->