### PR TITLE
fix: emit customer.products.updated when trials expire

### DIFF
--- a/server/src/cron/productCron/processExpiredTrialRow.ts
+++ b/server/src/cron/productCron/processExpiredTrialRow.ts
@@ -10,6 +10,7 @@ import type { InferSelectModel } from "drizzle-orm";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan.js";
 import { sendBillingUpdatedWebhook } from "@/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook";
+import { billingPlanToSendProductsUpdated } from "@/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated";
 import { CusService } from "@/internal/customers/CusService";
 import { activateFreeDefaultProduct } from "@/internal/customers/cusProducts/actions/activateFreeDefaultProduct";
 import { tryProcessRevertExpiry } from "@/internal/customers/cusProducts/actions/revertTrialExpiry";
@@ -105,18 +106,26 @@ export const processExpiredTrialRow = async ({
 		source: "productCron",
 	});
 
+	const autumnBillingPlan = {
+		customerId: originalFullCustomer.id ?? originalFullCustomer.internal_id,
+		insertCustomerProducts: activatedDefault ? [activatedDefault] : [],
+		updateCustomerProducts: [
+			{
+				customerProduct: trialFullCusProduct,
+				updates: { status: CusProductStatus.Expired },
+			},
+		],
+	};
+
+	await billingPlanToSendProductsUpdated({
+		ctx,
+		autumnBillingPlan,
+		billingContext: { fullCustomer: originalFullCustomer },
+	});
+
 	void sendBillingUpdatedWebhook({
 		ctx,
-		autumnBillingPlan: {
-			customerId: originalFullCustomer.id ?? originalFullCustomer.internal_id,
-			insertCustomerProducts: activatedDefault ? [activatedDefault] : [],
-			updateCustomerProducts: [
-				{
-					customerProduct: trialFullCusProduct,
-					updates: { status: CusProductStatus.Expired },
-				},
-			],
-		},
+		autumnBillingPlan,
 		originalFullCustomer,
 		tags: ["trial_ended"],
 	});

--- a/server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts
+++ b/server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts
@@ -46,8 +46,9 @@ const hasPaidScheduledProduct = ({
 
 /**
  * Get the webhook scenario for an updateCustomerProduct, or null if no webhook needed.
- * - Expire: status=expired → "expired"
  * - Cancel: canceled=true with timestamps set → "cancel" or "downgrade"
+ *   (even when status is also expired — immediate cancel must stay cancel)
+ * - Expire: status=expired with no cancel timestamps → "expired"
  * - Uncancel: canceled=false with timestamps cleared → "renew"
  */
 const getUpdateScenario = ({
@@ -57,10 +58,6 @@ const getUpdateScenario = ({
 	updates: UpdateCustomerProductUpdates;
 	insertCustomerProducts: FullCusProduct[];
 }): AttachScenario | null => {
-	if (updates.status === CusProductStatus.Expired) {
-		return AttachScenario.Expired;
-	}
-
 	// Cancel: canceled=true with timestamps set
 	if (
 		updates.canceled === true &&
@@ -70,6 +67,10 @@ const getUpdateScenario = ({
 		return hasPaidScheduledProduct({ customerProducts: insertCustomerProducts })
 			? AttachScenario.Downgrade
 			: AttachScenario.Cancel;
+	}
+
+	if (updates.status === CusProductStatus.Expired) {
+		return AttachScenario.Expired;
 	}
 
 	// Uncancel: canceled=false with timestamps cleared

--- a/server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts
+++ b/server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts
@@ -46,6 +46,7 @@ const hasPaidScheduledProduct = ({
 
 /**
  * Get the webhook scenario for an updateCustomerProduct, or null if no webhook needed.
+ * - Expire: status=expired → "expired"
  * - Cancel: canceled=true with timestamps set → "cancel" or "downgrade"
  * - Uncancel: canceled=false with timestamps cleared → "renew"
  */
@@ -56,6 +57,10 @@ const getUpdateScenario = ({
 	updates: UpdateCustomerProductUpdates;
 	insertCustomerProducts: FullCusProduct[];
 }): AttachScenario | null => {
+	if (updates.status === CusProductStatus.Expired) {
+		return AttachScenario.Expired;
+	}
+
 	// Cancel: canceled=true with timestamps set
 	if (
 		updates.canceled === true &&

--- a/server/src/internal/customers/cusProducts/actions/revertTrialExpiry.ts
+++ b/server/src/internal/customers/cusProducts/actions/revertTrialExpiry.ts
@@ -1,5 +1,6 @@
 import {
 	type AutumnBillingPlan,
+	AttachScenario,
 	CusProductStatus,
 	type customerProducts,
 	customerProducts as customerProductsTable,
@@ -10,6 +11,7 @@ import type { DrizzleCli } from "@/db/initDrizzle";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { applyPooledBalanceCustomerProductTransitions } from "@/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCustomerProductTransitions";
 import { sendBillingUpdatedWebhook } from "@/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook";
+import { billingPlanToSendProductsUpdated } from "@/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated";
 import { CusService } from "@/internal/customers/CusService";
 import { RELEVANT_STATUSES } from "@/internal/customers/cusProducts/CusProductService";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
@@ -19,8 +21,8 @@ import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCust
  * cusProduct and unpause the previous one atomically so we never leave a
  * customer without an active plan.
  *
- * Emits the `billing.updated` webhook (tag: `trial_ended`) describing both
- * the trial expiry and the restored previous plan.
+ * Emits `customer.products.updated` for the expired trial and restored
+ * previous plan, plus `billing.updated` (tag: `trial_ended`).
  *
  * Returns true if handled, false to fall through to standard expiry.
  */
@@ -131,6 +133,13 @@ export const tryProcessRevertExpiry = async ({
 				},
 			],
 		};
+
+		await billingPlanToSendProductsUpdated({
+			ctx,
+			autumnBillingPlan,
+			billingContext: { fullCustomer },
+			fallbackUpdateScenario: AttachScenario.New,
+		});
 
 		void sendBillingUpdatedWebhook({
 			ctx,

--- a/server/tests/unit/billing/update-subscription/billing-plan-send-products-updated.spec.ts
+++ b/server/tests/unit/billing/update-subscription/billing-plan-send-products-updated.spec.ts
@@ -141,6 +141,29 @@ describe(chalk.yellowBright("billingPlanToSendProductsUpdated"), () => {
 		expect(calls).toHaveLength(0);
 	});
 
+	test("queues expired webhook for status=expired updates", async () => {
+		const calls = await runPlan({
+			updateCustomerProduct: {
+				customerProduct: customerProducts.create({
+					id: "cus_prod_trial",
+				}),
+				updates: { status: CusProductStatus.Expired },
+			},
+			insertCustomerProducts: [
+				customerProducts.create({
+					id: "cus_prod_hobby",
+					productId: "prod_hobby",
+				}),
+			],
+		});
+
+		expect(calls).toHaveLength(2);
+		expect(calls[0]?.customerProductId).toBe("cus_prod_trial");
+		expect(calls[0]?.scenario).toBe(AttachScenario.Expired);
+		expect(calls[1]?.customerProductId).toBe("cus_prod_hobby");
+		expect(calls[1]?.scenario).toBe(AttachScenario.Upgrade);
+	});
+
 	test("matches each inserted product to its own expired counterpart", async () => {
 		const calls = await runPlan({
 			updateCustomerProducts: [
@@ -207,10 +230,14 @@ describe(chalk.yellowBright("billingPlanToSendProductsUpdated"), () => {
 			],
 		});
 
-		expect(calls).toHaveLength(2);
-		expect(calls[0]?.customerProductId).toBe("cus_prod_new_1");
-		expect(calls[0]?.scenario).toBe(AttachScenario.Upgrade);
-		expect(calls[1]?.customerProductId).toBe("cus_prod_new_2");
-		expect(calls[1]?.scenario).toBe(AttachScenario.New);
+		expect(calls).toHaveLength(4);
+		expect(calls[0]?.customerProductId).toBe("cus_prod_expired_1");
+		expect(calls[0]?.scenario).toBe(AttachScenario.Expired);
+		expect(calls[1]?.customerProductId).toBe("cus_prod_expired_2");
+		expect(calls[1]?.scenario).toBe(AttachScenario.Expired);
+		expect(calls[2]?.customerProductId).toBe("cus_prod_new_1");
+		expect(calls[2]?.scenario).toBe(AttachScenario.Upgrade);
+		expect(calls[3]?.customerProductId).toBe("cus_prod_new_2");
+		expect(calls[3]?.scenario).toBe(AttachScenario.New);
 	});
 });

--- a/server/tests/unit/billing/update-subscription/billing-plan-send-products-updated.spec.ts
+++ b/server/tests/unit/billing/update-subscription/billing-plan-send-products-updated.spec.ts
@@ -141,6 +141,23 @@ describe(chalk.yellowBright("billingPlanToSendProductsUpdated"), () => {
 		expect(calls).toHaveLength(0);
 	});
 
+	test("keeps cancel scenario when immediate cancel also sets status=expired", async () => {
+		const calls = await runPlan({
+			updateCustomerProduct: {
+				customerProduct: customerProducts.create({}),
+				updates: {
+					canceled: true,
+					canceled_at: Date.now(),
+					ended_at: Date.now(),
+					status: CusProductStatus.Expired,
+				},
+			},
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.scenario).toBe(AttachScenario.Cancel);
+	});
+
 	test("queues expired webhook for status=expired updates", async () => {
 		const calls = await runPlan({
 			updateCustomerProduct: {


### PR DESCRIPTION
## Summary
- Trial expiry currently only fires `billing.updated` (`trial_ended`). Mintlify's endpoint only listens for `customer.products.updated`, so Hobby fallback never reaches them.
- Treat `status=expired` as the `expired` scenario in `billingPlanToSendProductsUpdated`, then queue that webhook from both product-cron trial expiry paths (standard Hobby fallback and revert).
- This is a hotfix over `main`. It also emits `expired` for other billing-plan status→expired updates that already go through the shared helper (e.g. attach replacements).

## Test plan
- [x] `bun test server/tests/unit/billing/update-subscription/billing-plan-send-products-updated.spec.ts`
- [ ] After merge, confirm a Mintlify Pro trial expiry creates `customer.products.updated` with `scenario: expired` (and Hobby `new` if the default is activated)
- [ ] Replay/resend remaining missed Hobby webhooks separately


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes trial expiry so it now emits `customer.products.updated` with `scenario: expired`, which listeners like Mintlify rely on to see the Hobby fallback. Previously trial expiry only sent `billing.updated` (`trial_ended`).

- Treats `status=expired` as the `expired` scenario in `billingPlanToSendProductsUpdated`.
- Keeps `cancel`/`downgrade` precedence when immediate cancellation also sets `status=expired`.
- Queues the webhook from both product-cron trial expiry paths (standard Hobby fallback and revert).

<sup>Written for commit 8e8e92af7f2d7fd550de4fb440b82d7b33112404. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This hotfix emits `customer.products.updated` when a trial expires so downstream integrations receive the expired trial and any replacement product.

Key changes:
- **[Bug fixes, API changes]** Classifies status-only product expiration as the `expired` webhook scenario while preserving `cancel` or `downgrade` for immediate cancellations.
- **[Bug fixes]** Queues product-update webhooks from both normal trial expiry and previous-product restoration paths.
- **[Improvements]** Adds regression coverage for trial expiration and cancellation precedence.

One earlier reliability concern remains: if webhook enqueueing fails after the trial is persisted as expired, the error is logged but the cron will not select that trial again, so the notification can be permanently missed.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a temporary webhook-queue failure can still permanently lose the trial-expiry notification.

The cancellation-precedence finding is fully fixed, but the earlier webhook-delivery finding remains unresolved: enqueue errors are caught after product state is persisted, and the expired trial will not be selected by a later cron run for retry.

**Files Needing Attention:** server/src/cron/productCron/processExpiredTrialRow.ts, server/src/internal/customers/cusProducts/actions/revertTrialExpiry.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/cron/productCron/processExpiredTrialRow.ts | Adds product-update webhook enqueueing after standard trial expiry, but the previously reported lost-event behavior on enqueue failure remains. |
| server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts | Correctly preserves cancellation precedence while adding the expired scenario for status-only expiry updates. |
| server/src/internal/customers/cusProducts/actions/revertTrialExpiry.ts | Emits product updates for both the expired trial and restored product, while sharing the outstanding enqueue-failure reliability risk. |
| server/tests/unit/billing/update-subscription/billing-plan-send-products-updated.spec.ts | Adds focused regression coverage for expired events and immediate-cancellation precedence. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Cron as Product expiry cron
    participant Billing as Billing state
    participant Queue as Webhook queue
    participant Receiver as Customer endpoint
    Cron->>Billing: Expire trial
    alt Default product activated
        Cron->>Billing: Add default product
    else Previous product restored
        Cron->>Billing: Reactivate previous product
    end
    Cron->>Queue: Queue expired product update
    Cron->>Queue: Queue replacement product update
    Queue-->>Receiver: customer.products.updated
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: keep cancel scenario when expiry an..."](https://github.com/useautumn/autumn/commit/8e8e92af7f2d7fd550de4fb440b82d7b33112404) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61924182)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)
- Knowledge Base — [Customer, subject, and entitlement operations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/customer-management.md)
- Knowledge Base — [Webhook contracts and delivery events](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/webhook-contracts.md)
- Knowledge Base — [Scheduled operations and trigger automation](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/scheduled-operations-and-triggers.md)
</details>


<!-- /greptile_comment -->