### PR TITLE
feat(atmn-nightly): add `env` command showing org, environment and key

### DIFF
--- a/packages/atmn-nightly/src/actions/env.ts
+++ b/packages/atmn-nightly/src/actions/env.ts
@@ -1,0 +1,42 @@
+import { DEFAULT_BASE_URL, type Target } from "../env/resolveTarget";
+import { renderEnv } from "../render/renderEnv";
+import type { FetchOrgInfo, OrgInfo } from "./env/types/orgInfo";
+import type { WriteLine } from "./sandbox/types/sandboxClient";
+
+export type EnvOptions = {
+	/** Resolved by the CLI from its global flags: -p, --sandbox, -l all land here. */
+	target: Target;
+	fetchOrgInfo: FetchOrgInfo;
+	json?: boolean;
+	write?: WriteLine;
+};
+
+/** Report which org, env and key this directory's commands would act on. */
+export const runEnv = async ({
+	target,
+	fetchOrgInfo,
+	json = false,
+	write = (text) => process.stdout.write(text),
+}: EnvOptions): Promise<OrgInfo> => {
+	const info = await fetchOrgInfo();
+
+	if (json) {
+		write(`${JSON.stringify(info, null, 2)}\n`);
+		return info;
+	}
+
+	write(
+		`${renderEnv({
+			info,
+			secretKeyName: target.secretKeyName,
+			// The default is noise; a local or staging server is the surprise worth showing.
+			...(target.baseUrl === undefined || target.baseUrl === DEFAULT_BASE_URL
+				? {}
+				: { baseUrl: target.baseUrl }),
+			...(target.sandboxId === undefined
+				? {}
+				: { sandboxId: target.sandboxId }),
+		})}\n`,
+	);
+	return info;
+};

--- a/packages/atmn-nightly/src/actions/env/fetchOrgInfo.ts
+++ b/packages/atmn-nightly/src/actions/env/fetchOrgInfo.ts
@@ -1,0 +1,31 @@
+import { AutumnApiError } from "../../generated/client";
+import type { OrgInfo } from "./types/orgInfo";
+
+const ORG_INFO_PATH = "/v1/organization/me";
+
+/** Not in the spec, so hand-written like the key-minting call rather than generated. */
+export const fetchOrgInfo = async ({
+	baseUrl,
+	secretKey,
+	fetch = globalThis.fetch,
+}: {
+	baseUrl: string;
+	secretKey: string;
+	fetch?: typeof globalThis.fetch;
+}): Promise<OrgInfo> => {
+	const response = await fetch(`${baseUrl}${ORG_INFO_PATH}`, {
+		method: "GET",
+		headers: { authorization: `Bearer ${secretKey}` },
+	});
+
+	const text = await response.text();
+	const body: unknown = text ? JSON.parse(text) : null;
+	if (!response.ok) {
+		throw new AutumnApiError({
+			status: response.status,
+			body,
+			path: ORG_INFO_PATH,
+		});
+	}
+	return body as OrgInfo;
+};

--- a/packages/atmn-nightly/src/actions/env/types/orgInfo.ts
+++ b/packages/atmn-nightly/src/actions/env/types/orgInfo.ts
@@ -1,0 +1,10 @@
+/** What the server says about the key it was given: the org and the env it unlocks. */
+export type OrgInfo = {
+	id: string;
+	name: string;
+	slug: string;
+	env: string;
+	user?: { id: string; email: string; name: string };
+};
+
+export type FetchOrgInfo = () => Promise<OrgInfo>;

--- a/packages/atmn-nightly/src/cli.ts
+++ b/packages/atmn-nightly/src/cli.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { Command } from "commander";
+import { runEnv } from "./actions/env";
+import { fetchOrgInfo } from "./actions/env/fetchOrgInfo";
 import { runLogin } from "./actions/login";
 import { runPull } from "./actions/pull";
 import { configSearchDirs, runPush } from "./actions/push";
@@ -16,6 +18,7 @@ import {
 	resolveTarget,
 	type Target,
 	type TargetFlags,
+	targetBaseUrl,
 } from "./env/resolveTarget";
 import type { CreateSandboxParams } from "./generated/client";
 import { createClient } from "./generated/client";
@@ -76,6 +79,23 @@ export const buildProgram = (): Command => {
 		.description("authenticate and write org keys to your .env")
 		.action(async (_options: unknown, command: Command) => {
 			await runLogin({ target: prepareTarget({ command }) });
+		});
+
+	program
+		.command("env")
+		.description("show the org, environment and key your commands target")
+		.option("--json", "print the response instead of the summary")
+		.action(async (options: { json?: boolean }, command: Command) => {
+			const target = prepareTarget({ command });
+			await runEnv({
+				target,
+				fetchOrgInfo: () =>
+					fetchOrgInfo({
+						baseUrl: targetBaseUrl({ target }),
+						secretKey: requireSecretKey({ target }),
+					}),
+				json: options.json === true,
+			});
 		});
 
 	program

--- a/packages/atmn-nightly/src/render/renderEnv.ts
+++ b/packages/atmn-nightly/src/render/renderEnv.ts
@@ -1,0 +1,47 @@
+import chalk from "chalk";
+import type { OrgInfo } from "../actions/env/types/orgInfo";
+import { stripTerminalControls } from "./stripTerminalControls";
+
+const GAP = "  ";
+
+const envLabel = ({ env }: { env: string }): string => {
+	if (env === "sandbox") return "Sandbox";
+	if (env === "live") return "Production";
+	return env;
+};
+
+/**
+ * Headless rendering, like the sandbox table: a label column a terminal or a
+ * CI log can read. Nothing here decides anything — it reports what the server
+ * said about the key, plus where that key came from.
+ */
+export const renderEnv = ({
+	info,
+	secretKeyName,
+	baseUrl,
+	sandboxId,
+}: {
+	info: OrgInfo;
+	/** The env var the key was read from; says which flag or pin picked it. */
+	secretKeyName: string;
+	/** Only shown when it is not the spec's server. */
+	baseUrl?: string;
+	sandboxId?: string;
+}): string => {
+	const rows: [string, string][] = [
+		[
+			"Organization",
+			`${stripTerminalControls(info.name)} ${chalk.dim(`(${info.slug})`)}`,
+		],
+		["Environment", envLabel({ env: info.env })],
+	];
+	if (sandboxId !== undefined) rows.push(["Sandbox", sandboxId]);
+	if (info.user?.email !== undefined) rows.push(["User", info.user.email]);
+	rows.push(["Key", secretKeyName]);
+	if (baseUrl !== undefined) rows.push(["Server", baseUrl]);
+
+	const width = Math.max(...rows.map(([label]) => label.length));
+	return rows
+		.map(([label, value]) => `${chalk.dim(label.padEnd(width))}${GAP}${value}`)
+		.join("\n");
+};

--- a/packages/atmn-nightly/src/render/renderEnv.ts
+++ b/packages/atmn-nightly/src/render/renderEnv.ts
@@ -11,6 +11,22 @@ const envLabel = ({ env }: { env: string }): string => {
 };
 
 /**
+ * A sandbox key authenticates as the sandbox's own org, so the id the server
+ * answers with is the sandbox the key really unlocks. A pin whose key answers
+ * as something else is a stale or copied key, and worth saying out loud.
+ */
+const sandboxCell = ({
+	sandboxId,
+	authenticatedId,
+}: {
+	sandboxId: string;
+	authenticatedId: string;
+}): string =>
+	sandboxId === authenticatedId
+		? sandboxId
+		: `${sandboxId} ${chalk.yellow(`← key belongs to ${authenticatedId}`)}`;
+
+/**
  * Headless rendering, like the sandbox table: a label column a terminal or a
  * CI log can read. Nothing here decides anything — it reports what the server
  * said about the key, plus where that key came from.
@@ -31,12 +47,21 @@ export const renderEnv = ({
 	const rows: [string, string][] = [
 		[
 			"Organization",
-			`${stripTerminalControls(info.name)} ${chalk.dim(`(${info.slug})`)}`,
+			`${stripTerminalControls(info.name)} ${chalk.dim(`(${stripTerminalControls(info.slug)})`)}`,
 		],
-		["Environment", envLabel({ env: info.env })],
+		["Environment", envLabel({ env: stripTerminalControls(info.env) })],
 	];
-	if (sandboxId !== undefined) rows.push(["Sandbox", sandboxId]);
-	if (info.user?.email !== undefined) rows.push(["User", info.user.email]);
+	if (sandboxId !== undefined) {
+		rows.push([
+			"Sandbox",
+			sandboxCell({
+				sandboxId,
+				authenticatedId: stripTerminalControls(info.id),
+			}),
+		]);
+	}
+	if (info.user?.email !== undefined)
+		rows.push(["User", stripTerminalControls(info.user.email)]);
 	rows.push(["Key", secretKeyName]);
 	if (baseUrl !== undefined) rows.push(["Server", baseUrl]);
 

--- a/packages/atmn-nightly/test/cliTargetFlags.test.ts
+++ b/packages/atmn-nightly/test/cliTargetFlags.test.ts
@@ -5,54 +5,17 @@
  */
 
 import { afterEach, beforeEach, expect, test } from "bun:test";
-import type { Command } from "commander";
-import { buildProgram } from "../src/cli";
 import {
-	resolveTarget,
-	type Target,
-	type TargetFlags,
-} from "../src/env/resolveTarget";
+	isolateTargetEnv,
+	targetFor as parseTarget,
+} from "./helpers/targetFor";
 
-const CLEARED = [
-	"AUTUMN_BASE_URL",
-	"AUTUMN_SANDBOX_ID",
-	"AUTUMN_CLIENT_ID",
-	"ATMN_CLI_CLIENT_ID",
-] as const;
+const env = isolateTargetEnv();
+beforeEach(env.clear);
+afterEach(env.restore);
 
-const saved = new Map<string, string | undefined>();
-
-beforeEach(() => {
-	for (const key of CLEARED) {
-		saved.set(key, process.env[key]);
-		delete process.env[key];
-	}
-});
-
-afterEach(() => {
-	for (const [key, value] of saved) {
-		if (value === undefined) delete process.env[key];
-		else process.env[key] = value;
-	}
-	saved.clear();
-});
-
-/** The real program, with push's action swapped for a capture so parsing
- * neither reads a .env nor builds a client. */
-const targetFor = async ({ argv }: { argv: string[] }): Promise<Target> => {
-	const program = buildProgram();
-	const push = program.commands.find((command) => command.name() === "push");
-	if (push === undefined) throw new Error("the push command is gone");
-
-	let resolved: Target | undefined;
-	push.action((_options: unknown, command: Command) => {
-		resolved = resolveTarget(command.optsWithGlobals<TargetFlags>());
-	});
-	await program.parseAsync(argv, { from: "user" });
-
-	if (resolved === undefined) throw new Error("the push action never ran");
-	return resolved;
-};
+const targetFor = ({ argv }: { argv: string[] }) =>
+	parseTarget({ command: "push", argv });
 
 test("--local reaches push from either side of the command", async () => {
 	const before = await targetFor({ argv: ["--local", "push"] });

--- a/packages/atmn-nightly/test/env.test.ts
+++ b/packages/atmn-nightly/test/env.test.ts
@@ -6,34 +6,15 @@
  */
 
 import { afterEach, beforeEach, expect, test } from "bun:test";
-import type { Command } from "commander";
 import { runEnv } from "../src/actions/env";
 import type { OrgInfo } from "../src/actions/env/types/orgInfo";
-import { buildProgram } from "../src/cli";
-import {
-	resolveTarget,
-	type Target,
-	type TargetFlags,
-} from "../src/env/resolveTarget";
+import { resolveTarget } from "../src/env/resolveTarget";
 import { renderEnv } from "../src/render/renderEnv";
+import { isolateTargetEnv, targetFor } from "./helpers/targetFor";
 
-const CLEARED = ["AUTUMN_BASE_URL", "AUTUMN_SANDBOX_ID"] as const;
-const saved = new Map<string, string | undefined>();
-
-beforeEach(() => {
-	for (const key of CLEARED) {
-		saved.set(key, process.env[key]);
-		delete process.env[key];
-	}
-});
-
-afterEach(() => {
-	for (const [key, value] of saved) {
-		if (value === undefined) delete process.env[key];
-		else process.env[key] = value;
-	}
-	saved.clear();
-});
+const env = isolateTargetEnv();
+beforeEach(env.clear);
+afterEach(env.restore);
 
 const ORG: OrgInfo = {
 	id: "org_123",
@@ -69,15 +50,42 @@ test("names the pinned sandbox and a non-default server", async () => {
 	const { lines, write } = capture();
 	await runEnv({
 		target: resolveTarget({ sandbox: "sb_1", local: true }),
-		fetchOrgInfo: async () => ({ ...ORG, env: "sandbox" }),
+		// A sandbox key authenticates as the sandbox's own org.
+		fetchOrgInfo: async () => ({ ...ORG, id: "sb_1", env: "sandbox" }),
 		write,
 	});
 
 	const output = lines.join("");
 	expect(output).toContain("Sandbox");
 	expect(output).toContain("sb_1");
+	expect(output).not.toContain("key belongs to");
 	expect(output).toContain("AUTUMN_SANDBOX_SB_1_SECRET_KEY");
 	expect(output).toContain("http://localhost:8080");
+});
+
+test("flags a pinned sandbox whose key answers as another org", async () => {
+	const { lines, write } = capture();
+	await runEnv({
+		target: resolveTarget({ sandbox: "sb_1" }),
+		fetchOrgInfo: async () => ({ ...ORG, id: "sb_other", env: "sandbox" }),
+		write,
+	});
+
+	expect(lines.join("")).toContain("sb_1 ← key belongs to sb_other");
+});
+
+test("strips terminal controls from every server-provided string", () => {
+	const output = renderEnv({
+		info: {
+			...ORG,
+			name: "Acme\u001b[2J",
+			slug: "acme\u001b]0;x\u0007",
+			user: { id: "u", email: "dev@example.com\u001b[2J", name: "Dev" },
+		},
+		secretKeyName: "AUTUMN_SECRET_KEY",
+	});
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: the point of the test
+	expect(output.replace(/\u001b\[[0-9;]*m/g, "")).not.toMatch(/\u001b|\u0007/);
 });
 
 test("--json prints the response verbatim", async () => {
@@ -105,29 +113,13 @@ test("renderEnv lines every value up in one column", () => {
 	].map(([value, line]) =>
 		output.split("\n")[line as number]?.indexOf(value as string),
 	);
+	for (const start of starts) expect(start).toBeGreaterThanOrEqual(0);
 	expect(new Set(starts).size).toBe(1);
 });
 
-/** The real program, with env's action swapped for a capture so parsing
- * neither reads a .env nor calls the server. */
-const targetFor = async ({ argv }: { argv: string[] }): Promise<Target> => {
-	const program = buildProgram();
-	const env = program.commands.find((command) => command.name() === "env");
-	if (env === undefined) throw new Error("the env command is gone");
-
-	let resolved: Target | undefined;
-	env.action((_options: unknown, command: Command) => {
-		resolved = resolveTarget(command.optsWithGlobals<TargetFlags>());
-	});
-	await program.parseAsync(argv, { from: "user" });
-
-	if (resolved === undefined) throw new Error("the env action never ran");
-	return resolved;
-};
-
 test("--prod reaches env from either side of the command", async () => {
-	const before = await targetFor({ argv: ["-p", "env"] });
-	const after = await targetFor({ argv: ["env", "-p"] });
+	const before = await targetFor({ command: "env", argv: ["-p", "env"] });
+	const after = await targetFor({ command: "env", argv: ["env", "-p"] });
 
 	expect(before.secretKeyName).toBe("AUTUMN_PROD_SECRET_KEY");
 	expect(after).toEqual(before);

--- a/packages/atmn-nightly/test/env.test.ts
+++ b/packages/atmn-nightly/test/env.test.ts
@@ -1,0 +1,134 @@
+/**
+ * `atmn env` never touches the network here: the org lookup is injected. What
+ * is under test is that the command reports the target every other command
+ * resolves — so `-p` shows the production key, a pin shows its sandbox — and
+ * that the global flags reach it from either side of the command name.
+ */
+
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import type { Command } from "commander";
+import { runEnv } from "../src/actions/env";
+import type { OrgInfo } from "../src/actions/env/types/orgInfo";
+import { buildProgram } from "../src/cli";
+import {
+	resolveTarget,
+	type Target,
+	type TargetFlags,
+} from "../src/env/resolveTarget";
+import { renderEnv } from "../src/render/renderEnv";
+
+const CLEARED = ["AUTUMN_BASE_URL", "AUTUMN_SANDBOX_ID"] as const;
+const saved = new Map<string, string | undefined>();
+
+beforeEach(() => {
+	for (const key of CLEARED) {
+		saved.set(key, process.env[key]);
+		delete process.env[key];
+	}
+});
+
+afterEach(() => {
+	for (const [key, value] of saved) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	saved.clear();
+});
+
+const ORG: OrgInfo = {
+	id: "org_123",
+	name: "Acme",
+	slug: "acme",
+	env: "live",
+	user: { id: "user_1", email: "dev@example.com", name: "Dev" },
+};
+
+const capture = () => {
+	const lines: string[] = [];
+	return { lines, write: (text: string) => lines.push(text) };
+};
+
+test("reports the production key when the target is --prod", async () => {
+	const { lines, write } = capture();
+	await runEnv({
+		target: resolveTarget({ prod: true }),
+		fetchOrgInfo: async () => ORG,
+		write,
+	});
+
+	const output = lines.join("");
+	expect(output).toContain("Acme");
+	expect(output).toContain("(acme)");
+	expect(output).toContain("Production");
+	expect(output).toContain("AUTUMN_PROD_SECRET_KEY");
+	expect(output).toContain("dev@example.com");
+	expect(output).not.toContain("Server");
+});
+
+test("names the pinned sandbox and a non-default server", async () => {
+	const { lines, write } = capture();
+	await runEnv({
+		target: resolveTarget({ sandbox: "sb_1", local: true }),
+		fetchOrgInfo: async () => ({ ...ORG, env: "sandbox" }),
+		write,
+	});
+
+	const output = lines.join("");
+	expect(output).toContain("Sandbox");
+	expect(output).toContain("sb_1");
+	expect(output).toContain("AUTUMN_SANDBOX_SB_1_SECRET_KEY");
+	expect(output).toContain("http://localhost:8080");
+});
+
+test("--json prints the response verbatim", async () => {
+	const { lines, write } = capture();
+	await runEnv({
+		target: resolveTarget({}),
+		fetchOrgInfo: async () => ORG,
+		json: true,
+		write,
+	});
+
+	expect(JSON.parse(lines.join(""))).toEqual(ORG);
+});
+
+test("renderEnv lines every value up in one column", () => {
+	const output = renderEnv({
+		info: ORG,
+		secretKeyName: "AUTUMN_SECRET_KEY",
+	});
+	const starts = [
+		["Acme", 0],
+		["Production", 1],
+		["dev@example.com", 2],
+		["AUTUMN_SECRET_KEY", 3],
+	].map(([value, line]) =>
+		output.split("\n")[line as number]?.indexOf(value as string),
+	);
+	expect(new Set(starts).size).toBe(1);
+});
+
+/** The real program, with env's action swapped for a capture so parsing
+ * neither reads a .env nor calls the server. */
+const targetFor = async ({ argv }: { argv: string[] }): Promise<Target> => {
+	const program = buildProgram();
+	const env = program.commands.find((command) => command.name() === "env");
+	if (env === undefined) throw new Error("the env command is gone");
+
+	let resolved: Target | undefined;
+	env.action((_options: unknown, command: Command) => {
+		resolved = resolveTarget(command.optsWithGlobals<TargetFlags>());
+	});
+	await program.parseAsync(argv, { from: "user" });
+
+	if (resolved === undefined) throw new Error("the env action never ran");
+	return resolved;
+};
+
+test("--prod reaches env from either side of the command", async () => {
+	const before = await targetFor({ argv: ["-p", "env"] });
+	const after = await targetFor({ argv: ["env", "-p"] });
+
+	expect(before.secretKeyName).toBe("AUTUMN_PROD_SECRET_KEY");
+	expect(after).toEqual(before);
+});

--- a/packages/atmn-nightly/test/helpers/targetFor.ts
+++ b/packages/atmn-nightly/test/helpers/targetFor.ts
@@ -1,0 +1,58 @@
+import type { Command } from "commander";
+import { buildProgram } from "../../src/cli";
+import {
+	resolveTarget,
+	type Target,
+	type TargetFlags,
+} from "../../src/env/resolveTarget";
+
+/** Env vars the resolver reads; cleared so a developer's own .env stays out of the assertions. */
+const CLEARED = [
+	"AUTUMN_BASE_URL",
+	"AUTUMN_SANDBOX_ID",
+	"AUTUMN_CLIENT_ID",
+	"ATMN_CLI_CLIENT_ID",
+] as const;
+
+/** Clears the resolver's env vars for a test file; returns the restore for afterEach. */
+export const isolateTargetEnv = () => {
+	const saved = new Map<string, string | undefined>();
+	return {
+		clear: () => {
+			for (const key of CLEARED) {
+				saved.set(key, process.env[key]);
+				delete process.env[key];
+			}
+		},
+		restore: () => {
+			for (const [key, value] of saved) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+			saved.clear();
+		},
+	};
+};
+
+/** The real program, with one command's action swapped for a capture so parsing
+ * neither reads a .env nor talks to a server. */
+export const targetFor = async ({
+	command: name,
+	argv,
+}: {
+	command: string;
+	argv: string[];
+}): Promise<Target> => {
+	const program = buildProgram();
+	const found = program.commands.find((command) => command.name() === name);
+	if (found === undefined) throw new Error(`the ${name} command is gone`);
+
+	let resolved: Target | undefined;
+	found.action((_options: unknown, command: Command) => {
+		resolved = resolveTarget(command.optsWithGlobals<TargetFlags>());
+	});
+	await program.parseAsync(argv, { from: "user" });
+
+	if (resolved === undefined) throw new Error(`the ${name} action never ran`);
+	return resolved;
+};


### PR DESCRIPTION
Ports the original `atmn env` into atmn-nightly.

## What it does

`atmn-nightly env` calls `GET /v1/organization/me` with the resolved target's key and prints an aligned label column:

```
Organization  Acme (acme)
Environment   Production
User          dev@example.com
Key           AUTUMN_PROD_SECRET_KEY
```

- `Sandbox <id>` appears when `--sandbox` or `AUTUMN_SANDBOX_ID` pins one; `Server <url>` appears only when the target is not the spec's default server (`--local`, `--port`, `--base-url`, or `AUTUMN_BASE_URL`).
- `--json` prints the raw response.
- A missing key fails with the same `requireSecretKey` message every other command uses.

## Flag handling

No new flag parsing. The command goes through the existing `prepareTarget` → `resolveTarget` path, so `-p/--prod`, `--sandbox`, `-l`, `--port`, `-b`, and `--client-id` all behave exactly as they do for `push`/`pull`/`reset`, and work on either side of the command name.

## Structure

- `actions/env.ts` – `runEnv` with injected `fetchOrgInfo` and `write` (testable, no network)
- `actions/env/fetchOrgInfo.ts` – hand-written call; `/v1/organization/me` isn't in the OpenAPI spec, so it sits beside the OAuth key-minting call rather than in the generated client
- `render/renderEnv.ts` – headless rendering, mirrors `renderSandboxes`
- `test/env.test.ts` – output for prod/sandbox/local targets, `--json`, column alignment, and a real Commander parse proving `-p` reaches `env` from both sides

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M2185G0XAGR2VK6WAHWCKMQR"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `atmn-nightly env`, which shows the org, environment, and key the directory's commands would act on, calling `GET /v1/organization/me` with the resolved target's key.

- Prints an aligned label column, or the raw response with `--json`.
- Shows `Sandbox <id>` when pinned, and warns when that sandbox's key authenticates as a different org.
- Shows `Server <url>` only when the target isn't the default server.
- Reuses the shared `prepareTarget` → `resolveTarget` path, so `-p/--prod`, `--sandbox`, `-l`, `--port`, `-b`, and `--client-id` behave exactly as for push/pull/reset, on either side of the command name.
- Injects `fetchOrgInfo` and `write` so tests never touch the network, sanitizes every server-provided string, and shares a `targetFor` test helper with the existing flag tests.
- Keeps the `/v1/organization/me` call hand-written next to the key-minting call because the endpoint isn't in the OpenAPI spec.

<sup>Written for commit 3d5f9978bc7a56bc4f48143cbe4d44abdf32aaa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ports the `env` command to `atmn-nightly`, allowing users to inspect the organization, environment, user, key source, sandbox, and non-default server selected by the CLI.

**Key changes**
- **[API changes]** Adds an `env` CLI command backed by `GET /v1/organization/me`.
- **[Improvements]** Supports aligned human-readable output and raw JSON output.
- **[Improvements]** Reuses the existing target-resolution path for production, sandbox, local, base URL, port, and client ID flags.
- **[Bug fixes]** Sanitizes all server-provided values before terminal rendering.
- **[Improvements]** Warns when a pinned sandbox is paired with a key belonging to a different sandbox.
- **[Improvements]** Extracts reusable Commander target-parsing and environment-isolation test helpers.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no outstanding correctness, security, or repository-rule issues.

The previous terminal-output concern was fully addressed by sanitizing every server-provided value used in summary output, and the new sandbox identity comparison matches the server’s sandbox authentication semantics. No new actionable failures remain.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/atmn-nightly/src/actions/env.ts | Coordinates organization lookup and renders either JSON or a target summary. |
| packages/atmn-nightly/src/actions/env/fetchOrgInfo.ts | Implements the authenticated organization-information request with standard API error handling. |
| packages/atmn-nightly/src/cli.ts | Registers the new command and routes it through the existing target and secret-key resolution flow. |
| packages/atmn-nightly/src/render/renderEnv.ts | Produces sanitized, aligned output and identifies mismatched pinned sandbox keys. |
| packages/atmn-nightly/test/env.test.ts | Covers production, sandbox, local-server, JSON, sanitization, alignment, and flag-parsing behavior. |
| packages/atmn-nightly/test/helpers/targetFor.ts | Centralizes isolated target-flag parsing for CLI tests. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant User
  participant CLI as atmn-nightly env
  participant Target as Target resolver
  participant API as Autumn API
  User->>CLI: env [target flags] [--json]
  CLI->>Target: prepareTarget / resolveTarget
  Target-->>CLI: base URL, key name, secret key, sandbox ID
  CLI->>API: GET /v1/organization/me
  API-->>CLI: organization and environment details
  alt --json
    CLI-->>User: Raw JSON response
  else Summary output
    CLI-->>User: Sanitized aligned target summary
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(atmn-nightly): sanitize env output, ..."](https://github.com/useautumn/autumn/commit/3d5f9978bc7a56bc4f48143cbe4d44abdf32aaa4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61763768)</sub>

<!-- /greptile_comment -->