### PR TITLE
fix(catalogV2, atmn): variant license overlay round-trips through get and the diff

### DIFF
--- a/packages/atmn-generator/src/overlay/overlay.ts
+++ b/packages/atmn-generator/src/overlay/overlay.ts
@@ -63,6 +63,11 @@ export const OVERLAY: Overlay = {
 				reason:
 					"A link always follows the child's active version (wire/07_licenses); pinning it from config is a change the server reports forever.",
 			},
+			"variants.customize.upsert_licenses.version_slug": {
+				hidden: true,
+				reason:
+					"Same as licenses.version_slug: a variant's license link follows the child's active version too.",
+			},
 			name: {
 				required: true,
 				reason:

--- a/packages/atmn-nightly/src/generated/emit.ts
+++ b/packages/atmn-nightly/src/generated/emit.ts
@@ -611,7 +611,6 @@ export const COLLECTIONS: Readonly<Record<string, CollectionSpec>> = {
 			"variants.customize.upsertLicenses.licensePlanId",
 			"variants.customize.upsertLicenses.metadata",
 			"variants.customize.upsertLicenses.prepaidOnly",
-			"variants.customize.upsertLicenses.versionSlug",
 			"variants.internalId",
 			"variants.name",
 			"variants.newVersionSlug",

--- a/packages/atmn-nightly/src/generated/plans.ts
+++ b/packages/atmn-nightly/src/generated/plans.ts
@@ -1040,7 +1040,6 @@ export type Plan = {
 			/** License links to add or override for this customer, keyed by license_plan_id. Omitted fields inherit the plan catalog link (included defaults to 1 when the license is not in the catalog). A bare entry restores the license to pure catalog inheritance. */
 			upsertLicenses?: Array<{
 				licensePlanId: string;
-				versionSlug?: string;
 				included?: number;
 				prepaidOnly?: boolean;
 				customize?: {

--- a/packages/atmn-nightly/src/generated/variants.ts
+++ b/packages/atmn-nightly/src/generated/variants.ts
@@ -634,7 +634,6 @@ export type Variant = {
 		/** License links to add or override for this customer, keyed by license_plan_id. Omitted fields inherit the plan catalog link (included defaults to 1 when the license is not in the catalog). A bare entry restores the license to pure catalog inheritance. */
 		upsertLicenses?: Array<{
 			licensePlanId: string;
-			versionSlug?: string;
 			included?: number;
 			prepaidOnly?: boolean;
 			customize?: {

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/buildVariantEditDiff.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/buildVariantEditDiff.ts
@@ -11,6 +11,7 @@ import {
 	diffPlanV1,
 	type FullProduct,
 	type PlanLicenseParams,
+	type RemovePlanLicense,
 } from "@autumn/shared";
 import { diffFullProducts } from "@/internal/catalogV2/actions/buildPlanChange/diffFullProducts";
 import { fullProductToApiPlanV1Sync } from "@/internal/catalogV2/actions/buildPlanChange/fullProductToApiPlanV1Sync";
@@ -40,6 +41,22 @@ const isEmptyDiff = (diff: DiffedCustomizePlanV1) =>
 	diff.free_trial === undefined &&
 	diff.upsert_licenses === undefined &&
 	diff.remove_licenses === undefined;
+
+const removeLicensesFromPlan = ({
+	plan,
+	removeLicenses,
+}: {
+	plan: DiffablePlanV1;
+	removeLicenses: RemovePlanLicense[];
+}): DiffablePlanV1 => {
+	const removed = new Set(removeLicenses.map((entry) => entry.license_plan_id));
+	return {
+		...plan,
+		licenses: (plan.licenses ?? []).filter(
+			(license) => !removed.has(license.license_plan_id),
+		),
+	};
+};
 
 /** Apply variants[n].customize.upsert_licenses as a slot-level patch onto
  * the current license list (follow's rebase first), not a wholesale replace. */
@@ -84,9 +101,11 @@ const mergeUpsertLicensesOntoPlan = ({
 			});
 		}
 
+		const versionSlug = upsert.version_slug ?? existing?.version_slug;
 		const nextLicense: ApiPlanLicenseV1 = {
 			license_plan_id: upsert.license_plan_id,
 			version: existing?.version ?? 1,
+			...(versionSlug !== undefined ? { version_slug: versionSlug } : {}),
 			included: upsert.included ?? existing?.included ?? 0,
 			prepaid_only: upsert.prepaid_only ?? existing?.prepaid_only ?? true,
 			...(nextCustomize !== undefined ? { customize: nextCustomize } : {}),
@@ -138,8 +157,9 @@ const hasContentCustomize = (
 
 /**
  * Follow applies the base current→next diff onto the variant; customize then
- * patches on top. Declared customize alone recomposes over the declaring
- * base row's pre-edit content.
+ * patches on top — its license lanes last, so an overlay that drops a base
+ * link wins over the base's declared licenses[]. Declared customize alone
+ * recomposes over the declaring base row's pre-edit content.
  */
 export const buildVariantEditDiff = ({
 	variantProduct,
@@ -171,7 +191,7 @@ export const buildVariantEditDiff = ({
 		});
 	}
 	if (customize) {
-		const { upsert_licenses, ...contentCustomize } = customize;
+		const { upsert_licenses, remove_licenses, ...contentCustomize } = customize;
 		if (!follow) {
 			const basePlan = fullProductToApiPlanV1Sync({
 				product: baseCurrent ?? baseNext,
@@ -187,9 +207,18 @@ export const buildVariantEditDiff = ({
 				: { ...basePlan, licenses: currentPlan.licenses };
 		} else if (hasContentCustomize(customize)) {
 			nextPlan = {
-				...applyCustomizeToPlan({ plan: nextPlan, customize: contentCustomize }),
+				...applyCustomizeToPlan({
+					plan: nextPlan,
+					customize: contentCustomize,
+				}),
 				licenses: nextPlan.licenses,
 			};
+		}
+		if (remove_licenses !== undefined) {
+			nextPlan = removeLicensesFromPlan({
+				plan: nextPlan,
+				removeLicenses: remove_licenses,
+			});
 		}
 		if (upsert_licenses !== undefined) {
 			nextPlan = mergeUpsertLicensesOntoPlan({
@@ -200,10 +229,12 @@ export const buildVariantEditDiff = ({
 		}
 	}
 
+	// Removes are real here: a link only leaves nextPlan when the overlay drops it.
 	const editDiff = diffPlanV1({
 		from: currentPlan,
 		to: nextPlan,
 		includeAdds: true,
+		includeRemoves: true,
 	});
 	if (isEmptyDiff(editDiff)) return undefined;
 	return editDiff;

--- a/server/src/internal/products/productUtils/productResponseUtils/buildApiPlanVariant.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/buildApiPlanVariant.ts
@@ -1,6 +1,6 @@
 import type {
-	ApiPlanV1,
 	ApiPlanVariantV1,
+	DiffablePlanV1,
 	Feature,
 	FullProduct,
 	RevenueCatPlanMapping,
@@ -19,7 +19,7 @@ export const buildApiPlanVariant = async ({
 	revenuecatMappings,
 }: {
 	ctx?: AutumnContext;
-	basePlan: ApiPlanV1;
+	basePlan: DiffablePlanV1;
 	variant: FullProduct;
 	features: Feature[];
 	expand?: string[];

--- a/server/src/internal/products/productUtils/productResponseUtils/buildVariantDetails.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/buildVariantDetails.ts
@@ -1,5 +1,6 @@
 import {
 	type ApiPlanV1,
+	type DiffablePlanV1,
 	diffPlanV1,
 	type Feature,
 	type FullProduct,
@@ -28,9 +29,9 @@ const fetchBaseFullProduct = async ({
 };
 
 /**
- * A variant plan's up-link to its base: base_plan_id + the customize diff.
- * Base plan sources, in precedence order: pre-rendered basePlan, hydrated
- * baseFullProduct, DB fetch (when resolveBaseFullProduct).
+ * A variant plan's up-link to its base: base_plan_id + the customize diff,
+ * license links included. Base plan sources, in precedence order:
+ * pre-rendered basePlan, hydrated baseFullProduct, DB fetch (when resolveBaseFullProduct).
  */
 export const buildVariantDetails = async ({
 	ctx,
@@ -45,11 +46,11 @@ export const buildVariantDetails = async ({
 }: {
 	ctx?: AutumnContext;
 	product: FullProduct;
-	plan: ApiPlanV1;
+	plan: DiffablePlanV1;
 	features: Feature[];
 	expand?: string[];
 	currency?: string;
-	basePlan?: ApiPlanV1;
+	basePlan?: DiffablePlanV1;
 	baseFullProduct?: FullProduct;
 	resolveBaseFullProduct: boolean;
 }): Promise<ApiPlanV1["variant_details"]> => {
@@ -71,7 +72,12 @@ export const buildVariantDetails = async ({
 			: undefined);
 	if (!resolvedBasePlan) return undefined;
 
-	const customize = diffPlanV1({ from: resolvedBasePlan, to: plan });
+	const customize = diffPlanV1({
+		from: resolvedBasePlan,
+		to: plan,
+		includeAdds: true,
+		includeRemoves: true,
+	});
 	const hasCustomize = Object.keys(customize).length > 0;
 
 	return {

--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -6,6 +6,7 @@ import {
 	type ApiPlanV1,
 	ApiPlanV1Schema,
 	billingControlsFromColumns,
+	type DiffablePlanV1,
 	type Feature,
 	type FullCustomer,
 	type FullProduct,
@@ -54,7 +55,7 @@ type GetPlanResponseArgs = {
 	expand?: string[];
 	currency?: string;
 	/** Pre-rendered base plan — reuse it instead of re-rendering per variant. */
-	basePlan?: ApiPlanV1;
+	basePlan?: DiffablePlanV1;
 	baseFullProduct?: FullProduct;
 	resolveBaseFullProduct?: boolean;
 	/** RevenueCat mappings live in their own table, so the row is read in. */
@@ -226,10 +227,15 @@ export async function getPlanResponse({
 	} satisfies ApiPlanV1;
 
 	// 10. Graph edges: up-link to the base plan, down-links to variants.
+	// License links ride along so a variant's customize can state its license overlay.
+	const planWithLicenses = {
+		...plan,
+		...(apiLicenses ? { licenses: apiLicenses } : {}),
+	};
 	const variantDetails = await buildVariantDetails({
 		ctx,
 		product,
-		plan,
+		plan: planWithLicenses,
 		features,
 		expand,
 		currency,
@@ -243,7 +249,7 @@ export async function getPlanResponse({
 					product.variants.map((variant) =>
 						buildApiPlanVariant({
 							ctx,
-							basePlan: plan,
+							basePlan: planWithLicenses,
 							variant,
 							features,
 							expand,
@@ -255,8 +261,7 @@ export async function getPlanResponse({
 			: undefined;
 
 	const planResponse = {
-		...plan,
-		...(apiLicenses ? { licenses: apiLicenses } : {}),
+		...planWithLicenses,
 		...(variantDetails ? { variant_details: variantDetails } : {}),
 		...(variants ? { variants } : {}),
 	};

--- a/server/tests/integration/atmn/crud/variants/variant-customize-licenses-round-trips.test.ts
+++ b/server/tests/integration/atmn/crud/variants/variant-customize-licenses-round-trips.test.ts
@@ -1,0 +1,142 @@
+/**
+ * atmn crud/variants — a variant that swaps its base's license link via
+ * customize.removeLicenses / upsertLicenses round-trips: the get exposes the
+ * overlay, an unchanged push previews none, and the links stay put.
+ */
+
+import { expect, test } from "bun:test";
+import { uniqueTestId } from "@tests/integration/catalog-v2/utils/uniqueTestId.js";
+import { expectRoundTrip } from "@tests/utils/atmnUtils/expectRoundTrip.js";
+import { initAtmnScenario } from "@tests/utils/atmnUtils/initAtmnScenario.js";
+import { s } from "@tests/utils/testInitUtils/initScenario.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+const creditsItem = `{
+	featureId: "credits",
+	included: 600,
+	pooled: true,
+	reset: { interval: "month" },
+	rollover: { maxPercentage: 100, expiryDurationType: "month", expiryDurationLength: 1 },
+}`;
+
+const config = `{
+	features: [
+		feature({ featureId: "credits", name: "Credits", type: "metered", consumable: true }),
+	],
+	plans: [
+		plan({
+			planId: "seat",
+			name: "Seat",
+			addOn: true,
+			price: { amount: 25, interval: "month" },
+			items: [${creditsItem}],
+		}),
+		plan({
+			planId: "seatAnnual",
+			name: "Seat (annual)",
+			addOn: true,
+			price: { amount: 250, interval: "year" },
+			items: [${creditsItem}],
+		}),
+		plan({
+			planId: "starter",
+			name: "Starter",
+			licenses: [{ licensePlanId: "seat", included: 1 }],
+		}),
+		plan({
+			planId: "pro",
+			name: "Pro",
+			price: { amount: 49, interval: "month" },
+			licenses: [{ licensePlanId: "seat", included: 1 }],
+			variants: [
+				{
+					variantPlanId: "proAnnual",
+					name: "Pro (annual)",
+					customize: {
+						price: { amount: 490, interval: "year" },
+						removeLicenses: [{ licensePlanId: "seat" }],
+						upsertLicenses: [{ licensePlanId: "seatAnnual", included: 1 }],
+					},
+				},
+			],
+		}),
+	],
+}`;
+
+type Scenario = Awaited<ReturnType<typeof initAtmnScenario>>;
+
+const licenseLinksOf = async ({
+	scenario,
+	planId,
+}: {
+	scenario: Scenario;
+	planId: string;
+}): Promise<Array<{ licensePlanId: string; included: number }>> => {
+	const product = await ProductService.getFull({
+		db: scenario.ctx.db,
+		orgId: scenario.ctx.org.id,
+		env: scenario.ctx.env,
+		idOrInternalId: planId,
+	});
+	return (product.licenses ?? []).map((link) => ({
+		licensePlanId: link.product.id,
+		included: link.included,
+	}));
+};
+
+const expectLinksUnchanged = async ({
+	scenario,
+}: {
+	scenario: Scenario;
+}): Promise<void> => {
+	expect(await licenseLinksOf({ scenario, planId: "starter" })).toEqual([
+		{ licensePlanId: "seat", included: 1 },
+	]);
+	expect(await licenseLinksOf({ scenario, planId: "pro" })).toEqual([
+		{ licensePlanId: "seat", included: 1 },
+	]);
+	expect(await licenseLinksOf({ scenario, planId: "proAnnual" })).toEqual([
+		{ licensePlanId: "seatAnnual", included: 1 },
+	]);
+};
+
+test.concurrent(
+	"variant customize.removeLicenses / upsertLicenses round-trips",
+	async () => {
+		const scenario = await initAtmnScenario({
+			setup: [
+				s.platform.create({
+					userEmail: `${uniqueTestId("atmn")}@autumn.test`,
+				}),
+			],
+			config,
+		});
+
+		try {
+			const { freshWire } = await expectRoundTrip({ scenario });
+			await expectLinksUnchanged({ scenario });
+
+			const plans = freshWire.plans as Array<Record<string, unknown>>;
+			const wirePro = plans.find((row) => row.plan_id === "pro");
+			const variants = wirePro?.variants as Array<Record<string, unknown>>;
+			expect(variants).toHaveLength(1);
+			expect(variants[0].customize).toEqual({
+				price: expect.objectContaining({ amount: 490, interval: "year" }),
+				remove_licenses: [{ license_plan_id: "seat" }],
+				upsert_licenses: [
+					expect.objectContaining({
+						license_plan_id: "seatAnnual",
+						included: 1,
+					}),
+				],
+			});
+			expect(plans.some((row) => row.plan_id === "proAnnual")).toBe(false);
+
+			// A second --yes push of the unchanged config must leave every link alone.
+			await scenario.push();
+			await expectLinksUnchanged({ scenario });
+		} finally {
+			scenario.cleanup();
+		}
+	},
+);

--- a/server/tests/integration/atmn/crud/variants/variant-customize-licenses-round-trips.test.ts
+++ b/server/tests/integration/atmn/crud/variants/variant-customize-licenses-round-trips.test.ts
@@ -1,25 +1,34 @@
 /**
  * atmn crud/variants — a variant that swaps its base's license link via
  * customize.removeLicenses / upsertLicenses round-trips: the get exposes the
- * overlay, an unchanged push previews none, and the links stay put.
+ * overlay, every push of the config (unchanged, or with an unrelated edit
+ * while customers are attached) leaves exactly one link on the variant, and
+ * a phantom link already in the DB is repaired by the next push.
  */
 
 import { expect, test } from "bun:test";
 import { uniqueTestId } from "@tests/integration/catalog-v2/utils/uniqueTestId.js";
-import { expectRoundTrip } from "@tests/utils/atmnUtils/expectRoundTrip.js";
-import { initAtmnScenario } from "@tests/utils/atmnUtils/initAtmnScenario.js";
+import {
+	expectPreviewNone,
+	expectRoundTrip,
+} from "@tests/utils/atmnUtils/expectRoundTrip.js";
+import {
+	atmnConfigSource,
+	initAtmnScenario,
+} from "@tests/utils/atmnUtils/initAtmnScenario.js";
 import { s } from "@tests/utils/testInitUtils/initScenario.js";
+import { planLicenseRepo } from "@/internal/licenses/repos/planLicenseRepo.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 
-const creditsItem = `{
+const creditsItem = ({ included }: { included: number }) => `{
 	featureId: "credits",
-	included: 600,
+	included: ${included},
 	pooled: true,
 	reset: { interval: "month" },
 	rollover: { maxPercentage: 100, expiryDurationType: "month", expiryDurationLength: 1 },
 }`;
 
-const config = `{
+const config = ({ seatCredits = 600 }: { seatCredits?: number } = {}) => `{
 	features: [
 		feature({ featureId: "credits", name: "Credits", type: "metered", consumable: true }),
 	],
@@ -29,14 +38,14 @@ const config = `{
 			name: "Seat",
 			addOn: true,
 			price: { amount: 25, interval: "month" },
-			items: [${creditsItem}],
+			items: [${creditsItem({ included: seatCredits })}],
 		}),
 		plan({
 			planId: "seatAnnual",
 			name: "Seat (annual)",
 			addOn: true,
 			price: { amount: 250, interval: "year" },
-			items: [${creditsItem}],
+			items: [${creditsItem({ included: 600 })}],
 		}),
 		plan({
 			planId: "starter",
@@ -65,6 +74,20 @@ const config = `{
 
 type Scenario = Awaited<ReturnType<typeof initAtmnScenario>>;
 
+const fullPlan = ({
+	scenario,
+	planId,
+}: {
+	scenario: Scenario;
+	planId: string;
+}) =>
+	ProductService.getFull({
+		db: scenario.ctx.db,
+		orgId: scenario.ctx.org.id,
+		env: scenario.ctx.env,
+		idOrInternalId: planId,
+	});
+
 const licenseLinksOf = async ({
 	scenario,
 	planId,
@@ -72,18 +95,14 @@ const licenseLinksOf = async ({
 	scenario: Scenario;
 	planId: string;
 }): Promise<Array<{ licensePlanId: string; included: number }>> => {
-	const product = await ProductService.getFull({
-		db: scenario.ctx.db,
-		orgId: scenario.ctx.org.id,
-		env: scenario.ctx.env,
-		idOrInternalId: planId,
-	});
+	const product = await fullPlan({ scenario, planId });
 	return (product.licenses ?? []).map((link) => ({
 		licensePlanId: link.product.id,
 		included: link.included,
 	}));
 };
 
+/** starter→seat, pro→seat, proAnnual→seatAnnual — and nothing else. */
 const expectLinksUnchanged = async ({
 	scenario,
 }: {
@@ -100,17 +119,18 @@ const expectLinksUnchanged = async ({
 	]);
 };
 
+const setup = () =>
+	initAtmnScenario({
+		setup: [
+			s.platform.create({ userEmail: `${uniqueTestId("atmn")}@autumn.test` }),
+		],
+		config: config(),
+	});
+
 test.concurrent(
 	"variant customize.removeLicenses / upsertLicenses round-trips",
 	async () => {
-		const scenario = await initAtmnScenario({
-			setup: [
-				s.platform.create({
-					userEmail: `${uniqueTestId("atmn")}@autumn.test`,
-				}),
-			],
-			config,
-		});
+		const scenario = await setup();
 
 		try {
 			const { freshWire } = await expectRoundTrip({ scenario });
@@ -135,6 +155,69 @@ test.concurrent(
 			// A second --yes push of the unchanged config must leave every link alone.
 			await scenario.push();
 			await expectLinksUnchanged({ scenario });
+		} finally {
+			scenario.cleanup();
+		}
+	},
+);
+
+test.concurrent(
+	"an unrelated in-place edit with customers attached keeps the variant on one link",
+	async () => {
+		const scenario = await setup();
+
+		try {
+			await scenario.push();
+			await scenario.seedCustomer({ planId: "pro" });
+			await scenario.seedCustomer({ planId: "proAnnual" });
+			await scenario.seedCustomer({ planId: "seat" });
+
+			scenario.writeConfig(
+				atmnConfigSource({ body: config({ seatCredits: 1000 }) }),
+			);
+			await scenario.push();
+			await expectLinksUnchanged({ scenario });
+
+			const seat = await fullPlan({ scenario, planId: "seat" });
+			expect(seat.entitlements[0]?.allowance).toBe(1000);
+			await expectPreviewNone({
+				client: scenario.client,
+				wire: await scenario.wireFromConfig(),
+			});
+		} finally {
+			scenario.cleanup();
+		}
+	},
+);
+
+test.concurrent(
+	"a phantom base link already on the variant row is removed by the next push",
+	async () => {
+		const scenario = await setup();
+
+		try {
+			await scenario.push();
+			const proAnnual = await fullPlan({ scenario, planId: "proAnnual" });
+			const seat = await fullPlan({ scenario, planId: "seat" });
+			await planLicenseRepo.upsert({
+				db: scenario.ctx.db,
+				parentInternalProductId: proAnnual.internal_id,
+				licenseInternalProductId: seat.internal_id,
+				included: 1,
+				prepaidOnly: true,
+			});
+			expect(
+				(await licenseLinksOf({ scenario, planId: "proAnnual" })).map(
+					(link) => link.licensePlanId,
+				),
+			).toEqual(expect.arrayContaining(["seat", "seatAnnual"]));
+
+			await scenario.push();
+			await expectLinksUnchanged({ scenario });
+			await expectPreviewNone({
+				client: scenario.client,
+				wire: await scenario.wireFromConfig(),
+			});
 		} finally {
 			scenario.cleanup();
 		}

--- a/server/tests/unit/catalogV2/variants/variant-license-overlay.test.ts
+++ b/server/tests/unit/catalogV2/variants/variant-license-overlay.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import type { FullPlanLicense, FullProduct } from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/db/products";
+import { buildVariantEditDiff } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/buildVariantEditDiff";
+import { getPlanResponse } from "@/internal/products/productUtils/productResponseUtils/getPlanResponse.js";
+
+/**
+ * A variant whose overlay swaps the base's license link for its own: the
+ * read side must state the swap as customize, and the diff side must not
+ * re-add the base's link on an unchanged config.
+ */
+
+const planLicense = ({
+	parent,
+	licenseProduct,
+	included = 1,
+}: {
+	parent: FullProduct;
+	licenseProduct: FullProduct;
+	included?: number;
+}): FullPlanLicense => ({
+	id: `license_${parent.id}_${licenseProduct.id}`,
+	parent_internal_product_id: parent.internal_id,
+	is_custom: false,
+	license_internal_product_id: licenseProduct.internal_id,
+	included,
+	prepaid_only: true,
+	customized: false,
+	metadata: null,
+	created_at: 1,
+	updated_at: 1,
+	product: licenseProduct,
+});
+
+const seat = products.createFull({ id: "seat", name: "Seat" });
+const seatAnnual = products.createFull({
+	id: "seat_annual",
+	name: "Seat (annual)",
+});
+
+const pro: FullProduct = {
+	...products.createFull({ id: "pro", name: "Pro" }),
+	licenses: [],
+};
+pro.licenses = [planLicense({ parent: pro, licenseProduct: seat })];
+
+const proAnnual: FullProduct = {
+	...products.createFull({ id: "pro_annual", name: "Pro (annual)" }),
+	base_internal_product_id: pro.internal_id,
+	licenses: [],
+};
+proAnnual.licenses = [
+	planLicense({ parent: proAnnual, licenseProduct: seatAnnual }),
+];
+
+const declaredProLicenses = [{ license_plan_id: "seat", included: 1 }];
+
+const swapSeatOverlay = {
+	remove_licenses: [{ license_plan_id: "seat" }],
+	upsert_licenses: [{ license_plan_id: "seat_annual", included: 1 }],
+};
+
+describe("variant license overlay — read side", () => {
+	test("variants[].customize states remove_licenses / upsert_licenses relative to the base", async () => {
+		const plan = await getPlanResponse({
+			product: { ...pro, variants: [proAnnual] },
+			features: [],
+			expandLicensePlans: true,
+			expandVariants: true,
+			resolveBaseFullProduct: false,
+		});
+
+		expect(plan.variants?.[0]?.customize).toEqual({
+			remove_licenses: [{ license_plan_id: "seat" }],
+			upsert_licenses: [
+				{
+					license_plan_id: "seat_annual",
+					version_slug: "v1",
+					included: 1,
+					prepaid_only: true,
+				},
+			],
+		});
+	});
+
+	test("a variant sharing the base's links carries no license lane", async () => {
+		const sameLinks: FullProduct = {
+			...proAnnual,
+			licenses: [planLicense({ parent: proAnnual, licenseProduct: seat })],
+		};
+		const plan = await getPlanResponse({
+			product: { ...pro, variants: [sameLinks] },
+			features: [],
+			expandLicensePlans: true,
+			expandVariants: true,
+			resolveBaseFullProduct: false,
+		});
+
+		expect(plan.variants?.[0]?.customize).toBeUndefined();
+	});
+});
+
+describe("variant license overlay — diff side", () => {
+	test("unchanged config: declared overlay over the base's licenses[] is a no-op edit", () => {
+		expect(
+			buildVariantEditDiff({
+				variantProduct: proAnnual,
+				baseCurrent: pro,
+				baseNext: pro,
+				follow: true,
+				customize: swapSeatOverlay,
+				declaredLicenses: declaredProLicenses,
+			}),
+		).toBeUndefined();
+	});
+
+	test("first push of the overlay onto a variant still linked to seat: remove seat, add seat_annual", () => {
+		const stillOnSeat: FullProduct = {
+			...proAnnual,
+			licenses: [planLicense({ parent: proAnnual, licenseProduct: seat })],
+		};
+
+		expect(
+			buildVariantEditDiff({
+				variantProduct: stillOnSeat,
+				baseCurrent: pro,
+				baseNext: pro,
+				follow: true,
+				customize: swapSeatOverlay,
+				declaredLicenses: declaredProLicenses,
+			}),
+		).toEqual({
+			remove_licenses: [{ license_plan_id: "seat" }],
+			upsert_licenses: [
+				{ license_plan_id: "seat_annual", included: 1, prepaid_only: true },
+			],
+		});
+	});
+});

--- a/shared/utils/planV1Utils/diff/diffPlanLicenses.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanLicenses.ts
@@ -35,15 +35,17 @@ const byLicensePlanId = <T extends { license_plan_id: string }>(
 
 /** Link-field patch. Numeric `version` / expanded `plan` are display — ignored;
  * `version_slug` (the version anchor) is a term.
- * New links are skipped unless `includeAdds` — those are lifecycle, not terms. */
+ * Link lifecycle is skipped unless asked: `includeAdds` / `includeRemoves`. */
 export const diffPlanLicenses = ({
 	from,
 	to,
 	includeAdds = false,
+	includeRemoves = false,
 }: {
 	from?: ApiPlanLicenseV1[];
 	to?: ApiPlanLicenseV1[];
 	includeAdds?: boolean;
+	includeRemoves?: boolean;
 }): {
 	upsert_licenses?: CustomizePlanLicense[];
 	remove_licenses?: RemovePlanLicense[];
@@ -76,9 +78,18 @@ export const diffPlanLicenses = ({
 		);
 	}
 
+	const remove_licenses: RemovePlanLicense[] = includeRemoves
+		? [...fromById.keys()]
+				.filter((licensePlanId) => !toById.has(licensePlanId))
+				.map((license_plan_id) => ({ license_plan_id }))
+		: [];
+
 	return {
 		...(upsert_licenses.length > 0
 			? { upsert_licenses: upsert_licenses.sort(byLicensePlanId) }
+			: {}),
+		...(remove_licenses.length > 0
+			? { remove_licenses: remove_licenses.sort(byLicensePlanId) }
 			: {}),
 	};
 };

--- a/shared/utils/planV1Utils/diff/diffPlanV1.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1.ts
@@ -5,8 +5,8 @@ import {
 	CustomizePlanV1BaseSchema,
 	refineCustomizePlanV1Schema,
 } from "@api/billing/common/customizePlan/customizePlanV1.js";
-import type { ApiPlanV1 } from "@api/products/apiPlanV1.js";
 import type { ApiPlanLicenseV1 } from "@api/products/apiPlanLicenseV1.js";
+import type { ApiPlanV1 } from "@api/products/apiPlanV1.js";
 import type { BasePriceParams } from "@api/products/components/basePrice/basePrice.js";
 import type { CreatePlanItemParamsV1 } from "@api/products/items/crud/createPlanItemParamsV1.js";
 import type { PlanItemFilter } from "@api/products/items/filter/planItemFilter.js";
@@ -264,8 +264,7 @@ export const customizePlanV1DiffsEqual = ({
 		arraysEqual({
 			left: a.upsert_licenses,
 			right: b.upsert_licenses,
-			equals: (left, right) =>
-				customizePlanLicensesAreSame({ left, right }),
+			equals: (left, right) => customizePlanLicensesAreSame({ left, right }),
 		}) &&
 		arraysEqual({
 			left: a.remove_licenses,
@@ -280,11 +279,13 @@ export const diffPlanV1 = ({
 	from,
 	to,
 	includeAdds = false,
+	includeRemoves = false,
 	filterPrecision = PlanItemFilterPrecision.Identity,
 }: {
 	from: DiffablePlanV1;
 	to: DiffablePlanV1;
 	includeAdds?: boolean;
+	includeRemoves?: boolean;
 	filterPrecision?: PlanItemFilterPrecision;
 }): DiffedCustomizePlanV1 => {
 	const diff: DiffedCustomizePlanV1 = {};
@@ -329,6 +330,7 @@ export const diffPlanV1 = ({
 			from: from.licenses,
 			to: to.licenses,
 			includeAdds,
+			includeRemoves,
 		}),
 	);
 


### PR DESCRIPTION
## Problem

A variant's license overlay (`customize.remove_licenses` / `customize.upsert_licenses`) did not survive a round trip:

- **Read**: `getPlanResponse` built the variant details from a base plan without `licenses`, and `diffPlanV1` skips link lifecycle by default, so `variants[].customize` never carried the license overlay. `atmn pull` wrote `customize: { price }` only.
- **Diff**: `buildVariantEditDiff` propagated the base's declared `licenses[]` onto the variant first, then merged only `upsert_licenses` and discarded `remove_licenses`. An unchanged config previewed `~ proAnnual + seat (license)` on every run, and with customers attached plus any unrelated edit, `push --yes` really wrote the second link.

Reproduced end to end: `pro` links `seat`, variant `proAnnual` customises `removeLicenses: [seat]` + `upsertLicenses: [seatAnnual]`; after a push, the catalog read lost the overlay and the next apply left `proAnnual` linked to both.

## Fix

- `shared/utils/planV1Utils/diff/diffPlanLicenses.ts`, `diffPlanV1.ts`: opt-in `includeRemoves` that emits `remove_licenses` for links present in `from` but not `to` (default off; existing callers unchanged).
- `getPlanResponse.ts`, `buildVariantDetails.ts`, `buildApiPlanVariant.ts`: diff base → variant with licenses attached and `includeAdds` + `includeRemoves`, so `variants[].customize` states the variant's actual license overlay relative to its base.
- `buildVariantEditDiff.ts`: apply `remove_licenses` then `upsert_licenses` after the base's declared-license propagation, carry `version_slug` through the merge, diff with `includeRemoves`. Unchanged config ⇒ no edit ⇒ preview none. An org already holding a phantom link previews `- seat (license)` and the next apply removes it.
- Generator overlay: hide `variants.customize.upsert_licenses.version_slug` (same rule as `licenses.version_slug`) so pull never pins the child version; generated files regenerated.

## Tests

- `server/tests/unit/catalogV2/variants/variant-license-overlay.test.ts` (4).
- `server/tests/integration/atmn/crud/variants/variant-customize-licenses-round-trips.test.ts` (3): round trip with fresh-wire overlay assertion and second push; unrelated edit with seeded customers; phantom-link repair. Each asserts exactly `starter→seat`, `pro→seat`, `proAnnual→seatAnnual` and preview none.

Gates: `bun ts`; `bun test tests/unit/catalogV2` 473/0; unit shared + products 497/0; atmn-generator test 76/0 + generate + check; atmn-nightly ts + unit 239/0; licenses and variants e2e files one at a time all green except the known pre-existing "variant renamed" red.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M20C2JKFA15VPKF6GKTGB55Z"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Variant license overlays now round-trip through catalog reads, previews, and `atmn` config. Previously, reads lost `remove_licenses` and pushes could re-add inherited base links, causing unchanged configs to churn and variants to retain duplicate links.

**Bug Fixes**

- License diffs can now emit removals when explicitly requested without changing existing callers.
- Variant overlays apply after inherited base licenses and preserve `version_slug` while merging.
- Generated `atmn` output hides child `version_slug` values for variant license overrides.
- Tests cover unchanged pushes, unrelated edits with customers, and phantom-link repair.

<sup>Written for commit f805e470b51de2472f1561169216340c49e7d614. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes a variant's license-link customization survive catalog reads and subsequent diffs.

## Key changes
- **[Bug fixes]** Includes license additions and removals when deriving a variant's customization relative to its base plan.
- **[Bug fixes]** Applies declared license removals before additions while computing variant edits, preventing removed base links from being restored.
- **[Improvements]** Preserves license version information while constructing the intended variant state and adds round-trip and phantom-link repair coverage.
- **[API changes]** Hides `versionSlug` for variant license upserts from generated atmn configuration types, matching ordinary plan-license behavior.
</details>


<h3>Confidence Score: 4/5</h3>

The PR should not merge until variant license version anchors are either persisted correctly or rejected before the preview claims they will be applied.

Variant license swaps and removals now round-trip correctly, but an accepted `version_slug` can appear in the computed edit and then be discarded during persistence, producing a wrong version link and repeated diffs.

**Files Needing Attention:** server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/buildVariantEditDiff.ts; server/src/internal/catalogV2/actions/buildPlanChange/buildPlanLicenseChanges/toPlanLicenseParams.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/buildVariantEditDiff.ts | Applies variant license removals and additions in overlay order, but requested version slugs are still lost before persistence. |
| server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts | Carries complete license arrays into base-to-variant response diffing. |
| server/src/internal/products/productUtils/productResponseUtils/buildVariantDetails.ts | Emits both added and removed license links in variant customization details. |
| shared/utils/planV1Utils/diff/diffPlanLicenses.ts | Adds opt-in, deterministically ordered removal detection while preserving existing caller defaults. |
| packages/atmn-generator/src/overlay/overlay.ts | Hides variant license version slugs from generated configuration surfaces. |
| server/tests/integration/atmn/crud/variants/variant-customize-licenses-round-trips.test.ts | Covers unchanged pushes, unrelated edits, and repair of an extra inherited license link. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  B[Base plan licenses] --> D[Build variant customization diff]
  V[Variant licenses] --> D
  D --> O[remove_licenses and upsert_licenses]
  O --> E[Build variant edit]
  E --> P[Persist final license links]
  P --> R[Catalog read]
  R --> D
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/buildVariantEditDiff.ts:104-108
**License version is discarded**

When a caller asks a variant license to use a specific `version_slug`, this code includes that version in the computed edit, but the update path drops it before saving. For example, a request for version `v2` keeps the current version for an existing link or uses the active version for a new link. The requested change is silently ignored and can reappear on every preview because license diffs compare `version_slug`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(atmn): cover destructive variant li..."](https://github.com/useautumn/autumn/commit/f805e470b51de2472f1561169216340c49e7d614) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61702534)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->