### PR TITLE
Show standalone balance IDs in dashboard

### DIFF
--- a/vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts
+++ b/vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts
@@ -133,7 +133,7 @@ export function getCustomerBalanceSourceParts({
 	});
 	const productName =
 		getCustomerBalancePlanName({ balance, fullCustomer }) ??
-		(isPooledBalance ? "Pooled" : "No plan");
+		(isPooledBalance ? "Pooled" : (balance.external_id ?? "No plan"));
 
 	const { interval, interval_count } = balance.entitlement;
 	let intervalLabel: string;

--- a/vite/tests/views/customers2/customer-balance-utils.test.ts
+++ b/vite/tests/views/customers2/customer-balance-utils.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import {
+	EntInterval,
+	FeatureType,
+	type FullCusEntWithFullCusProduct,
+} from "@autumn/shared";
+import { getCustomerBalanceSourceLabel } from "@/views/customers2/components/table/customer-balance/customerBalanceUtils";
+
+test("uses a standalone balance id as its source label", () => {
+	const balance = {
+		external_id: "goodwill",
+		customer_product: null,
+		pooled_balance_id: null,
+		pooled_balance: null,
+		entitlement: {
+			interval: EntInterval.Lifetime,
+			interval_count: 1,
+			feature: { type: FeatureType.Metered },
+		},
+	} as unknown as FullCusEntWithFullCusProduct;
+
+	expect(getCustomerBalanceSourceLabel({ balance, entities: [] })).toBe(
+		"goodwill · Lifetime",
+	);
+});


### PR DESCRIPTION
Use the standalone balance external ID as the source label when no plan is attached, so balances such as goodwill are visible instead of rendering only an unlabeled interval. Adds focused regression coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a standalone balance's external ID as its source label in the dashboard when no plan is attached, so balances like goodwill are visible instead of a generic "No plan" label. Falls back to "No plan" when no external ID exists, and adds regression coverage for the new label.

<sup>Written for commit 2611b80ed3cbe4d30c99e6788a4d0872a08cb0a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes standalone balance IDs visible as dashboard source labels and adds focused regression coverage.

Key changes:
- **[Bug fixes]** Uses a standalone balance’s external ID when no plan is attached.
- **[Improvements]** Adds a regression test for a lifetime metered balance named `goodwill`.

The fallback also affects generated prepaid carryover balances, causing their internal hashed identifiers to appear in the dashboard.
</details>


<h3>Confidence Score: 4/5</h3>

The PR should not merge until generated prepaid carryover IDs are excluded from the new user-facing fallback.

A reachable carryover balance now displays an internal hashed identifier in the customer dashboard because it has no attached plan and therefore enters the broadened external-ID fallback.

**Files Needing Attention:** vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts | Adds the intended standalone-ID fallback, but also displays generated carryover identifiers. |
| vite/tests/views/customers2/customer-balance-utils.test.ts | Covers a user-created standalone balance but not the existing generated carryover case. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts:136
**Carryover IDs Become Visible**

This fallback also applies to one-off prepaid carryovers, which have no attached plan but use an internal external ID such as `one_off_prepaid_carryover_a1b2c3d4e5`. For example, when a customer leaves a plan with unused prepaid credits, the dashboard now shows that generated identifier instead of the previous “No plan” label. Please distinguish user-created standalone balance IDs from generated carryover IDs and add coverage for the carryover case.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["show standalone balance ids"](https://github.com/useautumn/autumn/commit/2611b80ed3cbe4d30c99e6788a4d0872a08cb0a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62078463)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->