### PR TITLE
Show standalone balance names in dashboard

### DIFF
--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -330,7 +330,7 @@ export const getCursorPaginatedFullCusQuery = ({
 					AND ce.pooled_balance_id IS NULL
 					AND ce.pooled_contribution_id IS NULL
 					AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
-					AND ${looseEntitlementIsLiveSql()}
+					AND (${looseEntitlementIsLiveSql()} OR ce.next_reset_at IS NOT NULL)
 					${customerLevelOnly("ce")}
 				ORDER BY ce.id DESC
 				LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -426,8 +426,8 @@ const buildExtraEntitlementsCTE = ({
             AND ce.customer_product_id IS NULL
             AND ce.pooled_balance_id IS NULL
             AND ce.pooled_contribution_id IS NULL
-            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR (ce.expires_at IS NULL AND ce.balance = 0 AND ce.unlimited IS NOT TRUE))
-            AND (${looseEntitlementIsLiveSql()} OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE))
+            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
+            AND (${looseEntitlementIsLiveSql()} OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
           ORDER BY ce.id DESC
           LIMIT ${EXPIRED_EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
         ) expired_ce`

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -426,8 +426,8 @@ const buildExtraEntitlementsCTE = ({
             AND ce.customer_product_id IS NULL
             AND ce.pooled_balance_id IS NULL
             AND ce.pooled_contribution_id IS NULL
-            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
-            AND (${looseEntitlementIsLiveSql()} OR (ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
+            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR (ce.expires_at IS NULL AND ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
+            AND (ce.expires_at <= EXTRACT(EPOCH FROM now()) * 1000 OR ${looseEntitlementIsLiveSql()} OR (ce.expires_at IS NULL AND ce.balance = 0 AND ce.unlimited IS NOT TRUE AND ce.next_reset_at IS NULL))
           ORDER BY ce.id DESC
           LIMIT ${EXPIRED_EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
         ) expired_ce`
@@ -453,7 +453,7 @@ const buildExtraEntitlementsCTE = ({
             AND ce.pooled_balance_id IS NULL
             AND ce.pooled_contribution_id IS NULL
             AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
-            AND ${looseEntitlementIsLiveSql()}
+            AND (${looseEntitlementIsLiveSql()} OR ce.next_reset_at IS NOT NULL)
           ORDER BY ce.id DESC
           LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
         ) active_ce
@@ -828,7 +828,7 @@ export const getPaginatedFullCusQuery = ({
 		AND ce.pooled_balance_id IS NULL
 		AND ce.pooled_contribution_id IS NULL
         ${looseEntitlementExpiryFilterSql({ includeExpiredLooseEntitlements: false })}
-        AND ${looseEntitlementIsLiveSql()}
+        AND (${looseEntitlementIsLiveSql()} OR ce.next_reset_at IS NOT NULL)
         ${customerLevelOnly("ce")}
       ORDER BY ce.id DESC
 	  LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
@@ -301,7 +301,7 @@ export const getFullSubjectRowsQuery = ({
 					AND ce.pooled_balance_id IS NULL
 					AND ce.pooled_contribution_id IS NULL
 					AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
-					AND ${looseEntitlementIsLiveSql()}
+					AND (${looseEntitlementIsLiveSql()} OR ce.next_reset_at IS NOT NULL)
 					${customerEntitlementSubjectPredicate}
 				ORDER BY subject_entity_priority ASC, ce.id DESC
 				LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}

--- a/shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts
+++ b/shared/utils/cusEntUtils/classifyCusEnt/isCusEntDisplayExpired.ts
@@ -9,7 +9,7 @@ export const isCusEntDisplayExpired = ({
 }: {
 	cusEnt: Pick<
 		FullCusEntWithFullCusProduct,
-		"expires_at" | "customer_product" | "balance" | "unlimited"
+		"expires_at" | "customer_product" | "balance" | "unlimited" | "next_reset_at"
 	>;
 	now?: number;
 }): boolean =>
@@ -17,4 +17,5 @@ export const isCusEntDisplayExpired = ({
 	cusEnt.customer_product?.status === CusProductStatus.Expired ||
 	(cusEnt.customer_product == null &&
 		cusEnt.balance === 0 &&
-		cusEnt.unlimited !== true);
+		cusEnt.unlimited !== true &&
+		cusEnt.next_reset_at == null);

--- a/vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts
+++ b/vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts
@@ -133,7 +133,7 @@ export function getCustomerBalanceSourceParts({
 	});
 	const productName =
 		getCustomerBalancePlanName({ balance, fullCustomer }) ??
-		(isPooledBalance ? "Pooled" : "No plan");
+		(isPooledBalance ? "Pooled" : (balance.external_id ?? "No plan"));
 
 	const { interval, interval_count } = balance.entitlement;
 	let intervalLabel: string;

--- a/vite/tests/views/customers2/customer-balance-utils.test.ts
+++ b/vite/tests/views/customers2/customer-balance-utils.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import {
+	EntInterval,
+	FeatureType,
+	type FullCusEntWithFullCusProduct,
+} from "@autumn/shared";
+import { getCustomerBalanceSourceLabel } from "@/views/customers2/components/table/customer-balance/customerBalanceUtils";
+
+test("labels standalone balances by external id", () => {
+	const balance = {
+		external_id: "goodwill",
+		customer_product: null,
+		pooled_balance_id: null,
+		pooled_balance: null,
+		entitlement: {
+			interval: EntInterval.Lifetime,
+			interval_count: 1,
+			feature: { type: FeatureType.Metered },
+		},
+	} as unknown as FullCusEntWithFullCusProduct;
+
+	expect(getCustomerBalanceSourceLabel({ balance, entities: [] })).toBe(
+		"goodwill · Lifetime",
+	);
+});

--- a/vite/tests/views/customers2/customer-feature-usage.test.ts
+++ b/vite/tests/views/customers2/customer-feature-usage.test.ts
@@ -52,7 +52,7 @@ describe("customer feature usage pooled balances", () => {
 			...buildCustomerEntitlement({ id: "resetting", pooled: false }),
 			balance: 0,
 			unlimited: false,
-			next_reset_at: 1,
+			next_reset_at: Date.now() + 1000,
 			customer_product: null,
 		};
 
@@ -62,6 +62,23 @@ describe("customer feature usage pooled balances", () => {
 		});
 
 		expect(filtered).toEqual([]);
+	});
+
+	test("shows consumed resetting balances in the active view", () => {
+		const resetting = {
+			...buildCustomerEntitlement({ id: "resetting", pooled: false }),
+			balance: 0,
+			unlimited: false,
+			next_reset_at: Date.now() + 1000,
+			customer_product: null,
+		};
+
+		const filtered = filterCustomerFeatureUsage({
+			entitlements: [resetting],
+			statuses: ["active"],
+		});
+
+		expect(filtered.map(({ id }) => id)).toEqual(["resetting"]);
 	});
 
 	test("shows the synthetic pool and hides its contribution sources", () => {

--- a/vite/tests/views/customers2/customer-feature-usage.test.ts
+++ b/vite/tests/views/customers2/customer-feature-usage.test.ts
@@ -35,6 +35,7 @@ describe("customer feature usage pooled balances", () => {
 			...buildCustomerEntitlement({ id: "consumed", pooled: false }),
 			balance: 0,
 			unlimited: false,
+			next_reset_at: null,
 			customer_product: null,
 		};
 
@@ -44,6 +45,23 @@ describe("customer feature usage pooled balances", () => {
 		});
 
 		expect(filtered.map(({ id }) => id)).toEqual(["consumed"]);
+	});
+
+	test("keeps consumed resetting balances out of the expired view", () => {
+		const resetting = {
+			...buildCustomerEntitlement({ id: "resetting", pooled: false }),
+			balance: 0,
+			unlimited: false,
+			next_reset_at: 1,
+			customer_product: null,
+		};
+
+		const filtered = filterCustomerFeatureUsage({
+			entitlements: [resetting],
+			statuses: ["expired"],
+		});
+
+		expect(filtered).toEqual([]);
 	});
 
 	test("shows the synthetic pool and hides its contribution sources", () => {


### PR DESCRIPTION
Fixes the dashboard label for standalone balances so external IDs such as goodwill are shown alongside the interval. Adds a regression test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dashboard so standalone balances show their external ID (e.g., `goodwill`) next to the interval instead of "No plan". Also includes resetting standalone balances in customer queries so they no longer disappear from the dashboard.

**Bug Fixes**
- Standalone balances with a `next_reset_at` are now included in active entitlement queries.
- Zero-balance entitlements are only classified as expired when they have no expiry date.
- Adds a regression test for the standalone balance label.

<sup>Written for commit e2b7c06e086ab416ac29819c7f17ccad548f588a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates standalone balance labels and attempts to keep resetting standalone balances visible in customer queries.

**Key changes**
- **[Bug fixes]** Displays a standalone balance’s external ID, such as `goodwill`, instead of “No plan.”
- **[Bug fixes]** Retains zero-balance standalone entitlements when they have a scheduled reset.
- **[Bug fixes]** Adjusts expired standalone-balance classification.
- **[Improvements]** Adds regression coverage for standalone labels and active/expired filtering.

Two server-side issues remain: resetting balances are still removed after hydration in one primary customer path, and permanent boolean entitlements can be duplicated when expired balances are included.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because one customer path still hides resetting standalone balances and the expired-balance query can duplicate boolean entitlements.

Two concrete query behaviors need correction: the cache-side filter negates the new reset-aware SQL selection, while overlapping active and expired predicates can emit the same boolean entitlement twice.

**Files Needing Attention:** server/src/internal/customers/getFullCusQuery.ts; server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/getFullCusQuery.ts | Expands active and expired standalone-entitlement selection, but allows permanent boolean entitlements into both UNION ALL branches. |
| server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts | Loads resetting zero-balance entitlements, although the downstream cache filter removes them again. |
| server/src/internal/customers/cursorPaginatedFullCusQuery.ts | Updates list hydration to retain standalone balances with a scheduled reset. |
| vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts | Uses the standalone balance external ID as the source-label fallback. |
| vite/tests/views/customers2/customer-balance-utils.test.ts | Adds regression coverage for the standalone external-ID label. |
| vite/tests/views/customers2/customer-feature-usage.test.ts | Uses a future reset timestamp in active and expired display-filter coverage. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  DB[(Customer entitlements)]
  SQL[Subject hydration SQL]
  Keep[Keep zero balance when next_reset_at exists]
  Filter[Cache-side drained-balance filter]
  Drop[Resetting balance removed]
  Response[Dashboard customer response]

  DB --> SQL
  SQL --> Keep
  Keep --> Filter
  Filter -->|Predicate ignores next_reset_at| Drop
  Drop --> Response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/customers/getFullCusQuery.ts:429-430
**Boolean entitlements are duplicated**

The new expired condition also matches plan-less boolean entitlements, which normally have a zero balance, no reset, and no expiry. These entitlements remain active through `looseEntitlementIsLiveSql()`, so requesting expired balances selects the same entitlement through both sides of the `UNION ALL`. For example, a permanent boolean flag can appear twice in the customer's balances. The active and expired branches need to remain mutually exclusive.

### Issue 2
server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts:304
**Resetting balances remain hidden**

This query now loads an empty plan-less balance when it has a scheduled reset, but every result from this customer hydration path is later passed through `filterDrainedLooseEntitlements`. That filter still removes zero-balance entries without considering `next_reset_at`. For example, a standalone monthly credit used down to zero is returned here and then immediately removed from the dashboard customer response, so this part of the fix does not take effect.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["show standalone balance names"](https://github.com/useautumn/autumn/commit/e2b7c06e086ab416ac29819c7f17ccad548f588a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62075609)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->