### PR TITLE
Move the auto top-up attempt limit into admin org limits

### DIFF
--- a/server/src/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs.ts
+++ b/server/src/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs.ts
@@ -1,4 +1,5 @@
-import type { AutoTopup, OrgConfig } from "@autumn/shared";
+import type { AutoTopup, Organization } from "@autumn/shared";
+import { getOrgAutoTopupAttemptLimit } from "@/internal/misc/edgeConfig/orgLimitsStore.js";
 
 export type AutoTopupWindowLimitConfig = {
 	limit: number;
@@ -21,17 +22,17 @@ export const DEFAULT_AUTO_TOPUP_FAILED_ATTEMPT_LIMIT: AutoTopupWindowLimitConfig
 
 export const getAutoTopupRateLimitConfigs = ({
 	autoTopupConfig,
-	orgConfig,
+	org,
 }: {
 	autoTopupConfig: AutoTopup;
-	orgConfig: OrgConfig;
+	org: Pick<Organization, "id" | "slug">;
 }) => {
 	return {
 		purchaseLimit: autoTopupConfig.purchase_limit,
 		attemptLimit: {
 			...DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT,
 			limit:
-				orgConfig.auto_topup_attempt_limit ??
+				getOrgAutoTopupAttemptLimit({ orgId: org.id, orgSlug: org.slug }) ??
 				DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT.limit,
 		},
 		failedAttemptLimit: DEFAULT_AUTO_TOPUP_FAILED_ATTEMPT_LIMIT,

--- a/server/src/internal/balances/autoTopUp/helpers/limits/preflightAutoTopupLimits.ts
+++ b/server/src/internal/balances/autoTopUp/helpers/limits/preflightAutoTopupLimits.ts
@@ -90,10 +90,7 @@ export const preflightAutoTopupLimits = async ({
 	}
 
 	const { purchaseLimit, attemptLimit, failedAttemptLimit } =
-		getAutoTopupRateLimitConfigs({
-			autoTopupConfig,
-			orgConfig: ctx.org.config,
-		});
+		getAutoTopupRateLimitConfigs({ autoTopupConfig, org: ctx.org });
 
 	const normalizedAttempt = normalizeWindowCounter({
 		now,

--- a/server/src/internal/balances/autoTopUp/helpers/limits/recordAutoTopupAttempt.ts
+++ b/server/src/internal/balances/autoTopUp/helpers/limits/recordAutoTopupAttempt.ts
@@ -37,10 +37,7 @@ export const recordAutoTopupAttempt = async ({
 	const outcome = succeeded ? "success" : "failure";
 
 	const { purchaseLimit, attemptLimit, failedAttemptLimit } =
-		getAutoTopupRateLimitConfigs({
-			autoTopupConfig,
-			orgConfig: ctx.org.config,
-		});
+		getAutoTopupRateLimitConfigs({ autoTopupConfig, org: ctx.org });
 
 	const normalizedAttempt = normalizeWindowCounter({
 		now,

--- a/server/src/internal/misc/edgeConfig/orgLimitsSchemas.ts
+++ b/server/src/internal/misc/edgeConfig/orgLimitsSchemas.ts
@@ -21,6 +21,7 @@ export const OrgLimitsConfigSchema = z.object({
 			z.object({
 				maxCusProducts: z.number().min(1).optional(),
 				maxEntities: z.number().min(1).optional(),
+				maxAutoTopupAttempts: z.number().int().min(1).optional(),
 				pagination: PaginationOverrideSchema,
 			}),
 		)

--- a/server/src/internal/misc/edgeConfig/orgLimitsStore.ts
+++ b/server/src/internal/misc/edgeConfig/orgLimitsStore.ts
@@ -56,6 +56,19 @@ export const getOrgEntitiesLimit = ({
 	return orgConfig?.maxEntities ?? DEFAULT_ENTITIES_LIMIT;
 };
 
+export const getOrgAutoTopupAttemptLimit = ({
+	orgId,
+	orgSlug,
+}: {
+	orgId?: string;
+	orgSlug?: string;
+}): number | undefined => {
+	const orgs = store.get().orgs;
+	const orgConfig =
+		(orgId ? orgs[orgId] : undefined) ?? (orgSlug ? orgs[orgSlug] : undefined);
+	return orgConfig?.maxAutoTopupAttempts;
+};
+
 const defaultMaxLimit = ({
 	type,
 	apiVersion,

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -18,6 +18,7 @@ import "./internal/misc/miscRedisConfig/miscRedisConfigStore.js";
 import "./internal/misc/cacheV2Ramp/cacheV2RampStore.js";
 import "./internal/misc/jobQueues/jobQueueStore.js";
 import "./internal/misc/batchReset/batchResetConfigStore.js";
+import "./internal/misc/edgeConfig/orgLimitsStore.js";
 
 // Number of worker processes (defaults to CPU cores)
 const NUM_PROCESSES = process.env.NODE_ENV === "development" ? 3 : 4;

--- a/server/tests/unit/balances/auto-topup/auto-topup-rate-limit-configs.test.ts
+++ b/server/tests/unit/balances/auto-topup/auto-topup-rate-limit-configs.test.ts
@@ -1,30 +1,38 @@
 import { describe, expect, test } from "bun:test";
-import { AutoTopupSchema, OrgConfigSchema } from "@autumn/shared";
+import { AutoTopupSchema } from "@autumn/shared";
 import {
 	DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT,
 	getAutoTopupRateLimitConfigs,
 } from "@/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs";
+import { _setOrgLimitsConfigForTesting } from "@/internal/misc/edgeConfig/orgLimitsStore";
 
 const autoTopupConfig = AutoTopupSchema.parse({
 	feature_id: "credits",
 	threshold: 10,
 	quantity: 100,
 });
+const org = { id: "org_limited", slug: "limited" };
 
 describe("getAutoTopupRateLimitConfigs", () => {
-	test("uses the default attempt limit when the org sets none", () => {
+	test("uses the default attempt limit when the org has no override", () => {
+		_setOrgLimitsConfigForTesting({ config: { orgs: {} } });
+
 		const { attemptLimit } = getAutoTopupRateLimitConfigs({
 			autoTopupConfig,
-			orgConfig: OrgConfigSchema.parse({}),
+			org,
 		});
 
 		expect(attemptLimit).toEqual(DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT);
 	});
 
-	test("uses the org attempt limit within the default window", () => {
+	test("uses the org limits override within the default window", () => {
+		_setOrgLimitsConfigForTesting({
+			config: { orgs: { [org.id]: { maxAutoTopupAttempts: 10 } } },
+		});
+
 		const { attemptLimit } = getAutoTopupRateLimitConfigs({
 			autoTopupConfig,
-			orgConfig: OrgConfigSchema.parse({ auto_topup_attempt_limit: 10 }),
+			org,
 		});
 
 		expect(attemptLimit).toEqual({

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -70,7 +70,6 @@ export const OrgConfigSchema = z.object({
 	disabled_auto_topup: z.boolean().default(false),
 	persist_free_overage: z.boolean().default(false),
 	dryrun_autotopups: z.boolean().default(false),
-	auto_topup_attempt_limit: z.number().int().min(1).nullish(),
 
 	forward_customer_metadata: z.boolean().default(false),
 

--- a/vite/src/views/admin/components/OrgLimitsConfigForm.tsx
+++ b/vite/src/views/admin/components/OrgLimitsConfigForm.tsx
@@ -7,6 +7,7 @@ import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import {
 	buildOrgLimitsJsonText,
+	DEFAULT_AUTO_TOPUP_ATTEMPTS,
 	DEFAULT_CUS_PRODUCT_LIMIT,
 	getEntryRows,
 	getStatusMessage,
@@ -14,6 +15,29 @@ import {
 	type OrgLimitsConfig,
 	type OrgLimitsEntry,
 } from "./orgLimitsConfigTypes";
+
+const parsePositiveInt = (value: string): number | undefined => {
+	const parsed = parseInt(value.trim(), 10);
+	return Number.isNaN(parsed) || parsed < 1 ? undefined : parsed;
+};
+
+const parseEntry = ({
+	limit,
+	attempts,
+}: {
+	limit: string;
+	attempts: string;
+}): OrgLimitsEntry | undefined => {
+	const maxCusProducts = parsePositiveInt(limit);
+	const maxAutoTopupAttempts = parsePositiveInt(attempts);
+	if (maxCusProducts === undefined && maxAutoTopupAttempts === undefined) {
+		return undefined;
+	}
+	return {
+		...(maxCusProducts !== undefined ? { maxCusProducts } : {}),
+		...(maxAutoTopupAttempts !== undefined ? { maxAutoTopupAttempts } : {}),
+	};
+};
 
 export const OrgLimitsConfigForm = ({
 	config: loadedConfig,
@@ -32,6 +56,7 @@ export const OrgLimitsConfigForm = ({
 	const [syncSource, setSyncSource] = useState<"form" | "json">("form");
 	const [newOrgId, setNewOrgId] = useState("");
 	const [newLimit, setNewLimit] = useState("");
+	const [newAttempts, setNewAttempts] = useState("");
 
 	const mutation = useMutation({
 		mutationFn: async (payload: unknown) => {
@@ -77,20 +102,18 @@ export const OrgLimitsConfigForm = ({
 
 	const addEntry = () => {
 		const orgId = newOrgId.trim();
-		const limit = parseInt(newLimit.trim(), 10);
+		const entry = parseEntry({ limit: newLimit, attempts: newAttempts });
 
-		if (!orgId || Number.isNaN(limit) || limit < 1) return;
+		if (!orgId || !entry) return;
 
 		setSyncSource("form");
 		setConfig((current) => ({
 			...current,
-			orgs: {
-				...current.orgs,
-				[orgId]: { maxCusProducts: limit },
-			},
+			orgs: { ...current.orgs, [orgId]: entry },
 		}));
 		setNewOrgId("");
 		setNewLimit("");
+		setNewAttempts("");
 	};
 
 	const removeEntry = ({ orgId }: { orgId: string }) => {
@@ -128,7 +151,9 @@ export const OrgLimitsConfigForm = ({
 							Org overrides
 						</div>
 						<div className="text-pretty text-xs text-tertiary-foreground">
-							Orgs without an override get {DEFAULT_CUS_PRODUCT_LIMIT}.
+							Orgs without an override get {DEFAULT_CUS_PRODUCT_LIMIT} customer
+							products and {DEFAULT_AUTO_TOPUP_ATTEMPTS} auto top-up attempts
+							per 10 minutes.
 						</div>
 					</div>
 
@@ -147,15 +172,21 @@ export const OrgLimitsConfigForm = ({
 								onChange={(event) => setNewLimit(event.target.value)}
 								className="tabular-nums"
 							/>
+							<Input
+								placeholder="Auto top-up attempts per 10 min (e.g. 10)"
+								type="number"
+								min={1}
+								value={newAttempts}
+								onChange={(event) => setNewAttempts(event.target.value)}
+								className="tabular-nums"
+							/>
 							<Button
 								variant="secondary"
 								size="sm"
 								onClick={addEntry}
 								disabled={
 									!newOrgId.trim() ||
-									!newLimit.trim() ||
-									Number.isNaN(parseInt(newLimit, 10)) ||
-									parseInt(newLimit, 10) < 1
+									!parseEntry({ limit: newLimit, attempts: newAttempts })
 								}
 							>
 								Add org limit
@@ -165,7 +196,7 @@ export const OrgLimitsConfigForm = ({
 						<div className="flex flex-col gap-2 border-t border-border pt-3">
 							{entryRows.length === 0 && (
 								<div className="text-pretty text-xs italic text-tertiary-foreground">
-									No overrides — every org uses {DEFAULT_CUS_PRODUCT_LIMIT}.
+									No overrides — every org uses the defaults.
 								</div>
 							)}
 							{entryRows.map((entry) => (
@@ -179,6 +210,10 @@ export const OrgLimitsConfigForm = ({
 										</div>
 										<div className="text-xs tabular-nums text-muted-foreground">
 											Max customer products: {entry.maxCusProducts}
+										</div>
+										<div className="text-xs tabular-nums text-muted-foreground">
+											Auto top-up attempts per 10 min:{" "}
+											{entry.maxAutoTopupAttempts}
 										</div>
 									</div>
 									<Button

--- a/vite/src/views/admin/components/OrgLimitsConfigForm.tsx
+++ b/vite/src/views/admin/components/OrgLimitsConfigForm.tsx
@@ -17,9 +17,12 @@ import {
 } from "./orgLimitsConfigTypes";
 
 const parsePositiveInt = (value: string): number | undefined => {
-	const parsed = parseInt(value.trim(), 10);
-	return Number.isNaN(parsed) || parsed < 1 ? undefined : parsed;
+	const parsed = Number(value.trim());
+	return Number.isInteger(parsed) && parsed >= 1 ? parsed : undefined;
 };
+
+const isBlankOrPositiveInt = (value: string) =>
+	value.trim() === "" || parsePositiveInt(value) !== undefined;
 
 const parseEntry = ({
 	limit,
@@ -109,7 +112,7 @@ export const OrgLimitsConfigForm = ({
 		setSyncSource("form");
 		setConfig((current) => ({
 			...current,
-			orgs: { ...current.orgs, [orgId]: entry },
+			orgs: { ...current.orgs, [orgId]: { ...current.orgs[orgId], ...entry } },
 		}));
 		setNewOrgId("");
 		setNewLimit("");
@@ -186,6 +189,8 @@ export const OrgLimitsConfigForm = ({
 								onClick={addEntry}
 								disabled={
 									!newOrgId.trim() ||
+									!isBlankOrPositiveInt(newLimit) ||
+									!isBlankOrPositiveInt(newAttempts) ||
 									!parseEntry({ limit: newLimit, attempts: newAttempts })
 								}
 							>

--- a/vite/src/views/admin/components/OrgLimitsDialog.tsx
+++ b/vite/src/views/admin/components/OrgLimitsDialog.tsx
@@ -41,8 +41,8 @@ export function OrgLimitsDialog({
 				<DialogHeader>
 					<DialogTitle className="text-balance">Org Limits</DialogTitle>
 					<DialogDescription className="text-pretty">
-						Raise the cap on customer products returned per query, one org at a
-						time.
+						Raise the cap on customer products returned per query and on auto
+						top-up attempts, one org at a time.
 					</DialogDescription>
 				</DialogHeader>
 

--- a/vite/src/views/admin/components/orgLimitsConfigTypes.ts
+++ b/vite/src/views/admin/components/orgLimitsConfigTypes.ts
@@ -1,7 +1,9 @@
 export const DEFAULT_CUS_PRODUCT_LIMIT = 15;
+export const DEFAULT_AUTO_TOPUP_ATTEMPTS = 2;
 
 export type OrgLimitsEntry = {
 	maxCusProducts?: number;
+	maxAutoTopupAttempts?: number;
 };
 
 export type OrgLimitsConfig = {
@@ -40,6 +42,8 @@ export const getEntryRows = ({ config }: { config: OrgLimitsConfig }) => {
 		.map(([orgId, entry]) => ({
 			orgId,
 			maxCusProducts: entry.maxCusProducts ?? DEFAULT_CUS_PRODUCT_LIMIT,
+			maxAutoTopupAttempts:
+				entry.maxAutoTopupAttempts ?? DEFAULT_AUTO_TOPUP_ATTEMPTS,
 		}))
 		.sort((a, b) => a.orgId.localeCompare(b.orgId));
 };

--- a/vite/src/views/settings/sections/BillingSettingsSection.tsx
+++ b/vite/src/views/settings/sections/BillingSettingsSection.tsx
@@ -25,7 +25,6 @@ import { SettingsSection } from "../SettingsSection";
 type TtlUnit = "hours" | "days";
 
 const MAX_TTL_HOURS = 24 * 30;
-const DEFAULT_AUTO_TOPUP_ATTEMPTS = 2;
 
 // Hidden until the DynamoDB idempotency store is fully rolled out.
 const IDEMPOTENCY_TTL_CONFIG_ENABLED: boolean = false;
@@ -163,17 +162,6 @@ export const BillingSettingsSection = () => {
 	const handleSave = () => {
 		if (!isDirty || isPending) return;
 
-		const attemptLimit = pending.auto_topup_attempt_limit;
-		if (
-			attemptLimit != null &&
-			(!Number.isInteger(attemptLimit) || attemptLimit < 1)
-		) {
-			toast.error(
-				"Auto top-up attempt limit must be a whole number of at least 1",
-			);
-			return;
-		}
-
 		if (isTtlDirty && pendingTtl) {
 			const ttlHours = toHours(pendingTtl);
 			if (
@@ -221,26 +209,6 @@ export const BillingSettingsSection = () => {
 						/>
 					</SettingsRow>
 				))}
-				<SettingsRow
-					label="Auto top-up attempt limit"
-					description="How many auto top-ups a customer can trigger per feature every 10 minutes"
-				>
-					<Input
-						type="number"
-						aria-label="Auto top-up attempt limit"
-						className="w-20"
-						min={1}
-						placeholder={String(DEFAULT_AUTO_TOPUP_ATTEMPTS)}
-						value={displayConfig.auto_topup_attempt_limit ?? ""}
-						onChange={(e) =>
-							handleChange(
-								"auto_topup_attempt_limit",
-								e.target.value === "" ? null : Number(e.target.value),
-							)
-						}
-						disabled={isPending}
-					/>
-				</SettingsRow>
 				{IDEMPOTENCY_TTL_CONFIG_ENABLED && (
 					<SettingsRow
 						label="Idempotency key duration"


### PR DESCRIPTION
Follows #3327. The attempt limit is an internal safety valve, so it should not be an org-facing setting. This moves it into the admin Org Limits edge config, alongside the per-org customer product and entity caps, and removes the org config field and billing settings row that #3327 added.

- `OrgLimitsConfigSchema`: new optional `maxAutoTopupAttempts` per org.
- `orgLimitsStore`: `getOrgAutoTopupAttemptLimit`, same shape as the existing getters.
- `getAutoTopupRateLimitConfigs` takes the org and prefers the override over the default count; the 10 minute window, the failed-attempt limit and the customer `purchase_limit` are unchanged.
- Admin → Edge Config → Org Limits: the add-entry form takes an optional attempts value next to max customer products, and entries list both. Raw JSON editor works as before.
- Removed: `auto_topup_attempt_limit` from `OrgConfigSchema`, and the row, guard and constant from the billing settings card. The `SettingsRow` refactor stays.

Verified: server and dashboard typecheck clean; unit test covers default and override via the store's testing hook.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the auto top-up attempt limit out of org-facing billing settings and into the admin Org Limits edge config, since it's an internal safety valve rather than a customer setting.

- Adds an optional `maxAutoTopupAttempts` per org to the Org Limits schema and a corresponding store getter.
- The rate limit config now prefers the org override over the default; the 10-minute window and other limits are unchanged.
- Registers the Org Limits store before workers start polling, so overrides are loaded before auto top-ups are processed.
- The admin Org Limits form accepts an optional attempts value, merges new values into existing org entries instead of replacing them, and validates whole-number input.
- Removes `auto_topup_attempt_limit` from `OrgConfigSchema` and its billing settings row.

<sup>Written for commit 181dd47f0a85b02f128961124d0a61bf3a56c739. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Moves the auto top-up attempt limit from customer-facing organization settings into the internal Admin Org Limits configuration.

**Key changes**
- **[API changes]** Adds an optional positive-integer `maxAutoTopupAttempts` field to each organization’s Edge Config limits.
- **[Improvements]** Resolves the attempt limit by organization ID or slug while retaining the default of two attempts per ten minutes.
- **[Bug fixes]** Registers and refreshes the Org Limits store before queue workers begin consuming auto-top-up jobs.
- **[Bug fixes]** Preserves unrelated limits when an administrator updates an existing organization entry and rejects decimal or non-positive form values.
- **[Improvements]** Removes the now-internal setting from the organization billing settings UI and shared organization configuration model.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the outstanding worker-startup concern is fixed and no new actionable failures were found.

The worker entry point now registers the Org Limits store before awaiting its initial refresh and starts queue polling only afterward. The form also preserves existing organization limits and rejects invalid whole-number inputs. charlietlamb dismissed the migration concern after confirming that production contained zero values for the short-lived setting, so removing it changes no live organization behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs.ts | Resolves the auto top-up attempt limit from the internal per-organization Edge Config store. |
| server/src/internal/misc/edgeConfig/orgLimitsStore.ts | Adds ID-or-slug lookup for the optional per-organization auto top-up attempt limit. |
| server/src/workers.ts | Registers the Org Limits store before workers await Edge Config initialization and start queue polling. |
| vite/src/views/admin/components/OrgLimitsConfigForm.tsx | Adds validated attempt-limit input while preserving existing fields when updating an organization. |
| shared/models/orgModels/orgConfig.ts | Removes the customer-facing auto top-up attempt-limit field from the shared organization configuration. |
| server/tests/unit/balances/auto-topup/auto-topup-rate-limit-configs.test.ts | Covers both the default limit and an organization-specific Edge Config override. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Admin Org Limits] --> B[Edge Config store]
    B --> C[Resolve organization override]
    C --> D{Override exists?}
    D -->|Yes| E[Use configured attempt limit]
    D -->|No| F[Use default of 2]
    E --> G[Auto top-up preflight and recording]
    F --> G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Register the org limits store before wor..."](https://github.com/useautumn/autumn/commit/181dd47f0a85b02f128961124d0a61bf3a56c739) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61595180)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Backend service runtime](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/service-runtime.md)
- Knowledge Base — [Asynchronous jobs and worker processing](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/async-job-processing.md)
- Knowledge Base — [Operational web applications and UI primitives](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/operational-web-applications.md)
</details>


<!-- /greptile_comment -->