### PR TITLE
Keep credit dimension rate rows in place while editing

### DIFF
--- a/vite/src/views/products/features/credit-systems/components/CreditDimensionFieldTable.tsx
+++ b/vite/src/views/products/features/credit-systems/components/CreditDimensionFieldTable.tsx
@@ -34,7 +34,7 @@ interface FieldCellContext {
 	table: TableInstance<FieldTableRow>;
 }
 
-const metaOf = (table: TableInstance<FieldTableRow>): FieldTableMeta =>
+const tableMeta = (table: TableInstance<FieldTableRow>): FieldTableMeta =>
 	table.options.meta as FieldTableMeta;
 
 const COLUMNS: ColumnDef<FieldTableRow, unknown>[] = [
@@ -47,9 +47,12 @@ const COLUMNS: ColumnDef<FieldTableRow, unknown>[] = [
 				<HashIcon size={14} className="shrink-0 text-tertiary-foreground" />
 				<CreditDimensionNameInput
 					field={row.original.unnamed ? "" : row.original.field}
-					onRename={(to) => metaOf(table).onRenameField(row.original.field, to)}
+					onRename={(to) =>
+						tableMeta(table).onRenameField(row.original.field, to)
+					}
 					isTaken={(name) =>
-						name !== row.original.field && metaOf(table).fields.includes(name)
+						name !== row.original.field &&
+						tableMeta(table).fields.includes(name)
 					}
 				/>
 			</span>
@@ -65,8 +68,8 @@ const COLUMNS: ColumnDef<FieldTableRow, unknown>[] = [
 					aria-label={`${field} values`}
 					className="h-auto min-h-8 py-1.5 flex-wrap gap-1 !border-0 !shadow-none !bg-transparent !rounded-none !px-0.5"
 					values={values}
-					onAdd={(value) => metaOf(table).onAddValue(field, value)}
-					onRemove={(value) => metaOf(table).onRemoveValue(field, value)}
+					onAdd={(value) => tableMeta(table).onAddValue(field, value)}
+					onRemove={(value) => tableMeta(table).onRemoveValue(field, value)}
 					placeholder="big, small"
 				/>
 			);
@@ -82,7 +85,7 @@ const COLUMNS: ColumnDef<FieldTableRow, unknown>[] = [
 				<RemoveButton
 					className="opacity-100"
 					onClick={() => {
-						const meta = metaOf(table);
+						const meta = tableMeta(table);
 						if (row.original.unnamed) {
 							return meta.onRemoveUnnamedField(row.original.field);
 						}

--- a/vite/src/views/products/features/credit-systems/components/CreditDimensionMultiplierTable.tsx
+++ b/vite/src/views/products/features/credit-systems/components/CreditDimensionMultiplierTable.tsx
@@ -15,8 +15,8 @@ import {
 	type MatchRow,
 	type MatchTableMeta,
 	matchColumns,
-	metaOf,
 	removeColumn,
+	tableMeta,
 } from "./creditMatchColumns";
 
 interface MultiplierRow extends MatchRow {
@@ -42,22 +42,20 @@ const factorColumn: ColumnDef<MultiplierRow, unknown> = {
 				placeholder="1"
 				value={rule.multiplier.factor}
 				onClear={() =>
-					metaOf<MultiplierTableMeta, MultiplierRow>(table).onMultiplierChange(
-						index,
-						{
-							...rule,
-							multiplier: { ...rule.multiplier, factor: undefined },
-						},
-					)
+					tableMeta<MultiplierTableMeta, MultiplierRow>(
+						table,
+					).onMultiplierChange(index, {
+						...rule,
+						multiplier: { ...rule.multiplier, factor: undefined },
+					})
 				}
 				onValueChange={(factor) =>
-					metaOf<MultiplierTableMeta, MultiplierRow>(table).onMultiplierChange(
-						index,
-						{
-							...rule,
-							multiplier: { ...rule.multiplier, factor },
-						},
-					)
+					tableMeta<MultiplierTableMeta, MultiplierRow>(
+						table,
+					).onMultiplierChange(index, {
+						...rule,
+						multiplier: { ...rule.multiplier, factor },
+					})
 				}
 				className="text-sm"
 			/>

--- a/vite/src/views/products/features/credit-systems/components/CreditDimensionRateTable.tsx
+++ b/vite/src/views/products/features/credit-systems/components/CreditDimensionRateTable.tsx
@@ -17,8 +17,8 @@ import {
 	type MatchTableMeta,
 	MutedCell,
 	matchColumns,
-	metaOf,
 	removeColumn,
+	tableMeta,
 } from "./creditMatchColumns";
 
 interface RateRow extends MatchRow {
@@ -54,10 +54,10 @@ const priorityColumn: ColumnDef<RateRow, unknown> = {
 				placeholder="—"
 				value={priority}
 				onValueChange={(next) =>
-					metaOf<RateTableMeta, RateRow>(table).onPriorityChange(index, next)
+					tableMeta<RateTableMeta, RateRow>(table).onPriorityChange(index, next)
 				}
 				onClear={() =>
-					metaOf<RateTableMeta, RateRow>(table).onPriorityChange(
+					tableMeta<RateTableMeta, RateRow>(table).onPriorityChange(
 						index,
 						undefined,
 					)
@@ -88,7 +88,7 @@ const creditsColumn: ColumnDef<RateRow, unknown> = {
 		if (rate.dimension?.tier_behavior === "graduated") {
 			return <MutedCell>tiered</MutedCell>;
 		}
-		const meta = metaOf<RateTableMeta, RateRow>(table);
+		const meta = tableMeta<RateTableMeta, RateRow>(table);
 		return (
 			<CreditNumberInput
 				variant="headless"

--- a/vite/src/views/products/features/credit-systems/components/creditMatchColumns.tsx
+++ b/vite/src/views/products/features/credit-systems/components/creditMatchColumns.tsx
@@ -39,7 +39,7 @@ export interface MatchCellContext<T extends MatchRow> {
 	table: TableInstance<T>;
 }
 
-export const metaOf = <M extends MatchTableMeta, T extends MatchRow>(
+export const tableMeta = <M extends MatchTableMeta, T extends MatchRow>(
 	table: TableInstance<T>,
 ): M => table.options.meta as M;
 
@@ -54,10 +54,10 @@ export const matchColumns = <T extends MatchRow>(
 			return (
 				<CreditDimensionValueSelect
 					ariaLabel={`${label} ${field}`}
-					values={metaOf(table).values[field] ?? []}
+					values={tableMeta(table).values[field] ?? []}
 					value={match[field]}
 					onValueChange={(value) =>
-						metaOf(table).onMatchChange(
+						tableMeta(table).onMatchChange(
 							index,
 							setMatchValue({ match, field, value }),
 						)
@@ -96,7 +96,7 @@ export const removeColumn = <T extends MatchRow>(): ColumnDef<T, unknown> => ({
 				variant="skeleton"
 				iconOrientation="center"
 				icon={<X className="h-3.5 w-3.5" />}
-				onClick={() => metaOf(table).onRemove(row.original.index)}
+				onClick={() => tableMeta(table).onRemove(row.original.index)}
 				className="!text-subtle hover:!text-foreground rounded-md p-1"
 			/>
 		</div>

--- a/vite/src/views/products/features/credit-systems/hooks/useCreditDimensionEditor.ts
+++ b/vite/src/views/products/features/credit-systems/hooks/useCreditDimensionEditor.ts
@@ -23,6 +23,7 @@ export function useCreditDimensionEditor({
 		item,
 		onChange,
 		onRestrictDrafts: rates.restrictDrafts,
+		onRenameField: rates.renameOrderField,
 	});
 	const multipliers = useCreditMultipliers({ item, onChange });
 

--- a/vite/src/views/products/features/credit-systems/hooks/useCreditDimensionFields.ts
+++ b/vite/src/views/products/features/credit-systems/hooks/useCreditDimensionFields.ts
@@ -23,10 +23,12 @@ export function useCreditDimensionFields({
 	item,
 	onChange,
 	onRestrictDrafts,
+	onRenameField,
 }: {
 	item: CreditSchemaItem;
 	onChange: (item: CreditSchemaItem) => void;
 	onRestrictDrafts: (isAllowed: (draft: CreditRateDraft) => boolean) => void;
+	onRenameField: (rename: { from: string; to: string }) => void;
 }) {
 	const [draftValues, setDraftValues] = useState<DimensionValues>(() =>
 		dimensionValues(item),
@@ -73,6 +75,7 @@ export function useCreditDimensionFields({
 			return;
 		}
 		setDraftValues(renameDimensionValuesKey({ values, from, to }));
+		onRenameField({ from, to });
 		onChange(withRenamedField({ item, from, to }));
 	};
 

--- a/vite/src/views/products/features/credit-systems/hooks/useCreditRateRows.ts
+++ b/vite/src/views/products/features/credit-systems/hooks/useCreditRateRows.ts
@@ -13,13 +13,13 @@ import {
 	coveringRule,
 	createRateDraft,
 	type DimensionValues,
-	draftsOf,
+	draftsFrom,
 	filledRateRows,
 	missingCombinationCount,
 	nameRateRows,
-	rateRowsOf,
 	rateRules,
-	rulesOf,
+	savedRulesFrom,
+	toRateRows,
 	withRateCredits,
 	withRateMatch,
 	withRatePriority,
@@ -48,11 +48,20 @@ export function useCreditRateRows({
 	// over by name — otherwise the row remounts on the first keystroke and the
 	// cell being typed into loses focus.
 	const keysByRuleName = useRef(new Map<string, string>());
+	// Saved rules and drafts live in separate stores, so the display order has to
+	// be remembered or a row would move as soon as it gained a cost.
+	const [rowOrder, setRowOrder] = useState<string[]>([]);
 
 	const rules = useMemo(() => rateRules(item), [item.dimensions]);
 	const rows = useMemo(
-		() => rateRowsOf({ rules, drafts, keysByRuleName: keysByRuleName.current }),
-		[rules, drafts],
+		() =>
+			toRateRows({
+				rules,
+				drafts,
+				keysByRuleName: keysByRuleName.current,
+				order: rowOrder,
+			}),
+		[rules, drafts, rowOrder],
 	);
 
 	const baseRate = item.tier_behavior === "graduated" ? undefined : item;
@@ -105,8 +114,9 @@ export function useCreditRateRows({
 		for (const { key, name, dimension } of nameRateRows(next)) {
 			if (dimension) keysByRuleName.current.set(name, key);
 		}
-		setDrafts(draftsOf(next));
-		onChange(withRateRules({ item, rules: rulesOf(next) }));
+		setRowOrder(next.map((row) => row.key));
+		setDrafts(draftsFrom(next));
+		onChange(withRateRules({ item, rules: savedRulesFrom(next) }));
 	};
 
 	return {
@@ -118,7 +128,11 @@ export function useCreditRateRows({
 			missingCombinationCount({ values, rows }),
 		restrictDrafts: (isAllowed: (draft: CreditRateDraft) => boolean) =>
 			setDrafts((current) => current.filter(isAllowed)),
-		addRow: () => setDrafts([...drafts, createRateDraft()]),
+		addRow: () => {
+			const draft = createRateDraft();
+			setRowOrder([...rows.map((row) => row.key), draft.key]);
+			setDrafts([...drafts, draft]);
+		},
 		setRowMatch: (index: number, match: CreditMatch) =>
 			setRows(
 				replaceAt(rows, index, withRateMatch({ row: rows[index], match })),

--- a/vite/src/views/products/features/credit-systems/hooks/useCreditRateRows.ts
+++ b/vite/src/views/products/features/credit-systems/hooks/useCreditRateRows.ts
@@ -18,6 +18,7 @@ import {
 	missingCombinationCount,
 	nameRateRows,
 	rateRules,
+	renamedRowOrder,
 	savedRulesFrom,
 	toRateRows,
 	withRateCredits,
@@ -128,6 +129,11 @@ export function useCreditRateRows({
 			missingCombinationCount({ values, rows }),
 		restrictDrafts: (isAllowed: (draft: CreditRateDraft) => boolean) =>
 			setDrafts((current) => current.filter(isAllowed)),
+		// A rename rebuilds rule names, and row keys derive from them.
+		renameOrderField: ({ from, to }: { from: string; to: string }) =>
+			setRowOrder((current) =>
+				renamedRowOrder({ order: current, item, from, to }),
+			),
 		addRow: () => {
 			const draft = createRateDraft();
 			setRowOrder([...rows.map((row) => row.key), draft.key]);

--- a/vite/src/views/products/features/credit-systems/utils/credit-dimension-utils.test.ts
+++ b/vite/src/views/products/features/credit-systems/utils/credit-dimension-utils.test.ts
@@ -13,6 +13,7 @@ import {
 	multiplierRules,
 	nameRateRows,
 	rateRules,
+	renamedRowOrder,
 	setMatchValue,
 	toRateRows,
 	withAllowedValues,
@@ -21,6 +22,7 @@ import {
 	withRateCredits,
 	withRateMatch,
 	withRateRules,
+	withRenamedField,
 } from "./creditDimensionUtils";
 
 const row: CreditSchemaItem = {
@@ -283,5 +285,36 @@ test("pricing a lower row leaves it where it was in the table", () => {
 	expect(rebuilt.map((row) => row.match)).toEqual([
 		{ size: "small" },
 		{ size: "large" },
+	]);
+});
+
+test("renaming a dimension leaves its rate rows in place", () => {
+	const item: CreditSchemaItem = {
+		metered_feature_id: "action",
+		credit_amount: 1,
+		dimensions: {
+			size_small: { match: { size: "small" }, credit_amount: 2 },
+			size_large: { match: { size: "large" }, credit_amount: 5 },
+		},
+	};
+
+	// The table shows large first — the order a user dragged or built it into,
+	// which is not the order the rules are stored in.
+	const before = toRateRows({ rules: rateRules(item), drafts: [] });
+	const order = [...before.map((row) => row.key)].reverse();
+
+	// The rename rebuilds every rule name from the new match, so the keys the
+	// order was recorded under have to be carried across with it.
+	const renamed = withRenamedField({ item, from: "size", to: "tier" });
+	const after = toRateRows({
+		rules: rateRules(renamed),
+		drafts: [],
+		order: renamedRowOrder({ order, item, from: "size", to: "tier" }),
+	});
+
+	// Renaming size -> tier must not disturb that: large stays first.
+	expect(after.map((row) => row.match)).toEqual([
+		{ tier: "large" },
+		{ tier: "small" },
 	]);
 });

--- a/vite/src/views/products/features/credit-systems/utils/credit-dimension-utils.test.ts
+++ b/vite/src/views/products/features/credit-systems/utils/credit-dimension-utils.test.ts
@@ -6,15 +6,15 @@ import {
 import {
 	createRateDraft,
 	dimensionValues,
-	draftsOf,
+	draftsFrom,
 	filledRateRows,
 	mergeDimensionValues,
 	missingCombinationCount,
 	multiplierRules,
 	nameRateRows,
-	rateRowsOf,
 	rateRules,
 	setMatchValue,
+	toRateRows,
 	withAllowedValues,
 	withMultiplierRules,
 	withoutDimensions,
@@ -154,7 +154,7 @@ test("missing combinations count the full grid minus rows already there", () => 
 	expect(
 		missingCombinationCount({
 			values: { size: ["small", "large"], region: ["eu", "us"], tier: [] },
-			rows: rateRowsOf({ rules: rateRules(row), drafts: [] }),
+			rows: toRateRows({ rules: rateRules(row), drafts: [] }),
 		}),
 	).toBe(3);
 	expect(missingCombinationCount({ values: { size: [] }, rows: [] })).toBe(0);
@@ -163,7 +163,7 @@ test("missing combinations count the full grid minus rows already there", () => 
 test("filling keeps exact rows, inherits from covering rules, drafts the rest, and folds partial rows away", () => {
 	const filled = filledRateRows({
 		values: { size: ["small", "large"], region: ["eu", "us"] },
-		rows: rateRowsOf({
+		rows: toRateRows({
 			rules: rateRules(row),
 			drafts: [createRateDraft({ size: "small" })],
 		}),
@@ -222,7 +222,7 @@ test("collision suffixes keep names within the API limit", () => {
 });
 
 test("two rows with the same match stay independently addressable", () => {
-	const rows = rateRowsOf({
+	const rows = toRateRows({
 		rules: [],
 		drafts: [createRateDraft(), createRateDraft()],
 	});
@@ -235,7 +235,7 @@ test("two rows with the same match stay independently addressable", () => {
 		withRateMatch({ row: rows[0], match: { size: "large" } }),
 		rows[1],
 	];
-	expect(draftsOf(edited).map((draft) => draft.match)).toEqual([
+	expect(draftsFrom(edited).map((draft) => draft.match)).toEqual([
 		{ size: "large" },
 		{},
 	]);
@@ -243,7 +243,7 @@ test("two rows with the same match stay independently addressable", () => {
 
 test("a draft keeps its key once it is saved as a rule", () => {
 	const draft = createRateDraft({ size: "large" });
-	const [row] = rateRowsOf({ rules: [], drafts: [draft] });
+	const [row] = toRateRows({ rules: [], drafts: [draft] });
 
 	// Typing a cost turns the draft into a rule, which the item is rebuilt from.
 	const priced = withRateCredits({ row, credits: 5 });
@@ -251,11 +251,37 @@ test("a draft keeps its key once it is saved as a rule", () => {
 	const keysByRuleName = new Map([[named.name, named.key]]);
 
 	const dimension = named.dimension ?? { match: {}, credit_amount: 0 };
-	const [rebuilt] = rateRowsOf({
+	const [rebuilt] = toRateRows({
 		rules: [{ name: named.name, dimension }],
 		drafts: [],
 		keysByRuleName,
 	});
 
 	expect(rebuilt.key).toBe(draft.key);
+});
+
+test("pricing a lower row leaves it where it was in the table", () => {
+	const first = createRateDraft({ size: "small" });
+	const second = createRateDraft({ size: "large" });
+	const rows = toRateRows({ rules: [], drafts: [first, second] });
+	const order = rows.map((row) => row.key);
+
+	// The second row gains a cost, so it becomes a saved rule while the first
+	// stays a draft — the split that used to float it to the top.
+	const priced = withRateCredits({ row: rows[1], credits: 5 });
+	const [named] = nameRateRows([priced]);
+	const dimension = named.dimension ?? { match: {}, credit_amount: 0 };
+
+	const rebuilt = toRateRows({
+		rules: [{ name: named.name, dimension }],
+		drafts: [{ key: first.key, match: first.match }],
+		keysByRuleName: new Map([[named.name, named.key]]),
+		order,
+	});
+
+	expect(rebuilt.map((row) => row.key)).toEqual(order);
+	expect(rebuilt.map((row) => row.match)).toEqual([
+		{ size: "small" },
+		{ size: "large" },
+	]);
 });

--- a/vite/src/views/products/features/credit-systems/utils/credit-rate-priority.test.ts
+++ b/vite/src/views/products/features/credit-systems/utils/credit-rate-priority.test.ts
@@ -4,9 +4,9 @@ import {
 	findAmbiguousCreditDimensions,
 } from "@autumn/shared";
 import {
-	rateRowsOf,
 	rateRules,
-	rulesOf,
+	savedRulesFrom,
+	toRateRows,
 	withRatePriority,
 	withRateRules,
 } from "./creditDimensionUtils";
@@ -22,11 +22,14 @@ const clashing: CreditSchemaItem = {
 };
 
 const preferFirstRow = (item: CreditSchemaItem) => {
-	const rows = rateRowsOf({ rules: rateRules(item), drafts: [] });
+	const rows = toRateRows({ rules: rateRules(item), drafts: [] });
 	const [first, ...rest] = rows;
 	return withRateRules({
 		item,
-		rules: rulesOf([withRatePriority({ row: first, priority: 1 }), ...rest]),
+		rules: savedRulesFrom([
+			withRatePriority({ row: first, priority: 1 }),
+			...rest,
+		]),
 	});
 };
 
@@ -47,13 +50,13 @@ test("a priority resolves the clash and survives the save", () => {
 
 test("clearing a priority drops the field and brings the clash back", () => {
 	const saved = preferFirstRow(clashing);
-	const rows = rateRowsOf({ rules: rateRules(saved), drafts: [] });
+	const rows = toRateRows({ rules: rateRules(saved), drafts: [] });
 	const preferred = rows.find((row) => row.dimension?.priority !== undefined);
 	if (!preferred) throw new Error("expected a preferred row");
 
 	const cleared = withRateRules({
 		item: saved,
-		rules: rulesOf(
+		rules: savedRulesFrom(
 			rows.map((row) =>
 				row === preferred
 					? withRatePriority({ row, priority: undefined })

--- a/vite/src/views/products/features/credit-systems/utils/creditDimensionUtils.ts
+++ b/vite/src/views/products/features/credit-systems/utils/creditDimensionUtils.ts
@@ -294,18 +294,47 @@ export const nameRateRows = (rows: CreditRateRow[]): CreditRateRow[] => {
 	);
 };
 
+/** The key a saved rule's row is identified by, absent a claim from its draft. */
+const ruleRowKey = (name: string) => `rule:${name}`;
+
 /**
- * Saved rules and drafts are stored apart, so reassembling them alone would
- * group every saved row above every draft — typing a cost into a lower row
- * would jump it up the table. `order` restores the row order the table last
- * rendered; rows it does not name (a newly added draft) keep their place at
- * the end.
+ * Rule names derive from their match, so a rename changes every row's key.
+ * Rewriting the recorded order keeps those rows in place instead of sorting
+ * them to the bottom as unknown.
+ */
+export const renamedRowOrder = ({
+	order,
+	item,
+	from,
+	to,
+}: {
+	order: string[];
+	item: CreditSchemaItem;
+	from: string;
+	to: string;
+}): string[] => {
+	const renamedKey = new Map(
+		rateRules(item).map(({ name, dimension }) => [
+			ruleRowKey(name),
+			ruleRowKey(
+				ruleName(renameMatchKey({ match: dimension.match, from, to })),
+			),
+		]),
+	);
+	return order.map((key) => renamedKey.get(key) ?? key);
+};
+
+/**
+ * Rules and drafts are stored apart, so rebuilding alone groups every saved row
+ * above every draft — typing a cost into a lower row would jump it up the table.
+ * `order` restores what the table last rendered; rows it does not name (a newly
+ * added draft) sort to the end.
  */
 export const toRateRows = ({
 	rules,
 	drafts,
 	keysByRuleName,
-	order,
+	order = [],
 }: {
 	rules: CreditRateRule[];
 	drafts: CreditRateDraft[];
@@ -316,7 +345,7 @@ export const toRateRows = ({
 }): CreditRateRow[] => {
 	const rows: CreditRateRow[] = [
 		...rules.map(({ name, dimension }) => ({
-			key: keysByRuleName?.get(name) ?? `rule:${name}`,
+			key: keysByRuleName?.get(name) ?? ruleRowKey(name),
 			name,
 			match: dimension.match,
 			dimension,
@@ -324,14 +353,12 @@ export const toRateRows = ({
 		...drafts.map(({ key, match }) => ({ key, name: "", match })),
 	];
 
-	if (!order?.length) return rows;
-
 	const rank = new Map(order.map((key, index) => [key, index]));
-	const rankFor = (row: CreditRateRow) => rank.get(row.key) ?? order.length;
-	return rows
-		.map((row, index) => ({ row, index }))
-		.sort((a, b) => rankFor(a.row) - rankFor(b.row) || a.index - b.index)
-		.map(({ row }) => row);
+	// Sort is stable, so unranked rows keep their built order behind the rest.
+	return rows.sort(
+		(a, b) =>
+			(rank.get(a.key) ?? order.length) - (rank.get(b.key) ?? order.length),
+	);
 };
 
 export const savedRulesFrom = (rows: CreditRateRow[]): CreditRateRule[] =>

--- a/vite/src/views/products/features/credit-systems/utils/creditDimensionUtils.ts
+++ b/vite/src/views/products/features/credit-systems/utils/creditDimensionUtils.ts
@@ -23,9 +23,13 @@ export type CreditMultiplierRule = {
 };
 export type DimensionValues = Record<string, string[]>;
 
-type Matched = { match: CreditMatch };
+/** Rates and multipliers alike; both are keyed by the match they apply to. */
+type MatchableRule = { match: CreditMatch };
 
-const matchesOf = (item: CreditSchemaItem): CreditMatch[] =>
+/** Rates and multipliers both match on dimensions, so both are read here. */
+const matchesFromRatesAndMultipliers = (
+	item: CreditSchemaItem,
+): CreditMatch[] =>
 	[
 		...Object.values(item.dimensions ?? {}),
 		...Object.values(item.multipliers ?? {}),
@@ -36,7 +40,7 @@ const unique = (values: string[]) => Array.from(new Set(values));
 /** Every field and value referenced by a rate or multiplier, in first-seen order. */
 export const dimensionValues = (item: CreditSchemaItem): DimensionValues => {
 	const values: DimensionValues = {};
-	for (const match of matchesOf(item)) {
+	for (const match of matchesFromRatesAndMultipliers(item)) {
 		for (const [field, value] of Object.entries(match)) {
 			values[field] = unique([...(values[field] ?? []), value]);
 		}
@@ -92,7 +96,9 @@ const uniqueName = (name: string, taken: Set<string>) => {
 	return candidate;
 };
 
-const namedByMatch = <T extends Matched>(rules: T[]): Record<string, T> => {
+const namedByMatch = <T extends MatchableRule>(
+	rules: T[],
+): Record<string, T> => {
 	const taken = new Set<string>();
 	return Object.fromEntries(
 		rules.map((rule) => [uniqueName(ruleName(rule.match), taken), rule]),
@@ -134,7 +140,7 @@ export const isMatchAllowed = (match: CreditMatch, allowed: DimensionValues) =>
 		allowed[field]?.includes(value),
 	);
 
-const onlyAllowed = <T extends Matched>(
+const onlyAllowed = <T extends MatchableRule>(
 	rules: Record<string, T> | undefined,
 	allowed: DimensionValues,
 ): Record<string, T> =>
@@ -198,7 +204,9 @@ export const withRenamedField = ({
 	from: string;
 	to: string;
 }): CreditSchemaItem => {
-	const rename = <T extends Matched>(rules: Record<string, T> | undefined) =>
+	const rename = <T extends MatchableRule>(
+		rules: Record<string, T> | undefined,
+	) =>
 		mapRecordValues({
 			record: rules ?? {},
 			mapValue: (rule) => ({
@@ -253,11 +261,10 @@ export const setMatchValue = ({
 	return value === undefined ? others : { ...others, [field]: value };
 };
 
-/** A row of the rates table: a saved rule, or a draft that only has its match so far. */
 /**
- * A row in the rates table. `key` is its identity for React and the table: rows
- * are reassembled from the item on every render, and every content-derived id
- * (index, name, match) collides or changes as the row is edited.
+ * A row of the rates table: a saved rule, or a draft that only has its match so
+ * far. `key` is its identity — rows are rebuilt from the item on every render,
+ * and every content-derived id (index, name, match) collides or changes mid-edit.
  */
 export type CreditRateRow = {
 	key: string;
@@ -287,31 +294,52 @@ export const nameRateRows = (rows: CreditRateRow[]): CreditRateRow[] => {
 	);
 };
 
-export const rateRowsOf = ({
+/**
+ * Saved rules and drafts are stored apart, so reassembling them alone would
+ * group every saved row above every draft — typing a cost into a lower row
+ * would jump it up the table. `order` restores the row order the table last
+ * rendered; rows it does not name (a newly added draft) keep their place at
+ * the end.
+ */
+export const toRateRows = ({
 	rules,
 	drafts,
 	keysByRuleName,
+	order,
 }: {
 	rules: CreditRateRule[];
 	drafts: CreditRateDraft[];
 	/** Keys claimed by a row before it was saved, so it keeps its identity. */
 	keysByRuleName?: Map<string, string>;
-}): CreditRateRow[] => [
-	...rules.map(({ name, dimension }) => ({
-		key: keysByRuleName?.get(name) ?? `rule:${name}`,
-		name,
-		match: dimension.match,
-		dimension,
-	})),
-	...drafts.map(({ key, match }) => ({ key, name: "", match })),
-];
+	/** Row keys in display order. */
+	order?: string[];
+}): CreditRateRow[] => {
+	const rows: CreditRateRow[] = [
+		...rules.map(({ name, dimension }) => ({
+			key: keysByRuleName?.get(name) ?? `rule:${name}`,
+			name,
+			match: dimension.match,
+			dimension,
+		})),
+		...drafts.map(({ key, match }) => ({ key, name: "", match })),
+	];
 
-export const rulesOf = (rows: CreditRateRow[]): CreditRateRule[] =>
+	if (!order?.length) return rows;
+
+	const rank = new Map(order.map((key, index) => [key, index]));
+	const rankFor = (row: CreditRateRow) => rank.get(row.key) ?? order.length;
+	return rows
+		.map((row, index) => ({ row, index }))
+		.sort((a, b) => rankFor(a.row) - rankFor(b.row) || a.index - b.index)
+		.map(({ row }) => row);
+};
+
+export const savedRulesFrom = (rows: CreditRateRow[]): CreditRateRule[] =>
 	rows.flatMap((row) =>
 		row.dimension ? [{ name: row.name, dimension: row.dimension }] : [],
 	);
 
-export const draftsOf = (rows: CreditRateRow[]): CreditRateDraft[] =>
+export const draftsFrom = (rows: CreditRateRow[]): CreditRateDraft[] =>
 	rows.flatMap((row) =>
 		row.dimension ? [] : [{ key: row.key, match: row.match }],
 	);
@@ -448,7 +476,7 @@ export const filledRateRows = ({
 	values: DimensionValues;
 	rows: CreditRateRow[];
 }): CreditRateRow[] => {
-	const rules = rulesOf(rows);
+	const rules = savedRulesFrom(rows);
 	return fullCombinations(values).map((match) => {
 		const exact = rows.find((row) => sameMatch(row.match, match));
 		if (exact) return exact;

--- a/vite/src/views/products/features/credit-systems/utils/creditSchemaUtils.ts
+++ b/vite/src/views/products/features/credit-systems/utils/creditSchemaUtils.ts
@@ -32,7 +32,7 @@ export const isGraduated = (
 	item: CreditSchemaItem,
 ): item is GraduatedCreditSchemaItem => item.tier_behavior === "graduated";
 
-export const rateTypeOf = (item: CreditSchemaItem): CreditRateType =>
+export const rateTypeFor = (item: CreditSchemaItem): CreditRateType =>
 	isGraduated(item) ? "graduated" : "flat";
 
 export const createSchemaItem = (): CreditSchemaItem => ({
@@ -50,7 +50,7 @@ export const setRateType = ({
 	item: CreditSchemaItem;
 	rateType: CreditRateType;
 }): CreditSchemaItem => {
-	if (rateType === rateTypeOf(item)) return item;
+	if (rateType === rateTypeFor(item)) return item;
 
 	const {
 		credit_amount: _creditAmount,


### PR DESCRIPTION
## Problem

In the credit system dimensions editor, typing a value into one of the lower rate rows made it jump to the top of the table. Every row with a value clustered above the rows without one.

Saved rules and drafts live in separate stores, and the rates table was rebuilt as *all rules followed by all drafts*:

```ts
rateRowsOf = ({ rules, drafts }) => [...rules.map(…), ...drafts.map(…)]
```

A row is a draft until a cost is typed, at which point it becomes a saved rule — so it moved from the second group to the first, and the row you were editing changed position under the cursor.

## Fix

Thread the display order through as row keys and sort the rebuilt rows by it. `useCreditRateRows` records the order in `setRows` and `addRow`; rows the order doesn't name (a freshly added draft) keep their place at the end.

Row identity was already stable via `keysByRuleName` — this reuses those keys rather than introducing a second notion of identity.

## Naming

Renamed the `-Of` helpers to say what they return:

| Before | After |
|---|---|
| `rateRowsOf` | `toRateRows` |
| `rulesOf` | `savedRulesFrom` |
| `draftsOf` | `draftsFrom` |
| `rateTypeOf` | `rateTypeFor` |
| `metaOf` | `tableMeta` |
| `matchesOf` | `matchesFromRatesAndMultipliers` |
| `Matched` (type) | `MatchableRule` |

`matchesOf` hid the part that actually matters — it reads **both** `dimensions` and `multipliers`, which is why a dimension survives deleting the last rate that used it.

## Tests

Added a regression test that reproduces the symptom: two draft rows, price the lower one, assert both keys stay in their original order. Verified it fails without the fix and passes with it.

`611 pass, 0 fail` · `@autumn/vite` typecheck clean · Biome clean.

## Note

Found while QA-ing the credit-overrides redesign branch. This is deliberately scoped to the row-ordering bug and the renames, so it can land on its own — the override work stays on its own branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the credit dimension rates table so editing a lower row no longer jumps it to the top, and keeps rate rows in place when a dimension field is renamed. Previously, rows were rebuilt as saved rules followed by drafts, so typing a cost into a lower row moved it to the top; renaming a dimension also rebuilt rule names and could sort affected rows to the bottom. The display order is now recorded, restored after rebuilds, and rewritten to post-rename keys when a field is renamed. Regression tests cover pricing a lower row and renaming a dimension.

**Refactors**
- Renames the `-Of` helper functions to describe what they return (`toRateRows`, `savedRulesFrom`, `draftsFrom`, `rateTypeFor`, `tableMeta`, `matchesFromRatesAndMultipliers`).

<sup>Written for commit 8de591bef4fab5946eec2da58fe3b86e8d074c7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR keeps credit-dimension rate rows in their displayed positions while users edit them and renames several helper functions for clarity.

**Key changes**
- **[Bug fixes]** Records rate-row display order so entering a price does not move a draft row above other drafts.
- **[Bug fixes]** Attempts to preserve row order when a dimension field is renamed.
- **[Improvements]** Renames credit-dimension helpers to make their return values and responsibilities clearer.
- **[Improvements]** Adds regression tests for pricing lower rows and renaming dimensions.

The original row-ordering fix is covered, but the dimension-rename follow-up remains incomplete for saved rows that retained draft-generated UUID keys.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because renaming a dimension can still reorder a saved rate row that originally began as a draft.

The previous blocking finding is only partially fixed. The new rename logic translates keys shaped like `rule:<old name>`, but a draft that becomes a saved rule retains its UUID key; the stored rule-name mapping is not renamed, so after a field rename the rebuilt rule receives a new generated key while its recorded order still contains the UUID, leaving the row unranked and able to move to the bottom.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/products/features/credit-systems/hooks/useCreditRateRows.ts | Stores row display order and connects field renames to order-key translation, but does not update the saved rule-name-to-UUID mapping. |
| vite/src/views/products/features/credit-systems/utils/creditDimensionUtils.ts | Adds row sorting and rename translation, but the translation only covers generated rule keys rather than keys retained from drafts. |
| vite/src/views/products/features/credit-systems/hooks/useCreditDimensionFields.ts | Notifies the rate-row hook before rebuilding rules with the renamed dimension field. |
| vite/src/views/products/features/credit-systems/utils/credit-dimension-utils.test.ts | Adds useful ordering regressions, though the rename test covers only rows that began as saved rules. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Draft rate row with UUID key] --> B[User enters a price]
  B --> C[Saved rule retains UUID key]
  C --> D[User renames dimension field]
  D --> E[Rule name changes]
  E --> F[Order translation only recognizes rule:name keys]
  F --> G[UUID-backed row can become unranked and move]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Carry row order across a dimension renam..."](https://github.com/useautumn/autumn/commit/8de591bef4fab5946eec2da58fe3b86e8d074c7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61297322)</sub>

<!-- /greptile_comment -->