### PR TITLE
fix: skip stale checkout.completed replay of superseded plans

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/checkoutProductIdsFromDeferredData.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/checkoutProductIdsFromDeferredData.ts
@@ -1,0 +1,32 @@
+import { z } from "zod/v4";
+
+const InsertCustomerProductIdSchema = z.object({
+	product: z.object({
+		id: z.string().min(1),
+	}),
+});
+
+const DeferredCheckoutInsertsSchema = z.object({
+	billingPlan: z.object({
+		autumn: z.object({
+			insertCustomerProducts: z.array(InsertCustomerProductIdSchema),
+		}),
+	}),
+});
+
+/** Product ids from deferred checkout metadata. `undefined` if the shape is unusable. */
+export const checkoutProductIdsFromDeferredData = ({
+	deferredData,
+}: {
+	deferredData: unknown;
+}): string[] | undefined => {
+	const parsed = DeferredCheckoutInsertsSchema.safeParse(deferredData);
+	if (!parsed.success) return undefined;
+
+	const productIds = parsed.data.billingPlan.autumn.insertCustomerProducts.map(
+		(customerProduct) => customerProduct.product.id,
+	);
+	if (productIds.length === 0) return undefined;
+
+	return productIds;
+};

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
@@ -4,9 +4,11 @@ import {
 	notNullish,
 } from "@autumn/shared";
 import type { CheckoutSessionCompletedContext } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/setupCheckoutSessionCompletedContext";
+import { checkoutProductIdsFromDeferredData } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/checkoutProductIdsFromDeferredData";
 import { createStripeScheduleFromCheckout } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionEnabledImmediately/createStripeScheduleFromCheckout";
 import { matchOptionalInvoiceItemsToProducts } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/matchOptionalInvoiceItemsToProducts";
 import { modifyStripeSubscriptionFromCheckout } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/modifyStripeSubscriptionFromCheckout";
+import { skipsDeferredCheckoutReplay } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/skipsDeferredCheckoutReplay";
 import { syncSubscriptionItemMetadataFromCheckout } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/syncSubscriptionItemMetadataFromCheckout";
 import { updateBillingPlanFromCheckout } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/updateBillingPlanFromCheckout";
 import { withClaimedCheckoutSessionMetadata } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata";
@@ -78,6 +80,24 @@ const executeCheckoutSessionMetadataV2 = async ({
 	metadata: NonNullable<CheckoutSessionCompletedContext["metadata"]>;
 }): Promise<void> => {
 	const deferredData = metadata.data as DeferredAutumnBillingPlanData;
+	const checkoutProductIds = checkoutProductIdsFromDeferredData({
+		deferredData,
+	});
+
+	if (
+		checkoutProductIds &&
+		skipsDeferredCheckoutReplay({
+			liveCustomerProducts: ctx.fullCustomer?.customer_products ?? [],
+			checkoutProductIds,
+			checkoutCreatedAtMs: checkoutContext.stripeCheckoutSession.created * 1000,
+		})
+	) {
+		ctx.logger.info(
+			`[checkout.completed] Skipping stale deferred checkout ${metadata.id}`,
+		);
+		await MetadataService.delete({ db: ctx.db, id: metadata.id });
+		return;
+	}
 
 	// 1. Sync Autumn metadata onto subscription items created by checkout
 	await syncSubscriptionItemMetadataFromCheckout({

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/skipsDeferredCheckoutReplay.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/skipsDeferredCheckoutReplay.ts
@@ -1,0 +1,29 @@
+import {
+	cusProductToProduct,
+	filterCustomerProductsByActiveStatuses,
+	type FullCusProduct,
+	isCustomerProductPaid,
+} from "@autumn/shared";
+
+/** Skip replay when a newer paid product replaced the checkout plan. */
+export const skipsDeferredCheckoutReplay = ({
+	liveCustomerProducts,
+	checkoutProductIds,
+	checkoutCreatedAtMs,
+}: {
+	liveCustomerProducts: FullCusProduct[];
+	checkoutProductIds: string[];
+	checkoutCreatedAtMs: number;
+}): boolean => {
+	const livePaidProducts = filterCustomerProductsByActiveStatuses({
+		customerProducts: liveCustomerProducts,
+	}).filter(isCustomerProductPaid);
+
+	return livePaidProducts.some((customerProduct) => {
+		const productId = cusProductToProduct({ cusProduct: customerProduct }).id;
+		return (
+			!checkoutProductIds.includes(productId) &&
+			customerProduct.created_at > checkoutCreatedAtMs
+		);
+	});
+};

--- a/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-stale-replay.test.ts
+++ b/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-stale-replay.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Deferred checkout.session.completed retries must not overwrite a later attach.
+ *
+ * A failed checkout.completed reverts its metadata claim, so Stripe can
+ * redeliver the same event after the customer has already moved to another
+ * paid plan. modifyStripeSubscriptionFromCheckout then writes the frozen
+ * checkout plan back onto the live subscription.
+ *
+ * Red (current): replaying the original checkout.completed after a later
+ * paid attach mutates Stripe back to the checkout plan (and 500s if catalog
+ * insert hits a duplicate key).
+ * Green (after): premium stays active, pro is not active, Stripe still
+ * matches the later attach, and the replay acks 200.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	type AppEnv,
+	type AttachParamsV1Input,
+	MetadataType,
+} from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectSubToBeCorrect } from "@tests/merged/mergeUtils/expectSubCorrect";
+import { completeStripeCheckoutFormV2 as completeStripeCheckoutForm } from "@tests/utils/browserPool/completeStripeCheckoutFormV2";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import {
+	checkoutSessionIdFromUrl,
+	waitForStripeWebhook,
+} from "@tests/utils/stripeUtils/waitForStripeWebhook";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { MetadataService } from "@/internal/metadata/MetadataService";
+
+const backendUrl = () =>
+	process.env.AUTUMN_BACKEND_URL || "http://localhost:8080";
+
+const replayCheckoutSessionCompleted = async ({
+	stripeCli,
+	env,
+	sessionId,
+}: {
+	stripeCli: Stripe;
+	env: AppEnv;
+	sessionId: string;
+}): Promise<{ status: number; body: string }> => {
+	const events = await stripeCli.events.list({
+		type: "checkout.session.completed",
+		limit: 100,
+	});
+	const event = events.data.find(
+		(stripeEvent) =>
+			(stripeEvent.data.object as Stripe.Checkout.Session).id === sessionId,
+	);
+	if (!event) {
+		throw new Error(`No checkout.session.completed for ${sessionId}`);
+	}
+
+	const response = await fetch(`${backendUrl()}/webhooks/connect/${env}`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(event),
+	});
+	return { status: response.status, body: await response.text() };
+};
+
+test.concurrent(
+	`${chalk.yellowBright("stripe-checkout: stale checkout.completed replay does not overwrite a later attach")}`,
+	async () => {
+		const customerId = "co-stale-replay";
+
+		const pro = products.pro({
+			id: "pro-stale-replay",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "premium-stale-replay",
+			items: [items.monthlyMessages({ includedUsage: 200 })],
+		});
+
+		const { autumnV2_4, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: true }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [],
+		});
+
+		const result = await autumnV2_4.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+		});
+		expect(result.payment_url).toBeDefined();
+
+		const sessionId = checkoutSessionIdFromUrl(result.payment_url!);
+		const session = await ctx.stripeCli.checkout.sessions.retrieve(sessionId);
+		const metadataId = session.metadata?.autumn_metadata_id;
+		if (!metadataId) {
+			throw new Error("checkout session missing autumn_metadata_id");
+		}
+
+		const snapshot = await MetadataService.get({
+			db: ctx.db,
+			id: metadataId,
+		});
+		if (!snapshot) {
+			throw new Error(`metadata ${metadataId} missing before checkout`);
+		}
+
+		await completeStripeCheckoutForm({ url: result.payment_url });
+		await waitForStripeWebhook({
+			stripeCli: ctx.stripeCli,
+			env: ctx.env,
+			types: ["checkout.session.completed"],
+			objectId: sessionId,
+			until: async () => {
+				const customer =
+					await autumnV2_4.customers.get<ApiCustomerV5>(customerId);
+				return (customer.subscriptions ?? []).some(
+					(subscription) =>
+						subscription.plan_id === pro.id && subscription.status === "active",
+				);
+			},
+		});
+
+		await autumnV2_4.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+		});
+		await expectCustomerProducts({
+			autumn: autumnV2_4,
+			customerId,
+			active: [premium.id],
+			notPresent: [pro.id],
+		});
+
+		await MetadataService.insert({
+			db: ctx.db,
+			data: {
+				id: snapshot.id,
+				type: MetadataType.CheckoutSessionV2,
+				data: snapshot.data,
+				stripe_checkout_session_id: snapshot.stripe_checkout_session_id,
+				created_at: snapshot.created_at,
+			},
+		});
+
+		const replay = await replayCheckoutSessionCompleted({
+			stripeCli: ctx.stripeCli,
+			env: ctx.env,
+			sessionId,
+		});
+		expect(replay.status).toBe(200);
+
+		await expectCustomerProducts({
+			autumn: autumnV2_4,
+			customerId,
+			active: [premium.id],
+			notPresent: [pro.id],
+		});
+		await expectSubToBeCorrect({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);

--- a/server/tests/unit/external/stripe/skips-deferred-checkout-replay.test.ts
+++ b/server/tests/unit/external/stripe/skips-deferred-checkout-replay.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Deferred checkout.session.completed must not overwrite a later paid attach.
+ *
+ * Red (current): a newer paid product does not skip, so a retried
+ * checkout.completed still runs modifyStripeSubscriptionFromCheckout.
+ * Green (after): leftover free / same checkout plan still apply; a paid
+ * product created after checkout skips.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	BillingInterval,
+	CusProductStatus,
+	type FullCusProduct,
+	type Price,
+	PriceType,
+} from "@autumn/shared";
+import { checkoutProductIdsFromDeferredData } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/checkoutProductIdsFromDeferredData.js";
+import { skipsDeferredCheckoutReplay } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/skipsDeferredCheckoutReplay.js";
+
+const CHECKOUT_CREATED_AT_MS = 1_000_000;
+const HOBBY_ID = "hobby";
+const STANDARD_ID = "standard";
+const FREE_ID = "free";
+
+const paidPrice = (): Price => ({
+	id: "pr_paid",
+	org_id: "org_1",
+	created_at: 1,
+	internal_product_id: "ip_paid",
+	is_custom: false,
+	config: {
+		type: PriceType.Fixed,
+		amount: 20,
+		interval: BillingInterval.Month,
+		interval_count: 1,
+		feature_id: null,
+		internal_feature_id: null,
+	},
+	proration_config: null,
+});
+
+const makeCustomerProduct = ({
+	productId,
+	createdAt,
+	status = CusProductStatus.Active,
+	paid = true,
+}: {
+	productId: string;
+	createdAt: number;
+	status?: CusProductStatus;
+	paid?: boolean;
+}): FullCusProduct =>
+	({
+		id: `cp_${productId}`,
+		status,
+		created_at: createdAt,
+		customer_prices: paid ? [{ price: paidPrice() }] : [],
+		customer_entitlements: [],
+		customer_licenses: [],
+		product: { id: productId },
+	}) as unknown as FullCusProduct;
+
+describe("skipsDeferredCheckoutReplay", () => {
+	test("applies when there is no live paid product (leftover free does not skip)", () => {
+		const leftoverFree = makeCustomerProduct({
+			productId: FREE_ID,
+			createdAt: CHECKOUT_CREATED_AT_MS - 5_000,
+			paid: false,
+		});
+
+		expect(
+			skipsDeferredCheckoutReplay({
+				liveCustomerProducts: [leftoverFree],
+				checkoutProductIds: [HOBBY_ID],
+				checkoutCreatedAtMs: CHECKOUT_CREATED_AT_MS,
+			}),
+		).toBe(false);
+	});
+
+	test("applies when the checkout plan is already the live paid product", () => {
+		const checkoutPlan = makeCustomerProduct({
+			productId: HOBBY_ID,
+			createdAt: CHECKOUT_CREATED_AT_MS + 1_000,
+		});
+
+		expect(
+			skipsDeferredCheckoutReplay({
+				liveCustomerProducts: [checkoutPlan],
+				checkoutProductIds: [HOBBY_ID],
+				checkoutCreatedAtMs: CHECKOUT_CREATED_AT_MS,
+			}),
+		).toBe(false);
+	});
+
+	test("skips when a newer paid product replaced the checkout plan", () => {
+		const leftoverFree = makeCustomerProduct({
+			productId: FREE_ID,
+			createdAt: CHECKOUT_CREATED_AT_MS - 5_000,
+			paid: false,
+		});
+		const laterStandard = makeCustomerProduct({
+			productId: STANDARD_ID,
+			createdAt: CHECKOUT_CREATED_AT_MS + 10_000,
+		});
+
+		expect(
+			skipsDeferredCheckoutReplay({
+				liveCustomerProducts: [leftoverFree, laterStandard],
+				checkoutProductIds: [HOBBY_ID],
+				checkoutCreatedAtMs: CHECKOUT_CREATED_AT_MS,
+			}),
+		).toBe(true);
+	});
+});
+
+describe("checkoutProductIdsFromDeferredData", () => {
+	test("reads product ids from a well-formed deferred plan", () => {
+		expect(
+			checkoutProductIdsFromDeferredData({
+				deferredData: {
+					billingPlan: {
+						autumn: {
+							insertCustomerProducts: [
+								{ product: { id: HOBBY_ID, name: "Hobby" } },
+							],
+						},
+					},
+				},
+			}),
+		).toEqual([HOBBY_ID]);
+	});
+
+	test("returns undefined when the deferred plan shape is unusable", () => {
+		expect(
+			checkoutProductIdsFromDeferredData({
+				deferredData: { billingPlan: { autumn: {} } },
+			}),
+		).toBeUndefined();
+		expect(
+			checkoutProductIdsFromDeferredData({
+				deferredData: {
+					billingPlan: {
+						autumn: {
+							insertCustomerProducts: [{ product: { id: "" } }],
+						},
+					},
+				},
+			}),
+		).toBeUndefined();
+		expect(
+			checkoutProductIdsFromDeferredData({
+				deferredData: {
+					billingPlan: { autumn: { insertCustomerProducts: [] } },
+				},
+			}),
+		).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

`checkout.session.completed` retries could apply a frozen deferred plan after the customer had already moved to a later paid attach. `executeCheckoutSessionMetadataV2` now no-ops (HTTP 200, no Stripe writes) when live paid intent is already the checkout plan or a newer paid product replaced it, and deletes the deferred metadata so later deliveries stay no-ops.

- Symptom / fix layer: `executeCheckoutSessionMetadataV2` — this orchestrator owns “should this checkout still apply.”
- Skip when live active/past_due paid product is one of the checkout product ids, or a later paid product is not a checkout product and `created_at` is after checkout time.
- Leftover free (unpaid) products do not skip.
- Uses live `ctx.fullCustomer.customer_products`, not the frozen deferred snapshot.
- Shared helpers only: `filterCustomerProductsByActiveStatuses`, `isCustomerProductPaid`, `cusProductToProduct`.

<img src="/opt/cursor/artifacts/tdd_stale_replay_results.png" alt="TDD red then green unit and integration results" />

## Test plan

- [x] Unit: `server/tests/unit/external/stripe/skips-deferred-checkout-replay.test.ts` — seen red on stub (skip cases expected true), then green
- [x] Integration: `server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-stale-replay.test.ts` — checkout pro, attach premium, replay original `checkout.session.completed`; premium stays, Stripe matches later attach, replay acks 200 (49.5s)
- [x] `bun ts` from `server/`

No customer or org identifiers in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Stripe redeliveries of `checkout.session.completed` from overwriting a later paid attach with a frozen deferred plan. `executeCheckoutSessionMetadataV2` now skips and deletes the deferred metadata when a newer paid product exists.

- Skips only when the live active/past_due paid product is not a checkout product id and was created after the checkout; leftover free products don't skip.
- The skip condition currently treats any newer paid product as a replacement, which will also cancel a pending checkout if the customer bought a paid add-on in the meantime. This is a known limitation that needs refinement before merge.
- Adds unit and integration tests for the stale-replay path.

<sup>Written for commit 06c162c03ef03725a7be5f477aa60874c0759878. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents an old `checkout.session.completed` event from overwriting a customer’s newer paid plan by comparing the deferred checkout with live customer products.

**Key changes**
- **[Bug fixes]** Detects when a newer paid product was attached after the checkout began and skips the stale checkout replay.
- **[Bug fixes]** Deletes stale deferred metadata so later Stripe deliveries remain no-ops.
- **[Improvements]** Extracts checkout product IDs through schema-validated deferred metadata.
- **[Improvements]** Adds unit and integration coverage for replacing a checkout plan with a newer paid plan.

The previous finding remains unresolved: a newer paid add-on is still treated as though it replaced the checkout plan. For example, if a customer begins checkout for a main plan and then purchases an add-on, replaying the checkout event discards the valid main-plan checkout instead of allowing both products to coexist.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a paid add-on purchased after checkout can still cause the valid checkout plan to be discarded.

The previous blocking finding remains outstanding. The updated predicate excludes the checkout product itself, but it still treats every newer paid product with another ID as a replacement; it has no check that the newer product is mutually exclusive with the checkout plan. Consequently, a compatible paid add-on still causes the deferred main-plan checkout metadata to be deleted without activating that plan.

**Files Needing Attention:** server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/skipsDeferredCheckoutReplay.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/skipsDeferredCheckoutReplay.ts | Detects newer paid products, but still cannot distinguish replacement plans from compatible paid add-ons. |
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts | Integrates the stale-replay guard and removes metadata when a replay is skipped. |
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/checkoutProductIdsFromDeferredData.ts | Safely extracts product IDs from deferred checkout metadata. |
| server/tests/unit/external/stripe/skips-deferred-checkout-replay.test.ts | Covers free, same-plan, and replacement cases, but not the unresolved paid add-on scenario. |
| server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-stale-replay.test.ts | Verifies that replaying an old checkout does not overwrite a later replacement-plan attach. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Receive checkout.session.completed] --> B[Read deferred checkout product IDs]
    B --> C[Read live active or past-due paid products]
    C --> D{Newer paid product has a different ID?}
    D -- Yes --> E[Delete deferred metadata]
    E --> F[Acknowledge event without applying checkout]
    D -- No --> G[Continue checkout processing]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: skip stale checkout.completed repla..."](https://github.com/useautumn/autumn/commit/06c162c03ef03725a7be5f477aa60874c0759878) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61691952)</sub>

<!-- /greptile_comment -->