### PR TITLE
Declare the type checker in the atmn generator and nightly packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -326,6 +326,7 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@typescript/native-preview": "catalog:",
       },
     },
     "packages/atmn-nightly": {
@@ -346,6 +347,7 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@typescript/native-preview": "catalog:",
       },
     },
     "packages/atmn-tests": {

--- a/packages/atmn-generator/package.json
+++ b/packages/atmn-generator/package.json
@@ -15,6 +15,7 @@
 		"yaml": "2.9.0"
 	},
 	"devDependencies": {
-		"@types/bun": "latest"
+		"@types/bun": "latest",
+		"@typescript/native-preview": "catalog:"
 	}
 }

--- a/packages/atmn-nightly/package.json
+++ b/packages/atmn-nightly/package.json
@@ -50,6 +50,7 @@
 		"yaml": "2.9.0"
 	},
 	"devDependencies": {
-		"@types/bun": "latest"
+		"@types/bun": "latest",
+		"@typescript/native-preview": "catalog:"
 	}
 }


### PR DESCRIPTION
Fixes the Type Check job that blocks the release PR #3315.

`dev` added `@autumn/atmn-generator` and `atmn-nightly` to the root `ts` script. Both run `bunx tsgo` but neither declares `@typescript/native-preview`, so in CI `bunx` finds no local binary and tries to install a package named `tsgo` from the registry (404). Locally a cached copy masks it, and turbo's shared cache replays the old success.

Both packages now declare `@typescript/native-preview: catalog:` like their siblings; the lockfile gains the two entries. Verified with `bunx --no-install tsgo --build --noEmit` in each package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Type Check job that blocks the release PR. The `atmn-generator` and `atmn-nightly` packages run `bunx tsgo` from the root `ts` script but didn't declare `@typescript/native-preview`, so CI tried to install a package named `tsgo` from the registry and got a 404. Both packages now declare `@typescript/native-preview` via the catalog, and the lockfile gains the two entries.

<sup>Written for commit 09005e46b4ff778c30485d233dc9932fa9f53932. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes clean CI type-check execution by declaring the existing TypeScript native checker in both packages that invoke `tsgo`.
- **[Bug fixes]** Adds `@typescript/native-preview` to `@autumn/atmn-generator`, allowing its type-check script to find the local `tsgo` binary.
- **[Bug fixes]** Adds the same checker dependency to `atmn-nightly`.
- **[Improvements]** Updates the Bun lockfile so frozen installs include both declarations consistently.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and directly addresses the missing local type-checker dependency.

Both package manifests now follow the established workspace pattern, and the lockfile consistently resolves the dependency to a version exposing the required `tsgo` binary.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/atmn-generator/package.json | Declares the development dependency that supplies the package's existing `tsgo` command. |
| packages/atmn-nightly/package.json | Declares the development dependency that supplies the package's existing `tsgo` command. |
| bun.lock | Records both workspace dependency declarations using the existing catalog resolution. |

<sub>Reviews (1): Last reviewed commit: ["Declare the type checker in the atmn gen..."](https://github.com/useautumn/autumn/commit/09005e46b4ff778c30485d233dc9932fa9f53932) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61660343)</sub>

<!-- /greptile_comment -->