### PR TITLE
fix(billing): reject conflicting pending invoice plans

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
@@ -11,7 +11,6 @@ import { handleCarryOverUsagesErrors } from "@/internal/billing/v2/actions/attac
 import { handleCurrentCustomerProductErrors } from "@/internal/billing/v2/actions/attach/errors/handleCurrentCustomerProductErrors";
 import { handleEndDateErrors } from "@/internal/billing/v2/actions/attach/errors/handleEndDateErrors";
 import { handleNewBillingSubscriptionErrors } from "@/internal/billing/v2/actions/attach/errors/handleNewBillingSubscriptionErrors";
-import { handlePendingPlanConflictErrors } from "@/internal/billing/v2/actions/attach/errors/handlePendingPlanConflictErrors";
 import { handleScheduledSwitchOneOffErrors } from "@/internal/billing/v2/actions/attach/errors/handleScheduledSwitchOneOffErrors";
 import { handleStartDateErrors } from "@/internal/billing/v2/actions/attach/errors/handleStartDateErrors";
 import { handleStripeCheckoutErrors } from "@/internal/billing/v2/actions/attach/errors/handleStripeCheckoutErrors";
@@ -21,6 +20,7 @@ import { handleCustomLineItemsErrors } from "@/internal/billing/v2/common/errors
 import { handleEntityLicenseAssignmentErrors } from "@/internal/billing/v2/common/errors/handleEntityLicenseAssignmentErrors";
 import { handleExternalPSPErrors } from "@/internal/billing/v2/common/errors/handleExternalPSPErrors";
 import { handleLicenseAttachTargetErrors } from "@/internal/billing/v2/common/errors/handleLicenseAttachTargetErrors";
+import { handlePendingPlanConflictErrors } from "@/internal/billing/v2/common/errors/handlePendingPlanConflictErrors";
 import { handleSubscriptionIdErrors } from "@/internal/billing/v2/common/errors/handleSubscriptionIdErrors";
 import { handleStripeBillingPlanErrors } from "@/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors";
 import { handleCustomPaymentMethodErrorsV2 } from "@/internal/customers/attach/attachUtils/handleAttachErrors";
@@ -70,7 +70,12 @@ export const handleAttachV2Errors = async ({
 	// 2. Current customer product errors (same product)
 	handleCurrentCustomerProductErrors({ billingContext });
 
-	await handlePendingPlanConflictErrors({ ctx, billingContext, preview });
+	await handlePendingPlanConflictErrors({
+		ctx,
+		fullCustomer: billingContext.fullCustomer,
+		attachProduct: billingContext.attachProduct,
+		preview,
+	});
 
 	// 3. new_billing_subscription validation errors
 	handleNewBillingSubscriptionErrors({ billingContext, params });

--- a/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
@@ -11,6 +11,7 @@ import { handleCarryOverUsagesErrors } from "@/internal/billing/v2/actions/attac
 import { handleCurrentCustomerProductErrors } from "@/internal/billing/v2/actions/attach/errors/handleCurrentCustomerProductErrors";
 import { handleEndDateErrors } from "@/internal/billing/v2/actions/attach/errors/handleEndDateErrors";
 import { handleNewBillingSubscriptionErrors } from "@/internal/billing/v2/actions/attach/errors/handleNewBillingSubscriptionErrors";
+import { handlePendingPlanConflictErrors } from "@/internal/billing/v2/actions/attach/errors/handlePendingPlanConflictErrors";
 import { handleScheduledSwitchOneOffErrors } from "@/internal/billing/v2/actions/attach/errors/handleScheduledSwitchOneOffErrors";
 import { handleStartDateErrors } from "@/internal/billing/v2/actions/attach/errors/handleStartDateErrors";
 import { handleStripeCheckoutErrors } from "@/internal/billing/v2/actions/attach/errors/handleStripeCheckoutErrors";
@@ -68,6 +69,8 @@ export const handleAttachV2Errors = async ({
 
 	// 2. Current customer product errors (same product)
 	handleCurrentCustomerProductErrors({ billingContext });
+
+	await handlePendingPlanConflictErrors({ ctx, billingContext, preview });
 
 	// 3. new_billing_subscription validation errors
 	handleNewBillingSubscriptionErrors({ billingContext, params });

--- a/server/src/internal/billing/v2/actions/attach/errors/handlePendingPlanConflictErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handlePendingPlanConflictErrors.ts
@@ -1,0 +1,58 @@
+import {
+	type AttachBillingContext,
+	CusProductStatus,
+	cp,
+	ErrCode,
+	isOneOffProduct,
+	MetadataType,
+	RecaseError,
+} from "@autumn/shared";
+import { StatusCodes } from "http-status-codes";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { MetadataService } from "@/internal/metadata/MetadataService";
+
+/** A second deferred attach for the same transition would mint a second payable invoice. */
+export const handlePendingPlanConflictErrors = async ({
+	ctx,
+	billingContext,
+	preview = false,
+}: {
+	ctx: AutumnContext;
+	billingContext: AttachBillingContext;
+	preview?: boolean;
+}) => {
+	if (preview) return;
+
+	const { attachProduct, fullCustomer } = billingContext;
+	if (attachProduct.is_add_on || isOneOffProduct({ product: attachProduct }))
+		return;
+
+	for (const customerProduct of fullCustomer.customer_products) {
+		if (customerProduct.status !== CusProductStatus.Pending) continue;
+		if (!customerProduct.metadata_id) continue;
+
+		const inScope = cp(customerProduct)
+			.main()
+			.recurring()
+			.hasProductGroup({ productGroup: attachProduct.group })
+			.onEntity({ internalEntityId: fullCustomer.entity?.internal_id }).valid;
+		if (!inScope) continue;
+
+		// Checkout-backed pending plans are arbitrated by checkCheckoutSessionLock.
+		const metadata = await MetadataService.get({
+			db: ctx.db,
+			id: customerProduct.metadata_id,
+		});
+		const invoiceBacked =
+			metadata?.type === MetadataType.DeferredInvoice &&
+			Boolean(metadata.stripe_invoice_id) &&
+			!metadata.stripe_checkout_session_id;
+		if (!invoiceBacked) continue;
+
+		throw new RecaseError({
+			code: ErrCode.PendingPlanConflict,
+			message: `Cannot attach because a pending plan '${customerProduct.product.name}' is awaiting payment. Pay or cancel it before attaching another plan.`,
+			statusCode: StatusCodes.CONFLICT,
+		});
+	}
+};

--- a/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachErrors.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachErrors.ts
@@ -3,10 +3,10 @@ import type {
 	MultiAttachBillingContext,
 	MultiAttachParamsV0,
 } from "@autumn/shared";
-import type { DrizzleCli } from "@/db/initDrizzle";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { handleRevertTrialErrors } from "@/internal/billing/v2/actions/attach/errors/handleRevertTrialErrors";
 import { handleProrationBehaviorErrors } from "@/internal/billing/v2/common/errors/handleBillingBehaviorErrors";
+import { handlePendingPlanConflictErrors } from "@/internal/billing/v2/common/errors/handlePendingPlanConflictErrors";
 import { handleSubscriptionIdErrors } from "@/internal/billing/v2/common/errors/handleSubscriptionIdErrors";
 import { handleStripeBillingPlanErrors } from "@/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors";
 import { handleMultiAttachBillingCycleAnchorErrors } from "./handleMultiAttachBillingCycleAnchorErrors";
@@ -16,21 +16,32 @@ import { handleMultiAttachStartDateErrors } from "./handleMultiAttachStartDateEr
 
 /** Runs all multi-attach validation checks. */
 export const handleMultiAttachErrors = async ({
-	db,
+	ctx,
 	billingContext,
 	redirectMode,
 	params,
+	preview,
 }: {
-	db: DrizzleCli;
+	ctx: AutumnContext;
 	billingContext: MultiAttachBillingContext;
 	redirectMode: string;
 	params: MultiAttachParamsV0;
+	preview: boolean;
 }) => {
 	handleMultiAttachStartDateErrors({ billingContext, params });
 
 	handleMultiAttachCurrentProductErrors({
 		productContexts: billingContext.productContexts,
 	});
+
+	for (const productContext of billingContext.productContexts) {
+		await handlePendingPlanConflictErrors({
+			ctx,
+			fullCustomer: productContext.fullCustomer,
+			attachProduct: productContext.fullProduct,
+			preview,
+		});
+	}
 
 	handleMultiAttachRedirectErrors({
 		redirectMode,
@@ -43,7 +54,7 @@ export const handleMultiAttachErrors = async ({
 
 	// Subscription ID uniqueness
 	await handleSubscriptionIdErrors({
-		db,
+		db: ctx.db,
 		internalCustomerId: billingContext.fullCustomer.internal_id,
 		subscriptionIds: billingContext.productContexts.map((pc) => pc.externalId),
 	});

--- a/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
@@ -52,10 +52,11 @@ export async function multiAttach({
 
 	// 2. Errors
 	await handleMultiAttachErrors({
-		db: ctx.db,
+		ctx,
 		billingContext,
 		redirectMode: params.redirect_mode,
 		params,
+		preview,
 	});
 
 	handleMultiAttachCurrencyErrors({ ctx, billingContext, params });

--- a/server/src/internal/billing/v2/common/errors/handlePendingPlanConflictErrors.ts
+++ b/server/src/internal/billing/v2/common/errors/handlePendingPlanConflictErrors.ts
@@ -1,34 +1,42 @@
 import {
-	type AttachBillingContext,
 	CusProductStatus,
 	cp,
 	ErrCode,
+	type FullCustomer,
+	type FullProduct,
 	isOneOffProduct,
 	MetadataType,
 	RecaseError,
 } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import { MetadataService } from "@/internal/metadata/MetadataService";
 
 /** A second deferred attach for the same transition would mint a second payable invoice. */
 export const handlePendingPlanConflictErrors = async ({
 	ctx,
-	billingContext,
+	fullCustomer,
+	attachProduct,
 	preview = false,
 }: {
 	ctx: AutumnContext;
-	billingContext: AttachBillingContext;
+	fullCustomer: FullCustomer;
+	attachProduct: FullProduct;
 	preview?: boolean;
 }) => {
 	if (preview) return;
-
-	const { attachProduct, fullCustomer } = billingContext;
 	if (attachProduct.is_add_on || isOneOffProduct({ product: attachProduct }))
 		return;
 
-	for (const customerProduct of fullCustomer.customer_products) {
-		if (customerProduct.status !== CusProductStatus.Pending) continue;
+	// fullCustomer.customer_products is capped and orders pending rows last.
+	const pendingCustomerProducts = await CusProductService.list({
+		db: ctx.db,
+		internalCustomerId: fullCustomer.internal_id,
+		inStatuses: [CusProductStatus.Pending],
+	});
+
+	for (const customerProduct of pendingCustomerProducts) {
 		if (!customerProduct.metadata_id) continue;
 
 		const inScope = cp(customerProduct)

--- a/server/tests/integration/billing/attach/errors/pending-plan-conflict.test.ts
+++ b/server/tests/integration/billing/attach/errors/pending-plan-conflict.test.ts
@@ -1,0 +1,174 @@
+// Red: retrying a payment-failed upgrade minted a second open invoice + pending plan,
+// and paying both crashed the second resume. Green: the retry is rejected with 409.
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	type AttachParamsV1Input,
+	CusProductStatus,
+	ErrCode,
+} from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { WEBHOOK_SETTLE_TIMEOUT_MS } from "@tests/utils/pollableCustomerExpect";
+import { payOpenInvoice } from "@tests/utils/stripeUtils/payOpenInvoice";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+
+test.concurrent(
+	`${chalk.yellowBright("pending-plan-conflict 1: retrying a payment-failed upgrade is rejected until the invoice settles")}`,
+	async () => {
+		const customerId = "pending-plan-conflict-retry";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV1, autumnV2_4, ctx, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [
+				s.billing.attach({ productId: pro.id }),
+				s.attachPaymentMethod({ type: "fail" }),
+			],
+		});
+
+		const first = await autumnV2_4.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+		});
+		expect(first.required_action?.code).toBe("payment_failed");
+
+		await autumnV2_4.billing.previewAttach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+		});
+
+		await expectAutumnError({
+			errCode: ErrCode.PendingPlanConflict,
+			errMessage: "pending plan",
+			func: () =>
+				autumnV2_4.billing.attach<AttachParamsV1Input>({
+					customer_id: customerId,
+					plan_id: premium.id,
+				}),
+		});
+
+		const rawRetry = await fetch(`${autumnV2_4.baseUrl}/billing.attach`, {
+			method: "POST",
+			headers: autumnV2_4.headers,
+			body: JSON.stringify({ customer_id: customerId, plan_id: premium.id }),
+		});
+		expect(rawRetry.status).toBe(409);
+
+		const openInvoices = await ctx.stripeCli.invoices.list({
+			customer: customer?.processor?.id ?? "",
+			status: "open",
+			limit: 100,
+		});
+		expect(openInvoices.has_more).toBe(false);
+		expect(openInvoices.data).toHaveLength(1);
+
+		await payOpenInvoice({ ctx, customerId });
+
+		await expectCustomerProducts({
+			autumn: autumnV2_4,
+			customerId,
+			settleTimeoutMs: WEBHOOK_SETTLE_TIMEOUT_MS,
+			active: [premium.id],
+			notPresent: [pro.id],
+		});
+
+		const premiumRows = (
+			await CusProductService.list({
+				db: ctx.db,
+				internalCustomerId: customer?.internal_id ?? "",
+				inStatuses: [CusProductStatus.Active, CusProductStatus.Pending],
+			})
+		).filter((row) => row.product.id === premium.id);
+		expect(premiumRows).toHaveLength(1);
+		expect(premiumRows[0].status).toBe(CusProductStatus.Active);
+
+		const v3Customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expectCustomerInvoiceCorrect({
+			customer: v3Customer,
+			count: 2,
+			latestStatus: "paid",
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("pending-plan-conflict 2: pending plans in other groups and add-ons do not block")}`,
+	async () => {
+		const customerId = "pending-plan-conflict-scope";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const otherGroupPlan = products.base({
+			id: "other-group",
+			group: "other",
+			items: [
+				items.monthlyWords({ includedUsage: 100 }),
+				items.monthlyPrice({ price: 15 }),
+			],
+		});
+		const addOn = products.base({
+			id: "addon",
+			isAddOn: true,
+			items: [
+				items.monthlyCredits({ includedUsage: 10 }),
+				items.monthlyPrice({ price: 5 }),
+			],
+		});
+
+		const { autumnV2_4 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium, otherGroupPlan, addOn] }),
+			],
+			actions: [
+				s.billing.attach({ productId: pro.id }),
+				s.attachPaymentMethod({ type: "fail" }),
+			],
+		});
+
+		const otherGroupAttach =
+			await autumnV2_4.billing.attach<AttachParamsV1Input>({
+				customer_id: customerId,
+				plan_id: otherGroupPlan.id,
+			});
+		expect(otherGroupAttach.required_action?.code).toBe("payment_failed");
+
+		const addOnAttach = await autumnV2_4.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: addOn.id,
+		});
+		expect(addOnAttach.required_action?.code).toBe("payment_failed");
+
+		const upgrade = await autumnV2_4.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+		});
+		expect(upgrade.required_action?.code).toBe("payment_failed");
+	},
+);

--- a/server/tests/integration/billing/attach/errors/pending-plan-conflict.test.ts
+++ b/server/tests/integration/billing/attach/errors/pending-plan-conflict.test.ts
@@ -18,6 +18,7 @@ import { payOpenInvoice } from "@tests/utils/stripeUtils/payOpenInvoice";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import { DEFAULT_CUS_PRODUCT_LIMIT } from "@/internal/misc/edgeConfig/orgLimitsStore";
 
 test.concurrent(
 	`${chalk.yellowBright("pending-plan-conflict 1: retrying a payment-failed upgrade is rejected until the invoice settles")}`,
@@ -170,5 +171,118 @@ test.concurrent(
 			plan_id: premium.id,
 		});
 		expect(upgrade.required_action?.code).toBe("payment_failed");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("pending-plan-conflict 3: retrying through multi_attach is rejected too")}`,
+	async () => {
+		const customerId = "pending-plan-conflict-multi";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV2_4, ctx, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [
+				s.billing.attach({ productId: pro.id }),
+				s.attachPaymentMethod({ type: "fail" }),
+			],
+		});
+
+		const first = await autumnV2_4.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+		});
+		expect(first.required_action?.code).toBe("payment_failed");
+
+		await autumnV2_4.billing.previewMultiAttach({
+			customer_id: customerId,
+			plans: [{ plan_id: premium.id }],
+		});
+
+		await expectAutumnError({
+			errCode: ErrCode.PendingPlanConflict,
+			func: () =>
+				autumnV2_4.billing.multiAttach({
+					customer_id: customerId,
+					plans: [{ plan_id: premium.id }],
+				}),
+		});
+
+		const openInvoices = await ctx.stripeCli.invoices.list({
+			customer: customer?.processor?.id ?? "",
+			status: "open",
+			limit: 100,
+		});
+		expect(openInvoices.has_more).toBe(false);
+		expect(openInvoices.data).toHaveLength(1);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("pending-plan-conflict 4: a pending plan beyond the customer snapshot cap still blocks")}`,
+	async () => {
+		const customerId = "pending-plan-conflict-capped";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const addOns = Array.from({ length: DEFAULT_CUS_PRODUCT_LIMIT }, (_, i) =>
+			products.base({
+				id: `free-addon-${i}`,
+				isAddOn: true,
+				items: [items.monthlyCredits({ includedUsage: 1 })],
+			}),
+		);
+
+		const { autumnV2_4 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium, ...addOns] }),
+			],
+			actions: [
+				s.billing.attach({ productId: pro.id }),
+				s.attachPaymentMethod({ type: "fail" }),
+			],
+		});
+
+		const first = await autumnV2_4.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+		});
+		expect(first.required_action?.code).toBe("payment_failed");
+
+		for (const addOn of addOns) {
+			await autumnV2_4.billing.attach<AttachParamsV1Input>(
+				{ customer_id: customerId, plan_id: addOn.id },
+				{ timeout: 0 },
+			);
+		}
+
+		await expectAutumnError({
+			errCode: ErrCode.PendingPlanConflict,
+			func: () =>
+				autumnV2_4.billing.attach<AttachParamsV1Input>({
+					customer_id: customerId,
+					plan_id: premium.id,
+				}),
+		});
 	},
 );

--- a/shared/enums/ErrCode.ts
+++ b/shared/enums/ErrCode.ts
@@ -1,6 +1,7 @@
 export const ErrCode = {
 	// Billing
 	PlanAlreadyAttached: "plan_already_attached",
+	PendingPlanConflict: "pending_plan_conflict",
 
 	// Idempotency
 	IdempotencyKeyAlreadyExists: "idempotency_key_already_exists",


### PR DESCRIPTION
Reject main recurring attach and multi-attach requests with `409 pending_plan_conflict` when an invoice-backed pending main plan already occupies the same customer/entity scope and product group. The shared validator queries pending products independently of the capped customer snapshot, preventing pagination from hiding a conflict.

Pending Stripe Checkout sessions retain their existing reuse/replacement behavior. Previews, unrelated groups, add-ons, and one-off attach targets are excluded. No schema migrations, payment-webhook changes, or historical state repairs; create-schedule is outside this change.

Validation:
- Observed the original failed-payment retry regression fail before the guard.
- Observed multi-attach bypass and capped-snapshot regressions fail before the review fixes.
- Latest run: all 4 pending-plan regressions passed, plus 7 compatibility tests covering multi-attach trials and checkout locks.
- Server typecheck, Biome, and push-time Knip passed.
- Reconfirmed the running development stack and actual successful sandbox Stripe webhook delivery before test execution.

The usual test launcher required unavailable Infisical login; verification used its underlying headless dispatcher against the local stack. No cloud sweep was run.

Review disposition: pagination and multi-attach gaps are fixed in 008ea7615. The concurrency concern in the automated summary below was checked and resolved: production attach and multi-attach endpoints acquire the same customer billing lock before loading their billing contexts. No additional lock was introduced.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M1XVSFEESFTVABMR2QJX5Z9P"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects retrying a payment-failed upgrade so a second payable invoice is no longer created. A main recurring attach or multi-attach plan now fails with `409 pending_plan_conflict` when an invoice-backed pending main plan occupies the same customer/entity scope and product group.

- Pending plans are queried directly rather than from the capped customer snapshot, so conflicts are caught even past the product limit.
- Previews, add-ons, one-off attaches, plans in other product groups, and checkout-backed pending plans keep their existing behavior.
- Simultaneous matching requests can still create duplicate invoices because validation and pending-plan creation are not serialized.

<sup>Written for commit 008ea76154f0926730c7cdd6d2e47d36e691fbbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents a failed invoice-backed plan change from being retried while its original invoice is still awaiting payment.

Key changes:
- **[Bug fixes, API changes]** Returns `409 pending_plan_conflict` when a main recurring plan conflicts with an existing invoice-backed pending plan in the same customer/entity scope and product group.
- **[Bug fixes]** Applies the conflict check to both single-plan and multi-plan attach operations.
- **[Improvements]** Queries all pending customer products rather than relying on the capped customer snapshot.
- **[Improvements]** Preserves previews, checkout-session handling, add-ons, one-off products, and unrelated product groups.
- **[Improvements]** Adds integration coverage for retries, multi-attach requests, unrelated scopes, and pending plans beyond the snapshot cap.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no outstanding correctness, security, or repository-rule issues were identified.

The new guard checks all pending rows, preserves the intended exclusions, uses the correct per-plan entity scope in multi-attach, and is preceded by existing validation that rejects conflicting same-request product groups. The earlier concurrency finding was withdrawn and its thread was resolved after confirming that production entrypoints serialize customer billing requests.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/common/errors/handlePendingPlanConflictErrors.ts | Implements the scoped conflict guard using an uncapped query of pending customer products. |
| server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts | Adds the pending-plan conflict validation to regular attach requests while excluding previews. |
| server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachErrors.ts | Applies the conflict validation to every correctly entity-scoped product in a multi-attach request. |
| server/tests/integration/billing/attach/errors/pending-plan-conflict.test.ts | Covers failed-payment retries, allowed unrelated targets, multi-attach behavior, and capped-snapshot regression cases. |
| shared/enums/ErrCode.ts | Exposes the new stable pending-plan conflict error code. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Attach or multi-attach request] --> B{Preview?}
    B -- Yes --> H[Continue existing flow]
    B -- No --> C{Add-on or one-off?}
    C -- Yes --> H
    C -- No --> D[Load all pending customer products]
    D --> E{Same entity scope and product group?}
    E -- No --> H
    E -- Yes --> F{Invoice-backed and not checkout-backed?}
    F -- No --> H
    F -- Yes --> G[Return 409 pending_plan_conflict]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(billing): check uncapped pending pla..."](https://github.com/useautumn/autumn/commit/008ea76154f0926730c7cdd6d2e47d36e691fbbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61302117)</sub>

<!-- /greptile_comment -->