### PR TITLE
Carry feature_override through plan-item diffs

### DIFF
--- a/server/src/internal/billing/v2/actions/generateRequest/generationSchemas.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/generationSchemas.ts
@@ -57,6 +57,21 @@ export const attachGenerationSchema = AttachParamsV1Schema.pick({
 	})
 	.strict();
 
+/** The generatable subset of the resolve-stage UPDATE_FIELDS — the omitted
+ * ones (status, processor_subscription_id, recalculate_balances) are not in
+ * this schema, so an update carrying only those cannot be generated. */
+const GENERATABLE_UPDATE_FIELDS = [
+	"billing_cycle_anchor",
+	"cancel_action",
+	"customize",
+	"discounts",
+	"feature_quantities",
+	"license_quantities",
+	"no_billing_changes",
+	"refund_last_payment",
+	"version",
+] as const;
+
 export const updateSubscriptionGenerationSchema =
 	ExtUpdateSubscriptionV1ParamsSchema.omit({
 		customer_data: true,
@@ -77,7 +92,17 @@ export const updateSubscriptionGenerationSchema =
 					"Customize the current plan: base price override, item replacement or patches, free trial, or license links.",
 			}),
 		})
-		.strict();
+		.strict()
+		// Mirrors the resolve-stage refine so an empty update fails generation,
+		// where the repair retry can still recover it, not the caller's request.
+		.refine(
+			(params) =>
+				GENERATABLE_UPDATE_FIELDS.some((key) => params[key] !== undefined),
+			{
+				message:
+					"At least one update parameter must be provided (feature_quantities, license_quantities, version, customize, cancel_action, billing_cycle_anchor, refund_last_payment, no_billing_changes or discounts)",
+			},
+		);
 
 export const createScheduleGenerationSchema = z
 	.strictObject({

--- a/server/tests/integration/billing/generateRequest/entities/generate-entity-scope-isolation.test.ts
+++ b/server/tests/integration/billing/generateRequest/entities/generate-entity-scope-isolation.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Contract: a generated request anchored to ONE entity must not disturb the
+ * customer's other entities or their schedules.
+ *
+ * The generation context carries every current plan with its entity_id, and
+ * update_subscription pins the anchor from customer_product_id — so a request
+ * that reaches a sibling entity is a scoping failure, not a model preference.
+ *
+ * Cases:
+ *   1. update anchored to entity 1 -> entity 2's plan, balance and status all
+ *      unchanged
+ *   2. an entity holds a scoped add-on the schedule never names; a generated
+ *      customer-level schedule must leave that entity plan in place
+ *
+ * Note: createSchedule deliberately replaces ALL of a customer's schedule rows
+ * (persistCreateSchedule: "a customer holds one schedule"), so the invariant a
+ * generated schedule owes is about the entity's PLANS, not its schedule row.
+ *
+ * Requires ANTHROPIC_API_KEY on the server under test.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV5,
+	ApiEntityV2,
+	CreateScheduleParamsV0Input,
+	UpdateSubscriptionV0Params,
+} from "@autumn/shared";
+import { CusProductStatus, ms } from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService.js";
+
+const GENERATE_PATH = "/agent.generate_billing_request";
+const LLM_TEST_TIMEOUT = 180_000;
+
+const MESSAGES_GRANT = 100;
+const RAISED_MESSAGES_GRANT = 400;
+const ADD_ON_WORDS = 25;
+
+test.concurrent(
+	`${chalk.yellowBright("generate entities: an anchored update leaves the sibling entity untouched")}`,
+	async () => {
+		const customerId = "gen-entity-anchor";
+		const plan = products.pro({
+			id: `${customerId}-plan`,
+			items: [items.monthlyMessages({ includedUsage: MESSAGES_GRANT })],
+		});
+
+		const { autumnV1, autumnV2_2, ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.billing.attach({ productId: plan.id, entityIndex: 0 }),
+				s.billing.attach({ productId: plan.id, entityIndex: 1 }),
+			],
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+		});
+		const customerProductFor = (entityId: string) => {
+			const match = fullCustomer.customer_products.find(
+				(customerProduct) => customerProduct.entity_id === entityId,
+			);
+			if (!match) throw new Error(`No customer product for entity ${entityId}`);
+			return match;
+		};
+		const anchored = customerProductFor(entities[0]!.id);
+		const sibling = customerProductFor(entities[1]!.id);
+
+		const generated = (await autumnV2_2.post(GENERATE_PATH, {
+			customer_id: customerId,
+			customer_product_id: anchored.id,
+			prompt: `Raise their included messages to ${RAISED_MESSAGES_GRANT}.`,
+			tool: "update_subscription",
+		})) as { request: Record<string, unknown>; unrepresentable: string[] };
+
+		// ── The generated request stays pinned to the anchored product ──────
+		expect(generated.request.customer_product_id).toBe(anchored.id);
+		expect(generated.request.customer_id).toBe(customerId);
+
+		await autumnV1.subscriptions.update<UpdateSubscriptionV0Params>({
+			...(generated.request as UpdateSubscriptionV0Params),
+			entity_id: entities[0]!.id,
+		});
+
+		// ── The anchored entity got the change ─────────────────────────────
+		const anchoredEntity = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entities[0]!.id,
+			{ skip_cache: "true" },
+		);
+		expectBalanceCorrect({
+			customer: anchoredEntity,
+			featureId: TestFeature.Messages,
+			granted: RAISED_MESSAGES_GRANT,
+			remaining: RAISED_MESSAGES_GRANT,
+			usage: 0,
+		});
+
+		// ── The sibling entity is byte-for-byte where it was ───────────────
+		const siblingEntity = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entities[1]!.id,
+			{ skip_cache: "true" },
+		);
+		expectBalanceCorrect({
+			customer: siblingEntity,
+			featureId: TestFeature.Messages,
+			granted: MESSAGES_GRANT,
+			remaining: MESSAGES_GRANT,
+			usage: 0,
+		});
+
+		const fullCustomerAfter = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+		});
+		const siblingAfter = fullCustomerAfter.customer_products.find(
+			(customerProduct) => customerProduct.id === sibling.id,
+		);
+		expect(siblingAfter?.status).toBe(sibling.status);
+		expect(siblingAfter?.internal_entity_id).toBe(sibling.internal_entity_id);
+	},
+	LLM_TEST_TIMEOUT,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("generate entities: a generated customer schedule preserves the entity's scoped add-on")}`,
+	async () => {
+		const customerId = "gen-entity-schedules";
+		const pro = products.pro({
+			id: `${customerId}-pro`,
+			items: [items.monthlyMessages({ includedUsage: MESSAGES_GRANT })],
+		});
+		const premium = products.premium({
+			id: `${customerId}-premium`,
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const addOn = products.recurringAddOn({
+			id: `${customerId}-addon`,
+			items: [items.monthlyWords({ includedUsage: ADD_ON_WORDS })],
+		});
+
+		const { autumnV1, autumnV2_2, ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [pro, premium, addOn] }),
+			],
+			actions: [],
+		});
+
+		const entityId = entities[0]!.id;
+		const now = Date.now();
+
+		// The entity holds a scoped add-on that no schedule phase ever names.
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			entity_id: entityId,
+			plan_id: addOn.id,
+		});
+
+		await autumnV1.billing.createSchedule<CreateScheduleParamsV0Input>({
+			customer_id: customerId,
+			phases: [
+				{ starts_at: now, plans: [{ plan_id: pro.id }] },
+				{ starts_at: now + ms.days(30), plans: [{ plan_id: pro.id }] },
+			],
+		});
+
+		const generated = (await autumnV2_2.post(GENERATE_PATH, {
+			customer_id: customerId,
+			prompt: `Keep them on the ${pro.id} plan now, then move them to the ${premium.id} plan in 30 days. Do not touch anything scoped to an entity.`,
+			tool: "create_schedule",
+		})) as { request: Record<string, unknown>; unrepresentable: string[] };
+
+		// ── The generated schedule is customer-scoped and never names the add-on
+		expect(generated.request.entity_id).toBeUndefined();
+		const generatedPhases = generated.request.phases as {
+			plans: { plan_id: string; entity_id?: string | null }[];
+		}[];
+		expect(generatedPhases.length).toBeGreaterThan(1);
+		expect(
+			generatedPhases
+				.flatMap(({ plans }) => plans)
+				.map(({ plan_id }) => plan_id),
+		).not.toContain(addOn.id);
+
+		await autumnV1.billing.createSchedule<CreateScheduleParamsV0Input>(
+			generated.request as CreateScheduleParamsV0Input,
+		);
+
+		// ── The entity's add-on and its balance survived ───────────────────
+		const entity = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entityId,
+			{ skip_cache: "true" },
+		);
+		expectBalanceCorrect({
+			customer: entity,
+			featureId: TestFeature.Words,
+			granted: ADD_ON_WORDS,
+			remaining: ADD_ON_WORDS,
+			usage: 0,
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+		});
+		const entityAddOn = fullCustomer.customer_products.find(
+			(customerProduct) =>
+				customerProduct.product.id === addOn.id &&
+				customerProduct.entity_id === entityId,
+		);
+		expect(entityAddOn?.status).toBe(CusProductStatus.Active);
+
+		// ── The customer-level schedule the prompt asked for exists ────────
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(
+			customer.subscriptions.some(
+				(subscription) => subscription.plan_id === pro.id,
+			),
+		).toBe(true);
+	},
+	LLM_TEST_TIMEOUT,
+);

--- a/server/tests/integration/billing/generateRequest/pooled/generate-pooled-balance-state.test.ts
+++ b/server/tests/integration/billing/generateRequest/pooled/generate-pooled-balance-state.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Contract: a generated update_subscription against a customer who already
+ * holds a POOLED balance must survive execution without corrupting the pool.
+ *
+ * The generation context is built from `toCreatePlanItemParams`, so what the
+ * model can see of an existing item is exactly what it can copy back into a
+ * remove_items + add_items pair. Anything the context drops is a setting the
+ * generated request silently deletes.
+ *
+ * Cases:
+ *   1. unrelated edit  -> same pool row, same contribution row, granted and
+ *      usage untouched
+ *   2. grant raise     -> ONE pool (identity preserved: pooled + rollover
+ *      copied through), granted moves by the delta, usage preserved
+ *   3. dimensioned pool-> a dimensioned track after the generated edit still
+ *      deducts at the override rate, i.e. feature_override survived
+ *
+ * Requires ANTHROPIC_API_KEY on the server under test: each case makes a real
+ * model call through /agent.generate_billing_request.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV3,
+	ApiCustomerV5,
+	FeatureConfigOverride,
+	UpdateSubscriptionV0Params,
+} from "@autumn/shared";
+import {
+	EntInterval,
+	PooledBalanceResetMode,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
+import { expectPooledBalanceCorrect } from "@tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.js";
+import {
+	getPooledBalanceDbState,
+	getPooledSourceCustomerProduct,
+} from "@tests/integration/billing/pooled-balances/utils/getPooledBalanceDbState.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const GENERATE_PATH = "/agent.generate_billing_request";
+const LLM_TEST_TIMEOUT = 180_000;
+
+const INITIAL_GRANT = 10_000;
+const RAISED_GRANT = 12_000;
+const WORDS_GRANT = 25;
+const RAISED_WORDS_GRANT = 75;
+const USAGE = 400;
+/** An items-style update expires the source product and inserts its successor,
+ * so the expired row's pooled entitlement lingers beside the live one. */
+const EXPIRED_PLUS_LIVE_SOURCES = 2;
+
+const ROLLOVER = {
+	max: 5_000,
+	length: 1,
+	duration: RolloverExpiryDurationType.Month,
+};
+
+const MONTHLY_POOL_LIFECYCLE = {
+	interval: EntInterval.Month,
+	nextResetAt: "present",
+	resetCycleAnchor: "present",
+	resetMode: PooledBalanceResetMode.Subscription,
+	stripeSubscriptionId: "stripe_subscription",
+} as const;
+
+/** Pooled credits with a rollover cap, plus an unrelated private words item. */
+const pooledPlan = ({
+	id,
+	featureOverride,
+}: {
+	id: string;
+	featureOverride?: FeatureConfigOverride;
+}) => {
+	const creditsItem = items.monthlyCredits({
+		includedUsage: INITIAL_GRANT,
+		rolloverConfig: ROLLOVER,
+	});
+	return products.pro({
+		id,
+		items: [
+			{
+				...creditsItem,
+				pooled: true,
+				config: {
+					...creditsItem.config,
+					...(featureOverride ? { feature_override: featureOverride } : {}),
+				},
+			},
+			items.monthlyWords({ includedUsage: WORDS_GRANT }),
+		],
+	});
+};
+
+const setupPooledGenerationScenario = async ({
+	customerId,
+	featureOverride,
+	trackFeatureId = TestFeature.Credits,
+	trackValue = USAGE,
+	trackProperties,
+}: {
+	customerId: string;
+	featureOverride?: FeatureConfigOverride;
+	trackFeatureId?: string;
+	trackValue?: number;
+	trackProperties?: Record<string, string>;
+}) => {
+	const plan = pooledPlan({ id: `${customerId}-plan`, featureOverride });
+	const scenario = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+			s.products({ list: [plan] }),
+		],
+		actions: [
+			s.billing.attach({ productId: plan.id, entityIndex: 0 }),
+			s.track({
+				featureId: trackFeatureId,
+				value: trackValue,
+				entityIndex: 1,
+				...(trackProperties ? { properties: trackProperties } : {}),
+				timeout: 3_000,
+			}),
+		],
+	});
+
+	const state = await getPooledBalanceDbState({
+		db: scenario.ctx.db,
+		customerId,
+	});
+	const sourceCustomerProduct = getPooledSourceCustomerProduct({
+		state,
+		productId: plan.id,
+		entityId: scenario.entities[0]!.id,
+	});
+	const [poolBefore] = state.pools;
+	const [contributionBefore] = state.contributions;
+	expect(poolBefore).toBeDefined();
+	expect(contributionBefore).toBeDefined();
+
+	return {
+		...scenario,
+		plan,
+		poolBefore: poolBefore!,
+		contributionBefore: contributionBefore!,
+		sourceCustomerProduct,
+	};
+};
+
+type Scenario = Awaited<ReturnType<typeof setupPooledGenerationScenario>>;
+
+/** Generates against the entity-scoped source product, then executes the
+ * generated V0 request through the same update endpoint the sheet posts to. */
+const generateAndApply = async ({
+	scenario,
+	prompt,
+}: {
+	scenario: Scenario;
+	prompt: string;
+}) => {
+	const generated = (await scenario.autumnV2_2.post(GENERATE_PATH, {
+		customer_id: scenario.customerId,
+		customer_product_id: scenario.sourceCustomerProduct.id,
+		prompt,
+		tool: "update_subscription",
+	})) as { request: Record<string, unknown>; unrepresentable: string[] };
+
+	expect(generated.unrepresentable).toEqual([]);
+	expect(generated.request.customer_product_id).toBe(
+		scenario.sourceCustomerProduct.id,
+	);
+
+	await scenario.autumnV1.subscriptions.update<UpdateSubscriptionV0Params>({
+		...(generated.request as UpdateSubscriptionV0Params),
+		entity_id: scenario.entities[0]!.id,
+	});
+
+	return generated;
+};
+
+const creditsItemFrom = (generated: { request: Record<string, unknown> }) => {
+	const generatedItems = generated.request.items as
+		| {
+				feature_id?: string;
+				included_usage?: number;
+				pooled?: boolean;
+				config?: Record<string, unknown>;
+		  }[]
+		| undefined;
+	expect(Array.isArray(generatedItems)).toBe(true);
+	return generatedItems?.find(
+		(item) => item.feature_id === TestFeature.Credits,
+	);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("generate pooled: an unrelated edit leaves the pool row untouched")}`,
+	async () => {
+		const customerId = "gen-pooled-unrelated";
+		const scenario = await setupPooledGenerationScenario({ customerId });
+
+		await generateAndApply({
+			scenario,
+			prompt: `Give them ${RAISED_WORDS_GRANT} included words instead of ${WORDS_GRANT}. Leave everything else exactly as it is.`,
+		});
+
+		// ── Pool identity, grant and usage all survive the unrelated edit ──
+		const state = await expectPooledBalanceCorrect({
+			db: scenario.ctx.db,
+			customerId,
+			pool: {
+				balance: INITIAL_GRANT - USAGE,
+				adjustment: 0,
+				granted: INITIAL_GRANT,
+				...MONTHLY_POOL_LIFECYCLE,
+			},
+			contributions: {
+				count: 1,
+				currentContribution: INITIAL_GRANT,
+				nextCycleContribution: INITIAL_GRANT,
+			},
+			sources: { count: EXPIRED_PLUS_LIVE_SOURCES, balance: 0, adjustment: 0 },
+		});
+		// The pool row itself must survive; its contribution is re-pointed at
+		// the successor product, so only the pool id is stable across the edit.
+		expect(state.pools[0]?.id).toBe(scenario.poolBefore.id);
+		expect(state.contributions[0]?.pooled_balance_id).toBe(
+			scenario.poolBefore.id,
+		);
+
+		// ── The requested change did land ──────────────────────────────────
+		const customer = await scenario.autumnV1.customers.get<ApiCustomerV3>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		expect(customer.features[TestFeature.Words]?.included_usage).toBe(
+			RAISED_WORDS_GRANT,
+		);
+	},
+	LLM_TEST_TIMEOUT,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("generate pooled: a grant raise keeps one pool and preserves usage")}`,
+	async () => {
+		const customerId = "gen-pooled-raise";
+		const scenario = await setupPooledGenerationScenario({ customerId });
+
+		const generated = await generateAndApply({
+			scenario,
+			prompt: `Raise their included credits to ${RAISED_GRANT}.`,
+		});
+
+		// ── The generated item still declares the pooled identity fields ───
+		const creditsItem = creditsItemFrom(generated);
+		expect(creditsItem?.included_usage).toBe(RAISED_GRANT);
+		expect(creditsItem?.pooled).toBe(true);
+		expect(creditsItem?.config?.rollover).toMatchObject({ max: ROLLOVER.max });
+
+		// ── Exactly ONE live pool: identity held, delta applied, usage kept ─
+		const state = await expectPooledBalanceCorrect({
+			db: scenario.ctx.db,
+			customerId,
+			pool: {
+				balance: RAISED_GRANT - USAGE,
+				adjustment: 0,
+				granted: RAISED_GRANT,
+				...MONTHLY_POOL_LIFECYCLE,
+			},
+			contributions: {
+				count: 1,
+				currentContribution: RAISED_GRANT,
+				nextCycleContribution: RAISED_GRANT,
+			},
+			sources: { count: EXPIRED_PLUS_LIVE_SOURCES, balance: 0, adjustment: 0 },
+		});
+		expect(state.pools[0]?.id).toBe(scenario.poolBefore.id);
+	},
+	LLM_TEST_TIMEOUT,
+);
+
+const DIMENSIONED_CREDITS: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				large: { match: { size: "large" }, credit_amount: 16 },
+			},
+		},
+	],
+};
+
+test.concurrent(
+	`${chalk.yellowBright("generate pooled: a grant raise preserves the dimension credit schema")}`,
+	async () => {
+		const customerId = "gen-pooled-dimensions";
+		const scenario = await setupPooledGenerationScenario({
+			customerId,
+			featureOverride: DIMENSIONED_CREDITS,
+			trackFeatureId: TestFeature.Action1,
+			trackValue: 25,
+			trackProperties: { size: "large" },
+		});
+
+		// 25 large actions x 16 credits = 400 credits off the shared pool.
+		await expectPooledBalanceCorrect({
+			db: scenario.ctx.db,
+			customerId,
+			pool: {
+				balance: INITIAL_GRANT - USAGE,
+				adjustment: 0,
+				granted: INITIAL_GRANT,
+				...MONTHLY_POOL_LIFECYCLE,
+			},
+			contributions: { count: 1, currentContribution: INITIAL_GRANT },
+			sources: { count: 1 },
+		});
+
+		await generateAndApply({
+			scenario,
+			prompt: `Raise their included credits to ${RAISED_GRANT}.`,
+		});
+		// ── The dimension rate survived the remove+add ─────────────────────
+		// Without feature_override the same track deducts 10 credits, not 160.
+		// The update rewrites the entitlement, so read through the cache once
+		// before tracking — a stale FullSubject would price at the old rate.
+		await scenario.autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		await scenario.autumnV1.track(
+			{
+				customer_id: customerId,
+				entity_id: scenario.entities[1]!.id,
+				feature_id: TestFeature.Action1,
+				value: 10,
+				properties: { size: "large" },
+			},
+			{ skipCache: true, timeout: 4_000 },
+		);
+
+		await expectPooledBalanceCorrect({
+			db: scenario.ctx.db,
+			customerId,
+			pool: {
+				balance: RAISED_GRANT - USAGE - 160,
+				adjustment: 0,
+				granted: RAISED_GRANT,
+				...MONTHLY_POOL_LIFECYCLE,
+			},
+			contributions: { count: 1, currentContribution: RAISED_GRANT },
+			sources: { count: EXPIRED_PLUS_LIVE_SOURCES },
+		});
+	},
+	LLM_TEST_TIMEOUT,
+);

--- a/server/tests/integration/billing/update-subscription/custom-plan-patch/update-customize-feature-override.test.ts
+++ b/server/tests/integration/billing/update-subscription/custom-plan-patch/update-customize-feature-override.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Contract: a customize patch that restates a credits item WITH its
+ * feature_override must keep the override's dimension rates live.
+ *
+ * Red (current): after the patch, a dimensioned track prices at the flat
+ * credit_amount (1) instead of the matched dimension rate (16) — the update
+ * path keeps the schema but loses the dimension rules.
+ * Green (after fix): the same track deducts 160, as it does pre-update.
+ *
+ * Attach-side coverage of the same field lives in
+ * attach/custom-plan-patch/attach-customize-feature-override.test.ts, which
+ * passes — so this is specific to the update path.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV3,
+	FeatureConfigOverride,
+	UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const GRANT = 10_000;
+const RAISED_GRANT = 12_000;
+
+const dimensioned: FeatureConfigOverride = {
+	schema: [
+		{
+			metered_feature_id: TestFeature.Action1,
+			credit_amount: 1,
+			dimensions: {
+				large: { match: { size: "large" }, credit_amount: 16 },
+			},
+		},
+	],
+} as unknown as FeatureConfigOverride;
+
+test(
+	`${chalk.yellowBright("update customize feature-override: dimension rate survives the patch")}`,
+	async () => {
+		const customerId = "probe-update-dimension";
+		const creditsItem = items.monthlyCredits({ includedUsage: GRANT });
+		const plan = products.pro({
+			id: `${customerId}-plan`,
+			items: [
+				{
+					...creditsItem,
+					pooled: true,
+					config: { ...creditsItem.config, feature_override: dimensioned },
+				},
+			],
+		});
+
+		const { autumnV1, autumnV2_3, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id, entityIndex: 0 })],
+		});
+
+		// Baseline: 2 large actions x 16 = 32 credits off the pool.
+		await autumnV1.track(
+			{
+				customer_id: customerId,
+				entity_id: entities[1]!.id,
+				feature_id: TestFeature.Action1,
+				value: 2,
+				properties: { size: "large" },
+			},
+			{ timeout: 4_000 },
+		);
+		const before = await autumnV1.customers.get<ApiCustomerV3>(customerId, {
+			skip_cache: "true",
+		});
+		expect(before.features[TestFeature.Credits]?.balance).toBe(GRANT - 32);
+
+		// A hand-written customize that restates the item WITH its override.
+		await autumnV2_3.billing.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			entity_id: entities[0]!.id,
+			plan_id: plan.id,
+			customize: {
+				remove_items: [{ feature_id: TestFeature.Credits }],
+				add_items: [
+					{
+						feature_id: TestFeature.Credits,
+						included: RAISED_GRANT,
+						pooled: true,
+						reset: { interval: ResetInterval.Month },
+						feature_override: {
+							credit_schema: [
+								{
+									metered_feature_id: TestFeature.Action1,
+									credit_cost: 1,
+									dimensions: {
+										large: { match: { size: "large" }, credit_cost: 16 },
+									},
+								},
+							],
+						},
+					},
+				],
+			},
+		});
+
+		// 10 large actions x 16 = 160 if the dimension survived; 10 if not.
+		await autumnV1.track(
+			{
+				customer_id: customerId,
+				entity_id: entities[1]!.id,
+				feature_id: TestFeature.Action1,
+				value: 10,
+				properties: { size: "large" },
+			},
+			{ skipCache: true, timeout: 4_000 },
+		);
+		const after = await autumnV1.customers.get<ApiCustomerV3>(customerId, {
+			skip_cache: "true",
+		});
+		expect(after.features[TestFeature.Credits]?.balance).toBe(
+			RAISED_GRANT - 32 - 160,
+		);
+	},
+	{ timeout: 120_000 },
+);

--- a/server/tests/unit/billing/generationContextItems.test.ts
+++ b/server/tests/unit/billing/generationContextItems.test.ts
@@ -1,0 +1,138 @@
+/**
+ * The generation context is what the model can copy back into an add_items
+ * entry. A field the context drops is a setting the generated request deletes,
+ * so every identity-bearing field of a plan item must survive compaction.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ApiPlanItemV1 } from "@autumn/shared";
+import {
+	BillingInterval,
+	BillingMethod,
+	itemsEqual,
+	ResetInterval,
+	RolloverExpiryDurationType,
+	toCreatePlanItemParams,
+} from "@autumn/shared";
+
+const dimensionedCreditsItem = {
+	feature_id: "credits",
+	included: 10_000,
+	pooled: true,
+	reset: { interval: ResetInterval.Month },
+	rollover: {
+		expiry_duration_type: RolloverExpiryDurationType.Month,
+		expiry_duration_length: 1,
+		max: 5_000,
+		max_percentage: null,
+	},
+	feature_override: {
+		credit_schema: [
+			{
+				metered_feature_id: "action1",
+				credit_cost: 1,
+				dimensions: {
+					large: { match: { size: "large" }, credit_amount: 16 },
+				},
+			},
+		],
+	},
+} as unknown as ApiPlanItemV1;
+
+describe("toCreatePlanItemParams", () => {
+	test("carries the pooled, rollover and reset identity fields", () => {
+		const params = toCreatePlanItemParams(dimensionedCreditsItem);
+
+		expect(params.pooled).toBe(true);
+		expect(params.included).toBe(10_000);
+		expect(params.reset).toEqual({ interval: ResetInterval.Month });
+		expect(params.rollover).toMatchObject({ max: 5_000 });
+	});
+
+	test("carries feature_override so a credit schema survives a remove+add", () => {
+		const params = toCreatePlanItemParams(dimensionedCreditsItem);
+
+		expect(params.feature_override).toEqual(
+			dimensionedCreditsItem.feature_override,
+		);
+	});
+
+	test("omits feature_override when the item has none", () => {
+		const params = toCreatePlanItemParams({
+			feature_id: "messages",
+			included: 100,
+			reset: { interval: ResetInterval.Month },
+		} as unknown as ApiPlanItemV1);
+
+		expect("feature_override" in params).toBe(false);
+	});
+
+	test("carries a priced item's price through unchanged", () => {
+		const params = toCreatePlanItemParams({
+			feature_id: "credits",
+			included: 0,
+			price: {
+				amount: 0.01,
+				billing_method: BillingMethod.UsageBased,
+				billing_units: 1,
+				interval: BillingInterval.Month,
+			},
+		} as unknown as ApiPlanItemV1);
+
+		expect(params.price).toMatchObject({ amount: 0.01 });
+	});
+});
+
+describe("itemsEqual feature_override", () => {
+	const item = (override?: Record<string, unknown>) =>
+		({
+			feature_id: "credits",
+			included: 100,
+			reset: { interval: ResetInterval.Month },
+			...(override ? { feature_override: override } : {}),
+		}) as unknown as ApiPlanItemV1;
+
+	const dimensioned = {
+		credit_schema: [
+			{
+				metered_feature_id: "action1",
+				credit_cost: 1,
+				dimensions: { large: { match: { size: "large" }, credit_cost: 16 } },
+			},
+		],
+	};
+
+	test("an override-only change makes two items differ", () => {
+		expect(itemsEqual(item(dimensioned), item())).toBe(false);
+	});
+
+	test("a changed dimension rate makes two items differ", () => {
+		const cheaper = {
+			credit_schema: [
+				{
+					metered_feature_id: "action1",
+					credit_cost: 1,
+					dimensions: { large: { match: { size: "large" }, credit_cost: 8 } },
+				},
+			],
+		};
+		expect(itemsEqual(item(dimensioned), item(cheaper))).toBe(false);
+	});
+
+	test("the same override compares equal regardless of key order", () => {
+		const reordered = {
+			credit_schema: [
+				{
+					dimensions: { large: { credit_cost: 16, match: { size: "large" } } },
+					credit_cost: 1,
+					metered_feature_id: "action1",
+				},
+			],
+		};
+		expect(itemsEqual(item(dimensioned), item(reordered))).toBe(true);
+	});
+
+	test("two items with no override are still equal", () => {
+		expect(itemsEqual(item(), item())).toBe(true);
+	});
+});

--- a/server/tests/unit/billing/generationSchemas.test.ts
+++ b/server/tests/unit/billing/generationSchemas.test.ts
@@ -226,3 +226,30 @@ describe("toGenerationOutputSchema salvage", () => {
 		expect(stats.salvaged).toBe(false);
 	});
 });
+
+describe("updateSubscriptionGenerationSchema non-empty guard", () => {
+	test("rejects an update with no update parameter", () => {
+		const parsed = updateSubscriptionGenerationSchema.safeParse({});
+		expect(parsed.success).toBe(false);
+	});
+
+	test("rejects an update carrying only a plan_id target", () => {
+		const parsed = updateSubscriptionGenerationSchema.safeParse({
+			plan_id: "pro",
+		});
+		expect(parsed.success).toBe(false);
+	});
+
+	test("accepts each generatable update field on its own", () => {
+		for (const params of [
+			{ cancel_action: "uncancel" },
+			{ version: 3 },
+			{ feature_quantities: [{ feature_id: "messages", quantity: 10 }] },
+			{ customize: { price: { amount: 50, interval: "month" } } },
+			{ billing_cycle_anchor: "now" },
+		]) {
+			const parsed = updateSubscriptionGenerationSchema.safeParse(params);
+			expect(parsed.success).toBe(true);
+		}
+	});
+});

--- a/shared/utils/planV1Utils/diff/comparePlanItems.ts
+++ b/shared/utils/planV1Utils/diff/comparePlanItems.ts
@@ -5,6 +5,7 @@ import { TierBehavior } from "@models/productModels/priceModels/priceConfig/usag
 
 type ApiPlanItem = ApiPlanV1["items"][number];
 export type PlanItemInput = ApiPlanItem | CreatePlanItemParamsV1;
+type PlanItemFeatureOverride = PlanItemInput["feature_override"];
 type PlanItemPrice = NonNullable<PlanItemInput["price"]>;
 type PlanItemRollover = NonNullable<PlanItemInput["rollover"]>;
 type PlanItemProration = NonNullable<PlanItemInput["proration"]>;
@@ -38,6 +39,19 @@ export const additionalCurrenciesCompatible = (
 				(entry.flat_amount ?? null) === (match.flat_amount ?? null))
 		);
 	});
+
+/** Key-order-independent, so two overrides built by different mappers compare
+ * equal on content rather than on construction order. */
+const stableStringify = (value: unknown): string => {
+	if (value === null || typeof value !== "object") return JSON.stringify(value);
+	if (Array.isArray(value)) {
+		return `[${value.map(stableStringify).join(",")}]`;
+	}
+	const entries = Object.entries(value)
+		.filter(([, entry]) => entry !== undefined)
+		.sort(([left], [right]) => left.localeCompare(right));
+	return `{${entries.map(([key, entry]) => `${key}:${stableStringify(entry)}`).join(",")}}`;
+};
 
 /** Unset `interval_count` is 1 when an interval is set; meaningless otherwise. */
 export const normalizeIntervalCount = ({
@@ -143,11 +157,39 @@ const rolloversEqual = (
 	);
 };
 
+/** The db comparator in entsAreSame keys its rates as `credit_amount`; the api
+ * override compared here uses `credit_cost`, so the two cannot share one. */
+const creditSchemaEntriesEqual = (
+	a: NonNullable<NonNullable<PlanItemFeatureOverride>["credit_schema"]>[number],
+	b: NonNullable<NonNullable<PlanItemFeatureOverride>["credit_schema"]>[number],
+): boolean =>
+	a.metered_feature_id === b.metered_feature_id &&
+	stableStringify(a) === stableStringify(b);
+
+/** An override is identity-bearing: a change to it alone is a real item change
+ * and must reach add_items, so an unmatched entry means the items differ. */
+const featureOverridesEqual = (
+	a: PlanItemFeatureOverride,
+	b: PlanItemFeatureOverride,
+): boolean => {
+	if (a == null && b == null) return true;
+	if (a == null || b == null) return false;
+	return (
+		stableStringify(a.markups) === stableStringify(b.markups) &&
+		arraysEqual({
+			equals: creditSchemaEntriesEqual,
+			left: a.credit_schema,
+			right: b.credit_schema,
+		})
+	);
+};
+
 /** User-controlled item fields only. `included` 0 / `unlimited` false /
  * `pooled` false / `interval_count` 1 are the unset defaults. */
 export const itemsEqual = (a: PlanItemInput, b: PlanItemInput): boolean => {
 	return (
 		a.feature_id === b.feature_id &&
+		featureOverridesEqual(a.feature_override, b.feature_override) &&
 		(a.entity_feature_id ?? null) === (b.entity_feature_id ?? null) &&
 		(a.pooled ?? false) === (b.pooled ?? false) &&
 		(a.included ?? 0) === (b.included ?? 0) &&

--- a/shared/utils/planV1Utils/diff/diffPlanV1.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1.ts
@@ -5,8 +5,8 @@ import {
 	CustomizePlanV1BaseSchema,
 	refineCustomizePlanV1Schema,
 } from "@api/billing/common/customizePlan/customizePlanV1.js";
-import type { ApiPlanV1 } from "@api/products/apiPlanV1.js";
 import type { ApiPlanLicenseV1 } from "@api/products/apiPlanLicenseV1.js";
+import type { ApiPlanV1 } from "@api/products/apiPlanV1.js";
 import type { BasePriceParams } from "@api/products/components/basePrice/basePrice.js";
 import type { CreatePlanItemParamsV1 } from "@api/products/items/crud/createPlanItemParamsV1.js";
 import type { PlanItemFilter } from "@api/products/items/filter/planItemFilter.js";
@@ -133,6 +133,9 @@ export const toCreatePlanItemParams = (
 			on_decrease: item.proration.on_decrease,
 		};
 	}
+	// Carries the item's credit schema and dimension rates; dropping it turns a
+	// remove+add that means to change one field into one that deletes pricing.
+	if (item.feature_override) out.feature_override = item.feature_override;
 	return out;
 };
 
@@ -264,8 +267,7 @@ export const customizePlanV1DiffsEqual = ({
 		arraysEqual({
 			left: a.upsert_licenses,
 			right: b.upsert_licenses,
-			equals: (left, right) =>
-				customizePlanLicensesAreSame({ left, right }),
+			equals: (left, right) => customizePlanLicensesAreSame({ left, right }),
 		}) &&
 		arraysEqual({
 			left: a.remove_licenses,


### PR DESCRIPTION
## What

`billing.generate` builds the model's view of a plan by compacting every item
through `toCreatePlanItemParams`. What that mapper emits is exactly what the
model can copy back into a `remove_items` + `add_items` pair, so a field it
drops is a setting the generated request silently deletes.

It dropped `feature_override` — where a credit system's schema and dimension
rates live. `itemsEqual` then ignored the same field, so a diff that changed
only an override produced no `add_items` at all. Together they turned an
override change into either a deletion or a no-op.

Three changes:

- `toCreatePlanItemParams` carries `feature_override`.
- `itemsEqual` compares it, via a small key-order-independent comparator. The
  existing `featureOverridesAreSame` takes the db shape (`schema`,
  `credit_amount`); this diff compares the api shape (`credit_schema`,
  `credit_cost`), so the two cannot share one.
- The update generation schema mirrors the resolve-stage "at least one update
  parameter" refine. Without it an empty generated update passed generation and
  failed later as a 400 the caller sees, instead of failing where the repair
  retry could still recover it. This was the most frequent failure in my runs,
  9 occurrences.

The mapper is shared by catalog edit diffs, variant creation and license
customize, so those paths were losing the override too.

## Tests

New coverage for `billing.generate` against a customer who already holds
complex state, executing the generated request and asserting nothing else
moved:

- **Pooled** — an unrelated edit leaves the pool row and contribution alone; a
  grant raise keeps ONE pool rather than splitting it on a changed identity,
  and preserves accrued usage.
- **Entities** — an update anchored to one entity leaves the sibling entity's
  plan, balance and status untouched; a generated customer-level schedule
  leaves an entity's scoped add-on in place.

Two behaviours worth knowing, both verified rather than assumed:

- An items-style update expires the customer product and inserts a successor,
  so two pooled source rows and a fresh contribution row are correct, not
  corruption.
- `createSchedule` replaces every schedule row a customer has, entity-scoped
  ones included, by design. So the invariant a generated schedule owes is about
  the entity's *plans*, not its schedule row.

## One test is deliberately red

`update-customize-feature-override.test.ts` documents a separate defect that is
**not** in `billing.generate`. A hand-written customize patch passing a
dimensioned override explicitly still loses the dimension rules — the schema
survives, the dimensions do not:

| dimensioned track, 10 large actions | credits deducted |
| --- | --- |
| before the update (attach path) | 160, correct |
| after the update patch | 10, flat rate |

The attach-side equivalent passes, so this is specific to the update path. The
fix belongs there, not in this PR.

## Verification

- 1940 unit tests across 214 files pass.
- Regression sweep of 39 integration files across `billing/pooled-balances` and
  `catalog-v2/plans/create`, zero failures — these are the suites most exposed
  to a change in `itemsEqual`, which every plan diff runs through.
- `generateRequest` folder: 3 files green, 1 red on the update-path bug above.

**Before merging**, note that the generate tests make real model calls and
output varies between runs — I saw a schedule case pass only on retry. Worth
deciding whether they belong in CI as-is or behind a tag.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `billing.generate` silently dropping `feature_override` when compacting plan items, so credit schemas and dimension rates now survive generated plan edits instead of being deleted or ignored.

- `toCreatePlanItemParams` now carries `feature_override`, and `itemsEqual` compares it with a key-order-independent comparator.
- The update generation schema now rejects empty updates at generation time, where the repair retry can recover, instead of failing later as a caller-visible 400.
- Adds integration coverage for pooled balances and entity scoping, plus a deliberately failing test documenting a separate update-path defect where dimension rates are lost on hand-written customize patches.

**Migration**

- The generate tests make real model calls and output varies between runs; decide before merging whether they belong in CI as-is or behind a tag.

<sup>Written for commit 3e56968716d60329bb36d5e63df87b6df588c701. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves credit-system overrides while generating and comparing plan-item diffs and rejects generated subscription updates that contain no actual update operation.

### Key changes
- **[Bug fixes]** Carries `feature_override` into generated plan-item parameters so credit schemas and dimension rates survive remove-and-add updates.
- **[Bug fixes]** Treats override-only changes as plan-item changes using key-order-independent comparison.
- **[Improvements]** Rejects empty generated subscription updates early, allowing generation repair rather than returning a later client error.
- **[Improvements]** Adds pooled-balance, entity-isolation, and generation-schema coverage.
- **[Improvements]** Adds a known-failing, unskipped regression test for a separate update-path defect; this currently makes the full integration command report failure.
</details>


<h3>Confidence Score: 4/5</h3>

The production changes appear sound, but the pull request should not merge while it adds a known-failing active test to the full integration suite.

The new plan-item mapping, comparison, and generation guard align with their existing schemas and contracts; the remaining blocker is the unskipped regression test whose asserted behavior is explicitly not implemented yet.

**Files Needing Attention:** server/tests/integration/billing/update-subscription/custom-plan-patch/update-customize-feature-override.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/planV1Utils/diff/diffPlanV1.ts | Preserves feature overrides when converting existing items into create-item parameters. |
| shared/utils/planV1Utils/diff/comparePlanItems.ts | Adds content-based comparison for API-shaped feature overrides. |
| server/src/internal/billing/v2/actions/generateRequest/generationSchemas.ts | Rejects generated updates that do not contain a resolvable update parameter. |
| server/tests/integration/billing/update-subscription/custom-plan-patch/update-customize-feature-override.test.ts | Adds an active test for a known-unfixed defect, causing full integration runs to fail. |
| server/tests/unit/billing/generationContextItems.test.ts | Covers override preservation and comparison, including key-order independence. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Existing plan item] --> B[toCreatePlanItemParams]
  B --> C[Generation context]
  C --> D[Generated update request]
  D --> E[Plan-item diff]
  E --> F{itemsEqual}
  F -->|Override unchanged| G[No item replacement]
  F -->|Override changed| H[remove_items + add_items]
  H --> I[feature_override retained]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/tests/integration/billing/update-subscription/custom-plan-patch/update-customize-feature-override.test.ts:43
**Known-Failing Test Is Active**

This unskipped test covers behavior that the current update path does not implement: after an override update, 10 large actions deduct 10 credits instead of the expected 160. Running the full `bun run test:integration` command discovers this test and reports a failure. Skip or quarantine it until the separate update-path defect is fixed.

```suggestion
test.skip(
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add failing coverage for dimension rates..."](https://github.com/useautumn/autumn/commit/3e56968716d60329bb36d5e63df87b6df588c701) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61574662)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->