### PR TITLE
Fix consumed standalone balance expiry edge cases

### DIFF
--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -426,8 +426,8 @@ const buildExtraEntitlementsCTE = ({
             AND ce.customer_product_id IS NULL
             AND ce.pooled_balance_id IS NULL
             AND ce.pooled_contribution_id IS NULL
-            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR (ce.expires_at IS NULL AND ce.balance = 0 AND ce.unlimited IS NOT TRUE))
-            AND (${looseEntitlementIsLiveSql()} OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE))
+            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
+            AND (${looseEntitlementIsLiveSql()} OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
           ORDER BY ce.id DESC
           LIMIT ${EXPIRED_EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
         ) expired_ce`

--- a/shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts
+++ b/shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts
@@ -9,7 +9,7 @@ export const isCusEntDisplayExpired = ({
 }: {
 	cusEnt: Pick<
 		FullCusEntWithFullCusProduct,
-		"expires_at" | "customer_product" | "balance" | "unlimited"
+		"expires_at" | "customer_product" | "balance" | "unlimited" | "next_reset_at"
 	>;
 	now?: number;
 }): boolean =>
@@ -17,4 +17,5 @@ export const isCusEntDisplayExpired = ({
 	cusEnt.customer_product?.status === CusProductStatus.Expired ||
 	(cusEnt.customer_product == null &&
 		cusEnt.balance === 0 &&
-		cusEnt.unlimited !== true);
+		cusEnt.unlimited !== true &&
+		cusEnt.next_reset_at == null);

--- a/vite/tests/views/customers2/customer-feature-usage.test.ts
+++ b/vite/tests/views/customers2/customer-feature-usage.test.ts
@@ -35,6 +35,7 @@ describe("customer feature usage pooled balances", () => {
 			...buildCustomerEntitlement({ id: "consumed", pooled: false }),
 			balance: 0,
 			unlimited: false,
+			next_reset_at: null,
 			customer_product: null,
 		};
 
@@ -44,6 +45,23 @@ describe("customer feature usage pooled balances", () => {
 		});
 
 		expect(filtered.map(({ id }) => id)).toEqual(["consumed"]);
+	});
+
+	test("keeps consumed resetting balances out of the expired view", () => {
+		const resetting = {
+			...buildCustomerEntitlement({ id: "resetting", pooled: false }),
+			balance: 0,
+			unlimited: false,
+			next_reset_at: 1,
+			customer_product: null,
+		};
+
+		const filtered = filterCustomerFeatureUsage({
+			entitlements: [resetting],
+			statuses: ["expired"],
+		});
+
+		expect(filtered).toEqual([]);
 	});
 
 	test("shows the synthetic pool and hides its contribution sources", () => {


### PR DESCRIPTION
Tighten consumed standalone balance visibility so future-expiring lifetime balances appear in Expired while resetting balances remain active. Adds focused regression coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes consumed standalone balance expiry classification so balances with a scheduled reset remain active instead of appearing in the Expired view. Both the server entitlement query and the shared display-expired helper now treat a zero-balance entitlement as expired only when `next_reset_at` is null.

Adds a regression test covering resetting consumed balances.

<sup>Written for commit 12076e8a47d6f539b8057922d6b91a43c19a1ef5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refines how consumed standalone balances are divided between active and expired customer views.

**Key changes**
- **[Bug fixes]** Treats a consumed standalone balance without a reset as expired.
- **[Improvements]** Keeps consumed balances with a scheduled reset out of the Expired filter.
- **[Improvements]** Adds focused UI-filter regression coverage for resetting balances.
- **[Bug fixes]** Updates the customer SQL query to use the same `next_reset_at` distinction, but currently leaves resetting zero-balance rows out of both query branches.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because consumed resetting standalone balances can disappear completely from the customer dashboard response.

The expired branch now rejects zero-balance rows with a reset time, while the unchanged active branch also rejects them because their current balance is zero. The added test cannot detect this because it bypasses the server query.

**Files Needing Attention:** server/src/internal/customers/getFullCusQuery.ts, vite/tests/views/customers2/customer-feature-usage.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/getFullCusQuery.ts | Changes expired entitlement selection but omits consumed resetting balances from both active and expired query results. |
| shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts | Correctly distinguishes consumed non-resetting balances from balances expected to reset, assuming the server returns the record. |
| vite/tests/views/customers2/customer-feature-usage.test.ts | Covers the in-memory display filter but does not exercise the changed server query that supplies entitlements. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Consumed standalone resetting balance] --> B{Expired branch}
  B -->|next_reset_at is non-null| C[Excluded]
  A --> D{Active branch}
  D -->|balance is zero, so loose-live check fails| E[Excluded]
  C --> F[Entitlement omitted from dashboard response]
  E --> F
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/customers/getFullCusQuery.ts:430
**Resetting balances disappear**

A consumed standalone balance that will reset is removed from the expired query but is not added to the active query. For example, a metered balance with `balance = 0` and a future `next_reset_at` fails this new fallback, while the active check also excludes it because its balance is zero. As a result, the dashboard receives no record instead of showing the resetting balance as active.

### Issue 2
vite/tests/views/customers2/customer-feature-usage.test.ts:50-65
**Test bypasses changed query**

This test supplies the resetting entitlement directly to the UI filter, so it still passes if the server query omits that entitlement entirely. Add server-side coverage that retrieves both a consumed lifetime balance and a consumed resetting balance through `getFullCusQuery`; otherwise the SQL behavior can regress while this test remains green.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix consumed balance expiry classificati..."](https://github.com/useautumn/autumn/commit/12076e8a47d6f539b8057922d6b91a43c19a1ef5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61565772)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Customer, subject, and entitlement operations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/customer-management.md)
- Knowledge Base — [Operational web applications and UI primitives](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/operational-web-applications.md)

<!-- /greptile_comment -->