### PR TITLE
Mint entity default pools before their webhooks fire

### DIFF
--- a/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
@@ -1,7 +1,6 @@
 import {
 	type CustomerData,
 	type Entity,
-	type FullCusProduct,
 	type FullCustomer,
 	isFreeProduct,
 	orgDefaultAppliesToEntities,

--- a/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
@@ -1,5 +1,4 @@
 import {
-	type AutumnBillingPlan,
 	type CustomerData,
 	type Entity,
 	type FullCusProduct,
@@ -40,11 +39,7 @@ export const attachDefaultProductsToEntities = async ({
 
 	const currentEpochMs = Date.now();
 	let customerProducts = fullCustomer.customer_products;
-	const insertedCustomerProducts: FullCusProduct[] = [];
-	const entityPlans: {
-		autumnBillingPlan: AutumnBillingPlan;
-		entityFullCustomer: FullCustomer;
-	}[] = [];
+	let pooledFullCustomer = fullCustomer;
 	for (const entity of entities) {
 		const entityFullCustomer = {
 			...fullCustomer,
@@ -72,27 +67,21 @@ export const attachDefaultProductsToEntities = async ({
 		});
 
 		customerProducts = [...customerProducts, ...insertCustomerProducts];
-		insertedCustomerProducts.push(...insertCustomerProducts);
-		entityPlans.push({ autumnBillingPlan, entityFullCustomer });
-	}
-
-	// Webhook consumers read the customer on receipt, so pools mint first.
-	const pooledFullCustomer = await applyPooledBalanceCustomerProductTransitions(
-		{
+		// Each entity is saved, pooled and announced before the next one starts.
+		pooledFullCustomer = await applyPooledBalanceCustomerProductTransitions({
 			ctx,
-			fullCustomer,
+			fullCustomer: { ...fullCustomer, customer_products: customerProducts },
 			outgoingCustomerProducts: [],
-			incomingCustomerProducts: insertedCustomerProducts,
+			incomingCustomerProducts: insertCustomerProducts,
 			now: currentEpochMs,
-		},
-	);
+		});
 
-	for (const { autumnBillingPlan, entityFullCustomer } of entityPlans) {
 		await billingPlanToSendProductsUpdated({
 			ctx,
 			autumnBillingPlan,
 			billingContext: { fullCustomer: entityFullCustomer },
 		});
+
 		void sendBillingUpdatedWebhook({
 			ctx,
 			autumnBillingPlan,

--- a/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
@@ -1,4 +1,5 @@
 import {
+	type AutumnBillingPlan,
 	type CustomerData,
 	type Entity,
 	type FullCusProduct,
@@ -40,6 +41,10 @@ export const attachDefaultProductsToEntities = async ({
 	const currentEpochMs = Date.now();
 	let customerProducts = fullCustomer.customer_products;
 	const insertedCustomerProducts: FullCusProduct[] = [];
+	const entityPlans: {
+		autumnBillingPlan: AutumnBillingPlan;
+		entityFullCustomer: FullCustomer;
+	}[] = [];
 	for (const entity of entities) {
 		const entityFullCustomer = {
 			...fullCustomer,
@@ -66,27 +71,34 @@ export const attachDefaultProductsToEntities = async ({
 			autumnBillingPlan,
 		});
 
+		customerProducts = [...customerProducts, ...insertCustomerProducts];
+		insertedCustomerProducts.push(...insertCustomerProducts);
+		entityPlans.push({ autumnBillingPlan, entityFullCustomer });
+	}
+
+	// Webhook consumers read the customer on receipt, so pools mint first.
+	const pooledFullCustomer = await applyPooledBalanceCustomerProductTransitions(
+		{
+			ctx,
+			fullCustomer,
+			outgoingCustomerProducts: [],
+			incomingCustomerProducts: insertedCustomerProducts,
+			now: currentEpochMs,
+		},
+	);
+
+	for (const { autumnBillingPlan, entityFullCustomer } of entityPlans) {
 		await billingPlanToSendProductsUpdated({
 			ctx,
 			autumnBillingPlan,
 			billingContext: { fullCustomer: entityFullCustomer },
 		});
-
 		void sendBillingUpdatedWebhook({
 			ctx,
 			autumnBillingPlan,
 			originalFullCustomer: entityFullCustomer,
 		});
-
-		customerProducts = [...customerProducts, ...insertCustomerProducts];
-		insertedCustomerProducts.push(...insertCustomerProducts);
 	}
 
-	return applyPooledBalanceCustomerProductTransitions({
-		ctx,
-		fullCustomer,
-		outgoingCustomerProducts: [],
-		incomingCustomerProducts: insertedCustomerProducts,
-		now: currentEpochMs,
-	});
+	return pooledFullCustomer;
 };

--- a/server/tests/integration/licenses/pooled-balances/license-pooled-default-plan.test.ts
+++ b/server/tests/integration/licenses/pooled-balances/license-pooled-default-plan.test.ts
@@ -140,6 +140,7 @@ test.concurrent(
 		const { allowed } = await autumnV2_3.check({
 			customer_id: customerId,
 			feature_id: TestFeature.Messages,
+			skip_cache: true,
 		});
 		expect(allowed).toBe(true);
 

--- a/server/tests/unit/entities/entity-default-webhooks.test.ts
+++ b/server/tests/unit/entities/entity-default-webhooks.test.ts
@@ -109,9 +109,9 @@ describe("entity default products", () => {
 
 		expect(calls.map(({ name }) => name)).toEqual([
 			"execute",
+			"pooled",
 			"customer.products.updated",
 			"billing.updated",
-			"pooled",
 		]);
 
 		const autumnBillingPlan = {
@@ -125,17 +125,17 @@ describe("entity default products", () => {
 			entity,
 		};
 		expect(calls[0]?.args.autumnBillingPlan).toEqual(autumnBillingPlan);
-		expect(calls[1]?.args).toMatchObject({
+		expect(calls[2]?.args).toMatchObject({
 			autumnBillingPlan,
 			billingContext: { fullCustomer: webhookCustomer },
 		});
-		expect(calls[2]?.args).toMatchObject({
+		expect(calls[3]?.args).toMatchObject({
 			autumnBillingPlan,
 			originalFullCustomer: webhookCustomer,
 		});
 		expect(
 			(
-				calls[2]?.args.originalFullCustomer as {
+				calls[3]?.args.originalFullCustomer as {
 					customer_products: unknown[];
 				}
 			).customer_products,
@@ -145,7 +145,7 @@ describe("entity default products", () => {
 		expect(withDefaults.pooled_customer_entitlements).toEqual(
 			pooledEntitlements,
 		);
-		expect(calls[3]?.args).toMatchObject({
+		expect(calls[1]?.args).toMatchObject({
 			outgoingCustomerProducts: [],
 			incomingCustomerProducts: [customerProduct],
 		});
@@ -168,9 +168,15 @@ describe("entity default products", () => {
 		})) as unknown as MockedCustomer;
 
 		const byName = (name: string) => calls.filter((call) => call.name === name);
-		expect(byName("execute")).toHaveLength(2);
-		expect(byName("pooled")).toHaveLength(1);
-		expect(calls[calls.length - 1]?.name).toBe("pooled");
+		expect(calls.map(({ name }) => name)).toEqual([
+			"execute",
+			"execute",
+			"pooled",
+			"customer.products.updated",
+			"billing.updated",
+			"customer.products.updated",
+			"billing.updated",
+		]);
 		expect(byName("pooled")[0]?.args).toMatchObject({
 			incomingCustomerProducts: [customerProduct, customerProduct],
 		});

--- a/server/tests/unit/entities/entity-default-webhooks.test.ts
+++ b/server/tests/unit/entities/entity-default-webhooks.test.ts
@@ -66,7 +66,8 @@ mock.module(pooledModulePath, () => ({
 		calls.push({ name: "pooled", args });
 		return {
 			...(args.fullCustomer as Record<string, unknown>),
-			customer_products: args.incomingCustomerProducts,
+			customer_products: (args.fullCustomer as MockedCustomer)
+				.customer_products,
 			pooled_customer_entitlements: pooledEntitlements,
 		};
 	},
@@ -151,7 +152,7 @@ describe("entity default products", () => {
 		});
 	});
 
-	test("runs one pooled transition across every entity's inserts", async () => {
+	test("pools and announces each entity before the next starts", async () => {
 		const fullCustomer = {
 			id: "customer_1",
 			internal_id: "internal_customer_1",
@@ -167,19 +168,18 @@ describe("entity default products", () => {
 			entities: [{ id: "entity_1" }, { id: "entity_2" }] as never,
 		})) as unknown as MockedCustomer;
 
-		const byName = (name: string) => calls.filter((call) => call.name === name);
-		expect(calls.map(({ name }) => name)).toEqual([
-			"execute",
+		const perEntity = [
 			"execute",
 			"pooled",
 			"customer.products.updated",
 			"billing.updated",
-			"customer.products.updated",
-			"billing.updated",
-		]);
-		expect(byName("pooled")[0]?.args).toMatchObject({
-			incomingCustomerProducts: [customerProduct, customerProduct],
-		});
+		];
+		expect(calls.map(({ name }) => name)).toEqual([...perEntity, ...perEntity]);
+		for (const call of calls.filter((call) => call.name === "pooled")) {
+			expect(call.args).toMatchObject({
+				incomingCustomerProducts: [customerProduct],
+			});
+		}
 		expect(fullCustomer.customer_products).toEqual([]);
 		expect(withDefaults.customer_products).toEqual([
 			customerProduct,


### PR DESCRIPTION
Follow-up to #3314, raised on the main hotfix (#3316). Same commit, cherry-picked.

Entity defaults ran the pooled transition after each entity's webhooks had already fired, unlike customer creation and free-default activation where the pool exists before any webhook. A consumer reading the customer on receipt could see it without its pool. Now every entity's plan executes, the pool mints once, then the emissions go out — inputs unchanged, only their timing. The unit test asserts the order for one and two entities.

Also passes `skip_cache: true` on the default-plan test's `check`, matching the rest of that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjrQjLd3FYKSdv6ZifFsxt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mints each entity's default pool before that entity's webhooks fire, so webhook consumers never see a customer without its pool.

- Runs the pooled transition and webhook emission per entity before the next entity starts, so a later failure can't leave earlier entities saved but unannounced.
- Aligns entity default behavior with customer creation and free-default activation.
- Adds `skip_cache: true` to the default-plan test's check to match the rest of that file.

<sup>Written for commit 644434c43e67a6e137ebaec842a2fc6c9f99e1ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ensures each entity’s default pooled balance exists before webhooks announce the entity’s updated products. The latest revision also removes an import made obsolete by the per-entity processing change.

**Key changes**
- **[Bug fixes]** Saves and pools each entity’s default products before sending its webhooks.
- **[Improvements]** Processes each entity completely before moving to the next, so an earlier successful entity is still announced if a later entity fails.
- **[Improvements]** Adds unit coverage for webhook and pooling order with one and two entities.
- **[Improvements]** Bypasses the cache in the pooled default-plan integration assertion.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the previously reported webhook-loss scenario fully addressed.

Each successfully processed entity is now saved, pooled, and announced before the next entity begins, so a later failure cannot prevent webhook delivery for earlier completed entities. The only change since the previous review removes an unused type import and introduces no new behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts | Processes each entity through saving, pooling, and webhook delivery before advancing; the latest change removes an obsolete type import. |
| server/tests/unit/entities/entity-default-webhooks.test.ts | Verifies the per-entity execution, pooling, and webhook sequence for single- and multi-entity batches. |
| server/tests/integration/licenses/pooled-balances/license-pooled-default-plan.test.ts | Forces a fresh entitlement check when validating the pooled default plan. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant E as Entity
    participant P as Default-plan execution
    participant B as Pooled balance
    participant W as Webhook consumer
    loop For each entity
        E->>P: Attach default products
        P->>B: Mint/update pooled balance
        B-->>P: Return updated customer
        P->>W: Send product and billing webhooks
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Drop an import left behind by the per-en..."](https://github.com/useautumn/autumn/commit/644434c43e67a6e137ebaec842a2fc6c9f99e1ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61364383)</sub>

<!-- /greptile_comment -->