### PR TITLE
Add org config for the auto top-up attempt limit

### DIFF
--- a/server/src/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs.ts
+++ b/server/src/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs.ts
@@ -1,4 +1,4 @@
-import type { AutoTopup } from "@autumn/shared";
+import type { AutoTopup, OrgConfig } from "@autumn/shared";
 
 export type AutoTopupWindowLimitConfig = {
 	limit: number;
@@ -21,12 +21,19 @@ export const DEFAULT_AUTO_TOPUP_FAILED_ATTEMPT_LIMIT: AutoTopupWindowLimitConfig
 
 export const getAutoTopupRateLimitConfigs = ({
 	autoTopupConfig,
+	orgConfig,
 }: {
 	autoTopupConfig: AutoTopup;
+	orgConfig: OrgConfig;
 }) => {
 	return {
 		purchaseLimit: autoTopupConfig.purchase_limit,
-		attemptLimit: DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT,
+		attemptLimit: {
+			...DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT,
+			limit:
+				orgConfig.auto_topup_attempt_limit ??
+				DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT.limit,
+		},
 		failedAttemptLimit: DEFAULT_AUTO_TOPUP_FAILED_ATTEMPT_LIMIT,
 	};
 };

--- a/server/src/internal/balances/autoTopUp/helpers/limits/preflightAutoTopupLimits.ts
+++ b/server/src/internal/balances/autoTopUp/helpers/limits/preflightAutoTopupLimits.ts
@@ -90,7 +90,10 @@ export const preflightAutoTopupLimits = async ({
 	}
 
 	const { purchaseLimit, attemptLimit, failedAttemptLimit } =
-		getAutoTopupRateLimitConfigs({ autoTopupConfig });
+		getAutoTopupRateLimitConfigs({
+			autoTopupConfig,
+			orgConfig: ctx.org.config,
+		});
 
 	const normalizedAttempt = normalizeWindowCounter({
 		now,

--- a/server/src/internal/balances/autoTopUp/helpers/limits/recordAutoTopupAttempt.ts
+++ b/server/src/internal/balances/autoTopUp/helpers/limits/recordAutoTopupAttempt.ts
@@ -37,7 +37,10 @@ export const recordAutoTopupAttempt = async ({
 	const outcome = succeeded ? "success" : "failure";
 
 	const { purchaseLimit, attemptLimit, failedAttemptLimit } =
-		getAutoTopupRateLimitConfigs({ autoTopupConfig });
+		getAutoTopupRateLimitConfigs({
+			autoTopupConfig,
+			orgConfig: ctx.org.config,
+		});
 
 	const normalizedAttempt = normalizeWindowCounter({
 		now,

--- a/server/tests/unit/balances/auto-topup/auto-topup-rate-limit-configs.test.ts
+++ b/server/tests/unit/balances/auto-topup/auto-topup-rate-limit-configs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { AutoTopupSchema, OrgConfigSchema } from "@autumn/shared";
+import {
+	DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT,
+	getAutoTopupRateLimitConfigs,
+} from "@/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs";
+
+const autoTopupConfig = AutoTopupSchema.parse({
+	feature_id: "credits",
+	threshold: 10,
+	quantity: 100,
+});
+
+describe("getAutoTopupRateLimitConfigs", () => {
+	test("uses the default attempt limit when the org sets none", () => {
+		const { attemptLimit } = getAutoTopupRateLimitConfigs({
+			autoTopupConfig,
+			orgConfig: OrgConfigSchema.parse({}),
+		});
+
+		expect(attemptLimit).toEqual(DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT);
+	});
+
+	test("uses the org attempt limit within the default window", () => {
+		const { attemptLimit } = getAutoTopupRateLimitConfigs({
+			autoTopupConfig,
+			orgConfig: OrgConfigSchema.parse({ auto_topup_attempt_limit: 10 }),
+		});
+
+		expect(attemptLimit).toEqual({
+			...DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT,
+			limit: 10,
+		});
+	});
+});

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -70,6 +70,7 @@ export const OrgConfigSchema = z.object({
 	disabled_auto_topup: z.boolean().default(false),
 	persist_free_overage: z.boolean().default(false),
 	dryrun_autotopups: z.boolean().default(false),
+	auto_topup_attempt_limit: z.number().int().min(1).nullish(),
 
 	forward_customer_metadata: z.boolean().default(false),
 

--- a/vite/src/views/settings/SettingsRow.tsx
+++ b/vite/src/views/settings/SettingsRow.tsx
@@ -1,0 +1,21 @@
+interface SettingsRowProps {
+	readonly label: string;
+	readonly description: React.ReactNode;
+	readonly children: React.ReactNode;
+}
+
+export const SettingsRow = ({
+	label,
+	description,
+	children,
+}: SettingsRowProps) => {
+	return (
+		<div className="flex items-center justify-between gap-4">
+			<div className="flex flex-col gap-0.5">
+				<span className="text-sm font-medium">{label}</span>
+				<span className="text-xs text-muted-foreground">{description}</span>
+			</div>
+			{children}
+		</div>
+	);
+};

--- a/vite/src/views/settings/sections/BillingSettingsSection.tsx
+++ b/vite/src/views/settings/sections/BillingSettingsSection.tsx
@@ -24,6 +24,7 @@ import { SettingsSection } from "../SettingsSection";
 type TtlUnit = "hours" | "days";
 
 const MAX_TTL_HOURS = 24 * 30;
+const DEFAULT_AUTO_TOPUP_ATTEMPTS = 2;
 
 // Hidden until the DynamoDB idempotency store is fully rolled out.
 const IDEMPOTENCY_TTL_CONFIG_ENABLED: boolean = false;
@@ -145,10 +146,13 @@ export const BillingSettingsSection = () => {
 		},
 	});
 
-	const handleToggle = (key: keyof OrgConfig, value: boolean) => {
+	const handleChange = <K extends keyof OrgConfig>(
+		key: K,
+		value: OrgConfig[K],
+	) => {
 		setPending((prev) => {
 			const next = { ...prev, [key]: value };
-			if (serverConfig[key] === value) {
+			if ((serverConfig[key] ?? null) === (value ?? null)) {
 				delete next[key];
 			}
 			return next;
@@ -209,11 +213,37 @@ export const BillingSettingsSection = () => {
 						<Switch
 							aria-label={label}
 							checked={!!displayConfig[key]}
-							onCheckedChange={(val) => handleToggle(key, val)}
+							onCheckedChange={(val) => handleChange(key, val)}
 							disabled={isPending}
 						/>
 					</div>
 				))}
+				<div className="flex items-center justify-between gap-4 py-3.5">
+					<div className="flex flex-col gap-0.5">
+						<span className="text-sm font-medium">
+							Auto top-up attempts per 10 minutes
+						</span>
+						<span className="text-xs text-muted-foreground">
+							How many auto top-ups a customer can trigger per feature in a 10
+							minute window
+						</span>
+					</div>
+					<Input
+						type="number"
+						aria-label="Auto top-up attempts per 10 minutes"
+						className="w-20"
+						min={1}
+						placeholder={String(DEFAULT_AUTO_TOPUP_ATTEMPTS)}
+						value={displayConfig.auto_topup_attempt_limit ?? ""}
+						onChange={(e) =>
+							handleChange(
+								"auto_topup_attempt_limit",
+								e.target.value === "" ? null : Number(e.target.value),
+							)
+						}
+						disabled={isPending}
+					/>
+				</div>
 				{IDEMPOTENCY_TTL_CONFIG_ENABLED && (
 					<div className="flex items-center justify-between gap-4 py-3.5">
 						<div className="flex flex-col gap-0.5">

--- a/vite/src/views/settings/sections/BillingSettingsSection.tsx
+++ b/vite/src/views/settings/sections/BillingSettingsSection.tsx
@@ -163,6 +163,17 @@ export const BillingSettingsSection = () => {
 	const handleSave = () => {
 		if (!isDirty || isPending) return;
 
+		const attemptLimit = pending.auto_topup_attempt_limit;
+		if (
+			attemptLimit != null &&
+			(!Number.isInteger(attemptLimit) || attemptLimit < 1)
+		) {
+			toast.error(
+				"Auto top-up attempt limit must be a whole number of at least 1",
+			);
+			return;
+		}
+
 		if (isTtlDirty && pendingTtl) {
 			const ttlHours = toHours(pendingTtl);
 			if (

--- a/vite/src/views/settings/sections/BillingSettingsSection.tsx
+++ b/vite/src/views/settings/sections/BillingSettingsSection.tsx
@@ -19,6 +19,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { SettingsRow } from "../SettingsRow";
 import { SettingsSection } from "../SettingsSection";
 
 type TtlUnit = "hours" | "days";
@@ -198,39 +199,24 @@ export const BillingSettingsSection = () => {
 			title="Configuration"
 			description="Configure how billing and subscriptions behave"
 		>
-			<div className="flex flex-col divide-y divide-border rounded-lg border bg-interactive-secondary px-4">
+			<div className="flex flex-col divide-y divide-border rounded-lg border bg-interactive-secondary px-4 [&>*]:py-3.5">
 				{BILLING_TOGGLES.map(({ key, label, description }) => (
-					<div
-						key={key}
-						className="flex items-center justify-between gap-4 py-3.5"
-					>
-						<div className="flex flex-col gap-0.5">
-							<span className="text-sm font-medium">{label}</span>
-							<span className="text-xs text-muted-foreground">
-								{description}
-							</span>
-						</div>
+					<SettingsRow key={key} label={label} description={description}>
 						<Switch
 							aria-label={label}
 							checked={!!displayConfig[key]}
 							onCheckedChange={(val) => handleChange(key, val)}
 							disabled={isPending}
 						/>
-					</div>
+					</SettingsRow>
 				))}
-				<div className="flex items-center justify-between gap-4 py-3.5">
-					<div className="flex flex-col gap-0.5">
-						<span className="text-sm font-medium">
-							Auto top-up attempts per 10 minutes
-						</span>
-						<span className="text-xs text-muted-foreground">
-							How many auto top-ups a customer can trigger per feature in a 10
-							minute window
-						</span>
-					</div>
+				<SettingsRow
+					label="Auto top-up attempt limit"
+					description="How many auto top-ups a customer can trigger per feature every 10 minutes"
+				>
 					<Input
 						type="number"
-						aria-label="Auto top-up attempts per 10 minutes"
+						aria-label="Auto top-up attempt limit"
 						className="w-20"
 						min={1}
 						placeholder={String(DEFAULT_AUTO_TOPUP_ATTEMPTS)}
@@ -243,18 +229,12 @@ export const BillingSettingsSection = () => {
 						}
 						disabled={isPending}
 					/>
-				</div>
+				</SettingsRow>
 				{IDEMPOTENCY_TTL_CONFIG_ENABLED && (
-					<div className="flex items-center justify-between gap-4 py-3.5">
-						<div className="flex flex-col gap-0.5">
-							<span className="text-sm font-medium">
-								Idempotency key duration
-							</span>
-							<span className="text-xs text-muted-foreground">
-								How long duplicate requests to balances endpoints (track, check)
-								are rejected
-							</span>
-						</div>
+					<SettingsRow
+						label="Idempotency key duration"
+						description="How long duplicate requests to balances endpoints (track, check) are rejected"
+					>
 						<div className="flex items-center gap-2">
 							<Input
 								type="number"
@@ -287,7 +267,7 @@ export const BillingSettingsSection = () => {
 								</SelectContent>
 							</Select>
 						</div>
-					</div>
+					</SettingsRow>
 				)}
 			</div>
 			<div className="pb-8">

--- a/vite/src/views/settings/sections/components/AllowedPaymentMethodsSubsection.tsx
+++ b/vite/src/views/settings/sections/components/AllowedPaymentMethodsSubsection.tsx
@@ -11,6 +11,7 @@ import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { SettingsRow } from "../../SettingsRow";
 
 const PAYMENT_METHOD_OPTIONS = [
 	{ value: "card", label: "Card" },
@@ -60,15 +61,14 @@ export const AllowedPaymentMethodsSubsection = () => {
 	};
 
 	return (
-		<div className="flex items-center justify-between gap-4">
-			<div className="flex flex-col gap-0.5">
-				<span className="text-sm font-medium">Payment methods</span>
-				<span className="text-xs text-muted-foreground">
-					{allowedMethods === null
-						? "Unset — invoices use your Stripe account's default payment methods"
-						: "Only these payment methods are offered on invoices Autumn creates"}
-				</span>
-			</div>
+		<SettingsRow
+			label="Payment methods"
+			description={
+				allowedMethods === null
+					? "Unset — invoices use your Stripe account's default payment methods"
+					: "Only these payment methods are offered on invoices Autumn creates"
+			}
+		>
 			<DropdownMenu>
 				<DropdownMenuTrigger asChild>
 					<IconButton
@@ -98,6 +98,6 @@ export const AllowedPaymentMethodsSubsection = () => {
 					))}
 				</DropdownMenuContent>
 			</DropdownMenu>
-		</div>
+		</SettingsRow>
 	);
 };

--- a/vite/src/views/settings/sections/components/DefaultNetTermsSubsection.tsx
+++ b/vite/src/views/settings/sections/components/DefaultNetTermsSubsection.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { SettingsRow } from "../../SettingsRow";
 
 export const DefaultNetTermsSubsection = () => {
 	const { org, mutate: refetchOrg } = useOrg();
@@ -44,15 +45,14 @@ export const DefaultNetTermsSubsection = () => {
 	};
 
 	return (
-		<div className="flex items-center justify-between gap-4">
-			<div className="flex flex-col gap-0.5">
-				<span className="text-sm font-medium">Net payment terms</span>
-				<span className="text-xs text-muted-foreground">
-					{savedDays === null
-						? "Unset — invoices Autumn creates are due 30 days after they're sent"
-						: "Used when neither the request nor the invoice template sets its own terms"}
-				</span>
-			</div>
+		<SettingsRow
+			label="Net payment terms"
+			description={
+				savedDays === null
+					? "Unset — invoices Autumn creates are due 30 days after they're sent"
+					: "Used when neither the request nor the invoice template sets its own terms"
+			}
+		>
 			<Input
 				type="number"
 				min={1}
@@ -67,6 +67,6 @@ export const DefaultNetTermsSubsection = () => {
 					if (event.key === "Enter") event.currentTarget.blur();
 				}}
 			/>
-		</div>
+		</SettingsRow>
 	);
 };


### PR DESCRIPTION
Auto top-ups are capped at 2 attempts per customer per feature in a fixed 10 minute window. The cap was a hard-coded default with no override, and a customer asked to raise it.

Adds `auto_topup_attempt_limit` to the org config. When set, it replaces the attempt count for the existing 10 minute window; the window, the failed-attempt limit and the per-customer `purchase_limit` are unchanged.

- `OrgConfigSchema`: optional positive integer, nullable so it can be cleared.
- `getAutoTopupRateLimitConfigs` takes the org config and prefers it over the default. Both callers already had `ctx`.
- Dashboard: a number input in the billing configuration card, saved through the existing `PATCH /organization/config` flow. Blank means default.

Verified: server and dashboard typecheck clean; new unit test covers default and override.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `auto_topup_attempt_limit` to the org config so customers can raise the auto top-up attempt cap from its hard-coded default of 2 per 10-minute window. The window, failed-attempt limit, and purchase limit stay unchanged.

- `OrgConfigSchema` accepts an optional positive integer; leaving it unset (or null) keeps the default of 2.
- `getAutoTopupRateLimitConfigs` now prefers the org config value over the default; both callers already pass `ctx.org.config`.
- Dashboard billing settings show a number input for attempts per 10 minutes (blank means default), validated as a whole number of at least 1 before saving.
- The settings rows were extracted into a shared `SettingsRow` component, consolidating duplicated layout across billing, payment methods, and net terms.
- Unit tests cover both the default and overridden limit.

<sup>Written for commit 502e67c0d5141d288f0c03e2b92d26f416c0e020. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an organization-level override for the number of auto top-up attempts allowed within the existing 10-minute window.

- **[API changes]** Extends the organization configuration schema with a nullable positive-integer `auto_topup_attempt_limit`.
- **[Improvements]** Applies the organization override during both auto top-up preflight checks and attempt recording, while retaining the default limit when unset.
- **[Improvements]** Adds a dashboard field for configuring or clearing the override through the existing organization configuration endpoint.
- **[Improvements]** Extracts repeated settings-row markup into a shared component.
- **[Bug fixes]** Adds unit coverage confirming the default and organization-specific limits.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, although the existing non-blocking dashboard validation concern remains.

The latest changes only extract repeated settings-row markup and preserve the previous layout and typing conventions. The earlier dashboard input still allows examples such as `0` or `1.5` to reach server validation, but this is a non-blocking usability issue and no new merge-blocking failure was found.

**Files Needing Attention:** vite/src/views/settings/sections/BillingSettingsSection.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/models/orgModels/orgConfig.ts | Adds the nullable positive-integer organization configuration field. |
| server/src/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs.ts | Selects the configured attempt limit while preserving the existing default window. |
| server/src/internal/balances/autoTopUp/helpers/limits/preflightAutoTopupLimits.ts | Supplies the organization configuration to the preflight rate-limit calculation. |
| server/src/internal/balances/autoTopUp/helpers/limits/recordAutoTopupAttempt.ts | Uses the same organization configuration when recording attempts. |
| vite/src/views/settings/sections/BillingSettingsSection.tsx | Adds the dashboard input and adopts the shared settings-row component; the previously reported client-side validation concern remains. |
| vite/src/views/settings/SettingsRow.tsx | Extracts common label, description, and control layout without changing existing spacing. |
| server/tests/unit/balances/auto-topup/auto-topup-rate-limit-configs.test.ts | Covers default and organization-overridden attempt limits. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Organization billing settings] --> B[PATCH organization config]
    B --> C[OrgConfigSchema validation]
    C --> D[auto_topup_attempt_limit]
    D --> E[getAutoTopupRateLimitConfigs]
    E --> F[Preflight limit check]
    E --> G[Attempt recording]
    D -. unset or null .-> H[Default: 2 attempts]
    H --> E
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Extract SettingsRow for label and contro..."](https://github.com/useautumn/autumn/commit/7e414365b700cb18855c32577220c9984f90beae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61573283)</sub>

<!-- /greptile_comment -->