### PR TITLE
fix: make checkout.session.completed retries idempotent after partial execution

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
@@ -17,6 +17,7 @@ import {
 } from "@/internal/billing/v2/actions/createSchedule/utils/persistDeferredCreateSchedule";
 import { addStripeSubscriptionScheduleIdToBillingPlan } from "@/internal/billing/v2/execute/addStripeSubscriptionScheduleIdToBillingPlan";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan";
+import { hasMaterializedCustomerProducts } from "@/internal/billing/v2/execute/hasMaterializedCustomerProducts";
 import { promotePendingCustomerProducts } from "@/internal/billing/v2/execute/promotePendingCustomerProducts";
 import { publishBillingTransition } from "@/internal/billing/v2/publish/publishBillingTransition.js";
 import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
@@ -132,12 +133,25 @@ const executeCheckoutSessionMetadataV2 = async ({
 		deferredData: dataWithOptionalItems,
 	});
 
-	// 3. Modify Stripe subscription to include other interval prices / 0 quantity prices
-	await modifyStripeSubscriptionFromCheckout({
+	// 3. Modify Stripe subscription to include other interval prices / 0 quantity prices.
+	// Skipped on a webhook retry: the first attempt already applied the plan to Stripe,
+	// and the customer may have moved to another plan since.
+	const alreadyMaterialized = await hasMaterializedCustomerProducts({
 		ctx,
-		checkoutContext,
-		deferredData: updatedDeferredData,
+		autumnBillingPlan: updatedDeferredData.billingPlan.autumn,
 	});
+
+	if (alreadyMaterialized) {
+		ctx.logger.warn(
+			`[checkout.completed] Metadata ${metadata.id} already materialized, skipping Stripe subscription update`,
+		);
+	} else {
+		await modifyStripeSubscriptionFromCheckout({
+			ctx,
+			checkoutContext,
+			deferredData: updatedDeferredData,
+		});
+	}
 
 	const stripeScheduleId = await createStripeScheduleFromCheckout({
 		ctx,
@@ -170,7 +184,6 @@ const executeCheckoutSessionMetadataV2 = async ({
 		ctx,
 		autumnBillingPlan: updatedDeferredData.billingPlan.autumn,
 		fullCustomer: updatedDeferredData.billingContext.fullCustomer,
-		metadataId: metadata.id,
 	});
 
 	// Execute autumn billing plan (includes customer products, upsertSubscription, upsertInvoice)

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
@@ -86,13 +86,29 @@ const executeCheckoutSessionMetadataV2 = async ({
 		checkoutContext,
 	});
 
+	// A webhook retry after a partial execution: the first attempt already applied
+	// the plan to Stripe (and the customer may have moved plans since), so every
+	// Stripe write and every freshly-generated row below is skipped.
+	const alreadyMaterialized = await hasMaterializedCustomerProducts({
+		ctx,
+		autumnBillingPlan: deferredData.billingPlan.autumn,
+	});
+	if (alreadyMaterialized) {
+		ctx.logger.warn(
+			`[checkout.completed] Metadata ${metadata.id} already materialized, skipping Stripe updates`,
+		);
+	}
+
 	// 1b. Fold in Stripe Checkout "optional items" the caller didn't request via
 	// plan_id but the customer selected and paid for. Skipped for create-schedule
 	// checkouts: the deferred phase bookkeeping only knows about the products it
 	// was told about ahead of time, and can't place an unplanned product into a
 	// phase after the fact.
 	let dataWithOptionalItems = deferredData;
-	if (!isCreateScheduleBillingContext(deferredData.billingContext)) {
+	if (
+		!alreadyMaterialized &&
+		!isCreateScheduleBillingContext(deferredData.billingContext)
+	) {
 		const optionalItemMatch = await matchOptionalInvoiceItemsToProducts({
 			ctx,
 			checkoutContext,
@@ -133,19 +149,8 @@ const executeCheckoutSessionMetadataV2 = async ({
 		deferredData: dataWithOptionalItems,
 	});
 
-	// 3. Modify Stripe subscription to include other interval prices / 0 quantity prices.
-	// Skipped on a webhook retry: the first attempt already applied the plan to Stripe,
-	// and the customer may have moved to another plan since.
-	const alreadyMaterialized = await hasMaterializedCustomerProducts({
-		ctx,
-		autumnBillingPlan: updatedDeferredData.billingPlan.autumn,
-	});
-
-	if (alreadyMaterialized) {
-		ctx.logger.warn(
-			`[checkout.completed] Metadata ${metadata.id} already materialized, skipping Stripe subscription update`,
-		);
-	} else {
+	// 3. Modify Stripe subscription to include other interval prices / 0 quantity prices
+	if (!alreadyMaterialized) {
 		await modifyStripeSubscriptionFromCheckout({
 			ctx,
 			checkoutContext,
@@ -153,11 +158,13 @@ const executeCheckoutSessionMetadataV2 = async ({
 		});
 	}
 
-	const stripeScheduleId = await createStripeScheduleFromCheckout({
-		ctx,
-		checkoutContext,
-		deferredData: updatedDeferredData,
-	});
+	const stripeScheduleId = alreadyMaterialized
+		? null
+		: await createStripeScheduleFromCheckout({
+				ctx,
+				checkoutContext,
+				deferredData: updatedDeferredData,
+			});
 
 	if (stripeScheduleId) {
 		addStripeSubscriptionScheduleIdToBillingPlan({
@@ -193,6 +200,10 @@ const executeCheckoutSessionMetadataV2 = async ({
 		stripeInvoice: checkoutContext.stripeInvoice,
 	});
 
+	// Deleted right after the DB commit: a retry past this point would re-apply
+	// balance deltas, so a redelivery after a failure below must find no metadata.
+	await MetadataService.delete({ db: ctx.db, id: metadata.id });
+
 	await persistDeferredCreateSchedule({
 		ctx,
 		billingContext: updatedDeferredData.billingContext,
@@ -217,9 +228,6 @@ const executeCheckoutSessionMetadataV2 = async ({
 		autumnBillingPlan: updatedDeferredData.billingPlan.autumn,
 		originalFullCustomer: updatedDeferredData.billingContext.fullCustomer,
 	});
-
-	// Delete metadata after successful execution
-	await MetadataService.delete({ db: ctx.db, id: metadata.id });
 
 	const newCustomerProducts =
 		updatedDeferredData.billingPlan.autumn.insertCustomerProducts;

--- a/server/src/internal/billing/v2/execute/executeDeferredBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeDeferredBillingPlan.ts
@@ -62,7 +62,6 @@ export const executeDeferredBillingPlan = async ({
 		ctx,
 		autumnBillingPlan: billingPlan.autumn,
 		fullCustomer: billingContext.fullCustomer,
-		metadataId: metadata.id,
 	});
 
 	await executeAutumnBillingPlan({

--- a/server/src/internal/billing/v2/execute/hasMaterializedCustomerProducts.ts
+++ b/server/src/internal/billing/v2/execute/hasMaterializedCustomerProducts.ts
@@ -1,0 +1,24 @@
+import { type AutumnBillingPlan, CusProductStatus } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { loadPlannedCustomerProducts } from "@/internal/billing/v2/execute/loadPlannedCustomerProducts";
+
+/**
+ * True once a previous execution of this plan already promoted a row past
+ * Pending — a retry must not re-apply the plan's Stripe changes.
+ */
+export const hasMaterializedCustomerProducts = async ({
+	ctx,
+	autumnBillingPlan,
+}: {
+	ctx: AutumnContext;
+	autumnBillingPlan: AutumnBillingPlan;
+}): Promise<boolean> => {
+	const existingCustomerProducts = await loadPlannedCustomerProducts({
+		ctx,
+		autumnBillingPlan,
+	});
+
+	return existingCustomerProducts.some(
+		(customerProduct) => customerProduct.status !== CusProductStatus.Pending,
+	);
+};

--- a/server/src/internal/billing/v2/execute/loadPlannedCustomerProducts.ts
+++ b/server/src/internal/billing/v2/execute/loadPlannedCustomerProducts.ts
@@ -1,0 +1,18 @@
+import type { AutumnBillingPlan, FullCusProduct } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { listFullCustomerProductsByIds } from "@/internal/licenses/repos/listFullCustomerProductsByIds";
+
+/** Rows a plan wants to insert that already exist, in any status. */
+export const loadPlannedCustomerProducts = async ({
+	ctx,
+	autumnBillingPlan,
+}: {
+	ctx: AutumnContext;
+	autumnBillingPlan: AutumnBillingPlan;
+}): Promise<FullCusProduct[]> =>
+	listFullCustomerProductsByIds({
+		db: ctx.db,
+		customerProductIds: autumnBillingPlan.insertCustomerProducts.map(
+			(customerProduct) => customerProduct.id,
+		),
+	});

--- a/server/src/internal/billing/v2/execute/promotePendingCustomerProducts.ts
+++ b/server/src/internal/billing/v2/execute/promotePendingCustomerProducts.ts
@@ -4,35 +4,40 @@ import {
 	type FullCustomer,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { loadPlannedCustomerProducts } from "@/internal/billing/v2/execute/loadPlannedCustomerProducts";
 import { reapplyExistingRolloversToCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/reapplyExistingRolloversToCustomerProduct";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 
+/**
+ * Promotes pending rows in place and drops every already-materialized row
+ * from the plan, so a webhook retry after a partial execution never
+ * re-inserts what the first attempt already wrote.
+ */
 export const promotePendingCustomerProducts = async ({
 	ctx,
 	autumnBillingPlan,
 	fullCustomer,
-	metadataId,
 }: {
 	ctx: AutumnContext;
 	autumnBillingPlan: AutumnBillingPlan;
 	fullCustomer: FullCustomer;
-	metadataId: string;
 }) => {
-	const pendingCustomerProducts = await CusProductService.getByMetadataId({
-		db: ctx.db,
-		metadataId,
-		orgId: ctx.org.id,
-		env: ctx.env,
-		inStatuses: [CusProductStatus.Pending],
+	const existingCustomerProducts = await loadPlannedCustomerProducts({
+		ctx,
+		autumnBillingPlan,
 	});
 
-	if (!pendingCustomerProducts.length) return autumnBillingPlan;
+	if (!existingCustomerProducts.length) return autumnBillingPlan;
 
-	const promotedIds = new Set<string>();
+	const existingIds = new Set(
+		existingCustomerProducts.map((customerProduct) => customerProduct.id),
+	);
 
-	for (const customerProduct of pendingCustomerProducts) {
+	for (const customerProduct of existingCustomerProducts) {
+		if (customerProduct.status !== CusProductStatus.Pending) continue;
+
 		const plannedCustomerProduct =
-			autumnBillingPlan.insertCustomerProducts?.find(
+			autumnBillingPlan.insertCustomerProducts.find(
 				(planned) => planned.id === customerProduct.id,
 			);
 		if (!plannedCustomerProduct) continue;
@@ -55,8 +60,6 @@ export const promotePendingCustomerProducts = async ({
 				customerProduct,
 			});
 		}
-
-		promotedIds.add(customerProduct.id);
 	}
 
 	return {
@@ -64,9 +67,8 @@ export const promotePendingCustomerProducts = async ({
 		customPrices: undefined,
 		customEntitlements: undefined,
 		customFreeTrial: undefined,
-		insertCustomerProducts:
-			autumnBillingPlan.insertCustomerProducts?.filter(
-				(planned) => !promotedIds.has(planned.id),
-			) ?? [],
+		insertCustomerProducts: autumnBillingPlan.insertCustomerProducts.filter(
+			(planned) => !existingIds.has(planned.id),
+		),
 	};
 };

--- a/server/tests/integration/billing/stripe-webhooks/checkout-session-completed/checkout-replay-after-attach.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/checkout-session-completed/checkout-replay-after-attach.test.ts
@@ -1,0 +1,144 @@
+/**
+ * TDD test: a redelivered checkout.session.completed must not downgrade a
+ * plan the customer attached after the checkout was already materialized.
+ *
+ * Stripe retries a sync-acked webhook that 500s. The first delivery promoted
+ * the pending row and rewrote the Stripe subscription before crashing, so the
+ * retry sees no pending rows but still holds the stale checkout plan.
+ *
+ * Red-failure mode (current behavior):
+ *  - the retry rewrites the Stripe subscription back to the checkout plan
+ *    (premium item deleted, pro item re-added), then throws on the duplicate
+ *    customer_products insert, so Stripe keeps retrying.
+ *
+ * Green-success criteria (after fix):
+ *  - the retry leaves the Stripe subscription on premium and completes
+ *    without throwing.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	ALL_STATUSES,
+	type ApiCustomerV3,
+	CusProductStatus,
+} from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { completeStripeCheckoutFormV2 as completeStripeCheckoutForm } from "@tests/utils/browserPool/completeStripeCheckoutFormV2";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { handleStripeCheckoutSessionCompleted } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/handleStripeCheckoutSessionCompleted";
+import { CusService } from "@/internal/customers/CusService";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import { MetadataService } from "@/internal/metadata/MetadataService";
+
+test.concurrent(
+	`${chalk.yellowBright("checkout replay: redelivered checkout.session.completed keeps a later attach")}`,
+	async () => {
+		const customerId = `checkout-replay-after-attach-${Date.now()}`;
+		const pro = products.pro({
+			id: "pro-replay",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "premium-replay",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { ctx, autumnV1, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [],
+		});
+		const internalCustomerId = customer?.internal_id ?? "";
+
+		// 1. Checkout pro; snapshot the deferred metadata before the webhook deletes it.
+		const checkout = await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+		});
+		expect(checkout.payment_url).toContain("checkout.stripe.com");
+
+		const pendingCustomerProduct = (
+			await CusProductService.list({
+				db: ctx.db,
+				internalCustomerId,
+				inStatuses: ALL_STATUSES,
+			})
+		).find((customerProduct) => customerProduct.product.id === pro.id);
+		expect(pendingCustomerProduct?.status).toBe(CusProductStatus.Pending);
+
+		const deferredMetadata = await MetadataService.get({
+			db: ctx.db,
+			id: pendingCustomerProduct?.metadata_id ?? "",
+		});
+		expect(deferredMetadata?.stripe_checkout_session_id).toBeTruthy();
+
+		await completeStripeCheckoutForm({ url: checkout.payment_url });
+		await timeout(12000);
+
+		await expectCustomerProducts({
+			customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+			active: [pro.id],
+		});
+
+		// 2. Upgrade to premium now that checkout saved a payment method.
+		await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: premium.id,
+		});
+		await expectCustomerProducts({
+			customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+			active: [premium.id],
+			notPresent: [pro.id],
+		});
+
+		// 3. Replay the checkout webhook as Stripe would after a reverted claim.
+		await MetadataService.insert({ db: ctx.db, data: deferredMetadata! });
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeEvent = {
+			id: `evt_replay_${Date.now()}`,
+			type: "checkout.session.completed",
+			data: { object: { id: deferredMetadata!.stripe_checkout_session_id } },
+		} as unknown as Stripe.CheckoutSessionCompletedEvent;
+
+		let replayError: unknown;
+		try {
+			await handleStripeCheckoutSessionCompleted({
+				ctx: { ...ctx, stripeEvent, fullCustomer },
+				event: stripeEvent,
+			});
+		} catch (error) {
+			replayError = error;
+		}
+
+		// 4. Stripe must still bill premium ($50), not the stale pro ($20).
+		const stripeSubscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: customer?.processor?.id ?? "",
+			limit: 100,
+		});
+		const unitAmounts = stripeSubscriptions.data.flatMap((subscription) =>
+			subscription.items.data.map((item) => item.price.unit_amount),
+		);
+		expect(unitAmounts).toContain(5000);
+		expect(unitAmounts).not.toContain(2000);
+
+		await expectCustomerProducts({
+			customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+			active: [premium.id],
+			notPresent: [pro.id],
+		});
+
+		expect(replayError).toBeUndefined();
+	},
+);


### PR DESCRIPTION
## Problem

`checkout.session.completed` is sync-acked, so a handler failure 500s and Stripe redelivers the same event for days. The handler mutates the Stripe subscription (`modifyStripeSubscriptionFromCheckout`) and promotes the pending customer product **before** `executeAutumnBillingPlan` runs, and none of that is transactional. If the plan execution then throws, every redelivery:

1. rewrites the live Stripe subscription back to the checkout's plan, clobbering anything the customer attached since (e.g. an upgrade), and
2. finds no `pending` rows (attempt 1 already flipped them to `active` and nulled `metadata_id`), so `promotePendingCustomerProducts` returns the plan untouched and the duplicate insert fails again → 500 → another retry.

## Fix

- `promotePendingCustomerProducts` now looks up the plan's customer product ids directly (any status) instead of `metadata_id` + `pending`. Rows that already exist are dropped from `insertCustomerProducts` together with the custom catalog rows, so a retry can complete the remaining DB work (expire old products, upsert sub/invoice, delete metadata) instead of crashing forever.
- `handleCheckoutSessionMetadataV2` checks `hasMaterializedCustomerProducts` before touching Stripe and skips `modifyStripeSubscriptionFromCheckout` when any planned row is already past `pending`.

Shared lookup lives in `loadPlannedCustomerProducts`; the `metadataId` param is gone from `promotePendingCustomerProducts` and both callers.

## Test

`checkout-replay-after-attach.test.ts`: real checkout for plan A → real attach of plan B → replay the original `checkout.session.completed` in-process with the deferred metadata restored (what a reverted claim leaves behind). Before the fix Stripe ends up billing plan A (`[2000]`); after, it stays on plan B (`5000`) and the replay completes without throwing.

Also re-ran the four promotion/expiry cases in `pending-customer-products.test.ts` (green). `billing-updated-attach.test.ts` needs a Svix app on the test org and couldn't run locally.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M20XXH102GWRR6JEY8V410CA"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `checkout.session.completed` webhook retries idempotent after partial execution.

- Retries skip all Stripe writes (subscription update, optional-item matching, and schedule creation) when planned customer products are already past pending, preventing downgrades after a later attach.
- `promotePendingCustomerProducts` looks up planned rows by ID and drops already-materialized ones from the insert list, so a retry completes the remaining DB work instead of failing on duplicate inserts.
- Metadata is deleted right after the DB commit so a redelivery after a failure below that point won't re-apply balance deltas.
- Adds a regression test that replays the webhook after an upgrade and verifies the subscription stays on the newer plan.

<sup>Written for commit 6b9bd601617209810c2604a57180bd18f4d0a408. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes replayed `checkout.session.completed` events avoid overwriting newer Stripe subscription state and allows partially executed database plans to resume without duplicate customer-product inserts.

**Key changes**
- **[Bug fixes]** Detects previously materialized customer products and skips stale Stripe subscription and schedule mutations on replay.
- **[Bug fixes]** Promotes or filters planned customer products by their stable IDs rather than relying on pending status and metadata ownership.
- **[Improvements]** Adds an integration test covering checkout completion, a later plan upgrade, and replay of the original event.
- **[Bug fixes]** Moves metadata deletion earlier to avoid replaying committed balance changes, but this currently prevents retries of required schedule persistence that follows the deletion.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a transient failure while persisting a deferred schedule can permanently leave billing state without its required schedule.

The replay protection fixes stale Stripe subscription and schedule mutations, including the previous schedule concern. However, metadata is now deleted before deferred schedule persistence, and a subsequent failure cannot be retried because redelivery interprets the missing metadata as completed processing.

**Files Needing Attention:** server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts | Adds replay detection and gates stale Stripe writes, but deletes retry metadata before required deferred-schedule persistence completes. |
| server/src/internal/billing/v2/execute/hasMaterializedCustomerProducts.ts | Detects whether any planned customer product has progressed beyond pending status. |
| server/src/internal/billing/v2/execute/loadPlannedCustomerProducts.ts | Loads existing customer products using the stable IDs recorded in the billing plan. |
| server/src/internal/billing/v2/execute/promotePendingCustomerProducts.ts | Promotes existing pending products and removes all existing planned rows from the later insert operation. |
| server/tests/integration/billing/stripe-webhooks/checkout-session-completed/checkout-replay-after-attach.test.ts | Verifies that replaying an old checkout does not overwrite a newer attached plan. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Handler
    participant DB
    participant Schedule

    Stripe->>Handler: checkout.session.completed
    Handler->>DB: Detect planned products
    Handler->>Handler: Skip stale Stripe writes on replay
    Handler->>DB: Promote products and execute billing plan
    Handler->>DB: Delete deferred metadata
    Handler->>Schedule: Persist deferred schedule
    alt Schedule persistence fails
        Schedule-->>Handler: Error
        Stripe->>Handler: Redeliver event
        Handler->>DB: Metadata absent
        Handler-->>Stripe: Skip as already materialized
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts:205
**Schedule Retry Is Lost**

Metadata is deleted before the deferred schedule is persisted. For example, if schedule persistence throws after the billing plan commits, Stripe retries the event, but the missing metadata makes the retry treat processing as complete and skip execution. The customer's billing products are then updated without the required schedule being saved. Delete the metadata only after this required work succeeds, or give the post-commit work its own durable retry mechanism.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: skip schedule and optional-item wri..."](https://github.com/useautumn/autumn/commit/6b9bd601617209810c2604a57180bd18f4d0a408) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61751264)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->