### PR TITLE
fix: 🐛 refuse a coupon that names a plan the same payload is taking away

### DIFF
--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleRewardErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleRewardErrors.ts
@@ -204,8 +204,26 @@ const assertRewardReferencesResolve = async ({
 	const featureIds = new Set(
 		updateCatalogPlan.projected.features.map((feature) => feature.id),
 	);
-	const projectedPlanIds = new Set(
-		updateCatalogPlan.projected.products.map((product) => product.id),
+	// A rename moves every version row, but the projection only carries the new
+	// id for the versions the payload restated — an untouched sibling version
+	// still projects the old one. Reading each projected id through the rename
+	// gives the plan ids this push actually leaves behind.
+	const renamedTo = new Map(
+		updateCatalogPlan.renamePlans.map(({ planId, toId }) => [planId, toId]),
+	);
+	const survivingPlanIds = new Set(
+		updateCatalogPlan.projected.products.map(
+			(product) => renamedTo.get(product.id) ?? product.id,
+		),
+	);
+	// An id this payload takes away: renamed off its rows, or removed with no
+	// version left holding it. The database still answers to it, so the lookup
+	// below would call it resolved — it has to be asked first.
+	const vacatedPlanIds = new Set(
+		[
+			...updateCatalogPlan.renamePlans.map(({ planId }) => planId),
+			...updateCatalogPlan.removePlans.map(({ planId }) => planId),
+		].filter((planId) => !survivingPlanIds.has(planId)),
 	);
 	const couponPlans = new Map<string, string[]>();
 	for (const upsert of updateCatalogPlan.upsertRewards) {
@@ -222,15 +240,14 @@ const assertRewardReferencesResolve = async ({
 		}
 	}
 
-	// A plan the projection holds is settled; anything else is looked up once.
-	// KNOWN GAP: the lookup reads pre-change state, so an id this same payload
-	// renames away still resolves and the coupon is rejected later, by the
-	// reward writer, after the rename has committed.
+	// An id the push keeps is settled; every other id is looked up once. A
+	// vacated id is looked up too, and found — the database is pre-change — so
+	// the vacating question below has to be asked before this answer is read.
 	const unresolved = [
 		...new Set(
 			[...couponPlans.values()]
 				.flat()
-				.filter((planId) => !projectedPlanIds.has(planId)),
+				.filter((planId) => !survivingPlanIds.has(planId)),
 		),
 	];
 	const known =
@@ -249,7 +266,11 @@ const assertRewardReferencesResolve = async ({
 
 	for (const [rewardId, planIds] of couponPlans) {
 		for (const planId of planIds) {
-			if (projectedPlanIds.has(planId) || known.has(planId)) continue;
+			if (vacatedPlanIds.has(planId))
+				invalid(
+					`Reward ${rewardId} applies to plan ${planId}, which this request removes or renames. Point the reward at the plan id this catalog keeps.`,
+				);
+			if (survivingPlanIds.has(planId) || known.has(planId)) continue;
 			invalid(
 				`Reward ${rewardId} applies to plan ${planId}, which this catalog does not have.`,
 			);

--- a/server/tests/integration/atmn/rewards-api-contract.test.ts
+++ b/server/tests/integration/atmn/rewards-api-contract.test.ts
@@ -15,6 +15,8 @@
  *  - S6  a rewards-only payload rejects a coupon naming a plan the org holds
  *  - S7  a coupon naming a missing plan is rejected only in the reward phase,
  *        after the plan rename in the same payload has committed
+ *  - S8  a coupon naming a plan the same payload renames or removes passes the
+ *        errors phase, because the lookup behind it reads pre-change state
  *  - S9  a payload may claim the id of a hidden legacy referral program
  *  - S10 replacing a reward while keeping its promo code fails, because the
  *        replacement is created before the row that still owns the code goes
@@ -27,6 +29,9 @@
  *  - S5  the applied result carries the id the row received
  *  - S6  a plan the payload leaves untouched still counts as present
  *  - S7  refused in the errors phase, so the rename does not land
+ *  - S8  an id this payload vacates is refused before the plan phase, so
+ *        neither the rename nor the removal lands; the id a rename lands on
+ *        still resolves
  *  - S9  409, the same answer a hidden reward's id gets
  *  - S10 the unlinked removal frees the code before the create needs it
  */
@@ -80,15 +85,17 @@ const promoCode = (id: string): string => id.replace(/[^a-zA-Z0-9]/g, "");
 const couponParams = ({
 	id,
 	planIds,
+	value = 10,
 }: {
 	id: string;
 	planIds: string[] | null;
+	value?: number;
 }): UpdateCatalogRewardParams => ({
 	coupon: {
 		id,
 		name: "Sale",
 		type: "percentage_discount" as never,
-		value: 10,
+		value,
 		duration: { type: "one_off" as never, length: null },
 		plan_ids: planIds,
 		promo_codes: [{ code: promoCode(id) }],
@@ -225,6 +232,43 @@ test.concurrent(
 			).rejects.toThrow(ghostPlan);
 			const afterGhost = await scenario.client.get({});
 			expect(afterGhost.plans.map((plan) => plan.id)).toContain(pro);
+
+			// S8: the plan the coupon names is the one this payload renames away.
+			// The database still holds the old id while the errors phase runs, so
+			// only the payload itself can say the reference is about to dangle.
+			await expect(
+				scenario.client.update({
+					plans: [{ plan_id: pro, new_plan_id: renamedPlan, name: "Pro" }],
+					rewards: [couponParams({ id: sale, planIds: [pro], value: 20 })],
+				} as never),
+			).rejects.toThrow(pro);
+			const afterVacated = await scenario.client.get({});
+			expect(afterVacated.plans.map((plan) => plan.id)).toContain(pro);
+
+			// The id the rename lands on is the one that will exist, so the same
+			// payload pointed at it goes through.
+			await scenario.client.update({
+				plans: [{ plan_id: pro, new_plan_id: renamedPlan, name: "Pro" }],
+				rewards: [
+					couponParams({ id: sale, planIds: [renamedPlan], value: 20 }),
+				],
+			} as never);
+			const afterRename = await scenario.client.get({});
+			expect(afterRename.plans.map((plan) => plan.id)).toContain(renamedPlan);
+
+			// The same question for a removal: the row is still in the database
+			// while the errors phase runs, and the plan phase deletes it before
+			// the reward writer would ever look.
+			await expect(
+				scenario.client.update({
+					remove_plans: [{ plan_id: renamedPlan }],
+					rewards: [
+						couponParams({ id: sale, planIds: [renamedPlan], value: 30 }),
+					],
+				} as never),
+			).rejects.toThrow(renamedPlan);
+			const afterRemoval = await scenario.client.get({});
+			expect(afterRemoval.plans.map((plan) => plan.id)).toContain(renamedPlan);
 		} finally {
 			scenario.cleanup();
 		}


### PR DESCRIPTION
## The gap

`assertRewardReferencesResolve` validated a coupon's `plan_ids` against `updateCatalogPlan.projected.products` and, for ids the payload does not manage, against a bounded `ProductService.listFull({ inIds })`. That lookup reads PRE-CHANGE database state, so an id this same payload renames away — or removes — was still found and the reference was called resolved. Plans execute before rewards, so the rename committed and the reward writer then threw `Plans not found: <id>` mid-phase: a rejected request that left the rename applied. Catalog writes are not transactional, so it half-applied.

## The fix

The errors phase now works out the plan ids the push actually leaves behind, and asks whether an id is being vacated before it reads the lookup's answer.

- `survivingPlanIds` reads every projected product id through `renamePlans`. A rename moves every version row, but the projection only carries the new id for the versions the payload restated — an untouched sibling version still projects the old one, so the raw projection cannot be trusted for this question. Mapping through the rename also makes a coupon that names the rename TARGET resolve, which it could not before.
- `vacatedPlanIds` is every `renamePlans[].planId` and `removePlans[].planId` that no longer survives. One version removed while other versions live keeps the id in `survivingPlanIds`, so the plan id is not vacated.
- The lookup input is deliberately NOT filtered by `vacatedPlanIds`: a vacated id is still looked up, still found, and the vacating check in the loop is what refuses it. That keeps the guard load-bearing rather than decorative (see the red below — the first version of this change filtered the lookup instead, and the guard could be deleted with the test still green).

`renamePlans` is the right signal, and it is populated for the payload shape that reproduces this. Instrumented errors phase, real request through `catalogV2.update` with `{ plan_id, new_plan_id, name }`:

```
[GAP] {"renamePlans":[{"planId":"atmn_pro_qti03je","toId":"atmn_renamed_uj9gwu1"}],"removePlans":[],"projected":["atmn_renamed_uj9gwu1"],"coupons":["atmn_sale_onqor6t"]}
```

Note `projected` already carries the NEW id here — the old reference passed purely through the database fallback.

## The red

New case S8 in `rewards-api-contract.test.ts`. Several layers reject a bad plan id with a message containing that plan id, so the test discriminates on TIMING, the way S7 does: it puts the rename in the same payload and asserts afterwards that the rename did not land.

Guard disabled, rename half:

```
244 | 			const afterVacated = await scenario.client.get({});
245 | 			expect(afterVacated.plans.map((plan) => plan.id)).toContain(pro);
                                                           ^
error: expect(received).toContain(expected)

Expected to contain: "atmn_pro_kb322pp"
Received: [ "atmn_renamed_6ka3mew" ]
```

Removal half of the guard disabled on its own (`removePlans` dropped from `vacatedPlanIds`), so the rename cases stay green and execution reaches the removal case:

```
269 | 			const afterRemoval = await scenario.client.get({});
270 | 			expect(afterRemoval.plans.map((plan) => plan.id)).toContain(renamedPlan);
                                                           ^
error: expect(received).toContain(expected)

Expected to contain: "atmn_renamed_pmqtrax"
Received: []
```

Both restored, both green. S8 also asserts the positive: the same payload pointed at the id the rename lands on goes through, so the guard does not over-reject.

## Gates

- `cd server && bun ts` — clean
- `cd server && bun test tests/unit/catalogV2` — 469 pass, 0 fail
- `rewards-api-contract.test.ts` (4), `push-rewards.test.ts` (1), `crud/referral-programs/max-redemptions-null-n-plan-ids-exclude-trial.test.ts` (1) — 6 passed, 0 failed
- `biome check --write` on the two touched files — no fixes applied; `git diff --name-only` is exactly those two files

## Not covered by a test

"One version of a plan removed while other versions survive" is handled by `survivingPlanIds` but has no e2e case — it needs a multi-version fixture that this file does not carry.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M20A2MJ8ZZD0Q2G8DD6PPJTT"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a gap where a coupon naming a plan that the same payload renames or removes passed the errors phase, letting the rename commit before the reward writer rejected the request and left the catalog half-applied.

- The old lookup read pre-change database state, so a vacated plan id still resolved.
- The guard now splits plan ids into `survivingPlanIds` (projected ids read through `renamePlans`) and `vacatedPlanIds` (renamed or removed ids that no longer survive) and refuses coupons on vacated ids.
- Vacated ids are still included in the lookup so the refusal is explicit, not a side effect of filtering.
- New test S8 covers rename and removal cases and asserts the rename target still resolves.
- No e2e coverage for removing one plan version while siblings survive; the logic is handled but needs a multi-version fixture.

<sup>Written for commit 9bd473301264e582e2dbe18081b2ecbc8d54b9ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents catalog updates from partially applying a plan rename or removal before discovering that a coupon still references the plan ID being taken away.

Key changes:
- **[Bug fixes]** Derives the plan IDs that will survive the complete catalog update, accounting for renames across sibling plan versions.
- **[Bug fixes]** Rejects coupons that reference an ID vacated by a rename or removal before catalog writes begin.
- **[Improvements]** Adds integration coverage showing that rename sources and removed IDs are rejected, rename targets remain valid, and rejected requests leave plans unchanged.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable correctness, security, or repository-rule issues were identified.

The validation runs before writes in both preview and update, correctly distinguishes surviving rename targets from vacated source IDs, and the integration test covers the primary rename and removal failure paths.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/actions/updateCatalog/errors/handleRewardErrors.ts | Computes post-update plan identity and rejects reward references to IDs removed or renamed by the same request. |
| server/tests/integration/atmn/rewards-api-contract.test.ts | Covers rename-source rejection, rename-target acceptance, removal rejection, and preservation of plan state after validation failure. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Compute projected catalog update] --> B[Map projected plan IDs through renames]
  B --> C[Determine surviving and vacated plan IDs]
  C --> D{Coupon references a vacated ID?}
  D -->|Yes| E[Reject before catalog writes]
  D -->|No| F{ID survives or exists unchanged?}
  F -->|Yes| G[Continue with update]
  F -->|No| H[Reject missing plan reference]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 refuse a coupon that names a pla..."](https://github.com/useautumn/autumn/commit/9bd473301264e582e2dbe18081b2ecbc8d54b9ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61734117)</sub>

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)

<!-- /greptile_comment -->