### PR TITLE
fix dashboard visibility for consumed standalone balances

### DIFF
--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -426,9 +426,8 @@ const buildExtraEntitlementsCTE = ({
             AND ce.customer_product_id IS NULL
             AND ce.pooled_balance_id IS NULL
             AND ce.pooled_contribution_id IS NULL
-            AND ce.expires_at IS NOT NULL
-            AND ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000
-            AND ${looseEntitlementIsLiveSql()}
+            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR (ce.expires_at IS NULL AND ce.balance = 0 AND ce.unlimited IS NOT TRUE))
+            AND (${looseEntitlementIsLiveSql()} OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE))
           ORDER BY ce.id DESC
           LIMIT ${EXPIRED_EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
         ) expired_ce`

--- a/shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts
+++ b/shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts
@@ -7,8 +7,14 @@ export const isCusEntDisplayExpired = ({
 	cusEnt,
 	now,
 }: {
-	cusEnt: Pick<FullCusEntWithFullCusProduct, "expires_at" | "customer_product">;
+	cusEnt: Pick<
+		FullCusEntWithFullCusProduct,
+		"expires_at" | "customer_product" | "balance" | "unlimited"
+	>;
 	now?: number;
 }): boolean =>
 	isCusEntExpired({ cusEnt, now }) ||
-	cusEnt.customer_product?.status === CusProductStatus.Expired;
+	cusEnt.customer_product?.status === CusProductStatus.Expired ||
+	(cusEnt.customer_product == null &&
+		cusEnt.balance === 0 &&
+		cusEnt.unlimited !== true);

--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts
@@ -1,7 +1,7 @@
 import {
 	CusProductStatus,
 	type FullCusEntWithFullCusProduct,
-	isCusEntExpired,
+	isCusEntDisplayExpired,
 	isPooledBalanceSourceCustomerEntitlement,
 } from "@autumn/shared";
 import type { CustomerProductsStatusOption } from "@/views/customers2/hooks/useCustomerProductsTableState";
@@ -27,7 +27,9 @@ export function filterCustomerFeatureUsage({
 				return false;
 			}
 			if (!ent.customer_product) {
-				return isCusEntExpired({ cusEnt: ent }) ? showExpired : showActive;
+				return isCusEntDisplayExpired({ cusEnt: ent })
+					? showExpired
+					: showActive;
 			}
 			if (ent.customer_product.status === CusProductStatus.Expired) {
 				return showExpired;

--- a/vite/tests/views/customers2/customer-feature-usage.test.ts
+++ b/vite/tests/views/customers2/customer-feature-usage.test.ts
@@ -30,6 +30,22 @@ const buildCustomerEntitlement = ({
 	}) as FullCusEntWithFullCusProduct;
 
 describe("customer feature usage pooled balances", () => {
+	test("shows consumed standalone balances in the expired view", () => {
+		const consumed = {
+			...buildCustomerEntitlement({ id: "consumed", pooled: false }),
+			balance: 0,
+			unlimited: false,
+			customer_product: null,
+		};
+
+		const filtered = filterCustomerFeatureUsage({
+			entitlements: [consumed],
+			statuses: ["expired"],
+		});
+
+		expect(filtered.map(({ id }) => id)).toEqual(["consumed"]);
+	});
+
 	test("shows the synthetic pool and hides its contribution sources", () => {
 		const ordinary = buildCustomerEntitlement({
 			id: "ordinary",


### PR DESCRIPTION
## Problem
Consumed standalone balances are omitted from the dashboard's Expired view, even though expired plan-linked balances remain visible.

## Fix
Include drained standalone entitlements in the dashboard history hydration and classify them as display-expired. Active customer reads remain unchanged.

## Validation
- Red/green regression test added for consumed standalone visibility.
- `bun test tests/views/customers2/customer-feature-usage.test.ts`
- `bun ts` in `server/`
- `bun ts` in `vite/`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dashboard so consumed standalone balances now show in the Expired view, matching how expired plan-linked balances behave. Previously, standalone entitlements with a zero balance were dropped from the history query and filtered as active in the feature-usage table.

- Expired-view history now includes standalone entitlements that are consumed (zero balance, not unlimited) even when they have no expiry date.
- The display-expired classifier and the feature-usage filter use the same consumed check for standalone entitlements.
- Active customer reads are unaffected; the change only widens the expired history and the filter.

<sup>Written for commit c5bcddbc91975db89b13e0cef526baace3cfe058. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hydrates consumed standalone balances for dashboard history and classifies them as display-expired, with a client-side regression test.

Key changes:
- **[Bug fixes]** Adds drained standalone entitlements without expiration dates to dashboard history hydration.
- **[Bug fixes]** Classifies productless, zero-balance entitlements as display-expired in shared and dashboard filtering logic.
- **[Improvements]** Adds client-side coverage for filtering a consumed standalone balance into the Expired view.

The implementation still misses consumed balances with future expiration dates and incorrectly treats resetting standalone balances as expired.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because realistic standalone balances remain omitted or are displayed under the wrong status.

A consumed balance with a future expiration is rejected by both server query branches, while a consumed balance that is scheduled to refill is incorrectly classified as expired.

**Files Needing Attention:** server/src/internal/customers/getFullCusQuery.ts; shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/getFullCusQuery.ts | Adds drained standalone rows to history hydration but excludes consumed rows whose expiration is still in the future. |
| shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts | Broadens display-expired classification without distinguishing permanently consumed balances from balances scheduled to refill. |
| vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts | Reuses the shared display-expired classifier for productless rows, propagating its reset-related misclassification. |
| vite/tests/views/customers2/customer-feature-usage.test.ts | Covers client filtering for a no-expiration consumed balance but not server hydration, future expiration, or scheduled resets. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Standalone entitlement] --> B{Balance is zero?}
  B -- No --> C[Active hydration]
  B -- Yes --> D{Expiration}
  D -- None --> E[History hydration]
  D -- Past --> E
  D -- Future --> F[Omitted by both query branches]
  E --> G{Future reset scheduled?}
  G -- No --> H[Expired view]
  G -- Yes --> I[Currently misclassified as expired]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/customers/getFullCusQuery.ts:429
**Future-expiring balances stay hidden**

A standalone balance that is consumed before its expiration date is still omitted from the dashboard. For example, if the balance reaches zero today but expires next week, the active query rejects it because it is drained, while this history query rejects it because its expiration is still in the future. The client would classify it as expired for display, but the server never sends it.

### Issue 2
shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts:18-20
**Resetting balances appear expired**

A resetting standalone balance is marked expired whenever its current balance reaches zero. For example, a monthly balance consumed halfway through its period still has a scheduled refill, but this condition moves it to the Expired view until that refill occurs. The classification needs to distinguish permanently drained one-time balances from active balances with a future reset.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix dashboard visibility for consumed st..."](https://github.com/useautumn/autumn/commit/c5bcddbc91975db89b13e0cef526baace3cfe058) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61560883)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Customer, subject, and entitlement operations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/customer-management.md)
- Knowledge Base — [Operational web applications and UI primitives](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/operational-web-applications.md)

<!-- /greptile_comment -->