### PR TITLE
charlie/writable usage schema

### DIFF
--- a/shared/api/billingControls/usageLimit.ts
+++ b/shared/api/billingControls/usageLimit.ts
@@ -9,9 +9,23 @@ import { BillingControlSourceSchema } from "./billingControlSource.js";
 export const ApiUsageLimitSchema = DbUsageLimitSchema.extend({
 	usage: z.number().min(0).optional().meta({
 		description:
-			"Current usage already consumed in the active interval. Response-only; not stored on billing controls.",
+			"Usage consumed in the active interval, stored in the usage-window counter.",
 	}),
 	source: BillingControlSourceSchema.optional(),
 });
 
 export type ApiUsageLimit = z.infer<typeof ApiUsageLimitSchema>;
+
+export const UsageLimitUpdateSchema = z.union([
+	ApiUsageLimitSchema,
+	ApiUsageLimitSchema.pick({
+		feature_id: true,
+		filter: true,
+		source: true,
+		usage: true,
+	})
+		.required({ usage: true })
+		.strict(),
+]);
+
+export type UsageLimitUpdate = z.input<typeof UsageLimitUpdateSchema>;


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts writable usage-limit updates through `UsageLimitUpdateSchema`, while preserving usage as a counter stored in the usage window instead of response-only data.

- Full updates accept complete usage-limit records.
- Usage-only updates require `feature_id` and `usage` and reject limit configuration fields.

<sup>Written for commit 296548d749f9eef4b906cdbfb0ac002be3f5f37d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a schema intended to support writing usage-window counters independently from complete usage-limit configuration.

**Key changes**
- **[API changes]** Adds `UsageLimitUpdateSchema`, accepting either a complete usage-limit record or a usage-only record.
- **[Improvements]** Clarifies that `usage` is stored in the active usage-window counter rather than in billing-control configuration.
- **[Bug fixes]** Keeps usage-only records structurally separate from complete limit configuration, although the new schema is not yet wired into update parameters.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the newly added writable usage schema is unreachable from the actual customer and entity update APIs.

Customer and entity update parameters continue to use the database configuration schema, so a usage-only payload never reaches `UsageLimitUpdateSchema` and cannot perform the advertised counter update. The prior incomplete-limit persistence finding is fixed because persistent update parameters now continue to require complete database usage-limit records.

**Files Needing Attention:** shared/api/billingControls/usageLimit.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/billingControls/usageLimit.ts | Adds the writable usage-limit union, but no customer or entity update contract currently consumes it. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
shared/api/billingControls/usageLimit.ts:19-29
**Update schema is unused**

The new writable schema is not connected to the customer or entity update parameters. Both still validate usage limits with `DbUsageLimitSchema`, which has no `usage` field. For example, sending `{ feature_id: "messages", usage: 10 }` in an update will not use this schema, so the request cannot update the usage-window counter as intended.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["Accept writable usage limit updates"](https://github.com/useautumn/autumn/commit/296548d749f9eef4b906cdbfb0ac002be3f5f37d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61662254)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Usage and billing API platform](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/api-platform.md)

<!-- /greptile_comment -->