### PR TITLE
Hotfix: mint pooled balances on every default-plan path

### DIFF
--- a/server/src/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCustomerProductTransitions.ts
+++ b/server/src/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCustomerProductTransitions.ts
@@ -23,7 +23,7 @@ export const applyPooledBalanceCustomerProductTransitions = async ({
 	outgoingCustomerProducts: FullCusProduct[];
 	incomingCustomerProducts: FullCusProduct[];
 	now: number;
-}): Promise<void> => {
+}): Promise<FullCustomer> => {
 	const customerId = fullCustomer.id || fullCustomer.internal_id;
 	const refreshedBeforeReset = await refreshFullCustomer({
 		ctx,
@@ -65,10 +65,10 @@ export const applyPooledBalanceCustomerProductTransitions = async ({
 		incomingCustomerProducts: refreshedIncomingCustomerProducts,
 		now,
 	});
-	if (!pooledBalancePlan) return;
+	if (!pooledBalancePlan) return refreshedFullCustomer;
 
 	await executePooledBalancePlan({ ctx, pooledBalancePlan });
-	await deleteCachedFullCustomer({
+	return refreshFullCustomer({
 		ctx,
 		customerId,
 		source: "pooled-balance-lifecycle-transition",

--- a/server/src/internal/customers/actions/createWithDefaults/compute/computeCreateCustomerPlan.ts
+++ b/server/src/internal/customers/actions/createWithDefaults/compute/computeCreateCustomerPlan.ts
@@ -1,5 +1,6 @@
 import type { AutumnBillingPlan } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { computePooledBalanceTransitionPlan } from "@/internal/billing/v2/pooledBalances/compute/computePooledBalanceTransitionPlan.js";
 import { initFullCustomerProductFromProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProductFromProduct.js";
 import type { CreateCustomerContext } from "../createCustomerContext.js";
 
@@ -27,7 +28,20 @@ export const computeCreateCustomerPlan = ({
 		}),
 	);
 
+	// A default plan mints pools like any other attach. Runs before the products
+	// are handed to the customer, since it fills their pooled balances in place.
+	const { pooledBalancePlan } = computePooledBalanceTransitionPlan({
+		ctx,
+		fullCustomer,
+		incomingCustomerProducts: insertCustomerProducts,
+		now: currentEpochMs,
+	});
+
 	context.fullCustomer.customer_products = insertCustomerProducts;
 
-	return { customerId: fullCustomer?.id ?? "", insertCustomerProducts };
+	return {
+		customerId: fullCustomer?.id ?? "",
+		insertCustomerProducts,
+		pooledBalancePlan,
+	};
 };

--- a/server/src/internal/customers/cusProducts/actions/activateFreeDefaultProduct.ts
+++ b/server/src/internal/customers/cusProducts/actions/activateFreeDefaultProduct.ts
@@ -7,6 +7,7 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan";
+import { computePooledBalanceTransitionPlan } from "@/internal/billing/v2/pooledBalances/compute/computePooledBalanceTransitionPlan";
 import { initFullCustomerProductFromProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProductFromProduct";
 import { productActions } from "@/internal/products/actions";
 
@@ -68,12 +69,23 @@ export const activateFreeDefaultProduct = async ({
 		},
 	});
 
+	// A default carrying pooled items mints its pool like any other transition,
+	// and the expiring product's contributions are torn down with it.
+	const { pooledBalancePlan } = computePooledBalanceTransitionPlan({
+		ctx,
+		fullCustomer,
+		outgoingCustomerProducts: [customerProduct],
+		incomingCustomerProducts: [newCustomerProduct],
+		now: Date.now(),
+	});
+
 	// 3. Execute autumn billing plan
 	await executeAutumnBillingPlan({
 		ctx,
 		autumnBillingPlan: {
 			customerId: fullCustomer?.id ?? "",
 			insertCustomerProducts: [newCustomerProduct],
+			pooledBalancePlan,
 		},
 	});
 

--- a/server/src/internal/entities/actions/batchCreateEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities.ts
@@ -96,7 +96,7 @@ const createEntities = async ({
 
 	newEntities.push(...insertedEntities);
 
-	await attachDefaultProductsToEntities({
+	const fullCusWithDefaults = await attachDefaultProductsToEntities({
 		ctx,
 		fullCustomer: fullCus,
 		entities: newEntities,
@@ -106,7 +106,7 @@ const createEntities = async ({
 	// Get api entity for each entity...
 	const apiEntities = [];
 	for (const entity of newEntities) {
-		const clonedFullCus = structuredClone(fullCus);
+		const clonedFullCus = structuredClone(fullCusWithDefaults);
 		clonedFullCus.entity = entity;
 
 		const apiEntity = await getApiEntity({

--- a/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
@@ -1,7 +1,6 @@
 import {
 	type CustomerData,
 	type Entity,
-	type FullCusProduct,
 	type FullCustomer,
 	isFreeProduct,
 	orgDefaultAppliesToEntities,

--- a/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
@@ -1,5 +1,4 @@
 import {
-	type AutumnBillingPlan,
 	type CustomerData,
 	type Entity,
 	type FullCusProduct,
@@ -40,11 +39,7 @@ export const attachDefaultProductsToEntities = async ({
 
 	const currentEpochMs = Date.now();
 	let customerProducts = fullCustomer.customer_products;
-	const insertedCustomerProducts: FullCusProduct[] = [];
-	const entityPlans: {
-		autumnBillingPlan: AutumnBillingPlan;
-		entityFullCustomer: FullCustomer;
-	}[] = [];
+	let pooledFullCustomer = fullCustomer;
 	for (const entity of entities) {
 		const entityFullCustomer = {
 			...fullCustomer,
@@ -72,27 +67,21 @@ export const attachDefaultProductsToEntities = async ({
 		});
 
 		customerProducts = [...customerProducts, ...insertCustomerProducts];
-		insertedCustomerProducts.push(...insertCustomerProducts);
-		entityPlans.push({ autumnBillingPlan, entityFullCustomer });
-	}
-
-	// Webhook consumers read the customer on receipt, so pools mint first.
-	const pooledFullCustomer = await applyPooledBalanceCustomerProductTransitions(
-		{
+		// Each entity is saved, pooled and announced before the next one starts.
+		pooledFullCustomer = await applyPooledBalanceCustomerProductTransitions({
 			ctx,
-			fullCustomer,
+			fullCustomer: { ...fullCustomer, customer_products: customerProducts },
 			outgoingCustomerProducts: [],
-			incomingCustomerProducts: insertedCustomerProducts,
+			incomingCustomerProducts: insertCustomerProducts,
 			now: currentEpochMs,
-		},
-	);
+		});
 
-	for (const { autumnBillingPlan, entityFullCustomer } of entityPlans) {
 		await billingPlanToSendProductsUpdated({
 			ctx,
 			autumnBillingPlan,
 			billingContext: { fullCustomer: entityFullCustomer },
 		});
+
 		void sendBillingUpdatedWebhook({
 			ctx,
 			autumnBillingPlan,

--- a/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
@@ -1,12 +1,14 @@
 import {
 	type CustomerData,
 	type Entity,
+	type FullCusProduct,
 	type FullCustomer,
 	isFreeProduct,
 	orgDefaultAppliesToEntities,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan";
+import { applyPooledBalanceCustomerProductTransitions } from "@/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCustomerProductTransitions";
 import { initFullCustomerProductFromProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProductFromProduct";
 import { sendBillingUpdatedWebhook } from "@/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook";
 import { billingPlanToSendProductsUpdated } from "@/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated";
@@ -22,8 +24,8 @@ export const attachDefaultProductsToEntities = async ({
 	fullCustomer: FullCustomer;
 	entities: Entity[];
 	customerData?: CustomerData;
-}) => {
-	if (!orgDefaultAppliesToEntities({ ctx })) return;
+}): Promise<FullCustomer> => {
+	if (!orgDefaultAppliesToEntities({ ctx })) return fullCustomer;
 
 	const defaultProducts = await setupDefaultProductsContext({
 		ctx,
@@ -36,10 +38,12 @@ export const attachDefaultProductsToEntities = async ({
 	);
 
 	const currentEpochMs = Date.now();
+	let customerProducts = fullCustomer.customer_products;
+	const insertedCustomerProducts: FullCusProduct[] = [];
 	for (const entity of entities) {
 		const entityFullCustomer = {
 			...fullCustomer,
-			customer_products: [...fullCustomer.customer_products],
+			customer_products: [...customerProducts],
 			entity,
 		};
 		const insertCustomerProducts = freeDefaultProducts.map((product) =>
@@ -74,9 +78,15 @@ export const attachDefaultProductsToEntities = async ({
 			originalFullCustomer: entityFullCustomer,
 		});
 
-		fullCustomer.customer_products = [
-			...fullCustomer.customer_products,
-			...insertCustomerProducts,
-		];
+		customerProducts = [...customerProducts, ...insertCustomerProducts];
+		insertedCustomerProducts.push(...insertCustomerProducts);
 	}
+
+	return applyPooledBalanceCustomerProductTransitions({
+		ctx,
+		fullCustomer,
+		outgoingCustomerProducts: [],
+		incomingCustomerProducts: insertedCustomerProducts,
+		now: currentEpochMs,
+	});
 };

--- a/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
@@ -1,4 +1,5 @@
 import {
+	type AutumnBillingPlan,
 	type CustomerData,
 	type Entity,
 	type FullCusProduct,
@@ -40,6 +41,10 @@ export const attachDefaultProductsToEntities = async ({
 	const currentEpochMs = Date.now();
 	let customerProducts = fullCustomer.customer_products;
 	const insertedCustomerProducts: FullCusProduct[] = [];
+	const entityPlans: {
+		autumnBillingPlan: AutumnBillingPlan;
+		entityFullCustomer: FullCustomer;
+	}[] = [];
 	for (const entity of entities) {
 		const entityFullCustomer = {
 			...fullCustomer,
@@ -66,27 +71,34 @@ export const attachDefaultProductsToEntities = async ({
 			autumnBillingPlan,
 		});
 
+		customerProducts = [...customerProducts, ...insertCustomerProducts];
+		insertedCustomerProducts.push(...insertCustomerProducts);
+		entityPlans.push({ autumnBillingPlan, entityFullCustomer });
+	}
+
+	// Webhook consumers read the customer on receipt, so pools mint first.
+	const pooledFullCustomer = await applyPooledBalanceCustomerProductTransitions(
+		{
+			ctx,
+			fullCustomer,
+			outgoingCustomerProducts: [],
+			incomingCustomerProducts: insertedCustomerProducts,
+			now: currentEpochMs,
+		},
+	);
+
+	for (const { autumnBillingPlan, entityFullCustomer } of entityPlans) {
 		await billingPlanToSendProductsUpdated({
 			ctx,
 			autumnBillingPlan,
 			billingContext: { fullCustomer: entityFullCustomer },
 		});
-
 		void sendBillingUpdatedWebhook({
 			ctx,
 			autumnBillingPlan,
 			originalFullCustomer: entityFullCustomer,
 		});
-
-		customerProducts = [...customerProducts, ...insertCustomerProducts];
-		insertedCustomerProducts.push(...insertCustomerProducts);
 	}
 
-	return applyPooledBalanceCustomerProductTransitions({
-		ctx,
-		fullCustomer,
-		outgoingCustomerProducts: [],
-		incomingCustomerProducts: insertedCustomerProducts,
-		now: currentEpochMs,
-	});
+	return pooledFullCustomer;
 };

--- a/server/src/internal/products/ProductService.ts
+++ b/server/src/internal/products/ProductService.ts
@@ -268,7 +268,7 @@ export class ProductService {
 		inIds?: string[];
 		onlyFree?: boolean;
 	}) {
-		const prods = (await db.query.products.findMany({
+		const rows = (await db.query.products.findMany({
 			where: and(
 				eq(products.org_id, orgId),
 				eq(products.env, env),
@@ -281,18 +281,14 @@ export class ProductService {
 						: undefined,
 				inIds ? inArray(products.id, inIds) : undefined,
 			),
-			with: {
-				entitlements: {
-					with: {
-						feature: true,
-					},
-					where: eq(entitlements.is_custom, false),
-				},
-				prices: { where: eq(prices.is_custom, false) },
-				free_trials: { where: eq(freeTrials.is_custom, false) },
-			},
-		})) as FullProduct[];
+			// A default plan is applied with initFullCustomerProduct, which reads its
+			// license links — a plan loaded without them applies with no seats.
+			with: composeProductWithLicensesQuery(),
+		})) as ProductWithLicenseRelations[];
 
+		const prods = rows.map((product) =>
+			normalizeFullProductLicenses({ product }),
+		);
 		parseFreeTrials({ products: prods });
 
 		const activeProducts = getActiveProducts(prods);

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-default-plan.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-default-plan.test.ts
@@ -140,6 +140,7 @@ test.concurrent(
 		const { allowed } = await autumnV2_3.check({
 			customer_id: customerId,
 			feature_id: TestFeature.Messages,
+			skip_cache: true,
 		});
 		expect(allowed).toBe(true);
 

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-default-plan.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-default-plan.test.ts
@@ -1,0 +1,224 @@
+/**
+ * TDD tests for pooled balances never being minted when a plan is applied as a
+ * DEFAULT rather than attached. Reported externally: a free parent linked to an
+ * unpriced license plan (included: 1) carrying a pooled credit item works under
+ * billing.attach, but not as a default.
+ *
+ * Red-failure mode (before the fix):
+ *  - The customer gets its customer_licenses row with no pooled balance behind
+ *    it, so the credit feature is absent from balances entirely and check is
+ *    denied. Nothing repairs it afterwards.
+ *
+ * Green-success criteria:
+ *  - Every path that applies a default plan computes the pooled balance
+ *    transition, so the pool is minted exactly as billing.attach mints it.
+ *
+ * The plan builders own this: executeAutumnBillingPlan already calls
+ * executePooledBalancePlan, which no-ops on an undefined pooledBalancePlan.
+ */
+
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import {
+	expectLicensePooledGrant,
+	pooledMonthlyMessages,
+	pooledSeatPlan,
+	seatLinkId,
+} from "./utils/licensePooledBalanceTestUtils.js";
+
+// The reported shape: one included seat granting a 600-credit monthly pool.
+const POOLED_GRANT = 600;
+const INCLUDED_SEATS = 1;
+
+/**
+ * Free parent carrying no credit item, linked to the license plan holding the
+ * pool. The link has to exist before the customer under test is created, so the
+ * scenario's own customer only seeds the catalog and the real one comes after.
+ */
+const seedDefaultPlan = async ({ prefix }: { prefix: string }) => {
+	const seatPlan = pooledSeatPlan({
+		id: `${prefix}-seat`,
+		item: pooledMonthlyMessages({ includedUsage: POOLED_GRANT }),
+		group: `${prefix}-seats`,
+	});
+	const parent = products.base({
+		id: `${prefix}-parent`,
+		items: [items.dashboard()],
+		isDefault: true,
+	});
+	const seedCustomerId = `${prefix}-seed`;
+
+	const { autumnV2_3, ctx } = await initScenario({
+		customerId: seedCustomerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.products({ list: [parent, seatPlan] }),
+		],
+		actions: [
+			s.licenses.link({
+				parentProductId: parent.id,
+				licenseProductId: seatPlan.id,
+				included: INCLUDED_SEATS,
+			}),
+		],
+	});
+
+	return { autumnV2_3, ctx, parent, seatPlan, defaultGroup: seedCustomerId };
+};
+
+/** Deterministic ids survive a failed run; a stale row would mask the default path. */
+const resetCustomer = async ({
+	autumn,
+	customerId,
+}: {
+	autumn: AutumnInt;
+	customerId: string;
+}) => {
+	await autumn.customers.delete(customerId).catch(() => undefined);
+};
+
+const expectDefaultedPool = async ({
+	autumn,
+	ctx,
+	customerId,
+	seatPlanId,
+	usage = 0,
+}: {
+	autumn: AutumnInt;
+	ctx: Awaited<ReturnType<typeof seedDefaultPlan>>["ctx"];
+	customerId: string;
+	seatPlanId: string;
+	usage?: number;
+}) => {
+	const customerLicenseLinkId = await seatLinkId({
+		db: ctx.db,
+		customerId,
+		licenseProductId: seatPlanId,
+	});
+	// No seat is assigned yet, so the pool has its grant but no contribution
+	// sources — the same state billing.attach leaves behind.
+	await expectLicensePooledGrant({
+		autumn,
+		ctx,
+		customerId,
+		customerLicenseLinkId,
+		grantPerSeat: POOLED_GRANT,
+		seatCount: INCLUDED_SEATS,
+		contributionCount: 0,
+		usage,
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: auto_enable_plan_id mints the pool on customer creation")}`,
+	async () => {
+		const prefix = "lic-pool-default-auto";
+		const customerId = `${prefix}-customer`;
+		const { autumnV2_3, ctx, parent, seatPlan } = await seedDefaultPlan({
+			prefix,
+		});
+
+		// The reported reproduction: no attach call, the plan is named as a default.
+		await resetCustomer({ autumn: autumnV2_3, customerId });
+		await autumnV2_3.customers.create({
+			id: customerId,
+			auto_enable_plan_id: parent.id,
+		});
+
+		await expectDefaultedPool({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			seatPlanId: seatPlan.id,
+		});
+
+		const { allowed } = await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(allowed).toBe(true);
+
+		// The attached path is the reference the report compared against; the
+		// same assertions passing on both is what proves the default matches it.
+		const attachedCustomerId = `${prefix}-attached`;
+		await resetCustomer({ autumn: autumnV2_3, customerId: attachedCustomerId });
+		await autumnV2_3.customers.create({ id: attachedCustomerId });
+		await autumnV2_3.billing.attach({
+			customer_id: attachedCustomerId,
+			plan_id: parent.id,
+		});
+		await expectDefaultedPool({
+			autumn: autumnV2_3,
+			ctx,
+			customerId: attachedCustomerId,
+			seatPlanId: seatPlan.id,
+		});
+	},
+	{ timeout: 240_000 },
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: a group default mints the pool on customer creation")}`,
+	async () => {
+		const prefix = "lic-pool-default-group";
+		const customerId = `${prefix}-customer`;
+		const { autumnV2_3, ctx, seatPlan, defaultGroup } = await seedDefaultPlan({
+			prefix,
+		});
+
+		// Same builder as auto_enable_plan_id, reached through the group default.
+		await resetCustomer({ autumn: autumnV2_3, customerId });
+		await autumnV2_3.customers.create({
+			id: customerId,
+			internalOptions: { disable_defaults: false, default_group: defaultGroup },
+		});
+
+		await expectDefaultedPool({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			seatPlanId: seatPlan.id,
+		});
+	},
+	{ timeout: 240_000 },
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license pooled: a defaulted pool deducts on track, matching an attached one")}`,
+	async () => {
+		const prefix = "lic-pool-default-track";
+		const customerId = `${prefix}-customer`;
+		const USED = 100;
+		const { autumnV2_3, ctx, parent, seatPlan } = await seedDefaultPlan({
+			prefix,
+		});
+
+		await resetCustomer({ autumn: autumnV2_3, customerId });
+		await autumnV2_3.customers.create({
+			id: customerId,
+			auto_enable_plan_id: parent.id,
+		});
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: USED,
+			},
+			{ timeout: 3_000 },
+		);
+
+		await expectDefaultedPool({
+			autumn: autumnV2_3,
+			ctx,
+			customerId,
+			seatPlanId: seatPlan.id,
+			usage: USED,
+		});
+	},
+	{ timeout: 240_000 },
+);

--- a/server/tests/unit/entities/entity-default-webhooks.test.ts
+++ b/server/tests/unit/entities/entity-default-webhooks.test.ts
@@ -11,14 +11,23 @@ const productsWebhookModulePath =
 	"@/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated";
 const defaultsModulePath =
 	"@/internal/customers/actions/createWithDefaults/setup/setupDefaultProductsContext";
+const pooledModulePath =
+	"@/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCustomerProductTransitions";
 
 const realExecute = { ...(await import(executeModulePath)) };
 const realInitProduct = { ...(await import(initProductModulePath)) };
 const realBillingWebhook = { ...(await import(billingWebhookModulePath)) };
 const realProductsWebhook = { ...(await import(productsWebhookModulePath)) };
 const realDefaults = { ...(await import(defaultsModulePath)) };
+const realPooled = { ...(await import(pooledModulePath)) };
 
 const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+const pooledEntitlements = [{ id: "cus_ent_pooled" }];
+/** The mocks return plain shapes, so the result is read through them. */
+type MockedCustomer = {
+	customer_products: unknown[];
+	pooled_customer_entitlements: unknown[];
+};
 const hobby = { id: "hobby", name: "Hobby", prices: [] };
 const customerProduct = {
 	id: "cus_prod_hobby",
@@ -50,6 +59,18 @@ mock.module(defaultsModulePath, () => ({
 		hasPaidProducts: false,
 	}),
 }));
+mock.module(pooledModulePath, () => ({
+	applyPooledBalanceCustomerProductTransitions: async (
+		args: Record<string, unknown>,
+	) => {
+		calls.push({ name: "pooled", args });
+		return {
+			...(args.fullCustomer as Record<string, unknown>),
+			customer_products: args.incomingCustomerProducts,
+			pooled_customer_entitlements: pooledEntitlements,
+		};
+	},
+}));
 
 const { attachDefaultProductsToEntities } = await import(
 	"@/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities"
@@ -61,6 +82,7 @@ afterAll(() => {
 	mock.module(billingWebhookModulePath, () => realBillingWebhook);
 	mock.module(productsWebhookModulePath, () => realProductsWebhook);
 	mock.module(defaultsModulePath, () => realDefaults);
+	mock.module(pooledModulePath, () => realPooled);
 });
 
 beforeEach(() => {
@@ -79,16 +101,17 @@ describe("entity default products", () => {
 			org: { config: { default_applies_to_entities: true } },
 		} as AutumnContext;
 
-		await attachDefaultProductsToEntities({
+		const withDefaults = (await attachDefaultProductsToEntities({
 			ctx,
 			fullCustomer: fullCustomer as never,
 			entities: [entity as never],
-		});
+		})) as unknown as MockedCustomer;
 
 		expect(calls.map(({ name }) => name)).toEqual([
 			"execute",
 			"customer.products.updated",
 			"billing.updated",
+			"pooled",
 		]);
 
 		const autumnBillingPlan = {
@@ -117,6 +140,47 @@ describe("entity default products", () => {
 				}
 			).customer_products,
 		).toEqual([]);
-		expect(fullCustomer.customer_products).toEqual([customerProduct]);
+		expect(fullCustomer.customer_products).toEqual([]);
+		expect(withDefaults.customer_products).toEqual([customerProduct]);
+		expect(withDefaults.pooled_customer_entitlements).toEqual(
+			pooledEntitlements,
+		);
+		expect(calls[3]?.args).toMatchObject({
+			outgoingCustomerProducts: [],
+			incomingCustomerProducts: [customerProduct],
+		});
+	});
+
+	test("runs one pooled transition across every entity's inserts", async () => {
+		const fullCustomer = {
+			id: "customer_1",
+			internal_id: "internal_customer_1",
+			customer_products: [] as (typeof customerProduct)[],
+		};
+		const ctx = {
+			org: { config: { default_applies_to_entities: true } },
+		} as AutumnContext;
+
+		const withDefaults = (await attachDefaultProductsToEntities({
+			ctx,
+			fullCustomer: fullCustomer as never,
+			entities: [{ id: "entity_1" }, { id: "entity_2" }] as never,
+		})) as unknown as MockedCustomer;
+
+		const byName = (name: string) => calls.filter((call) => call.name === name);
+		expect(byName("execute")).toHaveLength(2);
+		expect(byName("pooled")).toHaveLength(1);
+		expect(calls[calls.length - 1]?.name).toBe("pooled");
+		expect(byName("pooled")[0]?.args).toMatchObject({
+			incomingCustomerProducts: [customerProduct, customerProduct],
+		});
+		expect(fullCustomer.customer_products).toEqual([]);
+		expect(withDefaults.customer_products).toEqual([
+			customerProduct,
+			customerProduct,
+		]);
+		expect(withDefaults.pooled_customer_entitlements).toEqual(
+			pooledEntitlements,
+		);
 	});
 });

--- a/server/tests/unit/entities/entity-default-webhooks.test.ts
+++ b/server/tests/unit/entities/entity-default-webhooks.test.ts
@@ -109,9 +109,9 @@ describe("entity default products", () => {
 
 		expect(calls.map(({ name }) => name)).toEqual([
 			"execute",
+			"pooled",
 			"customer.products.updated",
 			"billing.updated",
-			"pooled",
 		]);
 
 		const autumnBillingPlan = {
@@ -125,17 +125,17 @@ describe("entity default products", () => {
 			entity,
 		};
 		expect(calls[0]?.args.autumnBillingPlan).toEqual(autumnBillingPlan);
-		expect(calls[1]?.args).toMatchObject({
+		expect(calls[2]?.args).toMatchObject({
 			autumnBillingPlan,
 			billingContext: { fullCustomer: webhookCustomer },
 		});
-		expect(calls[2]?.args).toMatchObject({
+		expect(calls[3]?.args).toMatchObject({
 			autumnBillingPlan,
 			originalFullCustomer: webhookCustomer,
 		});
 		expect(
 			(
-				calls[2]?.args.originalFullCustomer as {
+				calls[3]?.args.originalFullCustomer as {
 					customer_products: unknown[];
 				}
 			).customer_products,
@@ -145,7 +145,7 @@ describe("entity default products", () => {
 		expect(withDefaults.pooled_customer_entitlements).toEqual(
 			pooledEntitlements,
 		);
-		expect(calls[3]?.args).toMatchObject({
+		expect(calls[1]?.args).toMatchObject({
 			outgoingCustomerProducts: [],
 			incomingCustomerProducts: [customerProduct],
 		});
@@ -168,9 +168,15 @@ describe("entity default products", () => {
 		})) as unknown as MockedCustomer;
 
 		const byName = (name: string) => calls.filter((call) => call.name === name);
-		expect(byName("execute")).toHaveLength(2);
-		expect(byName("pooled")).toHaveLength(1);
-		expect(calls[calls.length - 1]?.name).toBe("pooled");
+		expect(calls.map(({ name }) => name)).toEqual([
+			"execute",
+			"execute",
+			"pooled",
+			"customer.products.updated",
+			"billing.updated",
+			"customer.products.updated",
+			"billing.updated",
+		]);
 		expect(byName("pooled")[0]?.args).toMatchObject({
 			incomingCustomerProducts: [customerProduct, customerProduct],
 		});

--- a/server/tests/unit/entities/entity-default-webhooks.test.ts
+++ b/server/tests/unit/entities/entity-default-webhooks.test.ts
@@ -66,7 +66,8 @@ mock.module(pooledModulePath, () => ({
 		calls.push({ name: "pooled", args });
 		return {
 			...(args.fullCustomer as Record<string, unknown>),
-			customer_products: args.incomingCustomerProducts,
+			customer_products: (args.fullCustomer as MockedCustomer)
+				.customer_products,
 			pooled_customer_entitlements: pooledEntitlements,
 		};
 	},
@@ -151,7 +152,7 @@ describe("entity default products", () => {
 		});
 	});
 
-	test("runs one pooled transition across every entity's inserts", async () => {
+	test("pools and announces each entity before the next starts", async () => {
 		const fullCustomer = {
 			id: "customer_1",
 			internal_id: "internal_customer_1",
@@ -167,19 +168,18 @@ describe("entity default products", () => {
 			entities: [{ id: "entity_1" }, { id: "entity_2" }] as never,
 		})) as unknown as MockedCustomer;
 
-		const byName = (name: string) => calls.filter((call) => call.name === name);
-		expect(calls.map(({ name }) => name)).toEqual([
-			"execute",
+		const perEntity = [
 			"execute",
 			"pooled",
 			"customer.products.updated",
 			"billing.updated",
-			"customer.products.updated",
-			"billing.updated",
-		]);
-		expect(byName("pooled")[0]?.args).toMatchObject({
-			incomingCustomerProducts: [customerProduct, customerProduct],
-		});
+		];
+		expect(calls.map(({ name }) => name)).toEqual([...perEntity, ...perEntity]);
+		for (const call of calls.filter((call) => call.name === "pooled")) {
+			expect(call.args).toMatchObject({
+				incomingCustomerProducts: [customerProduct],
+			});
+		}
 		expect(fullCustomer.customer_products).toEqual([]);
 		expect(withDefaults.customer_products).toEqual([
 			customerProduct,


### PR DESCRIPTION
Squash of #3314 (merged to `dev`) for `main`. Single commit, 8 files; all cherry-picks applied cleanly.

## Problem

Reported externally: a free parent plan linked to an unpriced license plan (`included: 1`) carrying a pooled credit item mints its pool under `billing.attach` but **not** when applied as a default — the customer gets its `customer_licenses` row with no pooled balance behind it, `check` is denied, and nothing repairs it afterwards.

## Two root causes

**Builders omit `pooledBalancePlan`.** `executePooledBalancePlan` no-ops on an undefined plan, and three builders inserted customer products bare — customer creation, `activateFreeDefaultProduct` (expiry and trial-end onto a default), `attachDefaultProductsToEntities`. Each now computes the transition attach already uses.

**`listDefault` never loaded license links.** The `auto_enable_plan_id` branch loads via `getFull`; the group-default branch via `listDefault`, which hand-rolled its relations without `licenses`, so that path produced no license row at all. It now uses `composeProductWithLicensesQuery` + `normalizeFullProductLicenses`, as `listFull` does.

## Verification

- `main` has every prerequisite (pooled licenses shipped in #3276); typecheck clean on all touched files; unit tests 2/2.
- On `dev`: three integration cases on the exact reported shape red → green (57 assertions), incl. attach parity; `bun tw core` (449 files) showed no regressions — every failure reproduced identically on pre-merge `dev`.
- pre-commit hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjrQjLd3FYKSdv6ZifFsxt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pooled balances not being minted when a plan is applied as a default instead of attached, so defaulted license plans now get their pooled credit balances exactly like `billing.attach` does — previously the customer got a license row with no pool, `check` was denied, and nothing repaired it. Also fixes the group-default path, which produced no license row at all because it never loaded license links.

- Entity defaults now mint the pool and fire their webhooks per entity, so a failure part-way no longer leaves earlier entities saved but unannounced, and entity creation returns the refreshed customer state.

<sup>Written for commit b34746dabc42439a3f3d007155fe9e62b244704b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This hotfix makes default-plan activation behave like an explicit plan attachment when the plan includes pooled balances through a license.

**Key changes**
- **[Bug fixes]** Computes and executes pooled-balance transitions when defaults are applied during customer creation, free-default activation, and entity creation.
- **[Bug fixes]** Loads and normalizes license links when finding group-default products, preventing linked licenses from being omitted.
- **[Improvements]** Returns refreshed customer state after pooled balances are applied so entity responses include the latest products and pooled entitlements.
- **[Improvements]** Processes persistence, pooled balances, and webhooks together for each entity before moving to the next entity.
- **[Improvements]** Adds integration coverage for automatic and group defaults, balance checks, usage tracking, and parity with explicit attachment.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the latest update is only an unused type-import cleanup, and no actionable defects remain.

The default-plan paths now load license links, compute pooled-balance transitions, execute them through the existing billing lifecycle, and propagate refreshed customer state to entity responses. The only change since the previous review removes an unused type import without changing behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCustomerProductTransitions.ts | Returns refreshed customer state after applying pooled-balance transitions. |
| server/src/internal/customers/actions/createWithDefaults/compute/computeCreateCustomerPlan.ts | Computes a pooled-balance plan when customer defaults are initialized. |
| server/src/internal/customers/cusProducts/actions/activateFreeDefaultProduct.ts | Includes incoming and outgoing pooled-balance effects when activating a free default. |
| server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts | Applies pooled transitions per entity and returns the accumulated refreshed customer. |
| server/src/internal/entities/actions/batchCreateEntities.ts | Uses refreshed default-product state when constructing entity API responses. |
| server/src/internal/products/ProductService.ts | Loads and normalizes license relationships for default products. |
| server/tests/integration/licenses/pooled-balances/license-pooled-default-plan.test.ts | Covers pooled grants and usage across automatic, group-default, and explicit-attach paths. |
| server/tests/unit/entities/entity-default-webhooks.test.ts | Verifies per-entity execution, pooling, webhook ordering, and returned customer state. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Caller
  participant DefaultFlow as Default-plan flow
  participant ProductService
  participant BillingExecutor
  participant PoolExecutor
  participant CustomerStore

  Caller->>DefaultFlow: Create customer/entity or activate default
  DefaultFlow->>ProductService: Load default product
  ProductService-->>DefaultFlow: Product with normalized license links
  DefaultFlow->>DefaultFlow: Initialize customer products
  DefaultFlow->>DefaultFlow: Compute pooled-balance transition
  DefaultFlow->>BillingExecutor: Execute billing plan
  BillingExecutor->>CustomerStore: Insert customer products/licenses
  BillingExecutor->>PoolExecutor: Execute pooled-balance plan
  PoolExecutor->>CustomerStore: Mint pooled balances
  CustomerStore-->>DefaultFlow: Refreshed customer state
  DefaultFlow-->>Caller: Customer/entity with usable pooled grant
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Drop an import left behind by the per-en..."](https://github.com/useautumn/autumn/commit/b34746dabc42439a3f3d007155fe9e62b244704b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61362172)</sub>

<!-- /greptile_comment -->