### PR TITLE
feat: persist writable usage counters

### DIFF
--- a/server/src/internal/customers/actions/update/getUsageLimitConfigUpdate.ts
+++ b/server/src/internal/customers/actions/update/getUsageLimitConfigUpdate.ts
@@ -11,7 +11,7 @@ export const getUsageLimitConfigUpdate = ({
 }): DbUsageLimit[] | undefined => {
 	if (usageLimits === undefined) return undefined;
 	const config = usageLimits.flatMap((entry) =>
-		entry.source !== "plan" && entry.limit !== undefined
+		entry.source !== "plan" && "limit" in entry
 			? [DbUsageLimitSchema.parse(entry)]
 			: [],
 	);

--- a/server/src/internal/customers/actions/update/getUsageLimitConfigUpdate.ts
+++ b/server/src/internal/customers/actions/update/getUsageLimitConfigUpdate.ts
@@ -1,0 +1,19 @@
+import {
+	type DbUsageLimit,
+	DbUsageLimitSchema,
+	type UsageLimitUpdate,
+} from "@autumn/shared";
+
+export const getUsageLimitConfigUpdate = ({
+	usageLimits,
+}: {
+	usageLimits?: UsageLimitUpdate[];
+}): DbUsageLimit[] | undefined => {
+	if (usageLimits === undefined) return undefined;
+	const config = usageLimits.flatMap((entry) =>
+		entry.source !== "plan" && entry.limit !== undefined
+			? [DbUsageLimitSchema.parse(entry)]
+			: [],
+	);
+	return usageLimits.length === 0 || config.length > 0 ? config : undefined;
+};

--- a/server/src/internal/customers/actions/update/prepareUsageLimitUsage.ts
+++ b/server/src/internal/customers/actions/update/prepareUsageLimitUsage.ts
@@ -52,20 +52,13 @@ export const prepareUsageLimitUsage = async ({
 		readFrom: "primary",
 	});
 	if (!fullSubject) return [];
-	const updatedSubject = { ...fullSubject };
-	if (configUsageLimits !== undefined && fullSubject.entity)
-		updatedSubject.entity = {
-			...fullSubject.entity,
-			usage_limits: configUsageLimits,
-		};
-	if (configUsageLimits !== undefined && !fullSubject.entity)
-		updatedSubject.customer = {
-			...fullSubject.customer,
-			usage_limits: configUsageLimits,
-		};
+	if (configUsageLimits !== undefined) {
+		const subject = fullSubject.entity ?? fullSubject.customer;
+		subject.usage_limits = configUsageLimits;
+	}
 
 	const limits = fullSubjectToUsageWindowLimits({
-		fullSubject: updatedSubject,
+		fullSubject,
 		featureIds: usageUpdates.map((entry) => entry.feature_id),
 		features: ctx.features,
 		now: ctx.timestamp,
@@ -100,24 +93,24 @@ export const prepareUsageLimitUsage = async ({
 						(window.internal_entity_id ?? null) === internalEntityId &&
 						(window.filter_key || "") === filterKey,
 				);
-		if (!existing && entry.usage === 0) continue;
-		if (!existing && limit) {
-			windows.push({
-				id: generateId("uw"),
-				internal_customer_id: limit.internal_customer_id,
-				internal_entity_id: limit.internal_entity_id,
-				feature_id: limit.feature_id,
-				internal_feature_id: limit.internal_feature_id,
-				filter_key: limit.filter_key,
-				anchor_customer_entitlement_id: limit.anchor_customer_entitlement_id,
-				window_start_at: limit.window_start_at,
-				window_end_at: limit.window_end_at,
-				usage: entry.usage,
-				updated_at: ctx.timestamp,
-			});
+		if (existing) {
+			windows.push({ ...existing, usage: entry.usage });
 			continue;
 		}
-		if (existing) windows.push({ ...existing, usage: entry.usage });
+		if (!limit || entry.usage === 0) continue;
+		windows.push({
+			id: generateId("uw"),
+			internal_customer_id: limit.internal_customer_id,
+			internal_entity_id: limit.internal_entity_id,
+			feature_id: limit.feature_id,
+			internal_feature_id: limit.internal_feature_id,
+			filter_key: limit.filter_key,
+			anchor_customer_entitlement_id: limit.anchor_customer_entitlement_id,
+			window_start_at: limit.window_start_at,
+			window_end_at: limit.window_end_at,
+			usage: entry.usage,
+			updated_at: ctx.timestamp,
+		});
 	}
 
 	return windows;

--- a/server/src/internal/customers/actions/update/prepareUsageLimitUsage.ts
+++ b/server/src/internal/customers/actions/update/prepareUsageLimitUsage.ts
@@ -1,4 +1,5 @@
 import {
+	type DbUsageLimit,
 	findFeatureById,
 	findUsageWindowByLimit,
 	fullSubjectToUsageWindowLimits,
@@ -12,27 +13,35 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { generateId } from "@/utils/genUtils.js";
 import { invalidateCachedFullSubject } from "../../cache/fullSubject/index.js";
 import { getFullSubject } from "../../repos/getFullSubject/getFullSubject.js";
-import { usageWindowRepo } from "../../usageWindows/repos/index.js";
 
-export const setUsageLimitUsage = async ({
+export const prepareUsageLimitUsage = async ({
 	ctx,
 	customerId,
 	entityId,
-	usageLimits,
+	usageLimits = [],
+	configUsageLimits,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	entityId?: string;
-	usageLimits: UsageLimitUpdate[];
-}): Promise<void> => {
+	usageLimits?: UsageLimitUpdate[];
+	configUsageLimits?: DbUsageLimit[];
+}): Promise<UsageWindow[]> => {
+	for (const entry of usageLimits) {
+		findFeatureById({
+			features: ctx.features,
+			featureId: entry.feature_id,
+			errorOnNotFound: true,
+		});
+	}
 	const usageUpdates = usageLimits.filter((entry) => entry.usage !== undefined);
-	if (usageUpdates.length === 0) return;
+	if (usageUpdates.length === 0) return [];
 
 	await invalidateCachedFullSubject({
 		ctx,
 		customerId,
 		entityId,
-		source: "setUsageLimitUsage:before",
+		source: "prepareUsageLimitUsage",
 		flushBalances: true,
 	});
 
@@ -42,30 +51,38 @@ export const setUsageLimitUsage = async ({
 		entityId,
 		readFrom: "primary",
 	});
-	if (!fullSubject) return;
+	if (!fullSubject) return [];
+	const updatedSubject = { ...fullSubject };
+	if (configUsageLimits !== undefined && fullSubject.entity)
+		updatedSubject.entity = {
+			...fullSubject.entity,
+			usage_limits: configUsageLimits,
+		};
+	if (configUsageLimits !== undefined && !fullSubject.entity)
+		updatedSubject.customer = {
+			...fullSubject.customer,
+			usage_limits: configUsageLimits,
+		};
 
 	const limits = fullSubjectToUsageWindowLimits({
-		fullSubject,
+		fullSubject: updatedSubject,
 		featureIds: usageUpdates.map((entry) => entry.feature_id),
 		features: ctx.features,
 		now: ctx.timestamp,
 		inStatuses: orgToInStatuses({ org: ctx.org }),
 	});
-	const windows: Array<{ window: UsageWindow; usage: number }> = [];
+	const windows: UsageWindow[] = [];
+	const internalEntityId = fullSubject.entity?.internal_id ?? null;
 
 	for (const entry of usageUpdates) {
-		findFeatureById({
-			features: ctx.features,
-			featureId: entry.feature_id,
-			errorOnNotFound: true,
-		});
+		if (entry.usage === undefined) continue;
 		const filterKey = usageLimitFilterKey(entry.filter);
 		const limit = limits.find(
 			(candidate) =>
 				candidate.feature_id === entry.feature_id &&
 				(candidate.filter_key || "") === filterKey,
 		);
-		if (entry.usage! > 0 && !limit) {
+		if (entry.usage > 0 && !limit) {
 			throw new RecaseError({
 				message: `No usage limit configured for feature ${entry.feature_id}`,
 				statusCode: 400,
@@ -80,37 +97,28 @@ export const setUsageLimitUsage = async ({
 			: (fullSubject.usage_windows ?? []).find(
 					(window) =>
 						window.feature_id === entry.feature_id &&
-						(window.internal_entity_id ?? null) === (entityId ? fullSubject.entity?.internal_id ?? entityId : null) &&
+						(window.internal_entity_id ?? null) === internalEntityId &&
 						(window.filter_key || "") === filterKey,
 				);
 		if (!existing && entry.usage === 0) continue;
 		if (!existing && limit) {
 			windows.push({
-				window: {
-					id: generateId("uw"),
-					internal_customer_id: limit.internal_customer_id,
-					internal_entity_id: limit.internal_entity_id,
-					feature_id: limit.feature_id,
-					internal_feature_id: limit.internal_feature_id,
-					filter_key: limit.filter_key,
-					anchor_customer_entitlement_id: limit.anchor_customer_entitlement_id,
-					window_start_at: limit.window_start_at,
-					window_end_at: limit.window_end_at,
-					usage: entry.usage!,
-					updated_at: ctx.timestamp,
-				},
-				usage: entry.usage!,
+				id: generateId("uw"),
+				internal_customer_id: limit.internal_customer_id,
+				internal_entity_id: limit.internal_entity_id,
+				feature_id: limit.feature_id,
+				internal_feature_id: limit.internal_feature_id,
+				filter_key: limit.filter_key,
+				anchor_customer_entitlement_id: limit.anchor_customer_entitlement_id,
+				window_start_at: limit.window_start_at,
+				window_end_at: limit.window_end_at,
+				usage: entry.usage,
+				updated_at: ctx.timestamp,
 			});
 			continue;
 		}
-		if (existing) windows.push({ window: existing, usage: entry.usage! });
+		if (existing) windows.push({ ...existing, usage: entry.usage });
 	}
 
-	await usageWindowRepo.setWindows({ db: ctx.db, windows });
-	await invalidateCachedFullSubject({
-		ctx,
-		customerId,
-		entityId,
-		source: "setUsageLimitUsage:after",
-	});
+	return windows;
 };

--- a/server/src/internal/customers/actions/update/prepareUsageLimitUsage.ts
+++ b/server/src/internal/customers/actions/update/prepareUsageLimitUsage.ts
@@ -1,5 +1,6 @@
 import {
 	type DbUsageLimit,
+	type FullSubject,
 	findFeatureById,
 	findUsageWindowByLimit,
 	fullSubjectToUsageWindowLimits,
@@ -13,6 +14,27 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { generateId } from "@/utils/genUtils.js";
 import { invalidateCachedFullSubject } from "../../cache/fullSubject/index.js";
 import { getFullSubject } from "../../repos/getFullSubject/getFullSubject.js";
+
+/** The subject as it will look once this request's usage-limit config is saved. */
+const withPendingUsageLimits = ({
+	fullSubject,
+	usageLimits,
+}: {
+	fullSubject: FullSubject;
+	usageLimits: DbUsageLimit[] | undefined;
+}): FullSubject => {
+	if (usageLimits === undefined) return fullSubject;
+	if (fullSubject.entity) {
+		return {
+			...fullSubject,
+			entity: { ...fullSubject.entity, usage_limits: usageLimits },
+		};
+	}
+	return {
+		...fullSubject,
+		customer: { ...fullSubject.customer, usage_limits: usageLimits },
+	};
+};
 
 export const prepareUsageLimitUsage = async ({
 	ctx,
@@ -52,13 +74,12 @@ export const prepareUsageLimitUsage = async ({
 		readFrom: "primary",
 	});
 	if (!fullSubject) return [];
-	if (configUsageLimits !== undefined) {
-		const subject = fullSubject.entity ?? fullSubject.customer;
-		subject.usage_limits = configUsageLimits;
-	}
 
 	const limits = fullSubjectToUsageWindowLimits({
-		fullSubject,
+		fullSubject: withPendingUsageLimits({
+			fullSubject,
+			usageLimits: configUsageLimits,
+		}),
 		featureIds: usageUpdates.map((entry) => entry.feature_id),
 		features: ctx.features,
 		now: ctx.timestamp,

--- a/server/src/internal/customers/actions/update/setUsageLimitUsage.ts
+++ b/server/src/internal/customers/actions/update/setUsageLimitUsage.ts
@@ -1,0 +1,115 @@
+import {
+	findFeatureById,
+	findUsageWindowByLimit,
+	fullSubjectToUsageWindowLimits,
+	orgToInStatuses,
+	RecaseError,
+	type UsageLimitUpdate,
+	type UsageWindow,
+	usageLimitFilterKey,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { generateId } from "@/utils/genUtils.js";
+import { invalidateCachedFullSubject } from "../../cache/fullSubject/index.js";
+import { getFullSubject } from "../../repos/getFullSubject/getFullSubject.js";
+import { usageWindowRepo } from "../../usageWindows/repos/index.js";
+
+export const setUsageLimitUsage = async ({
+	ctx,
+	customerId,
+	entityId,
+	usageLimits,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	entityId?: string;
+	usageLimits: UsageLimitUpdate[];
+}): Promise<void> => {
+	const usageUpdates = usageLimits.filter((entry) => entry.usage !== undefined);
+	if (usageUpdates.length === 0) return;
+
+	await invalidateCachedFullSubject({
+		ctx,
+		customerId,
+		entityId,
+		source: "setUsageLimitUsage:before",
+		flushBalances: true,
+	});
+
+	const fullSubject = await getFullSubject({
+		ctx,
+		customerId,
+		entityId,
+		readFrom: "primary",
+	});
+	if (!fullSubject) return;
+
+	const limits = fullSubjectToUsageWindowLimits({
+		fullSubject,
+		featureIds: usageUpdates.map((entry) => entry.feature_id),
+		features: ctx.features,
+		now: ctx.timestamp,
+		inStatuses: orgToInStatuses({ org: ctx.org }),
+	});
+	const windows: Array<{ window: UsageWindow; usage: number }> = [];
+
+	for (const entry of usageUpdates) {
+		findFeatureById({
+			features: ctx.features,
+			featureId: entry.feature_id,
+			errorOnNotFound: true,
+		});
+		const filterKey = usageLimitFilterKey(entry.filter);
+		const limit = limits.find(
+			(candidate) =>
+				candidate.feature_id === entry.feature_id &&
+				(candidate.filter_key || "") === filterKey,
+		);
+		if (entry.usage! > 0 && !limit) {
+			throw new RecaseError({
+				message: `No usage limit configured for feature ${entry.feature_id}`,
+				statusCode: 400,
+			});
+		}
+
+		const existing = limit
+			? findUsageWindowByLimit({
+					usageWindows: fullSubject.usage_windows ?? [],
+					limit,
+				})
+			: (fullSubject.usage_windows ?? []).find(
+					(window) =>
+						window.feature_id === entry.feature_id &&
+						(window.filter_key || "") === filterKey,
+				);
+		if (!existing && entry.usage === 0) continue;
+		if (!existing && limit) {
+			windows.push({
+				window: {
+					id: generateId("uw"),
+					internal_customer_id: limit.internal_customer_id,
+					internal_entity_id: limit.internal_entity_id,
+					feature_id: limit.feature_id,
+					internal_feature_id: limit.internal_feature_id,
+					filter_key: limit.filter_key,
+					anchor_customer_entitlement_id: limit.anchor_customer_entitlement_id,
+					window_start_at: limit.window_start_at,
+					window_end_at: limit.window_end_at,
+					usage: entry.usage!,
+					updated_at: ctx.timestamp,
+				},
+				usage: entry.usage!,
+			});
+			continue;
+		}
+		if (existing) windows.push({ window: existing, usage: entry.usage! });
+	}
+
+	await usageWindowRepo.setWindows({ db: ctx.db, windows });
+	await invalidateCachedFullSubject({
+		ctx,
+		customerId,
+		entityId,
+		source: "setUsageLimitUsage:after",
+	});
+};

--- a/server/src/internal/customers/actions/update/setUsageLimitUsage.ts
+++ b/server/src/internal/customers/actions/update/setUsageLimitUsage.ts
@@ -80,6 +80,7 @@ export const setUsageLimitUsage = async ({
 			: (fullSubject.usage_windows ?? []).find(
 					(window) =>
 						window.feature_id === entry.feature_id &&
+						(window.internal_entity_id ?? null) === (entityId ? fullSubject.entity?.internal_id ?? entityId : null) &&
 						(window.filter_key || "") === filterKey,
 				);
 		if (!existing && entry.usage === 0) continue;

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -1,6 +1,7 @@
 import {
 	type Customer,
 	CustomerAlreadyExistsError,
+	type CustomerBillingControlsParams,
 	CustomerNotFoundError,
 	notNullish,
 	ProcessorType,
@@ -8,6 +9,7 @@ import {
 	shouldForwardCustomerMetadata,
 	stripAutoTopupCountsForStorage,
 	type UpdateCustomerParamsV1,
+	type UsageLimitUpdate,
 } from "@autumn/shared";
 import type Stripe from "stripe";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
@@ -21,6 +23,7 @@ import { triggerAutoTopUpsOnEnabled } from "@/internal/balances/autoTopUp/trigge
 import { assertCustomerUsageLimitAlertsResolvable } from "@/internal/balances/usageAlerts/validate/assertCustomerUsageLimitAlertsResolvable";
 import { CusService } from "@/internal/customers/CusService";
 import { getApiCustomerByRollout } from "../getApiCustomerByRollout";
+import { setUsageLimitUsage } from "./setUsageLimitUsage.js";
 import {
 	syncAutoTopupPurchaseLimitCounts,
 	validateAutoTopupPurchaseLimitCounts,
@@ -87,7 +90,14 @@ export const updateCustomer = async ({
 	await assertCustomerUsageLimitAlertsResolvable({
 		ctx,
 		customer: originalCustomer,
-		billingControls: billing_controls,
+		billingControls: billing_controls
+			? {
+					...billing_controls,
+					usage_limits: billing_controls.usage_limits?.filter(
+						(entry) => "limit" in entry,
+					) as CustomerBillingControlsParams["usage_limits"],
+				}
+			: undefined,
 	});
 
 	// Try to update stripe ID. Distinguish omitted (undefined -> leave as is)
@@ -163,8 +173,17 @@ export const updateCustomer = async ({
 		}
 		if (billing_controls.spend_limits !== undefined)
 			billingControlUpdates.spend_limits = billing_controls.spend_limits;
-		if (billing_controls.usage_limits !== undefined)
-			billingControlUpdates.usage_limits = billing_controls.usage_limits;
+		if (billing_controls.usage_limits !== undefined) {
+			const configEntries = billing_controls.usage_limits
+				.filter((entry) => entry.source !== "plan" && "limit" in entry)
+				.map(({ usage: _usage, source: _source, ...entry }) => entry);
+			if (
+				billing_controls.usage_limits.length === 0 ||
+				configEntries.length > 0
+			)
+				billingControlUpdates.usage_limits =
+					configEntries as Customer["usage_limits"];
+		}
 		if (billing_controls.usage_alerts !== undefined)
 			billingControlUpdates.usage_alerts = billing_controls.usage_alerts;
 		if (billing_controls.overage_allowed !== undefined)
@@ -225,6 +244,13 @@ export const updateCustomer = async ({
 
 	ctx.skipCache = true;
 	const resolvedCustomerId = newCustomerId ?? customerId;
+	if (billing_controls?.usage_limits) {
+		await setUsageLimitUsage({
+			ctx,
+			customerId: resolvedCustomerId,
+			usageLimits: billing_controls.usage_limits as UsageLimitUpdate[],
+		});
+	}
 
 	const apiCustomer = await getApiCustomerByRollout({
 		disableReplicaRead: true,

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -96,7 +96,7 @@ export const updateCustomer = async ({
 					usage_limits: billing_controls.usage_limits?.filter(
 						(entry) => "limit" in entry,
 					) as CustomerBillingControlsParams["usage_limits"],
-				}
+				} as CustomerBillingControlsParams
 			: undefined,
 	});
 
@@ -182,7 +182,7 @@ export const updateCustomer = async ({
 				configEntries.length > 0
 			)
 				billingControlUpdates.usage_limits =
-					configEntries as Customer["usage_limits"];
+					configEntries as unknown as Customer["usage_limits"];
 		}
 		if (billing_controls.usage_alerts !== undefined)
 			billingControlUpdates.usage_alerts = billing_controls.usage_alerts;

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -1,7 +1,6 @@
 import {
 	type Customer,
 	CustomerAlreadyExistsError,
-	type CustomerBillingControlsParams,
 	CustomerNotFoundError,
 	notNullish,
 	ProcessorType,
@@ -9,7 +8,6 @@ import {
 	shouldForwardCustomerMetadata,
 	stripAutoTopupCountsForStorage,
 	type UpdateCustomerParamsV1,
-	type UsageLimitUpdate,
 } from "@autumn/shared";
 import type Stripe from "stripe";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
@@ -22,8 +20,11 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { triggerAutoTopUpsOnEnabled } from "@/internal/balances/autoTopUp/triggerAutoTopUpsOnEnabled";
 import { assertCustomerUsageLimitAlertsResolvable } from "@/internal/balances/usageAlerts/validate/assertCustomerUsageLimitAlertsResolvable";
 import { CusService } from "@/internal/customers/CusService";
+import { invalidateCachedFullSubject } from "../../cache/fullSubject/index.js";
+import { usageWindowRepo } from "../../usageWindows/repos/index.js";
 import { getApiCustomerByRollout } from "../getApiCustomerByRollout";
-import { setUsageLimitUsage } from "./setUsageLimitUsage.js";
+import { getUsageLimitConfigUpdate } from "./getUsageLimitConfigUpdate.js";
+import { prepareUsageLimitUsage } from "./prepareUsageLimitUsage.js";
 import {
 	syncAutoTopupPurchaseLimitCounts,
 	validateAutoTopupPurchaseLimitCounts,
@@ -87,16 +88,21 @@ export const updateCustomer = async ({
 		}
 	}
 
+	const configUsageLimits = getUsageLimitConfigUpdate({
+		usageLimits: billing_controls?.usage_limits,
+	});
+	const usageWindows = await prepareUsageLimitUsage({
+		ctx,
+		customerId,
+		usageLimits: billing_controls?.usage_limits,
+		configUsageLimits,
+	});
+
 	await assertCustomerUsageLimitAlertsResolvable({
 		ctx,
 		customer: originalCustomer,
 		billingControls: billing_controls
-			? {
-					...billing_controls,
-					usage_limits: billing_controls.usage_limits?.filter(
-						(entry) => "limit" in entry,
-					) as CustomerBillingControlsParams["usage_limits"],
-				} as CustomerBillingControlsParams
+			? { ...billing_controls, usage_limits: configUsageLimits }
 			: undefined,
 	});
 
@@ -173,17 +179,8 @@ export const updateCustomer = async ({
 		}
 		if (billing_controls.spend_limits !== undefined)
 			billingControlUpdates.spend_limits = billing_controls.spend_limits;
-		if (billing_controls.usage_limits !== undefined) {
-			const configEntries = billing_controls.usage_limits
-				.filter((entry) => entry.source !== "plan" && "limit" in entry)
-				.map(({ usage: _usage, source: _source, ...entry }) => entry);
-			if (
-				billing_controls.usage_limits.length === 0 ||
-				configEntries.length > 0
-			)
-				billingControlUpdates.usage_limits =
-					configEntries as unknown as Customer["usage_limits"];
-		}
+		if (configUsageLimits !== undefined)
+			billingControlUpdates.usage_limits = configUsageLimits;
 		if (billing_controls.usage_alerts !== undefined)
 			billingControlUpdates.usage_alerts = billing_controls.usage_alerts;
 		if (billing_controls.overage_allowed !== undefined)
@@ -235,6 +232,8 @@ export const updateCustomer = async ({
 			});
 		}
 
+		await usageWindowRepo.setWindows({ db: txCtx.db, windows: usageWindows });
+
 		await CusService.update({
 			ctx: txCtx,
 			idOrInternalId: originalCustomer.id || originalCustomer.internal_id,
@@ -244,11 +243,11 @@ export const updateCustomer = async ({
 
 	ctx.skipCache = true;
 	const resolvedCustomerId = newCustomerId ?? customerId;
-	if (billing_controls?.usage_limits) {
-		await setUsageLimitUsage({
+	if (usageWindows.length > 0) {
+		await invalidateCachedFullSubject({
 			ctx,
 			customerId: resolvedCustomerId,
-			usageLimits: billing_controls.usage_limits as UsageLimitUpdate[],
+			source: "updateCustomer:usage",
 		});
 	}
 

--- a/server/src/internal/customers/usageWindows/repos/index.ts
+++ b/server/src/internal/customers/usageWindows/repos/index.ts
@@ -1,5 +1,7 @@
 import { rollUsageWindows } from "./rollUsageWindows";
+import { setUsageWindows } from "./setUsageWindows";
 
 export const usageWindowRepo = {
 	rollWindows: rollUsageWindows,
+	setWindows: setUsageWindows,
 };

--- a/server/src/internal/customers/usageWindows/repos/setUsageWindows.ts
+++ b/server/src/internal/customers/usageWindows/repos/setUsageWindows.ts
@@ -1,5 +1,5 @@
 import { type UsageWindow, usageWindows } from "@autumn/shared";
-import { and, eq, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 
 export const setUsageWindows = async ({
@@ -7,51 +7,23 @@ export const setUsageWindows = async ({
 	windows,
 }: {
 	db: DrizzleCli;
-	windows: Array<{ window: UsageWindow; usage: number }>;
+	windows: UsageWindow[];
 }): Promise<void> => {
-	if (windows.length === 0) return;
-
-	await db.transaction(async (tx) => {
-		for (const { window, usage } of windows) {
-			const existing = await tx
-				.select({ id: usageWindows.id })
-				.from(usageWindows)
-				.where(
-					and(
-						eq(usageWindows.internal_customer_id, window.internal_customer_id),
-						eq(usageWindows.internal_feature_id, window.internal_feature_id),
-						sql`coalesce(${usageWindows.internal_entity_id}, '') = coalesce(${window.internal_entity_id}, '')`,
-						sql`coalesce(${usageWindows.filter_key}, '') = coalesce(${window.filter_key}, '')`,
-					),
-				)
-				.for("update");
-
-			if (existing[0]) {
-				await tx
-					.update(usageWindows)
-					.set({ usage, updated_at: Date.now() })
-					.where(eq(usageWindows.id, existing[0].id));
-				continue;
-			}
-
-			await tx
-				.insert(usageWindows)
-				.values({ ...window, usage })
-				.onConflictDoNothing();
-			const inserted = await tx
-				.select({ id: usageWindows.id })
-				.from(usageWindows)
-				.where(
-					and(
-						eq(usageWindows.internal_customer_id, window.internal_customer_id),
-						eq(usageWindows.internal_feature_id, window.internal_feature_id),
-						sql`coalesce(${usageWindows.internal_entity_id}, '') = coalesce(${window.internal_entity_id}, '')`,
-						sql`coalesce(${usageWindows.filter_key}, '') = coalesce(${window.filter_key}, '')`,
-					),
-				)
-				.limit(1);
-			if (inserted[0]?.id !== window.id)
-				await tx.update(usageWindows).set({ usage, updated_at: Date.now() }).where(eq(usageWindows.id, inserted[0].id));
-		}
-	});
+	for (const window of windows) {
+		await db.execute(sql`
+   INSERT INTO ${usageWindows} (
+    id, internal_customer_id, internal_feature_id, internal_entity_id,
+    feature_id, filter_key, anchor_customer_entitlement_id,
+    window_start_at, window_end_at, usage, updated_at
+   ) VALUES (
+    ${window.id}, ${window.internal_customer_id}, ${window.internal_feature_id},
+    ${window.internal_entity_id}, ${window.feature_id}, ${window.filter_key},
+    ${window.anchor_customer_entitlement_id}, ${window.window_start_at},
+    ${window.window_end_at}, ${window.usage}, ${Date.now()}
+   )
+   ON CONFLICT (internal_customer_id, internal_feature_id,
+    (COALESCE(internal_entity_id, '')), (COALESCE(filter_key, '')))
+   DO UPDATE SET usage = EXCLUDED.usage, updated_at = EXCLUDED.updated_at
+  `);
+	}
 };

--- a/server/src/internal/customers/usageWindows/repos/setUsageWindows.ts
+++ b/server/src/internal/customers/usageWindows/repos/setUsageWindows.ts
@@ -34,7 +34,24 @@ export const setUsageWindows = async ({
 				continue;
 			}
 
-			await tx.insert(usageWindows).values({ ...window, usage });
+			await tx
+				.insert(usageWindows)
+				.values({ ...window, usage })
+				.onConflictDoNothing();
+			const inserted = await tx
+				.select({ id: usageWindows.id })
+				.from(usageWindows)
+				.where(
+					and(
+						eq(usageWindows.internal_customer_id, window.internal_customer_id),
+						eq(usageWindows.internal_feature_id, window.internal_feature_id),
+						sql`coalesce(${usageWindows.internal_entity_id}, '') = coalesce(${window.internal_entity_id}, '')`,
+						sql`coalesce(${usageWindows.filter_key}, '') = coalesce(${window.filter_key}, '')`,
+					),
+				)
+				.limit(1);
+			if (inserted[0]?.id !== window.id)
+				await tx.update(usageWindows).set({ usage, updated_at: Date.now() }).where(eq(usageWindows.id, inserted[0].id));
 		}
 	});
 };

--- a/server/src/internal/customers/usageWindows/repos/setUsageWindows.ts
+++ b/server/src/internal/customers/usageWindows/repos/setUsageWindows.ts
@@ -1,0 +1,40 @@
+import { type UsageWindow, usageWindows } from "@autumn/shared";
+import { and, eq, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+export const setUsageWindows = async ({
+	db,
+	windows,
+}: {
+	db: DrizzleCli;
+	windows: Array<{ window: UsageWindow; usage: number }>;
+}): Promise<void> => {
+	if (windows.length === 0) return;
+
+	await db.transaction(async (tx) => {
+		for (const { window, usage } of windows) {
+			const existing = await tx
+				.select({ id: usageWindows.id })
+				.from(usageWindows)
+				.where(
+					and(
+						eq(usageWindows.internal_customer_id, window.internal_customer_id),
+						eq(usageWindows.internal_feature_id, window.internal_feature_id),
+						sql`coalesce(${usageWindows.internal_entity_id}, '') = coalesce(${window.internal_entity_id}, '')`,
+						sql`coalesce(${usageWindows.filter_key}, '') = coalesce(${window.filter_key}, '')`,
+					),
+				)
+				.for("update");
+
+			if (existing[0]) {
+				await tx
+					.update(usageWindows)
+					.set({ usage, updated_at: Date.now() })
+					.where(eq(usageWindows.id, existing[0].id));
+				continue;
+			}
+
+			await tx.insert(usageWindows).values({ ...window, usage });
+		}
+	});
+};

--- a/server/src/internal/entities/actions/updateEntity.ts
+++ b/server/src/internal/entities/actions/updateEntity.ts
@@ -1,17 +1,20 @@
 import {
-	type ApiEntityBillingControlsParams,
 	CustomerNotFoundError,
 	EntityNotFoundError,
 	ErrCode,
 	RecaseError,
 	type UpdateEntityParams,
 } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { EntityService } from "@/internal/api/entities/EntityService.js";
 import { assertEntityUsageLimitAlertsResolvable } from "@/internal/balances/usageAlerts/validate/assertEntityUsageLimitAlertsResolvable.js";
-import { setUsageLimitUsage } from "@/internal/customers/actions/update/setUsageLimitUsage.js";
+import { getUsageLimitConfigUpdate } from "@/internal/customers/actions/update/getUsageLimitConfigUpdate.js";
+import { prepareUsageLimitUsage } from "@/internal/customers/actions/update/prepareUsageLimitUsage.js";
 import { updateCachedEntityData } from "@/internal/customers/cache/fullSubject/actions/updateCachedEntityData.js";
+import { invalidateCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
 import { getFullSubject } from "@/internal/customers/repos/getFullSubject/getFullSubject.js";
+import { usageWindowRepo } from "@/internal/customers/usageWindows/repos/index.js";
 
 export const updateEntity = async ({
 	ctx,
@@ -49,60 +52,64 @@ export const updateEntity = async ({
 		throw new EntityNotFoundError({ entityId });
 	}
 
+	const configUsageLimits = getUsageLimitConfigUpdate({
+		usageLimits: billing_controls?.usage_limits,
+	});
+	const usageWindows = await prepareUsageLimitUsage({
+		ctx,
+		customerId,
+		entityId,
+		usageLimits: billing_controls?.usage_limits,
+		configUsageLimits,
+	});
+
 	assertEntityUsageLimitAlertsResolvable({
 		ctx,
 		entity,
 		fullSubject,
 		billingControls: billing_controls
-			? {
-					...billing_controls,
-					usage_limits: billing_controls.usage_limits?.filter(
-						(entry) => "limit" in entry,
-					) as ApiEntityBillingControlsParams["usage_limits"],
-				} as ApiEntityBillingControlsParams
+			? { ...billing_controls, usage_limits: configUsageLimits }
 			: undefined,
 	});
 
 	const filteredUpdates = Object.fromEntries(
 		Object.entries({
 			spend_limits: billing_controls?.spend_limits,
-			usage_limits: (() => {
-				const entries = billing_controls?.usage_limits;
-				if (entries === undefined) return undefined;
-				const configEntries = entries
-					.filter((entry) => entry.source !== "plan" && "limit" in entry)
-					.map(({ usage: _usage, source: _source, ...entry }) => entry);
-				return entries.length === 0 || configEntries.length > 0
-					? configEntries
-					: undefined;
-			})(),
+			usage_limits: configUsageLimits,
 			usage_alerts: billing_controls?.usage_alerts,
 			overage_allowed: billing_controls?.overage_allowed,
 		}).filter(([, value]) => value !== undefined),
 	);
 
-	if (Object.keys(filteredUpdates).length > 0) {
-		await EntityService.update({
-			db: ctx.db,
-			internalId: entity.internal_id,
-			update: filteredUpdates,
+	const hasConfigUpdates = Object.keys(filteredUpdates).length > 0;
+	if (hasConfigUpdates || usageWindows.length > 0) {
+		await ctx.db.transaction(async (tx) => {
+			await usageWindowRepo.setWindows({
+				db: tx as unknown as DrizzleCli,
+				windows: usageWindows,
+			});
+			if (hasConfigUpdates)
+				await EntityService.update({
+					db: tx as unknown as DrizzleCli,
+					internalId: entity.internal_id,
+					update: filteredUpdates,
+				});
 		});
-
+	}
+	if (hasConfigUpdates)
 		await updateCachedEntityData({
 			ctx,
 			customerId,
 			entityId,
 			updates: filteredUpdates,
 		});
-	}
-	if (billing_controls?.usage_limits) {
-		await setUsageLimitUsage({
+	if (usageWindows.length > 0)
+		await invalidateCachedFullSubject({
 			ctx,
 			customerId,
-			entityId: entity.id ?? entity.internal_id,
-			usageLimits: billing_controls.usage_limits,
+			entityId,
+			source: "updateEntity:usage",
 		});
-	}
 
 	return entity.id ?? entity.internal_id;
 };

--- a/server/src/internal/entities/actions/updateEntity.ts
+++ b/server/src/internal/entities/actions/updateEntity.ts
@@ -59,7 +59,7 @@ export const updateEntity = async ({
 					usage_limits: billing_controls.usage_limits?.filter(
 						(entry) => "limit" in entry,
 					) as ApiEntityBillingControlsParams["usage_limits"],
-				}
+				} as ApiEntityBillingControlsParams
 			: undefined,
 	});
 

--- a/server/src/internal/entities/actions/updateEntity.ts
+++ b/server/src/internal/entities/actions/updateEntity.ts
@@ -1,4 +1,5 @@
 import {
+	type ApiEntityBillingControlsParams,
 	CustomerNotFoundError,
 	EntityNotFoundError,
 	ErrCode,
@@ -8,6 +9,7 @@ import {
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { EntityService } from "@/internal/api/entities/EntityService.js";
 import { assertEntityUsageLimitAlertsResolvable } from "@/internal/balances/usageAlerts/validate/assertEntityUsageLimitAlertsResolvable.js";
+import { setUsageLimitUsage } from "@/internal/customers/actions/update/setUsageLimitUsage.js";
 import { updateCachedEntityData } from "@/internal/customers/cache/fullSubject/actions/updateCachedEntityData.js";
 import { getFullSubject } from "@/internal/customers/repos/getFullSubject/getFullSubject.js";
 
@@ -51,13 +53,29 @@ export const updateEntity = async ({
 		ctx,
 		entity,
 		fullSubject,
-		billingControls: billing_controls,
+		billingControls: billing_controls
+			? {
+					...billing_controls,
+					usage_limits: billing_controls.usage_limits?.filter(
+						(entry) => "limit" in entry,
+					) as ApiEntityBillingControlsParams["usage_limits"],
+				}
+			: undefined,
 	});
 
 	const filteredUpdates = Object.fromEntries(
 		Object.entries({
 			spend_limits: billing_controls?.spend_limits,
-			usage_limits: billing_controls?.usage_limits,
+			usage_limits: (() => {
+				const entries = billing_controls?.usage_limits;
+				if (entries === undefined) return undefined;
+				const configEntries = entries
+					.filter((entry) => entry.source !== "plan" && "limit" in entry)
+					.map(({ usage: _usage, source: _source, ...entry }) => entry);
+				return entries.length === 0 || configEntries.length > 0
+					? configEntries
+					: undefined;
+			})(),
 			usage_alerts: billing_controls?.usage_alerts,
 			overage_allowed: billing_controls?.overage_allowed,
 		}).filter(([, value]) => value !== undefined),
@@ -75,6 +93,14 @@ export const updateEntity = async ({
 			customerId,
 			entityId,
 			updates: filteredUpdates,
+		});
+	}
+	if (billing_controls?.usage_limits) {
+		await setUsageLimitUsage({
+			ctx,
+			customerId,
+			entityId: entity.id ?? entity.internal_id,
+			usageLimits: billing_controls.usage_limits,
 		});
 	}
 

--- a/shared/api/billingControls/customerBillingControls.ts
+++ b/shared/api/billingControls/customerBillingControls.ts
@@ -1,9 +1,11 @@
 import { z } from "zod/v4";
+import { CustomerBillingControlsParamsSchema } from "../../models/cusModels/billingControls/customerBillingControls.js";
+import { rejectDuplicateBillingControls } from "../../models/cusModels/billingControls/duplicates/rejectDuplicateBillingControls.js";
 import { ApiAutoTopupSchema } from "./autoTopup.js";
 import { ApiOverageAllowedSchema } from "./overageAllowed.js";
 import { ApiSpendLimitSchema } from "./spendLimit.js";
 import { ApiUsageAlertSchema } from "./usageAlert.js";
-import { ApiUsageLimitSchema } from "./usageLimit.js";
+import { ApiUsageLimitSchema, WritableUsageLimitsShape } from "./usageLimit.js";
 
 /**
  * Response-only variant of CustomerBillingControlsSchema: `auto_topups` may
@@ -35,3 +37,9 @@ export const CustomerBillingControlsResponseSchema = z.object({
 export type CustomerBillingControlsResponse = z.infer<
 	typeof CustomerBillingControlsResponseSchema
 >;
+
+/** Update-request variant: usage limits may also be counter-only writes. */
+export const CustomerBillingControlsUpdateSchema =
+	CustomerBillingControlsParamsSchema.extend(WritableUsageLimitsShape).check(
+		rejectDuplicateBillingControls,
+	);

--- a/shared/api/billingControls/entityBillingControls.ts
+++ b/shared/api/billingControls/entityBillingControls.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { findDuplicateBillingControlIssue } from "../../models/cusModels/billingControls/duplicates/findDuplicateBillingControlIssue.js";
+import { rejectDuplicateBillingControls } from "../../models/cusModels/billingControls/duplicates/rejectDuplicateBillingControls.js";
 import { DbOverageAllowedSchema } from "../../models/cusModels/billingControls/overageAllowed.js";
 import { DbSpendLimitSchema } from "../../models/cusModels/billingControls/spendLimit.js";
 import { DbUsageAlertSchema } from "../../models/cusModels/billingControls/usageAlert.js";
@@ -7,7 +7,7 @@ import { DbUsageLimitSchema } from "../../models/cusModels/billingControls/usage
 import { ApiOverageAllowedSchema } from "./overageAllowed.js";
 import { ApiSpendLimitSchema } from "./spendLimit.js";
 import { ApiUsageAlertSchema } from "./usageAlert.js";
-import { ApiUsageLimitSchema } from "./usageLimit.js";
+import { ApiUsageLimitSchema, WritableUsageLimitsShape } from "./usageLimit.js";
 
 export const ApiEntityBillingControlsSchema = z.object({
 	spend_limits: z.array(ApiSpendLimitSchema).optional().meta({
@@ -46,10 +46,15 @@ const ApiEntityBillingControlsParamsBaseSchema = z.object({
 });
 
 export const ApiEntityBillingControlsParamsSchema =
-	ApiEntityBillingControlsParamsBaseSchema.check((ctx) => {
-		const issue = findDuplicateBillingControlIssue(ctx.value);
-		if (issue) ctx.issues.push(issue);
-	});
+	ApiEntityBillingControlsParamsBaseSchema.check(
+		rejectDuplicateBillingControls,
+	);
+
+/** Update-request variant: usage limits may also be counter-only writes. */
+export const ApiEntityBillingControlsUpdateSchema =
+	ApiEntityBillingControlsParamsBaseSchema.extend(
+		WritableUsageLimitsShape,
+	).check(rejectDuplicateBillingControls);
 
 export type ApiEntityBillingControls = z.infer<
 	typeof ApiEntityBillingControlsSchema

--- a/shared/api/billingControls/usageLimit.ts
+++ b/shared/api/billingControls/usageLimit.ts
@@ -29,3 +29,12 @@ export const UsageLimitUpdateSchema = z.union([
 ]);
 
 export type UsageLimitUpdate = z.input<typeof UsageLimitUpdateSchema>;
+
+/** Request-side usage limits: entries may also be counter-only writes
+ * ({ feature_id, usage }) that leave configuration untouched. */
+export const WritableUsageLimitsShape = {
+	usage_limits: z.array(UsageLimitUpdateSchema).optional().meta({
+		description:
+			"List of hard usage caps per feature. An entry with only feature_id and usage sets the current counter without changing configuration.",
+	}),
+};

--- a/shared/api/customers/crud/updateCustomerParams.ts
+++ b/shared/api/customers/crud/updateCustomerParams.ts
@@ -1,7 +1,6 @@
-import { WritableUsageLimitsShape } from "@api/billingControls/usageLimit";
+import { CustomerBillingControlsUpdateSchema } from "@api/billingControls/customerBillingControls";
 import { CustomerDataSchema } from "@api/common/customerData";
 import { CustomerIdSchema } from "@api/common/customerId";
-import { CustomerBillingControlsParamsSchema } from "@models/cusModels/billingControls/customerBillingControls";
 import { z } from "zod/v4";
 
 export const UpdateCustomerParamsV0Schema = z
@@ -10,9 +9,7 @@ export const UpdateCustomerParamsV0Schema = z
 			"New unique identifier for the customer",
 		),
 		...CustomerDataSchema.shape,
-		billing_controls: CustomerBillingControlsParamsSchema.extend(
-			WritableUsageLimitsShape,
-		).optional(),
+		billing_controls: CustomerBillingControlsUpdateSchema.optional(),
 	})
 	.omit({
 		auto_enable_plan_id: true,

--- a/shared/api/customers/crud/updateCustomerParams.ts
+++ b/shared/api/customers/crud/updateCustomerParams.ts
@@ -1,7 +1,7 @@
+import { UsageLimitUpdateSchema } from "@api/billingControls/usageLimit";
 import { CustomerDataSchema } from "@api/common/customerData";
 import { CustomerIdSchema } from "@api/common/customerId";
 import { CustomerBillingControlsParamsSchema } from "@models/cusModels/billingControls/customerBillingControls";
-import { UsageLimitUpdateSchema } from "@models/cusModels/billingControls/usageLimit";
 import { z } from "zod/v4";
 
 export const UpdateCustomerParamsV0Schema = z

--- a/shared/api/customers/crud/updateCustomerParams.ts
+++ b/shared/api/customers/crud/updateCustomerParams.ts
@@ -1,4 +1,4 @@
-import { UsageLimitUpdateSchema } from "@api/billingControls/usageLimit";
+import { WritableUsageLimitsShape } from "@api/billingControls/usageLimit";
 import { CustomerDataSchema } from "@api/common/customerData";
 import { CustomerIdSchema } from "@api/common/customerId";
 import { CustomerBillingControlsParamsSchema } from "@models/cusModels/billingControls/customerBillingControls";
@@ -10,9 +10,9 @@ export const UpdateCustomerParamsV0Schema = z
 			"New unique identifier for the customer",
 		),
 		...CustomerDataSchema.shape,
-		billing_controls: CustomerBillingControlsParamsSchema.extend({
-			usage_limits: z.array(UsageLimitUpdateSchema).optional(),
-		}).optional(),
+		billing_controls: CustomerBillingControlsParamsSchema.extend(
+			WritableUsageLimitsShape,
+		).optional(),
 	})
 	.omit({
 		auto_enable_plan_id: true,

--- a/shared/api/customers/crud/updateCustomerParams.ts
+++ b/shared/api/customers/crud/updateCustomerParams.ts
@@ -1,5 +1,7 @@
 import { CustomerDataSchema } from "@api/common/customerData";
 import { CustomerIdSchema } from "@api/common/customerId";
+import { CustomerBillingControlsParamsSchema } from "@models/cusModels/billingControls/customerBillingControls";
+import { UsageLimitUpdateSchema } from "@models/cusModels/billingControls/usageLimit";
 import { z } from "zod/v4";
 
 export const UpdateCustomerParamsV0Schema = z
@@ -8,6 +10,9 @@ export const UpdateCustomerParamsV0Schema = z
 			"New unique identifier for the customer",
 		),
 		...CustomerDataSchema.shape,
+		billing_controls: CustomerBillingControlsParamsSchema.extend({
+			usage_limits: z.array(UsageLimitUpdateSchema).optional(),
+		}).optional(),
 	})
 	.omit({
 		auto_enable_plan_id: true,

--- a/shared/api/entities/crud/updateEntityParams.ts
+++ b/shared/api/entities/crud/updateEntityParams.ts
@@ -1,6 +1,6 @@
 import { z } from "zod/v4";
-import { UsageLimitUpdateSchema } from "../../../models/cusModels/billingControls/usageLimit.js";
 import { ApiEntityBillingControlsParamsSchema } from "../../billingControls/entityBillingControls.js";
+import { UsageLimitUpdateSchema } from "../../billingControls/usageLimit.js";
 
 const UpdateEntityBillingControlsSchema =
 	ApiEntityBillingControlsParamsSchema.extend({

--- a/shared/api/entities/crud/updateEntityParams.ts
+++ b/shared/api/entities/crud/updateEntityParams.ts
@@ -1,11 +1,6 @@
 import { z } from "zod/v4";
 import { ApiEntityBillingControlsParamsSchema } from "../../billingControls/entityBillingControls.js";
-import { UsageLimitUpdateSchema } from "../../billingControls/usageLimit.js";
-
-const UpdateEntityBillingControlsSchema =
-	ApiEntityBillingControlsParamsSchema.extend({
-		usage_limits: z.array(UsageLimitUpdateSchema).optional(),
-	});
+import { WritableUsageLimitsShape } from "../../billingControls/usageLimit.js";
 
 export const UpdateEntityParamsSchema = z.object({
 	customer_id: z.string().optional().meta({
@@ -14,9 +9,13 @@ export const UpdateEntityParamsSchema = z.object({
 	entity_id: z.string().meta({
 		description: "The ID of the entity.",
 	}),
-	billing_controls: UpdateEntityBillingControlsSchema.optional().meta({
-		description: "Billing controls to replace on the entity.",
-	}),
+	billing_controls: ApiEntityBillingControlsParamsSchema.extend(
+		WritableUsageLimitsShape,
+	)
+		.optional()
+		.meta({
+			description: "Billing controls to replace on the entity.",
+		}),
 });
 
 export type UpdateEntityParams = z.infer<typeof UpdateEntityParamsSchema>;

--- a/shared/api/entities/crud/updateEntityParams.ts
+++ b/shared/api/entities/crud/updateEntityParams.ts
@@ -1,6 +1,5 @@
 import { z } from "zod/v4";
-import { ApiEntityBillingControlsParamsSchema } from "../../billingControls/entityBillingControls.js";
-import { WritableUsageLimitsShape } from "../../billingControls/usageLimit.js";
+import { ApiEntityBillingControlsUpdateSchema } from "../../billingControls/entityBillingControls.js";
 
 export const UpdateEntityParamsSchema = z.object({
 	customer_id: z.string().optional().meta({
@@ -9,13 +8,9 @@ export const UpdateEntityParamsSchema = z.object({
 	entity_id: z.string().meta({
 		description: "The ID of the entity.",
 	}),
-	billing_controls: ApiEntityBillingControlsParamsSchema.extend(
-		WritableUsageLimitsShape,
-	)
-		.optional()
-		.meta({
-			description: "Billing controls to replace on the entity.",
-		}),
+	billing_controls: ApiEntityBillingControlsUpdateSchema.optional().meta({
+		description: "Billing controls to replace on the entity.",
+	}),
 });
 
 export type UpdateEntityParams = z.infer<typeof UpdateEntityParamsSchema>;

--- a/shared/api/entities/crud/updateEntityParams.ts
+++ b/shared/api/entities/crud/updateEntityParams.ts
@@ -1,5 +1,11 @@
 import { z } from "zod/v4";
+import { UsageLimitUpdateSchema } from "../../../models/cusModels/billingControls/usageLimit.js";
 import { ApiEntityBillingControlsParamsSchema } from "../../billingControls/entityBillingControls.js";
+
+const UpdateEntityBillingControlsSchema =
+	ApiEntityBillingControlsParamsSchema.extend({
+		usage_limits: z.array(UsageLimitUpdateSchema).optional(),
+	});
 
 export const UpdateEntityParamsSchema = z.object({
 	customer_id: z.string().optional().meta({
@@ -8,7 +14,7 @@ export const UpdateEntityParamsSchema = z.object({
 	entity_id: z.string().meta({
 		description: "The ID of the entity.",
 	}),
-	billing_controls: ApiEntityBillingControlsParamsSchema.optional().meta({
+	billing_controls: UpdateEntityBillingControlsSchema.optional().meta({
 		description: "Billing controls to replace on the entity.",
 	}),
 });

--- a/shared/models/cusModels/billingControls/customerBillingControls.ts
+++ b/shared/models/cusModels/billingControls/customerBillingControls.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { findDuplicateBillingControlIssue } from "./duplicates/findDuplicateBillingControlIssue.js";
+import { rejectDuplicateBillingControls } from "./duplicates/rejectDuplicateBillingControls.js";
 import {
 	type EntityBillingControls,
 	type EntityBillingControlsParams,
@@ -274,10 +274,7 @@ export const CustomerBillingControlsParamsSchema =
 		auto_topups: z.array(AutoTopupParamsSchema).optional().meta({
 			description: "List of auto top-up configurations per feature.",
 		}),
-	}).check((ctx) => {
-		const issue = findDuplicateBillingControlIssue(ctx.value);
-		if (issue) ctx.issues.push(issue);
-	});
+	}).check(rejectDuplicateBillingControls);
 
 export type CustomerBillingControlsParams = z.input<
 	typeof CustomerBillingControlsParamsSchema

--- a/shared/models/cusModels/billingControls/duplicates/rejectDuplicateBillingControls.ts
+++ b/shared/models/cusModels/billingControls/duplicates/rejectDuplicateBillingControls.ts
@@ -1,0 +1,12 @@
+import type { z } from "zod/v4";
+import { findDuplicateBillingControlIssue } from "./findDuplicateBillingControlIssue.js";
+import type { DuplicateCheckedBillingControls } from "./types/duplicateCheckedBillingControls.js";
+
+/** Zod check: one entry per identity across every billing-control list.
+ * Re-apply after extend(), which drops a schema's checks in this Zod version. */
+export const rejectDuplicateBillingControls = (
+	ctx: z.core.ParsePayload<DuplicateCheckedBillingControls>,
+): void => {
+	const issue = findDuplicateBillingControlIssue(ctx.value);
+	if (issue) ctx.issues.push(issue);
+};


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Customer and entity updates now persist explicitly supplied `usage` values to durable usage windows instead of only changing usage-limit configuration.

- Resolves usage writes against the pending limit config without mutating the subject, while filtering plan-sourced entries and stripping `usage` and `source` before saving configuration.
- Validates usage up front and returns 400 when positive usage has no configured limit; zero usage without a matching window is skipped.
- Upserts windows scoped by customer, feature, entity, and filter identity inside the same transaction as the limit-config change, so failed requests no longer partially persist other updates.
- Invalidates the subject cache before and after each usage write.
- Customer and entity update params now accept `usage_limits` entries with `usage`.
- Update-request schemas re-apply the duplicate billing-control check because Zod's `extend()` drops checks, preventing duplicate entries from being accepted.

<sup>Written for commit 9c43c465caa40b77745ec9da14a6b33a96045f71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR lets customer and entity update requests explicitly set durable usage counters while keeping limit configuration and usage-window state consistent.

**Key changes**
- **[API changes]** Customer and entity billing-control update schemas now accept usage-counter writes.
- **[Improvements]** Counter values are persisted to the matching customer- or entity-scoped usage window.
- **[Bug fixes]** Usage is validated before persistence, and usage-window writes share a transaction with configuration updates.
- **[Bug fixes]** The latest revision projects pending usage-limit configuration immutably instead of modifying the loaded subject object.
- **[Improvements]** Duplicate billing controls are rejected after schema extension, and subject caches are invalidated around usage changes.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the latest revision fixes the pending-limit mutation without introducing a new actionable issue.

The pending configuration is now projected onto a copied customer or entity object, and limit resolution reads those exact scope-specific fields while preserving inherited controls. Both previous findings were manually resolved without explanatory replies, so neither remains outstanding.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/actions/update/prepareUsageLimitUsage.ts | Validates usage writes and immutably projects pending customer- or entity-scoped limits before resolving usage windows. |
| server/src/internal/customers/actions/update/updateCustomer.ts | Persists customer configuration and usage-window changes in one transaction and invalidates cached subject state. |
| server/src/internal/entities/actions/updateEntity.ts | Applies equivalent transactional usage persistence and cache handling for entity-scoped updates. |
| server/src/internal/customers/usageWindows/repos/setUsageWindows.ts | Upserts usage counters using customer, feature, entity, and filter identity. |
| shared/api/billingControls/usageLimit.ts | Adds the request schema for counter-only usage updates. |
| shared/api/billingControls/customerBillingControls.ts | Exposes writable usage counters in customer update billing controls while retaining duplicate validation. |
| shared/api/billingControls/entityBillingControls.ts | Exposes writable usage counters in entity update billing controls while retaining duplicate validation. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Update as Customer/Entity Update
    participant Subject as Full Subject
    participant DB as Database
    participant Cache as Subject Cache

    Client->>Update: Submit config and/or usage counters
    Update->>Cache: Invalidate cached subject
    Update->>Subject: Load current subject from primary
    Update->>Subject: Project pending limit configuration
    Update->>Update: Resolve and validate target windows
    Update->>DB: Transactionally save config and usage windows
    Update->>Cache: Invalidate changed subject
    Update-->>Client: Return updated subject
```
</details>

<sub>Reviews (10): Last reviewed commit: ["Resolve usage windows against the pendin..."](https://github.com/useautumn/autumn/commit/9c43c465caa40b77745ec9da14a6b33a96045f71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61662293)</sub>

**Context used:**

- Knowledge Base — [Customer, subject, and entitlement operations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/customer-management.md)
- Knowledge Base — [Usage and billing API platform](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/api-platform.md)

<!-- /greptile_comment -->