### PR TITLE
Remove the plan-level allow_overdue_entitlements flag

### DIFF
--- a/packages/atmn-nightly/src/generated/client.ts
+++ b/packages/atmn-nightly/src/generated/client.ts
@@ -169,8 +169,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -1343,8 +1341,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -2154,8 +2150,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -3324,8 +3318,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -4137,8 +4129,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -5281,8 +5271,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -6076,8 +6064,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -7124,8 +7110,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -7829,8 +7813,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -8973,8 +8955,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -9766,8 +9746,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -10814,8 +10792,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -11527,8 +11503,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -12697,8 +12671,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -13524,8 +13496,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -14668,8 +14638,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -15453,8 +15421,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -16623,8 +16589,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -17448,8 +17412,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -18592,8 +18554,6 @@ autoEnable?: boolean | null;
 config?: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 } | null;
 /** The `active` flag before this update; true on the version being demoted. */
 active?: boolean | null;
@@ -24279,8 +24239,6 @@ archived: boolean;
 config: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 };
 /** Plan-level billing controls used as customer defaults. */
 billingControls?: {
@@ -25931,8 +25889,6 @@ archived: boolean;
 config: {
 /** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. Defaults to false. */
 ignorePastDue?: boolean;
-/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. Defaults to false. */
-allowOverdueEntitlements?: boolean;
 };
 /** Plan-level billing controls used as customer defaults. */
 billingControls?: {

--- a/packages/atmn-nightly/src/generated/emit.ts
+++ b/packages/atmn-nightly/src/generated/emit.ts
@@ -350,7 +350,6 @@ export const COLLECTIONS: Readonly<Record<string, CollectionSpec>> = {
 			"billingControls.usageLimits.interval",
 			"billingControls.usageLimits.limit",
 			"config",
-			"config.allowOverdueEntitlements",
 			"config.ignorePastDue",
 			"createInStripe",
 			"description",

--- a/packages/atmn-nightly/src/generated/plans.ts
+++ b/packages/atmn-nightly/src/generated/plans.ts
@@ -310,8 +310,6 @@ export type Plan = {
 	config?: {
 		/** If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state. */
 		ignorePastDue?: boolean;
-		/** If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior. */
-		allowOverdueEntitlements?: boolean;
 	};
 	/** Plan-level billing controls used as customer defaults. */
 	billingControls?: {

--- a/packages/openapi/openapi-internal.yml
+++ b/packages/openapi/openapi-internal.yml
@@ -2794,12 +2794,6 @@ components:
                 schedule even when the customer's product is in a past_due
                 state.
               default: false
-            allow_overdue_entitlements:
-              type: boolean
-              description: If true, this plan's entitlements remain usable while past due,
-                overriding the organization's overdue entitlement block without
-                changing cancellation or reset behavior.
-              default: false
           description: Miscellaneous plan-level configuration flags.
         billing_controls:
           type: object
@@ -12489,11 +12483,6 @@ paths:
                       description: If true, entitlements attached to this plan will still reset on
                         schedule even when the customer's product is in a
                         past_due state.
-                    allow_overdue_entitlements:
-                      type: boolean
-                      description: If true, this plan's entitlements remain usable while past due,
-                        overriding the organization's overdue entitlement block
-                        without changing cancellation or reset behavior.
                   description: Miscellaneous plan-level configuration flags.
                 billing_controls:
                   type: object
@@ -13685,12 +13674,6 @@ paths:
                         description: If true, entitlements attached to this plan will still reset on
                           schedule even when the customer's product is in a
                           past_due state.
-                        default: false
-                      allow_overdue_entitlements:
-                        type: boolean
-                        description: If true, this plan's entitlements remain usable while past due,
-                          overriding the organization's overdue entitlement
-                          block without changing cancellation or reset behavior.
                         default: false
                     description: Miscellaneous plan-level configuration flags.
                   billing_controls:
@@ -16793,12 +16776,6 @@ paths:
                           schedule even when the customer's product is in a
                           past_due state.
                         default: false
-                      allow_overdue_entitlements:
-                        type: boolean
-                        description: If true, this plan's entitlements remain usable while past due,
-                          overriding the organization's overdue entitlement
-                          block without changing cancellation or reset behavior.
-                        default: false
                     description: Miscellaneous plan-level configuration flags.
                   billing_controls:
                     type: object
@@ -19883,13 +19860,6 @@ paths:
                               description: If true, entitlements attached to this plan will still reset on
                                 schedule even when the customer's product is in
                                 a past_due state.
-                              default: false
-                            allow_overdue_entitlements:
-                              type: boolean
-                              description: If true, this plan's entitlements remain usable while past due,
-                                overriding the organization's overdue
-                                entitlement block without changing cancellation
-                                or reset behavior.
                               default: false
                           description: Miscellaneous plan-level configuration flags.
                         billing_controls:
@@ -25419,13 +25389,6 @@ paths:
                                           schedule even when the customer's
                                           product is in a past_due state.
                                         default: false
-                                      allow_overdue_entitlements:
-                                        type: boolean
-                                        description: If true, this plan's entitlements remain usable while past due,
-                                          overriding the organization's overdue
-                                          entitlement block without changing
-                                          cancellation or reset behavior.
-                                        default: false
                                     description: Miscellaneous plan-level configuration flags.
                                   billing_controls:
                                     type: object
@@ -27316,11 +27279,6 @@ paths:
                       description: If true, entitlements attached to this plan will still reset on
                         schedule even when the customer's product is in a
                         past_due state.
-                    allow_overdue_entitlements:
-                      type: boolean
-                      description: If true, this plan's entitlements remain usable while past due,
-                        overriding the organization's overdue entitlement block
-                        without changing cancellation or reset behavior.
                   description: Miscellaneous plan-level configuration flags.
                 billing_controls:
                   type: object
@@ -29661,12 +29619,6 @@ paths:
                         description: If true, entitlements attached to this plan will still reset on
                           schedule even when the customer's product is in a
                           past_due state.
-                        default: false
-                      allow_overdue_entitlements:
-                        type: boolean
-                        description: If true, this plan's entitlements remain usable while past due,
-                          overriding the organization's overdue entitlement
-                          block without changing cancellation or reset behavior.
                         default: false
                     description: Miscellaneous plan-level configuration flags.
                   billing_controls:
@@ -78310,13 +78262,6 @@ paths:
                                 schedule even when the customer's product is in
                                 a past_due state.
                               default: false
-                            allow_overdue_entitlements:
-                              type: boolean
-                              description: If true, this plan's entitlements remain usable while past due,
-                                overriding the organization's overdue
-                                entitlement block without changing cancellation
-                                or reset behavior.
-                              default: false
                           description: Miscellaneous plan-level configuration flags.
                         billing_controls:
                           type: object
@@ -83845,13 +83790,6 @@ paths:
                                           schedule even when the customer's
                                           product is in a past_due state.
                                         default: false
-                                      allow_overdue_entitlements:
-                                        type: boolean
-                                        description: If true, this plan's entitlements remain usable while past due,
-                                          overriding the organization's overdue
-                                          entitlement block without changing
-                                          cancellation or reset behavior.
-                                        default: false
                                     description: Miscellaneous plan-level configuration flags.
                                   billing_controls:
                                     type: object
@@ -85717,12 +85655,6 @@ paths:
                             description: If true, entitlements attached to this plan will still reset on
                               schedule even when the customer's product is in a
                               past_due state.
-                          allow_overdue_entitlements:
-                            type: boolean
-                            description: If true, this plan's entitlements remain usable while past due,
-                              overriding the organization's overdue entitlement
-                              block without changing cancellation or reset
-                              behavior.
                         description: Miscellaneous plan-level configuration flags.
                       billing_controls:
                         type: object
@@ -89995,15 +89927,6 @@ paths:
                                                     customer's product is in a
                                                     past_due state.
                                                   default: false
-                                                allow_overdue_entitlements:
-                                                  type: boolean
-                                                  description: If true, this plan's entitlements remain usable while past due,
-                                                    overriding the
-                                                    organization's overdue
-                                                    entitlement block without
-                                                    changing cancellation or
-                                                    reset behavior.
-                                                  default: false
                                               description: Miscellaneous plan-level configuration flags.
                                             - type: "null"
                                         active:
@@ -93952,17 +93875,6 @@ paths:
                                                                   product is in a
                                                                   past_due state.
                                                                 default: false
-                                                              allow_overdue_entitlements:
-                                                                type: boolean
-                                                                description: If true, this plan's entitlements remain usable while past due,
-                                                                  overriding the
-                                                                  organization's
-                                                                  overdue entitlement
-                                                                  block without
-                                                                  changing
-                                                                  cancellation or
-                                                                  reset behavior.
-                                                                default: false
                                                             description: Miscellaneous plan-level configuration flags.
                                                           - type: "null"
                                                       active:
@@ -96722,16 +96634,6 @@ paths:
                                                           customer's product is
                                                           in a past_due state.
                                                         default: false
-                                                      allow_overdue_entitlements:
-                                                        type: boolean
-                                                        description: If true, this plan's entitlements remain usable while past due,
-                                                          overriding the
-                                                          organization's overdue
-                                                          entitlement block
-                                                          without changing
-                                                          cancellation or reset
-                                                          behavior.
-                                                        default: false
                                                     description: Miscellaneous plan-level configuration flags.
                                                   - type: "null"
                                               active:
@@ -100690,17 +100592,6 @@ paths:
                                                                         the customer's
                                                                         product is in a
                                                                         past_due state.
-                                                                      default: false
-                                                                    allow_overdue_entitlements:
-                                                                      type: boolean
-                                                                      description: If true, this plan's entitlements remain usable while past due,
-                                                                        overriding the
-                                                                        organization's
-                                                                        overdue entitlement
-                                                                        block without
-                                                                        changing
-                                                                        cancellation or
-                                                                        reset behavior.
                                                                       default: false
                                                                   description: Miscellaneous plan-level configuration flags.
                                                                 - type: "null"
@@ -103445,17 +103336,6 @@ paths:
                                                                 product is in a
                                                                 past_due state.
                                                               default: false
-                                                            allow_overdue_entitlements:
-                                                              type: boolean
-                                                              description: If true, this plan's entitlements remain usable while past due,
-                                                                overriding the
-                                                                organization's
-                                                                overdue entitlement
-                                                                block without
-                                                                changing
-                                                                cancellation or
-                                                                reset behavior.
-                                                              default: false
                                                           description: Miscellaneous plan-level configuration flags.
                                                         - type: "null"
                                                     active:
@@ -107307,17 +107187,6 @@ paths:
                                                                               the customer's
                                                                               product is in a
                                                                               past_due state.
-                                                                            default: false
-                                                                          allow_overdue_entitlements:
-                                                                            type: boolean
-                                                                            description: If true, this plan's entitlements remain usable while past due,
-                                                                              overriding the
-                                                                              organization's
-                                                                              overdue entitlement
-                                                                              block without
-                                                                              changing
-                                                                              cancellation or
-                                                                              reset behavior.
                                                                             default: false
                                                                         description: Miscellaneous plan-level configuration flags.
                                                                       - type: "null"
@@ -109921,17 +109790,6 @@ paths:
                                                                       product is in a
                                                                       past_due state.
                                                                     default: false
-                                                                  allow_overdue_entitlements:
-                                                                    type: boolean
-                                                                    description: If true, this plan's entitlements remain usable while past due,
-                                                                      overriding the
-                                                                      organization's
-                                                                      overdue entitlement
-                                                                      block without
-                                                                      changing
-                                                                      cancellation or
-                                                                      reset behavior.
-                                                                    default: false
                                                                 description: Miscellaneous plan-level configuration flags.
                                                               - type: "null"
                                                           active:
@@ -113486,17 +113344,6 @@ paths:
                                                                                     product is in a
                                                                                     past_due state.
                                                                                   default: false
-                                                                                allow_overdue_entitlements:
-                                                                                  type: boolean
-                                                                                  description: If true, this plan's entitlements remain usable while past due,
-                                                                                    overriding the
-                                                                                    organization's
-                                                                                    overdue entitlement
-                                                                                    block without
-                                                                                    changing
-                                                                                    cancellation or
-                                                                                    reset behavior.
-                                                                                  default: false
                                                                               description: Miscellaneous plan-level configuration flags.
                                                                             - type: "null"
                                                                         active:
@@ -115880,17 +115727,6 @@ paths:
                                                                 the customer's
                                                                 product is in a
                                                                 past_due state.
-                                                              default: false
-                                                            allow_overdue_entitlements:
-                                                              type: boolean
-                                                              description: If true, this plan's entitlements remain usable while past due,
-                                                                overriding the
-                                                                organization's
-                                                                overdue entitlement
-                                                                block without
-                                                                changing
-                                                                cancellation or
-                                                                reset behavior.
                                                               default: false
                                                           description: Miscellaneous plan-level configuration flags.
                                                         - type: "null"
@@ -119744,17 +119580,6 @@ paths:
                                                                               product is in a
                                                                               past_due state.
                                                                             default: false
-                                                                          allow_overdue_entitlements:
-                                                                            type: boolean
-                                                                            description: If true, this plan's entitlements remain usable while past due,
-                                                                              overriding the
-                                                                              organization's
-                                                                              overdue entitlement
-                                                                              block without
-                                                                              changing
-                                                                              cancellation or
-                                                                              reset behavior.
-                                                                            default: false
                                                                         description: Miscellaneous plan-level configuration flags.
                                                                       - type: "null"
                                                                   active:
@@ -122352,17 +122177,6 @@ paths:
                                                                       the customer's
                                                                       product is in a
                                                                       past_due state.
-                                                                    default: false
-                                                                  allow_overdue_entitlements:
-                                                                    type: boolean
-                                                                    description: If true, this plan's entitlements remain usable while past due,
-                                                                      overriding the
-                                                                      organization's
-                                                                      overdue entitlement
-                                                                      block without
-                                                                      changing
-                                                                      cancellation or
-                                                                      reset behavior.
                                                                     default: false
                                                                 description: Miscellaneous plan-level configuration flags.
                                                               - type: "null"
@@ -125918,17 +125732,6 @@ paths:
                                                                                     product is in a
                                                                                     past_due state.
                                                                                   default: false
-                                                                                allow_overdue_entitlements:
-                                                                                  type: boolean
-                                                                                  description: If true, this plan's entitlements remain usable while past due,
-                                                                                    overriding the
-                                                                                    organization's
-                                                                                    overdue entitlement
-                                                                                    block without
-                                                                                    changing
-                                                                                    cancellation or
-                                                                                    reset behavior.
-                                                                                  default: false
                                                                               description: Miscellaneous plan-level configuration flags.
                                                                             - type: "null"
                                                                         active:
@@ -128334,16 +128137,6 @@ paths:
                                                           schedule even when the
                                                           customer's product is
                                                           in a past_due state.
-                                                        default: false
-                                                      allow_overdue_entitlements:
-                                                        type: boolean
-                                                        description: If true, this plan's entitlements remain usable while past due,
-                                                          overriding the
-                                                          organization's overdue
-                                                          entitlement block
-                                                          without changing
-                                                          cancellation or reset
-                                                          behavior.
                                                         default: false
                                                     description: Miscellaneous plan-level configuration flags.
                                                   - type: "null"
@@ -132303,17 +132096,6 @@ paths:
                                                                         the customer's
                                                                         product is in a
                                                                         past_due state.
-                                                                      default: false
-                                                                    allow_overdue_entitlements:
-                                                                      type: boolean
-                                                                      description: If true, this plan's entitlements remain usable while past due,
-                                                                        overriding the
-                                                                        organization's
-                                                                        overdue entitlement
-                                                                        block without
-                                                                        changing
-                                                                        cancellation or
-                                                                        reset behavior.
                                                                       default: false
                                                                   description: Miscellaneous plan-level configuration flags.
                                                                 - type: "null"
@@ -135107,17 +134889,6 @@ paths:
                                                                 product is in a
                                                                 past_due state.
                                                               default: false
-                                                            allow_overdue_entitlements:
-                                                              type: boolean
-                                                              description: If true, this plan's entitlements remain usable while past due,
-                                                                overriding the
-                                                                organization's
-                                                                overdue entitlement
-                                                                block without
-                                                                changing
-                                                                cancellation or
-                                                                reset behavior.
-                                                              default: false
                                                           description: Miscellaneous plan-level configuration flags.
                                                         - type: "null"
                                                     active:
@@ -138970,17 +138741,6 @@ paths:
                                                                               product is in a
                                                                               past_due state.
                                                                             default: false
-                                                                          allow_overdue_entitlements:
-                                                                            type: boolean
-                                                                            description: If true, this plan's entitlements remain usable while past due,
-                                                                              overriding the
-                                                                              organization's
-                                                                              overdue entitlement
-                                                                              block without
-                                                                              changing
-                                                                              cancellation or
-                                                                              reset behavior.
-                                                                            default: false
                                                                         description: Miscellaneous plan-level configuration flags.
                                                                       - type: "null"
                                                                   active:
@@ -141556,16 +141316,6 @@ paths:
                                                           schedule even when the
                                                           customer's product is
                                                           in a past_due state.
-                                                        default: false
-                                                      allow_overdue_entitlements:
-                                                        type: boolean
-                                                        description: If true, this plan's entitlements remain usable while past due,
-                                                          overriding the
-                                                          organization's overdue
-                                                          entitlement block
-                                                          without changing
-                                                          cancellation or reset
-                                                          behavior.
                                                         default: false
                                                     description: Miscellaneous plan-level configuration flags.
                                                   - type: "null"
@@ -145526,17 +145276,6 @@ paths:
                                                                         product is in a
                                                                         past_due state.
                                                                       default: false
-                                                                    allow_overdue_entitlements:
-                                                                      type: boolean
-                                                                      description: If true, this plan's entitlements remain usable while past due,
-                                                                        overriding the
-                                                                        organization's
-                                                                        overdue entitlement
-                                                                        block without
-                                                                        changing
-                                                                        cancellation or
-                                                                        reset behavior.
-                                                                      default: false
                                                                   description: Miscellaneous plan-level configuration flags.
                                                                 - type: "null"
                                                             active:
@@ -148325,17 +148064,6 @@ paths:
                                                                 the customer's
                                                                 product is in a
                                                                 past_due state.
-                                                              default: false
-                                                            allow_overdue_entitlements:
-                                                              type: boolean
-                                                              description: If true, this plan's entitlements remain usable while past due,
-                                                                overriding the
-                                                                organization's
-                                                                overdue entitlement
-                                                                block without
-                                                                changing
-                                                                cancellation or
-                                                                reset behavior.
                                                               default: false
                                                           description: Miscellaneous plan-level configuration flags.
                                                         - type: "null"
@@ -152188,17 +151916,6 @@ paths:
                                                                               the customer's
                                                                               product is in a
                                                                               past_due state.
-                                                                            default: false
-                                                                          allow_overdue_entitlements:
-                                                                            type: boolean
-                                                                            description: If true, this plan's entitlements remain usable while past due,
-                                                                              overriding the
-                                                                              organization's
-                                                                              overdue entitlement
-                                                                              block without
-                                                                              changing
-                                                                              cancellation or
-                                                                              reset behavior.
                                                                             default: false
                                                                         description: Miscellaneous plan-level configuration flags.
                                                                       - type: "null"
@@ -163270,12 +162987,6 @@ paths:
                             description: If true, entitlements attached to this plan will still reset on
                               schedule even when the customer's product is in a
                               past_due state.
-                          allow_overdue_entitlements:
-                            type: boolean
-                            description: If true, this plan's entitlements remain usable while past due,
-                              overriding the organization's overdue entitlement
-                              block without changing cancellation or reset
-                              behavior.
                         description: Miscellaneous plan-level configuration flags.
                       billing_controls:
                         type: object

--- a/server/src/internal/balances/check/getCheckSubject.ts
+++ b/server/src/internal/balances/check/getCheckSubject.ts
@@ -13,9 +13,7 @@ export const getCheckSubject = ({
 	return {
 		...fullSubject,
 		customer_products: fullSubject.customer_products.filter(
-			(customerProduct) =>
-				customerProduct.product.config?.allow_overdue_entitlements ||
-				customerProduct.status !== CusProductStatus.PastDue,
+			(customerProduct) => customerProduct.status !== CusProductStatus.PastDue,
 		),
 	};
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/planParamsToProductRowPatch.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/planParamsToProductRowPatch.ts
@@ -50,10 +50,6 @@ export const planParamsToProductRowPatch = ({
 				planParams.config.ignore_past_due ??
 				current?.config?.ignore_past_due ??
 				false,
-			allow_overdue_entitlements:
-				planParams.config.allow_overdue_entitlements ??
-				current?.config?.allow_overdue_entitlements ??
-				false,
 		};
 	}
 	if (planParams.metadata !== undefined) patch.metadata = planParams.metadata;

--- a/server/tests/integration/balances/check/check-overdue-entitlements.test.ts
+++ b/server/tests/integration/balances/check/check-overdue-entitlements.test.ts
@@ -17,7 +17,7 @@ import { CusService } from "@/internal/customers/CusService.js";
 import { invalidateCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
 import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache.js";
 
-test("overdue entitlements: visible balances, plan exemption, mixed deductions and payment recovery", async () => {
+test("overdue entitlements: visible balances, mixed deductions and payment recovery", async () => {
 	const overdue = products.base({
 		id: "overdue",
 		items: [items.monthlyMessages({ includedUsage: 100 }), items.dashboard()],
@@ -28,10 +28,7 @@ test("overdue entitlements: visible balances, plan exemption, mixed deductions a
 		items: [items.free({ featureId: TestFeature.Workflows, includedUsage: 7 })],
 	});
 	overdue.config = { ignore_past_due: true };
-	enterprise.config = {
-		ignore_past_due: false,
-		allow_overdue_entitlements: true,
-	};
+	enterprise.config = { ignore_past_due: false };
 	const active = products.base({
 		id: "active",
 		isAddOn: true,
@@ -154,7 +151,7 @@ test("overdue entitlements: visible balances, plan exemption, mixed deductions a
 				feature_id: TestFeature.Workflows,
 				send_event: true,
 			}),
-		).toMatchObject({ allowed: true, balance: { remaining: 6 } });
+		).toMatchObject({ allowed: false, balance: { remaining: 7 } });
 
 		await autumn.track({
 			customer_id: customerId,

--- a/server/tests/integration/catalog-v2/plans/update/update-plan-details.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/update-plan-details.test.ts
@@ -183,62 +183,6 @@ test.concurrent(
 	},
 );
 
-test("catalogV2 update details: overdue access and cancellation flags stay independent", async () => {
-	const { autumnV2_4: autumn, ctx } = await initScenario({
-		setup: [],
-		actions: [],
-	});
-	const planId = uniqueTestId("cv2_overdue_flags");
-	try {
-		await autumn.catalogV2.update({
-			plans: [
-				{
-					plan_id: planId,
-					name: "Overdue flag test",
-					config: { ignore_past_due: true, allow_overdue_entitlements: true },
-				},
-			],
-		});
-		await expectCatalogPlansCorrect({
-			autumn,
-			expected: [
-				{
-					id: planId,
-					config: { ignore_past_due: true, allow_overdue_entitlements: true },
-				},
-			],
-		});
-		await autumn.catalogV2.update({
-			plans: [
-				{ plan_id: planId, config: { allow_overdue_entitlements: false } },
-			],
-		});
-		await expectCatalogPlansCorrect({
-			autumn,
-			expected: [
-				{
-					id: planId,
-					config: { ignore_past_due: true, allow_overdue_entitlements: false },
-				},
-			],
-		});
-		await autumn.catalogV2.update({
-			plans: [{ plan_id: planId, config: { ignore_past_due: false } }],
-		});
-		await expectCatalogPlansCorrect({
-			autumn,
-			expected: [
-				{
-					id: planId,
-					config: { ignore_past_due: false, allow_overdue_entitlements: false },
-				},
-			],
-		});
-	} finally {
-		await deleteDbPlans({ ctx, planIds: [planId] });
-	}
-});
-
 test.concurrent(
 	`${chalk.yellowBright("catalogV2 update details: billing_controls patch persists / identical → none")}`,
 	async () => {

--- a/server/tests/integration/catalog-v2/plans/utils/expectCatalogPlans.ts
+++ b/server/tests/integration/catalog-v2/plans/utils/expectCatalogPlans.ts
@@ -97,7 +97,7 @@ type ExpectedPlan = {
 		on_end?: "bill" | "revert" | null;
 	} | null;
 	metadata?: Record<string, unknown>;
-	config?: { ignore_past_due?: boolean; allow_overdue_entitlements?: boolean };
+	config?: { ignore_past_due?: boolean };
 	billingControls?: CustomerBillingControls;
 	/** Deep equality — asserts absent columns too (cross-contamination checks). */
 	billingControlsExact?: CustomerBillingControls;

--- a/server/tests/unit/balances/check-v2/overdue-entitlements.test.ts
+++ b/server/tests/unit/balances/check-v2/overdue-entitlements.test.ts
@@ -58,7 +58,6 @@ const createPlan = ({
 	id = "overdue",
 	status = CusProductStatus.PastDue,
 	amount = 100,
-	allowOverdueEntitlements = false,
 	featureType = FeatureType.Metered,
 	unlimited = false,
 } = {}) => {
@@ -79,7 +78,6 @@ const createPlan = ({
 		status,
 		customerEntitlements: [entitlement],
 	});
-	plan.product.config.allow_overdue_entitlements = allowOverdueEntitlements;
 	return plan;
 };
 
@@ -99,17 +97,13 @@ const setup = ({ blocked = true, plans = [createPlan()] } = {}) => {
 	return { ctx, feature, fullSubject: cachedSubject };
 };
 
-test("overdue access: org default, status and plan exemption preserve normal limits", async () => {
-	for (const [blocked, status, allowOverdueEntitlements, allowed] of [
-		[false, CusProductStatus.PastDue, false, true],
-		[true, CusProductStatus.Active, false, true],
-		[true, CusProductStatus.PastDue, false, false],
-		[true, CusProductStatus.PastDue, true, true],
+test("overdue access: org default and status preserve normal limits", async () => {
+	for (const [blocked, status, allowed] of [
+		[false, CusProductStatus.PastDue, true],
+		[true, CusProductStatus.Active, true],
+		[true, CusProductStatus.PastDue, false],
 	] as const) {
-		const { ctx } = setup({
-			blocked,
-			plans: [createPlan({ status, allowOverdueEntitlements })],
-		});
+		const { ctx } = setup({ blocked, plans: [createPlan({ status })] });
 		const checkData = await getCheckDataV2({
 			ctx,
 			body: { customer_id: "cus_test", feature_id: "messages" },
@@ -383,32 +377,6 @@ test("overdue access: credit fallback and tracked responses select eligible fund
 			balance: { feature_id: "credits", remaining: 100 },
 		});
 	}
-	creditEntitlement.entitlement.feature_override = null;
-	creditPlan.product.config.allow_overdue_entitlements = true;
-	const exemptCreditCheck = await getCheckDataV2({
-		ctx,
-		body,
-		requiredBalance: 4,
-	});
-	expect(
-		await getCheckResponseV2({
-			ctx,
-			checkData: exemptCreditCheck,
-			requiredBalance: 4,
-		}),
-	).toMatchObject({
-		allowed: true,
-		required_balance: 20,
-		balance: { feature_id: "credits", remaining: 100 },
-	});
-	const prepared = prepareFeatureDeductionV2({
-		ctx,
-		fullSubject,
-		deduction: { feature, deduction: 4, enforceOverdueBlock: true },
-	});
-	expect(prepared.customerEntitlementDeductions).toMatchObject([
-		{ customer_entitlement_id: "credit_balance", credit_cost: 5 },
-	]);
 });
 
 test("overdue access: subject refresh rechecks eligibility before retrying a deduction", async () => {

--- a/server/tests/unit/catalogV2/computeProductDetailsPlan/diffProductDetails.test.ts
+++ b/server/tests/unit/catalogV2/computeProductDetailsPlan/diffProductDetails.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import {
-	type Product,
-	ProductConfigSchema,
-	productDetailsAreSame,
-	UpdateCatalogPlanParamsSchema,
-} from "@autumn/shared";
+import { type Product, productDetailsAreSame } from "@autumn/shared";
 import { products } from "@tests/utils/fixtures/db/products";
 import { diffProductDetails } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/diffProductDetails";
-import { planParamsToProductRowPatch } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/planParamsToProductRowPatch";
 
 const row = (overrides: Partial<Product> = {}): Product =>
 	({ ...products.create({ id: "pro" }), ...overrides }) as Product;
@@ -49,40 +43,6 @@ describe("productDetailsAreSame / diffProductDetails", () => {
 		expect(diffProductDetails({ current, next })).toEqual({
 			config: { ignore_past_due: false },
 		});
-	});
-
-	test("overdue access and cancellation flags patch independently", () => {
-		const current = row({ config: { ignore_past_due: true } });
-		const planParams = UpdateCatalogPlanParamsSchema.parse({
-			plan_id: current.id,
-			config: { allow_overdue_entitlements: true },
-		});
-		expect(planParams.config).toEqual({ allow_overdue_entitlements: true });
-		const next = {
-			...current,
-			...planParamsToProductRowPatch({ current, planParams }),
-		};
-		expect(next.config).toEqual({
-			ignore_past_due: true,
-			allow_overdue_entitlements: true,
-		});
-		expect(diffProductDetails({ current, next })).toEqual({
-			config: current.config,
-		});
-		const cancellationPatch = planParamsToProductRowPatch({
-			current: next,
-			planParams: UpdateCatalogPlanParamsSchema.parse({
-				plan_id: current.id,
-				config: { ignore_past_due: false },
-			}),
-		});
-		expect(cancellationPatch.config).toEqual({
-			ignore_past_due: false,
-			allow_overdue_entitlements: true,
-		});
-		expect(ProductConfigSchema.parse({}).allow_overdue_entitlements).toBe(
-			false,
-		);
 	});
 
 	test("pointer-only change diffs", () => {

--- a/shared/models/productModels/productConfig/productConfig.ts
+++ b/shared/models/productModels/productConfig/productConfig.ts
@@ -6,19 +6,11 @@ export const ProductConfigParamsSchema = z.object({
 		description:
 			"If true, entitlements attached to this plan will still reset on schedule even when the customer's product is in a past_due state.",
 	}),
-	allow_overdue_entitlements: z.boolean().optional().meta({
-		description:
-			"If true, this plan's entitlements remain usable while past due, overriding the organization's overdue entitlement block without changing cancellation or reset behavior.",
-	}),
 });
 
 export const ProductConfigSchema = ProductConfigParamsSchema.extend({
 	ignore_past_due:
 		ProductConfigParamsSchema.shape.ignore_past_due.default(false),
-	allow_overdue_entitlements:
-		ProductConfigParamsSchema.shape.allow_overdue_entitlements
-			.default(false)
-			.optional(),
 });
 
 export type ProductConfig = z.infer<typeof ProductConfigSchema>;

--- a/shared/utils/productV2Utils/compareProductUtils/compareProductUtils.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/compareProductUtils.ts
@@ -115,11 +115,6 @@ export const compareConfig = ({
 			condition: !!newConfig?.ignore_past_due === !!curConfig?.ignore_past_due,
 			message: `Ignore past due different: ${newConfig?.ignore_past_due} !== ${curConfig?.ignore_past_due}`,
 		},
-		allow_overdue_entitlements: {
-			condition:
-				!!newConfig?.allow_overdue_entitlements ===
-				!!curConfig?.allow_overdue_entitlements,
-		},
 	};
 
 	const detailsSame = Object.values(checks).every((d) => d.condition);

--- a/vite/src/views/products/plan/components/edit-plan-details/MoreSettingsSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/MoreSettingsSection.tsx
@@ -116,27 +116,6 @@ export const MoreSettingsSection = () => {
 						}
 					/>
 
-					<ConfigRow
-						title="Allow access while overdue"
-						description="Allow access when this plan is past due."
-						action={
-							<Switch
-								aria-label="Allow access while overdue"
-								checked={!!product.config?.allow_overdue_entitlements}
-								onCheckedChange={(checked) =>
-									setProduct({
-										...product,
-										config: {
-											...product.config,
-											ignore_past_due: product.config?.ignore_past_due ?? false,
-											allow_overdue_entitlements: checked,
-										},
-									})
-								}
-							/>
-						}
-					/>
-
 					{!isCustomPlan && (
 						<ConfigRow
 							title="Base plan"

--- a/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
+++ b/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
 	AppEnv,
-	compareConfig,
 	type Feature,
 	FeatureType,
 	FeatureUsageType,
@@ -128,44 +127,6 @@ describe("buildUpdateCatalogPlanParams", () => {
 			]),
 		);
 		expect(() => UpdateCatalogPlanParamsSchema.parse(body)).not.toThrow();
-	});
-
-	test("reverting the overdue access toggle restores an unchanged legacy config", () => {
-		expect(
-			compareConfig({
-				curConfig: undefined,
-				newConfig: {
-					ignore_past_due: false,
-					allow_overdue_entitlements: false,
-				},
-			}),
-		).toBe(true);
-		expect(
-			compareConfig({
-				curConfig: undefined,
-				newConfig: { ignore_past_due: false, allow_overdue_entitlements: true },
-			}),
-		).toBe(false);
-	});
-
-	test("overdue access override is detected and saved independently of cancellation protection", () => {
-		const current = { ...baseProduct, config: { ignore_past_due: true } };
-		const edited = {
-			...current,
-			config: { ...current.config, allow_overdue_entitlements: true },
-		};
-		expect(
-			compareConfig({ newConfig: edited.config, curConfig: current.config }),
-		).toBe(false);
-		const params = buildUpdateCatalogPlanParams({
-			baseProduct: current,
-			editedProduct: edited,
-			features,
-		});
-		expect(UpdateCatalogPlanParamsSchema.parse(params).config).toEqual({
-			ignore_past_due: true,
-			allow_overdue_entitlements: true,
-		});
 	});
 
 	test("rename sends new_plan_id and keeps the original plan_id", () => {
@@ -476,9 +437,9 @@ describe("buildUpdateCatalogPlanParams", () => {
 				features,
 			});
 			expect(params.billing_controls).toEqual({ [key]: items });
-			expect(
-				JSON.stringify(params.billing_controls).includes("null"),
-			).toBe(false);
+			expect(JSON.stringify(params.billing_controls).includes("null")).toBe(
+				false,
+			);
 		}
 	});
 


### PR DESCRIPTION
Overdue access blocking is an organization setting. #3304 also added a plan-level `allow_overdue_entitlements` opt-out to the product config, the plan editor and the CLI; that flag should not exist. This removes it and leaves `ignore_past_due` as the only plan-level flag, with `block_overdue_entitlements` staying org-level.

- `ProductConfigSchema` / params: field removed; `compareConfig` and the plan row patch no longer carry it.
- `getCheckSubject`: past-due plans are always excluded while the org block is on; no per-plan exemption.
- Plan editor: the "Allow access while overdue" toggle is gone.
- Internal OpenAPI spec and the `atmn-nightly` generated client regenerated; both diffs are the field's blocks only.
- Tests: the plan-exemption cases are removed and the integration check test now expects a past-due plan to be blocked.

Verified: server and dashboard typecheck clean; affected unit tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the plan-level `allow_overdue_entitlements` flag so overdue access blocking is now controlled only at the organization level. Plans could previously opt out of the org's overdue entitlement block per-plan; `ignore_past_due` is now the only plan-level config flag and the plan editor's "Allow access while overdue" toggle is removed.

**Behavior change**
- Plans that set `allow_overdue_entitlements: true` will now be blocked when past due if the org-level overdue block is enabled.

<sup>Written for commit 10157ddebc203490503b32fe7c7621b15b7299a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the unintended plan-level overdue-access exemption and makes overdue entitlement access depend exclusively on the organization setting.

Key changes:
- **[Bug fixes, Improvements]** Past-due plans can no longer bypass an organization’s overdue entitlement block through a plan-level setting.
- **[API changes]** Removes `allow_overdue_entitlements` from plan schemas, update parameters, the internal OpenAPI specification, and generated `atmn-nightly` types.
- **[Improvements]** Removes the corresponding plan-editor toggle and config comparison/patch handling.
- **[Bug fixes]** Updates unit and integration tests so past-due plans are blocked whenever the organization enables overdue blocking.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the schema, runtime behavior, editor, generated artifacts, and tests consistently removing the plan-level exemption.

No actionable failures remain; organization-level gating is preserved when overdue blocking is disabled, and all past-due plans are consistently excluded when it is enabled.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/check/getCheckSubject.ts | Removes the plan-level exemption so organization-level overdue blocking consistently excludes every past-due plan. |
| shared/models/productModels/productConfig/productConfig.ts | Removes the obsolete field from plan configuration input and persisted product schemas. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/planParamsToProductRowPatch.ts | Stops carrying the removed field through catalog plan updates while preserving `ignore_past_due`. |
| packages/openapi/openapi-internal.yml | Removes the field consistently from internal plan request and response schemas. |
| vite/src/views/products/plan/components/edit-plan-details/MoreSettingsSection.tsx | Removes the plan-level “Allow access while overdue” control from the editor. |
| server/tests/integration/balances/check/check-overdue-entitlements.test.ts | Updates end-to-end expectations to require organization-wide blocking for all past-due plans. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Entitlement check] --> B{Organization blocks overdue entitlements?}
  B -- No --> C[Evaluate active and past-due plans]
  B -- Yes --> D[Exclude past-due plans]
  D --> E[Evaluate remaining eligible plans]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Remove the plan-level allow\_overdue\_enti..."](https://github.com/useautumn/autumn/commit/10157ddebc203490503b32fe7c7621b15b7299a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61795659)</sub>

<!-- /greptile_comment -->