### PR TITLE
Add threshold billing plan item config

### DIFF
--- a/shared/api/products/items/apiPlanItemV1.ts
+++ b/shared/api/products/items/apiPlanItemV1.ts
@@ -57,6 +57,13 @@ export const API_PLAN_ITEM_PREPAID_EXAMPLE = {
 
 export const ApiPlanItemV1Schema = z
 	.object({
+		threshold_billing: z
+			.object({ threshold: z.number().finite().positive() })
+			.nullish()
+			.meta({
+				description:
+					"Bills this many feature units when outstanding overage reaches it.",
+			}),
 		feature_id: z.string().meta({
 			description: "The ID of the feature this item configures.",
 		}),

--- a/shared/api/products/items/crud/createPlanItemParamsV1.ts
+++ b/shared/api/products/items/crud/createPlanItemParamsV1.ts
@@ -81,6 +81,13 @@ export const PLAN_ITEM_PRICE_DESCRIPTION =
  * checks through `planItemParamsIssues`.
  */
 export const PlanItemParamsObjectSchema = z.object({
+	threshold_billing: z
+		.object({ threshold: z.number().finite().positive() })
+		.nullish()
+		.meta({
+			description:
+				"Bills this many feature units when outstanding overage reaches it.",
+		}),
 	feature_id: z.string().meta({
 		description: "The ID of the feature to configure.",
 	}),
@@ -204,8 +211,29 @@ export const planItemParamsIssues = (
 	}
 
 	// At a minimum, if price is present, at least amount OR tiers must be defined, and not both
+	if (value.threshold_billing && (!value.price || value.unlimited)) {
+		issues.push({
+			message: "threshold_billing requires a finite usage-based price",
+			input: value.threshold_billing,
+		});
+	}
 	if (value.price) {
+		if (
+			value.threshold_billing &&
+			value.price.billing_method !== BillingMethod.UsageBased
+		) {
+			issues.push({
+				message: "threshold_billing requires a finite usage-based price",
+				input: value.threshold_billing,
+			});
+		}
 		const { amount, tiers } = value.price;
+		if (value.threshold_billing && tiers?.length) {
+			issues.push({
+				message: "threshold_billing currently requires a flat usage price",
+				input: value.threshold_billing,
+			});
+		}
 
 		if (
 			value.proration &&

--- a/shared/api/products/items/mappers/planItemV0ToProductItem.ts
+++ b/shared/api/products/items/mappers/planItemV0ToProductItem.ts
@@ -84,13 +84,15 @@ const planItemV0ToItemConfig = ({
 	const featureOverride = planItemV0.feature_override
 		? apiFeatureOverrideToDb(planItemV0.feature_override)
 		: undefined;
+	const thresholdBilling = planItemV0.threshold_billing ?? undefined;
 
-	if (rollover || proration || featureOverride) {
+	if (rollover || proration || featureOverride || thresholdBilling) {
 		return {
 			rollover,
 			on_increase: proration?.on_increase,
 			on_decrease: proration?.on_decrease,
 			feature_override: featureOverride,
+			threshold_billing: thresholdBilling,
 		} satisfies ProductItemConfig;
 	}
 	return undefined;

--- a/shared/api/products/items/mappers/planItemV1ToV0.ts
+++ b/shared/api/products/items/mappers/planItemV1ToV0.ts
@@ -49,6 +49,7 @@ export function planItemV1ToV0({
 
 	return {
 		...restItem,
+		threshold_billing: item.threshold_billing,
 		unlimited: item.unlimited ?? false,
 		granted_balance: included,
 		reset: item.reset

--- a/shared/api/products/items/previousVersions/apiPlanItemV0.ts
+++ b/shared/api/products/items/previousVersions/apiPlanItemV0.ts
@@ -18,6 +18,9 @@ import { z } from "zod/v4";
 
 export const ApiPlanItemV0Schema = z
 	.object({
+		threshold_billing: z
+			.object({ threshold: z.number().finite().positive() })
+			.nullish(),
 		feature_id: z.string(),
 		feature: ApiFeatureV0Schema.optional(),
 

--- a/shared/api/products/items/thresholdBilling.test.ts
+++ b/shared/api/products/items/thresholdBilling.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { ApiPlanItemV1Schema } from "./apiPlanItemV1.js";
+import { CreatePlanItemParamsV1Schema } from "./crud/createPlanItemParamsV1.js";
+
+const item = {
+	feature_id: "messages",
+	included: 1000,
+	unlimited: false,
+	reset: { interval: "month" },
+	price: {
+		amount: 2,
+		interval: "month",
+		billing_units: 10,
+		billing_method: "usage_based",
+		max_purchase: null,
+	},
+	threshold_billing: { threshold: 100 },
+};
+
+describe("threshold billing item", () => {
+	test("preserves feature-unit thresholds in requests and responses", () => {
+		expect(CreatePlanItemParamsV1Schema.parse(item)).toMatchObject({
+			threshold_billing: { threshold: 100 },
+		});
+		expect(ApiPlanItemV1Schema.parse(item)).toMatchObject({
+			threshold_billing: { threshold: 100 },
+		});
+	});
+
+	test.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+		"rejects invalid threshold %s",
+		(threshold) => {
+			expect(
+				CreatePlanItemParamsV1Schema.safeParse({
+					...item,
+					threshold_billing: { threshold },
+				}).success,
+			).toBe(false);
+		},
+	);
+
+	test.each([
+		{ price: undefined },
+		{ unlimited: true },
+		{ price: { ...item.price, billing_method: "prepaid" } },
+		{
+			price: {
+				...item.price,
+				amount: undefined,
+				tiers: [{ to: "inf", amount: 2 }],
+			},
+		},
+	])("rejects incompatible item %j", (overrides) => {
+		expect(
+			CreatePlanItemParamsV1Schema.safeParse({ ...item, ...overrides }).success,
+		).toBe(false);
+	});
+
+	test("preserves omission and explicit removal", () => {
+		expect(
+			CreatePlanItemParamsV1Schema.parse({
+				...item,
+				threshold_billing: undefined,
+			}),
+		).not.toHaveProperty("threshold_billing", { threshold: 100 });
+		expect(
+			CreatePlanItemParamsV1Schema.parse({ ...item, threshold_billing: null }),
+		).toMatchObject({ threshold_billing: null });
+	});
+});

--- a/shared/models/productModels/priceModels/priceConfig/usagePriceConfig.ts
+++ b/shared/models/productModels/priceModels/priceConfig/usagePriceConfig.ts
@@ -57,6 +57,9 @@ export const PriceCurrencyConfigSchema = z.object({
 export type PriceCurrencyConfig = z.infer<typeof PriceCurrencyConfigSchema>;
 
 export const UsagePriceConfigSchema = z.object({
+	threshold_billing: z
+		.object({ threshold: z.number().finite().positive() })
+		.nullish(),
 	type: z.string(),
 	bill_when: z.nativeEnum(BillWhen),
 	billing_units: z.number().nullish(),

--- a/shared/models/productV2Models/productItemModels/productItemModels.ts
+++ b/shared/models/productV2Models/productItemModels/productItemModels.ts
@@ -73,6 +73,13 @@ export const RolloverConfigSchema = z.object({
 });
 
 const ProductItemConfigSchema = z.object({
+	threshold_billing: z
+		.object({ threshold: z.number().finite().positive() })
+		.nullish()
+		.meta({
+			description:
+				"Bills this many feature units when outstanding overage reaches it.",
+		}),
 	allocated_billing_behavior: z.enum(AllocatedBillingBehavior).nullish(),
 	on_increase: z.enum(OnIncrease).nullish(),
 	on_decrease: z.enum(OnDecrease).nullish(),

--- a/shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts
@@ -227,6 +227,12 @@ export const featureItemsAreSame = ({
 			}),
 			message: `Feature override different: ${JSON.stringify(item1.config?.feature_override)} !== ${JSON.stringify(item2.config?.feature_override)}`,
 		},
+		threshold_billing: {
+			condition:
+				(item1.config?.threshold_billing?.threshold ?? null) ===
+				(item2.config?.threshold_billing?.threshold ?? null),
+			message: `Threshold billing different: ${JSON.stringify(item1.config?.threshold_billing)} !== ${JSON.stringify(item2.config?.threshold_billing)}`,
+		},
 		// config: {
 		// 	condition: JSON.stringify(item1.config) === JSON.stringify(item2.config),
 		// 	message: `Config different: ${JSON.stringify(item1.config)} !== ${JSON.stringify(item2.config)}`,
@@ -389,6 +395,12 @@ export const featurePriceItemsAreSame = ({
 				override2: item2.config?.feature_override,
 			}),
 			message: `Feature override different: ${JSON.stringify(item1.config?.feature_override)} !== ${JSON.stringify(item2.config?.feature_override)}`,
+		},
+		threshold_billing: {
+			condition:
+				(item1.config?.threshold_billing?.threshold ?? null) ===
+				(item2.config?.threshold_billing?.threshold ?? null),
+			message: `Threshold billing different: ${JSON.stringify(item1.config?.threshold_billing)} !== ${JSON.stringify(item2.config?.threshold_billing)}`,
 		},
 		entity_feature_id: {
 			condition: item1.entity_feature_id == item2.entity_feature_id,

--- a/shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToPlanItemParamsV1.ts
+++ b/shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToPlanItemParamsV1.ts
@@ -72,6 +72,7 @@ export const productItemToPlanItemParamsV1 = ({
 		included: planItemV1.included,
 		unlimited: planItemV1.unlimited,
 		pooled: planItemV1.pooled ?? false,
+		threshold_billing: planItemV1.threshold_billing,
 		reset: planItemV1.reset ?? undefined,
 		price: planItemV1.price
 			? {

--- a/shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToPlanItemV1.ts
+++ b/shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToPlanItemV1.ts
@@ -219,6 +219,7 @@ export const productItemsToPlanItemsV1 = ({
 			included: included,
 			unlimited: item.included_usage === Infinite,
 			pooled: item.pooled ?? false,
+			threshold_billing: item.config?.threshold_billing,
 
 			reset,
 			price, // V1: price can be null (no need for conditional spread)

--- a/shared/utils/productV2Utils/productItemUtils/mapToItem.ts
+++ b/shared/utils/productV2Utils/productItemUtils/mapToItem.ts
@@ -126,6 +126,9 @@ export const toFeaturePriceItem = ({
 	if (ent.feature_override) {
 		itemConfig.feature_override = ent.feature_override;
 	}
+	if (config.threshold_billing) {
+		itemConfig.threshold_billing = config.threshold_billing;
+	}
 
 	const item: ProductItem = {
 		feature_id: ent.feature.id,

--- a/shared/utils/productV2Utils/productItemUtils/mappers/itemToPriceAndEnt.ts
+++ b/shared/utils/productV2Utils/productItemUtils/mappers/itemToPriceAndEnt.ts
@@ -304,6 +304,7 @@ const toFeatureAndPrice = ({
 		interval: itemToBillingInterval({ item }) as BillingInterval,
 		interval_count: itemToBillingIntervalCount({ item }),
 		stripe_price_id: null,
+		threshold_billing: item.config?.threshold_billing,
 	};
 
 	const currencies = buildUsagePriceCurrencies({


### PR DESCRIPTION
Adds optional `threshold_billing: { threshold }` configuration to plan items and carries it through API, persistence, mapping, and product comparison paths.

Validation covers positive thresholds and rejects unsupported prepaid, unlimited, and tiered pricing.






<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds threshold-based billing configuration for flat, usage-based plan items and carries the setting through validation, persistence, conversion, and comparison paths.

- **[API changes]** Adds nullable `threshold_billing: { threshold }` fields to current and compatibility plan-item schemas.
- **[Improvements]** Validates that thresholds are positive, finite, and used only with supported flat usage-based prices.
- **[Bug fixes]** Includes threshold billing in item comparisons so changing or removing a threshold creates a real catalog update.
- **[Improvements]** Preserves threshold billing across plan-item and product-item mapping paths and adds focused schema tests.
</details>


<h3>Confidence Score: 5/5</h3>

The threshold-billing changes appear safe to merge, with no outstanding actionable findings.

The current implementation validates supported threshold configurations, preserves the field through the relevant mappings, and detects threshold changes during catalog comparison. Both previous review threads were manually resolved, and no new threshold-billing changes were introduced after the previous review.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/products/items/crud/createPlanItemParamsV1.ts | Adds threshold configuration and rejects unsupported price, unlimited, prepaid, and tiered combinations. |
| shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts | Compares normalized threshold values so threshold changes and removals are detected. |
| shared/utils/productV2Utils/productItemUtils/mappers/itemToPriceAndEnt.ts | Persists threshold configuration into usage-price records. |
| shared/api/products/items/thresholdBilling.test.ts | Covers valid thresholds, invalid numeric values, incompatible item configurations, omission, and explicit removal. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Plan item API input] --> B[Threshold validation]
  B --> C[Product item configuration]
  C --> D[Usage price persistence]
  D --> E[Plan item API response]
  C --> F[Catalog item comparison]
  F --> G[Threshold update or removal detected]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Add threshold billing plan item config"](https://github.com/useautumn/autumn/commit/e972a71dda522560ae471ce9ea0aaab67714ba92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61631385)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)
- Knowledge Base — [Usage and billing API platform](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/api-platform.md)
- Knowledge Base — [Restore safe billing item edits](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/reverts/incident-mitigation_3072-20260825-billing-item-edits-9453a82.md)
</details>


<!-- /greptile_comment -->