### PR TITLE
Fall back to the catalog credit when stored rows miss paid seats

### DIFF
--- a/server/src/internal/billing/v2/utils/lineItems/licenseInvoiceCreditFromStoredLineItems.ts
+++ b/server/src/internal/billing/v2/utils/lineItems/licenseInvoiceCreditFromStoredLineItems.ts
@@ -34,8 +34,9 @@ export const licenseInvoiceCreditFromStoredLineItems = ({
 	// charge, so each charge row may only be credited once.
 	const consumedChargeRowIds = new Set<string>();
 
-	return catalogCredits.flatMap((catalogCredit) => {
-		const storedCredit = storedInvoiceCreditForPrice({
+	const credits = catalogCredits.map((catalogCredit) => ({
+		catalogCredit,
+		storedCredit: storedInvoiceCreditForPrice({
 			ctx,
 			customerProduct,
 			billingContext,
@@ -44,8 +45,28 @@ export const licenseInvoiceCreditFromStoredLineItems = ({
 				product: licenseProduct,
 			},
 			consumedChargeRowIds,
-		});
+		}),
+	}));
 
-		return storedCredit.resolved ? storedCredit.lineItems : [catalogCredit];
-	});
+	const resolvedCredits = credits.filter(
+		({ storedCredit }) => storedCredit.resolved,
+	);
+	const storedSeats = resolvedCredits.reduce(
+		(total, { storedCredit }) => total + storedCredit.coveredSeats,
+		0,
+	);
+	const paidSeats = resolvedCredits.reduce(
+		(total, { catalogCredit }) => total + (catalogCredit.paidQuantity ?? 0),
+		0,
+	);
+	if (storedSeats < paidSeats) {
+		ctx.logger.warn(
+			`[licenseInvoiceCreditFromStoredLineItems] Stored rows cover ${storedSeats} of ${paidSeats} paid seats for cusProduct=${customerProduct.id}; falling back to catalog credit`,
+		);
+		return catalogCredits;
+	}
+
+	return credits.flatMap(({ catalogCredit, storedCredit }) =>
+		storedCredit.resolved ? storedCredit.lineItems : [catalogCredit],
+	);
 };

--- a/server/src/internal/billing/v2/utils/lineItems/storedInvoiceCreditForPrice.ts
+++ b/server/src/internal/billing/v2/utils/lineItems/storedInvoiceCreditForPrice.ts
@@ -17,6 +17,7 @@ import {
 type StoredInvoiceCreditForPriceResult = {
 	lineItems: LineItem[];
 	resolved: boolean;
+	coveredSeats: number;
 };
 
 export const storedInvoiceCreditForPrice = ({
@@ -63,7 +64,7 @@ export const storedInvoiceCreditForPrice = ({
 		ctx.logger.warn(
 			`[storedInvoiceCreditForPrice] No usable stored charge row for cusProduct=${customerProduct.id} price=${price.id}; falling back to catalog synthesis`,
 		);
-		return { lineItems: [], resolved: false };
+		return { lineItems: [], resolved: false, coveredSeats: 0 };
 	}
 
 	const currentPeriodRefunds = refundRows.filter(
@@ -75,6 +76,7 @@ export const storedInvoiceCreditForPrice = ({
 			row.effective_period_end > now,
 	);
 	const lineItems: LineItem[] = [];
+	let coveredSeats = 0;
 	const creditableRows = consumedChargeRowIds
 		? usableRows.filter((row) => !consumedChargeRowIds.has(row.id))
 		: usableRows;
@@ -108,6 +110,9 @@ export const storedInvoiceCreditForPrice = ({
 		});
 		if (creditAmount === 0) continue;
 
+		coveredSeats +=
+			(chargeRow.paid_quantity ?? 0) /
+			Math.max(chargeRow.customer_product_ids.length, 1);
 		lineItems.push(
 			chargeRowToRefundLineItem({
 				chargeRow,
@@ -121,5 +126,5 @@ export const storedInvoiceCreditForPrice = ({
 		);
 	}
 
-	return { lineItems, resolved: true };
+	return { lineItems, resolved: true, coveredSeats };
 };

--- a/server/src/internal/billing/v2/utils/lineItems/storedInvoiceCreditForPrice.ts
+++ b/server/src/internal/billing/v2/utils/lineItems/storedInvoiceCreditForPrice.ts
@@ -108,11 +108,11 @@ export const storedInvoiceCreditForPrice = ({
 			now: effectiveNow,
 			alreadyRefunded,
 		});
-		if (creditAmount === 0) continue;
-
 		coveredSeats +=
 			(chargeRow.paid_quantity ?? 0) /
 			Math.max(chargeRow.customer_product_ids.length, 1);
+		if (creditAmount === 0) continue;
+
 		lineItems.push(
 			chargeRowToRefundLineItem({
 				chargeRow,

--- a/server/tests/integration/licenses/billing/update/update-license-quantity-stale-stored-rows.test.ts
+++ b/server/tests/integration/licenses/billing/update/update-license-quantity-stale-stored-rows.test.ts
@@ -13,6 +13,7 @@ import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/e
 import { waitForInvoiceLineItems } from "@tests/integration/billing/utils/expectInvoiceLineItemsCorrect";
 import { setupLicenseUpdateScenario } from "@tests/integration/licenses/billing/update/setupLicenseUpdateScenario";
 import { expectQuantityLineItemPairCorrect } from "@tests/integration/licenses/utils/expectLicenseBillingPreviewCorrect";
+import { pollUntil } from "@tests/utils/genUtils.js";
 import chalk from "chalk";
 import { invoiceLineItemRepo } from "@/internal/invoices/lineItems/repos";
 
@@ -39,10 +40,22 @@ test.concurrent(
 				proration_behavior: "prorate_immediately",
 			});
 
-		const latestStripeInvoiceId = async () => {
-			const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
-			const stripeId = customer.invoices?.[0]?.stripe_id;
+		const latestStripeInvoiceId = async ({
+			previous,
+		}: {
+			previous?: string;
+		} = {}) => {
+			const stripeId = await pollUntil({
+				fetch: async () => {
+					const customer =
+						await autumnV1.customers.get<ApiCustomerV3>(customerId);
+					return customer.invoices?.[0]?.stripe_id;
+				},
+				until: (id) => id !== undefined && id !== previous,
+				timeoutMs: 30_000,
+			});
 			expect(stripeId).toBeDefined();
+			expect(stripeId).not.toEqual(previous);
 			return stripeId as string;
 		};
 		const storedRowsFor = (stripeInvoiceId: string) =>
@@ -57,8 +70,9 @@ test.concurrent(
 
 		await updateTo(3);
 
-		const secondInvoiceId = await latestStripeInvoiceId();
-		expect(secondInvoiceId).not.toEqual(firstInvoiceId);
+		const secondInvoiceId = await latestStripeInvoiceId({
+			previous: firstInvoiceId,
+		});
 		const secondRows = await waitForInvoiceLineItems({
 			stripeInvoiceId: secondInvoiceId,
 			timeoutMs: 30_000,

--- a/server/tests/integration/licenses/billing/update/update-license-quantity-stale-stored-rows.test.ts
+++ b/server/tests/integration/licenses/billing/update/update-license-quantity-stale-stored-rows.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Paid updates 1 -> 2 -> 3, then a preview to 4 while the latest invoice's
+ * stored rows have not landed. Red: one seat credited, three charged. Green:
+ * two credited, three charged.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV3,
+	UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { waitForInvoiceLineItems } from "@tests/integration/billing/utils/expectInvoiceLineItemsCorrect";
+import { setupLicenseUpdateScenario } from "@tests/integration/licenses/billing/update/setupLicenseUpdateScenario";
+import { expectQuantityLineItemPairCorrect } from "@tests/integration/licenses/utils/expectLicenseBillingPreviewCorrect";
+import chalk from "chalk";
+import { invoiceLineItemRepo } from "@/internal/invoices/lineItems/repos";
+
+const SEAT_PRICE = 25;
+
+test.concurrent(
+	`${chalk.yellowBright("license-update-quantity: credit covers every paid seat when stored rows lag the latest invoice")}`,
+	async () => {
+		const customerId = "license-update-quantity-stale-rows";
+		const { autumnV1, autumnV2_3, ctx, parent, devSeat } =
+			await setupLicenseUpdateScenario({
+				customerId,
+				idPrefix: "lic-qty-stale",
+				seatPrice: SEAT_PRICE,
+				includedSeats: 1,
+				attachedSeats: 1,
+			});
+
+		const updateTo = (quantity: number) =>
+			autumnV2_3.billing.update<UpdateSubscriptionV1ParamsInput>({
+				customer_id: customerId,
+				plan_id: parent.id,
+				license_quantities: [{ license_plan_id: devSeat.id, quantity }],
+				proration_behavior: "prorate_immediately",
+			});
+
+		const latestStripeInvoiceId = async () => {
+			const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			const stripeId = customer.invoices?.[0]?.stripe_id;
+			expect(stripeId).toBeDefined();
+			return stripeId as string;
+		};
+		const storedRowsFor = (stripeInvoiceId: string) =>
+			invoiceLineItemRepo.getByStripeInvoiceId({ db: ctx.db, stripeInvoiceId });
+
+		await updateTo(2);
+		const firstInvoiceId = await latestStripeInvoiceId();
+		await waitForInvoiceLineItems({
+			stripeInvoiceId: firstInvoiceId,
+			timeoutMs: 30_000,
+		});
+
+		await updateTo(3);
+
+		const secondInvoiceId = await latestStripeInvoiceId();
+		expect(secondInvoiceId).not.toEqual(firstInvoiceId);
+		const secondRows = await waitForInvoiceLineItems({
+			stripeInvoiceId: secondInvoiceId,
+			timeoutMs: 30_000,
+		});
+		await invoiceLineItemRepo.deleteByInvoiceId({
+			db: ctx.db,
+			invoiceId: secondRows[0].invoice_id as string,
+		});
+		expect(await storedRowsFor(secondInvoiceId)).toHaveLength(0);
+
+		const preview =
+			await autumnV2_3.subscriptions.previewUpdate<UpdateSubscriptionV1ParamsInput>(
+				{
+					customer_id: customerId,
+					plan_id: parent.id,
+					license_quantities: [{ license_plan_id: devSeat.id, quantity: 4 }],
+					proration_behavior: "prorate_immediately",
+				},
+			);
+
+		expectQuantityLineItemPairCorrect({
+			preview,
+			proratedOldTotal: 2 * SEAT_PRICE,
+			proratedNewTotal: 3 * SEAT_PRICE,
+			oldQuantity: 2,
+			newQuantity: 3,
+		});
+
+		await updateTo(4);
+		const settled = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer: settled,
+			count: 3,
+			latestTotal: SEAT_PRICE,
+		});
+	},
+);


### PR DESCRIPTION
`billing.update` stores its invoice rows via an async job. The next license-quantity update or preview rebuilds the refund from those rows and only fell back to the catalog credit when it found none; with the latest invoice's rows not yet stored it credited the seats it found. After 1 → 2 → 3, a preview to 4 credited one seat and charged three.

Fix: if the stored credit covers fewer paid seats than the pool has, use the catalog credit.

Test: red `expected refund line with total -50, got [-24.9999, 75]` → green.



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes license-quantity refunds fall back to catalog-derived credit when asynchronously stored invoice rows cover fewer paid seats than expected.

- **[Bug fixes]** Compares the paid-seat coverage of stored invoice rows with the catalog credit before using those rows.
- **[Bug fixes]** Tracks covered seats per customer product, including rows whose remaining credit is zero.
- **[Improvements]** Adds an integration test for consecutive seat increases followed by a preview while the latest stored rows are unavailable.

All previous findings are resolved, and there are no code changes since the previous review that introduce new issues.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the earlier shared-seat, refund-coverage, and test-race concerns are resolved.

No new findings remain, and all previous review threads were resolved with the current code containing the stated fixes.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/utils/lineItems/licenseInvoiceCreditFromStoredLineItems.ts | Compares stored-row seat coverage with catalog-paid seats and falls back when stored data is incomplete. |
| server/src/internal/billing/v2/utils/lineItems/storedInvoiceCreditForPrice.ts | Returns per-product covered-seat counts while preserving coverage for fully refunded or discounted rows. |
| server/tests/integration/licenses/billing/update/update-license-quantity-stale-stored-rows.test.ts | Reliably creates missing latest-invoice rows and verifies both preview and settled quantity-update billing. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Billing
  participant StoredRows as Stored invoice rows
  participant Catalog

  Client->>Billing: Preview license quantity increase
  Billing->>StoredRows: Rebuild available credit
  StoredRows-->>Billing: Credit and covered-seat count
  Billing->>Catalog: Determine expected paid seats
  alt Stored rows cover every paid seat
    Billing-->>Client: Preview using stored-row credit
  else Stored rows cover too few paid seats
    Billing-->>Client: Preview using catalog credit
  end
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Count fully refunded seats as covered an..."](https://github.com/useautumn/autumn/commit/a5499757c9c85cf45bbbbabd5049da1b38f6b6cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61523439)</sub>

**Context used:**

- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)

<!-- /greptile_comment -->