### PR TITLE
Include resetting standalone balances in active customers

### DIFF
--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -330,7 +330,7 @@ export const getCursorPaginatedFullCusQuery = ({
 					AND ce.pooled_balance_id IS NULL
 					AND ce.pooled_contribution_id IS NULL
 					AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
-					AND ${looseEntitlementIsLiveSql()}
+					AND (${looseEntitlementIsLiveSql()} OR ce.next_reset_at IS NOT NULL)
 					${customerLevelOnly("ce")}
 				ORDER BY ce.id DESC
 				LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -426,8 +426,8 @@ const buildExtraEntitlementsCTE = ({
             AND ce.customer_product_id IS NULL
             AND ce.pooled_balance_id IS NULL
             AND ce.pooled_contribution_id IS NULL
-            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR (ce.expires_at IS NULL AND ce.balance = 0 AND ce.unlimited IS NOT TRUE))
-            AND (${looseEntitlementIsLiveSql()} OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE))
+            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
+            AND (${looseEntitlementIsLiveSql()} OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
           ORDER BY ce.id DESC
           LIMIT ${EXPIRED_EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
         ) expired_ce`

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -426,8 +426,8 @@ const buildExtraEntitlementsCTE = ({
             AND ce.customer_product_id IS NULL
             AND ce.pooled_balance_id IS NULL
             AND ce.pooled_contribution_id IS NULL
-            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
-            AND (${looseEntitlementIsLiveSql()} OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
+            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR (ce.expires_at IS NULL AND ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
+            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR ${looseEntitlementIsLiveSql()} OR (ce.expires_at IS NULL AND ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
           ORDER BY ce.id DESC
           LIMIT ${EXPIRED_EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
         ) expired_ce`
@@ -453,7 +453,7 @@ const buildExtraEntitlementsCTE = ({
             AND ce.pooled_balance_id IS NULL
             AND ce.pooled_contribution_id IS NULL
             AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
-            AND ${looseEntitlementIsLiveSql()}
+            AND (${looseEntitlementIsLiveSql()} OR ce.next_reset_at IS NOT NULL)
           ORDER BY ce.id DESC
           LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
         ) active_ce
@@ -828,7 +828,7 @@ export const getPaginatedFullCusQuery = ({
 		AND ce.pooled_balance_id IS NULL
 		AND ce.pooled_contribution_id IS NULL
         ${looseEntitlementExpiryFilterSql({ includeExpiredLooseEntitlements: false })}
-        AND ${looseEntitlementIsLiveSql()}
+        AND (${looseEntitlementIsLiveSql()} OR ce.next_reset_at IS NOT NULL)
         ${customerLevelOnly("ce")}
       ORDER BY ce.id DESC
 	  LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
@@ -301,7 +301,7 @@ export const getFullSubjectRowsQuery = ({
 					AND ce.pooled_balance_id IS NULL
 					AND ce.pooled_contribution_id IS NULL
 					AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
-					AND ${looseEntitlementIsLiveSql()}
+					AND (${looseEntitlementIsLiveSql()} OR ce.next_reset_at IS NOT NULL)
 					${customerEntitlementSubjectPredicate}
 				ORDER BY subject_entity_priority ASC, ce.id DESC
 				LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}

--- a/shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts
+++ b/shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts
@@ -9,7 +9,7 @@ export const isCusEntDisplayExpired = ({
 }: {
 	cusEnt: Pick<
 		FullCusEntWithFullCusProduct,
-		"expires_at" | "customer_product" | "balance" | "unlimited"
+		"expires_at" | "customer_product" | "balance" | "unlimited" | "next_reset_at"
 	>;
 	now?: number;
 }): boolean =>
@@ -17,4 +17,5 @@ export const isCusEntDisplayExpired = ({
 	cusEnt.customer_product?.status === CusProductStatus.Expired ||
 	(cusEnt.customer_product == null &&
 		cusEnt.balance === 0 &&
-		cusEnt.unlimited !== true);
+		cusEnt.unlimited !== true &&
+		cusEnt.next_reset_at == null);

--- a/vite/tests/views/customers2/customer-feature-usage.test.ts
+++ b/vite/tests/views/customers2/customer-feature-usage.test.ts
@@ -52,7 +52,7 @@ describe("customer feature usage pooled balances", () => {
 			...buildCustomerEntitlement({ id: "resetting", pooled: false }),
 			balance: 0,
 			unlimited: false,
-			next_reset_at: 1,
+			next_reset_at: Date.now() + 1000,
 			customer_product: null,
 		};
 
@@ -62,6 +62,23 @@ describe("customer feature usage pooled balances", () => {
 		});
 
 		expect(filtered).toEqual([]);
+	});
+
+	test("shows consumed resetting balances in the active view", () => {
+		const resetting = {
+			...buildCustomerEntitlement({ id: "resetting", pooled: false }),
+			balance: 0,
+			unlimited: false,
+			next_reset_at: Date.now() + 1000,
+			customer_product: null,
+		};
+
+		const filtered = filterCustomerFeatureUsage({
+			entitlements: [resetting],
+			statuses: ["active"],
+		});
+
+		expect(filtered.map(({ id }) => id)).toEqual(["resetting"]);
 	});
 
 	test("shows the synthetic pool and hides its contribution sources", () => {

--- a/vite/tests/views/customers2/customer-feature-usage.test.ts
+++ b/vite/tests/views/customers2/customer-feature-usage.test.ts
@@ -35,6 +35,7 @@ describe("customer feature usage pooled balances", () => {
 			...buildCustomerEntitlement({ id: "consumed", pooled: false }),
 			balance: 0,
 			unlimited: false,
+			next_reset_at: null,
 			customer_product: null,
 		};
 
@@ -44,6 +45,23 @@ describe("customer feature usage pooled balances", () => {
 		});
 
 		expect(filtered.map(({ id }) => id)).toEqual(["consumed"]);
+	});
+
+	test("keeps consumed resetting balances out of the expired view", () => {
+		const resetting = {
+			...buildCustomerEntitlement({ id: "resetting", pooled: false }),
+			balance: 0,
+			unlimited: false,
+			next_reset_at: 1,
+			customer_product: null,
+		};
+
+		const filtered = filterCustomerFeatureUsage({
+			entitlements: [resetting],
+			statuses: ["expired"],
+		});
+
+		expect(filtered).toEqual([]);
 	});
 
 	test("shows the synthetic pool and hides its contribution sources", () => {


### PR DESCRIPTION
Fixes the active entitlement query so consumed standalone balances with a reset scheduled are returned to the dashboard. Adds focused active-view regression coverage. This PR is intentionally left open for review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes entitlement querying so consumed standalone balances with a scheduled reset stay visible in the customer dashboard instead of being classified as expired.

- Active views across the customer query paths now include zero-balance standalone entitlements with `next_reset_at` set.
- Expired views only omit these when no reset is scheduled, and the display expiry check treats resetting balances as active.
- Adds regression tests covering both views using a future reset timestamp.

<sup>Written for commit 73b07b26556b5e2ff345693149a52ce9a39c8bc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates customer entitlement queries so consumed standalone balances remain visible when another reset is scheduled.

**Key changes**
- **[Bug fixes]** Includes zero-balance standalone entitlements with a scheduled reset in active customer and subject views.
- **[Bug fixes]** Keeps genuinely expired entitlements available to the expired view even when they retain a reset timestamp.
- **[Improvements]** Adjusts focused dashboard filtering coverage, although the active-view regression assertion was removed in the latest revision.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the flat paginated customer query still omits consumed standalone balances that have a scheduled reset.

The earlier expired-view issue is fixed because entitlements whose own expiration has passed are now admitted regardless of their reset timestamp. However, the previous flat-query finding remains outstanding: the latest revision removed the scheduled-reset exception from the flat paginated query, so a zero-balance standalone entitlement with a future reset can still disappear from active dashboard results. The removed active-view regression assertion is also a non-blocking test-coverage concern.

**Files Needing Attention:** server/src/internal/customers/getFullCusQuery.ts; vite/tests/views/customers2/customer-feature-usage.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cursorPaginatedFullCusQuery.ts | Includes standalone entitlements with scheduled resets in cursor-paginated active customer results. |
| server/src/internal/customers/getFullCusQuery.ts | Corrects active and expired entitlement classification, but the separate flat paginated query still omits resetting zero-balance entitlements. |
| server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts | Aligns full-subject active entitlement selection with scheduled-reset behavior. |
| vite/tests/views/customers2/customer-feature-usage.test.ts | Covers expired-view exclusion for resetting balances but no longer verifies their required active-view inclusion. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  E[Standalone entitlement] --> X{Already expired?}
  X -->|Yes| V[Expired view]
  X -->|No| R{Balance available or reset scheduled?}
  R -->|Yes| A[Active view]
  R -->|No| V
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/tests/views/customers2/customer-feature-usage.test.ts`, line 64 ([link](https://github.com/useautumn/autumn/blob/73b07b26556b5e2ff345693149a52ce9a39c8bc1/vite/tests/views/customers2/customer-feature-usage.test.ts#L64)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Active Regression Coverage Removed**

   The active-view regression test added for this fix was removed, leaving only a check that a resetting zero-balance entitlement is absent from the expired view. For example, if the UI later stops showing that entitlement in either view, the remaining test still passes, so the dashboard behavior this PR is intended to protect can regress unnoticed. Restore an assertion that the entitlement appears when the active filter is selected.

   **Knowledge Base Used:** [Operational web applications and UI primitives](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/operational-web-applications.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: vite/tests/views/customers2/customer-feature-usage.test.ts
   Line: 64
   
   Comment:
   **Active Regression Coverage Removed**
   
   The active-view regression test added for this fix was removed, leaving only a check that a resetting zero-balance entitlement is absent from the expired view. For example, if the UI later stops showing that entitlement in either view, the remaining test still passes, so the dashboard behavior this PR is intended to protect can regress unnoticed. Restore an assertion that the entitlement appears when the active filter is selected.
   
   **Knowledge Base Used:** [Operational web applications and UI primitives](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/operational-web-applications.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/tests/views/customers2/customer-feature-usage.test.ts:64
**Active Regression Coverage Removed**

The active-view regression test added for this fix was removed, leaving only a check that a resetting zero-balance entitlement is absent from the expired view. For example, if the UI later stops showing that entitlement in either view, the remaining test still passes, so the dashboard behavior this PR is intended to protect can regress unnoticed. Restore an assertion that the entitlement appears when the active filter is selected.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge main and resolve balance visibilit..."](https://github.com/useautumn/autumn/commit/73b07b26556b5e2ff345693149a52ce9a39c8bc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61570634)</sub>

**Context used:**

- Knowledge Base — [Customer, subject, and entitlement operations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/customer-management.md)
- Knowledge Base — [Operational web applications and UI primitives](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/operational-web-applications.md)

<!-- /greptile_comment -->