### PR TITLE
Move auto-top-up attempt limits to rate overrides

### DIFF
--- a/server/src/internal/admin/handleGetAdminRateLimitOverridesConfig.ts
+++ b/server/src/internal/admin/handleGetAdminRateLimitOverridesConfig.ts
@@ -4,7 +4,10 @@ import {
 	AUTO_TOPUP_ATTEMPTS_RATE_LIMIT,
 	DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT,
 } from "@/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs.js";
-import { RATE_LIMIT_CONFIGS } from "@/internal/misc/rateLimiter/rateLimitConfigs.js";
+import {
+	RATE_LIMIT_CONFIGS,
+	RateLimitScope,
+} from "@/internal/misc/rateLimiter/rateLimitConfigs.js";
 import {
 	getRateLimitOverridesFromSource,
 	getRuntimeRateLimitOverridesStatus,
@@ -16,7 +19,10 @@ export const handleGetAdminRateLimitOverridesConfig = createRoute({
 		const status = getRuntimeRateLimitOverridesStatus();
 		const config = await getRateLimitOverridesFromSource();
 
-		const defaults = Object.fromEntries(
+		const defaults: Record<
+			string,
+			{ limit: number; windowMs: number; scope: RateLimitScope }
+		> = Object.fromEntries(
 			Object.entries(RATE_LIMIT_CONFIGS).map(([type, cfg]) => [
 				type,
 				{
@@ -29,7 +35,7 @@ export const handleGetAdminRateLimitOverridesConfig = createRoute({
 		defaults[AUTO_TOPUP_ATTEMPTS_RATE_LIMIT] = {
 			limit: DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT.limit,
 			windowMs: 10 * 60 * 1000,
-			scope: "customer",
+			scope: RateLimitScope.Customer,
 		};
 
 		return c.json({

--- a/server/src/internal/admin/handleGetAdminRateLimitOverridesConfig.ts
+++ b/server/src/internal/admin/handleGetAdminRateLimitOverridesConfig.ts
@@ -1,5 +1,9 @@
 import { Scopes } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	AUTO_TOPUP_ATTEMPTS_RATE_LIMIT,
+	DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT,
+} from "@/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs.js";
 import { RATE_LIMIT_CONFIGS } from "@/internal/misc/rateLimiter/rateLimitConfigs.js";
 import {
 	getRateLimitOverridesFromSource,
@@ -22,6 +26,11 @@ export const handleGetAdminRateLimitOverridesConfig = createRoute({
 				},
 			]),
 		);
+		defaults[AUTO_TOPUP_ATTEMPTS_RATE_LIMIT] = {
+			limit: DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT.limit,
+			windowMs: 10 * 60 * 1000,
+			scope: "customer",
+		};
 
 		return c.json({
 			...config,

--- a/server/src/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs.ts
+++ b/server/src/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs.ts
@@ -1,5 +1,7 @@
 import type { AutoTopup, Organization } from "@autumn/shared";
-import { getOrgAutoTopupAttemptLimit } from "@/internal/misc/edgeConfig/orgLimitsStore.js";
+import { getOrgRateLimitOverride } from "@/internal/misc/rateLimiter/rateLimitOverridesStore.js";
+
+export const AUTO_TOPUP_ATTEMPTS_RATE_LIMIT = "auto_topup_attempts";
 
 export type AutoTopupWindowLimitConfig = {
 	limit: number;
@@ -32,8 +34,11 @@ export const getAutoTopupRateLimitConfigs = ({
 		attemptLimit: {
 			...DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT,
 			limit:
-				getOrgAutoTopupAttemptLimit({ orgId: org.id, orgSlug: org.slug }) ??
-				DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT.limit,
+				getOrgRateLimitOverride({
+					orgId: org.id,
+					orgSlug: org.slug,
+					type: AUTO_TOPUP_ATTEMPTS_RATE_LIMIT,
+				}) ?? DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT.limit,
 		},
 		failedAttemptLimit: DEFAULT_AUTO_TOPUP_FAILED_ATTEMPT_LIMIT,
 	};

--- a/server/src/internal/misc/edgeConfig/orgLimitsSchemas.ts
+++ b/server/src/internal/misc/edgeConfig/orgLimitsSchemas.ts
@@ -21,7 +21,6 @@ export const OrgLimitsConfigSchema = z.object({
 			z.object({
 				maxCusProducts: z.number().min(1).optional(),
 				maxEntities: z.number().min(1).optional(),
-				maxAutoTopupAttempts: z.number().int().min(1).optional(),
 				pagination: PaginationOverrideSchema,
 			}),
 		)

--- a/server/src/internal/misc/edgeConfig/orgLimitsStore.ts
+++ b/server/src/internal/misc/edgeConfig/orgLimitsStore.ts
@@ -56,19 +56,6 @@ export const getOrgEntitiesLimit = ({
 	return orgConfig?.maxEntities ?? DEFAULT_ENTITIES_LIMIT;
 };
 
-export const getOrgAutoTopupAttemptLimit = ({
-	orgId,
-	orgSlug,
-}: {
-	orgId?: string;
-	orgSlug?: string;
-}): number | undefined => {
-	const orgs = store.get().orgs;
-	const orgConfig =
-		(orgId ? orgs[orgId] : undefined) ?? (orgSlug ? orgs[orgSlug] : undefined);
-	return orgConfig?.maxAutoTopupAttempts;
-};
-
 const defaultMaxLimit = ({
 	type,
 	apiVersion,

--- a/server/src/internal/misc/rateLimiter/rateLimitOverridesSchemas.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitOverridesSchemas.ts
@@ -15,7 +15,7 @@ export const RateLimitOverridesConfigSchema = z.object({
 });
 
 export type OrgRateLimitOverride = {
-	limits: Partial<Record<RateLimitType, number>>;
+	limits: Record<string, number>;
 };
 export type RateLimitOverridesConfig = {
 	orgs: Record<string, OrgRateLimitOverride>;

--- a/server/src/internal/misc/rateLimiter/rateLimitOverridesStore.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitOverridesStore.ts
@@ -1,7 +1,6 @@
 import { ADMIN_RATE_LIMIT_OVERRIDES_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
 import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
 import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
-import type { RateLimitType } from "./rateLimitConfigs.js";
 import {
 	type RateLimitOverridesConfig,
 	RateLimitOverridesConfigSchema,
@@ -31,7 +30,7 @@ export const getOrgRateLimitOverride = ({
 }: {
 	orgId?: string;
 	orgSlug?: string;
-	type: RateLimitType;
+	type: string;
 }): number | undefined => {
 	const orgs = store.get().orgs;
 	const orgConfig =

--- a/server/tests/unit/balances/auto-topup/auto-topup-rate-limit-configs.test.ts
+++ b/server/tests/unit/balances/auto-topup/auto-topup-rate-limit-configs.test.ts
@@ -4,7 +4,7 @@ import {
 	DEFAULT_AUTO_TOPUP_ATTEMPT_LIMIT,
 	getAutoTopupRateLimitConfigs,
 } from "@/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs";
-import { _setOrgLimitsConfigForTesting } from "@/internal/misc/edgeConfig/orgLimitsStore";
+import { _setRateLimitOverridesConfigForTesting } from "@/internal/misc/rateLimiter/rateLimitOverridesStore";
 
 const autoTopupConfig = AutoTopupSchema.parse({
 	feature_id: "credits",
@@ -15,7 +15,7 @@ const org = { id: "org_limited", slug: "limited" };
 
 describe("getAutoTopupRateLimitConfigs", () => {
 	test("uses the default attempt limit when the org has no override", () => {
-		_setOrgLimitsConfigForTesting({ config: { orgs: {} } });
+		_setRateLimitOverridesConfigForTesting({ config: { orgs: {} } });
 
 		const { attemptLimit } = getAutoTopupRateLimitConfigs({
 			autoTopupConfig,
@@ -26,8 +26,8 @@ describe("getAutoTopupRateLimitConfigs", () => {
 	});
 
 	test("uses the org limits override within the default window", () => {
-		_setOrgLimitsConfigForTesting({
-			config: { orgs: { [org.id]: { maxAutoTopupAttempts: 10 } } },
+		_setRateLimitOverridesConfigForTesting({
+			config: { orgs: { [org.id]: { limits: { auto_topup_attempts: 10 } } } },
 		});
 
 		const { attemptLimit } = getAutoTopupRateLimitConfigs({

--- a/vite/src/views/admin/components/OrgLimitsConfigForm.tsx
+++ b/vite/src/views/admin/components/OrgLimitsConfigForm.tsx
@@ -7,7 +7,6 @@ import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import {
 	buildOrgLimitsJsonText,
-	DEFAULT_AUTO_TOPUP_ATTEMPTS,
 	DEFAULT_CUS_PRODUCT_LIMIT,
 	getEntryRows,
 	getStatusMessage,
@@ -26,20 +25,11 @@ const isBlankOrPositiveInt = (value: string) =>
 
 const parseEntry = ({
 	limit,
-	attempts,
 }: {
 	limit: string;
-	attempts: string;
 }): OrgLimitsEntry | undefined => {
 	const maxCusProducts = parsePositiveInt(limit);
-	const maxAutoTopupAttempts = parsePositiveInt(attempts);
-	if (maxCusProducts === undefined && maxAutoTopupAttempts === undefined) {
-		return undefined;
-	}
-	return {
-		...(maxCusProducts !== undefined ? { maxCusProducts } : {}),
-		...(maxAutoTopupAttempts !== undefined ? { maxAutoTopupAttempts } : {}),
-	};
+	return maxCusProducts === undefined ? undefined : { maxCusProducts };
 };
 
 export const OrgLimitsConfigForm = ({
@@ -59,7 +49,6 @@ export const OrgLimitsConfigForm = ({
 	const [syncSource, setSyncSource] = useState<"form" | "json">("form");
 	const [newOrgId, setNewOrgId] = useState("");
 	const [newLimit, setNewLimit] = useState("");
-	const [newAttempts, setNewAttempts] = useState("");
 
 	const mutation = useMutation({
 		mutationFn: async (payload: unknown) => {
@@ -105,7 +94,7 @@ export const OrgLimitsConfigForm = ({
 
 	const addEntry = () => {
 		const orgId = newOrgId.trim();
-		const entry = parseEntry({ limit: newLimit, attempts: newAttempts });
+		const entry = parseEntry({ limit: newLimit });
 
 		if (!orgId || !entry) return;
 
@@ -116,7 +105,6 @@ export const OrgLimitsConfigForm = ({
 		}));
 		setNewOrgId("");
 		setNewLimit("");
-		setNewAttempts("");
 	};
 
 	const removeEntry = ({ orgId }: { orgId: string }) => {
@@ -175,14 +163,6 @@ export const OrgLimitsConfigForm = ({
 								onChange={(event) => setNewLimit(event.target.value)}
 								className="tabular-nums"
 							/>
-							<Input
-								placeholder="Auto top-up attempts per 10 min (e.g. 10)"
-								type="number"
-								min={1}
-								value={newAttempts}
-								onChange={(event) => setNewAttempts(event.target.value)}
-								className="tabular-nums"
-							/>
 							<Button
 								variant="secondary"
 								size="sm"
@@ -190,8 +170,7 @@ export const OrgLimitsConfigForm = ({
 								disabled={
 									!newOrgId.trim() ||
 									!isBlankOrPositiveInt(newLimit) ||
-									!isBlankOrPositiveInt(newAttempts) ||
-									!parseEntry({ limit: newLimit, attempts: newAttempts })
+									!parseEntry({ limit: newLimit })
 								}
 							>
 								Add org limit
@@ -215,10 +194,6 @@ export const OrgLimitsConfigForm = ({
 										</div>
 										<div className="text-xs tabular-nums text-muted-foreground">
 											Max customer products: {entry.maxCusProducts}
-										</div>
-										<div className="text-xs tabular-nums text-muted-foreground">
-											Auto top-up attempts per 10 min:{" "}
-											{entry.maxAutoTopupAttempts}
 										</div>
 									</div>
 									<Button

--- a/vite/src/views/admin/components/orgLimitsConfigTypes.ts
+++ b/vite/src/views/admin/components/orgLimitsConfigTypes.ts
@@ -3,7 +3,6 @@ export const DEFAULT_AUTO_TOPUP_ATTEMPTS = 2;
 
 export type OrgLimitsEntry = {
 	maxCusProducts?: number;
-	maxAutoTopupAttempts?: number;
 };
 
 export type OrgLimitsConfig = {
@@ -42,8 +41,6 @@ export const getEntryRows = ({ config }: { config: OrgLimitsConfig }) => {
 		.map(([orgId, entry]) => ({
 			orgId,
 			maxCusProducts: entry.maxCusProducts ?? DEFAULT_CUS_PRODUCT_LIMIT,
-			maxAutoTopupAttempts:
-				entry.maxAutoTopupAttempts ?? DEFAULT_AUTO_TOPUP_ATTEMPTS,
 		}))
 		.sort((a, b) => a.orgId.localeCompare(b.orgId));
 };


### PR DESCRIPTION
Move the internal per-feature auto-top-up attempt limit into the existing Rate Limit Overrides config. Remove the duplicate Org Limits UI/config field and expose the auto-top-up limit type with its 2-per-10-minute default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the per-feature auto-top-up attempt limit out of the Org Limits config and into the existing Rate Limit Overrides config. The Org Limits UI field and `maxAutoTopupAttempts` config key are removed; the new `auto_topup_attempts` override defaults to 2 attempts per 10 minutes.

**Migration**
- Existing `maxAutoTopupAttempts` values must be set as `auto_topup_attempts` rate limit overrides; no automatic migration or fallback exists, so configured orgs silently fall back to the new default.
- The rate limit overrides admin endpoint now returns the default for this override.

<sup>Written for commit 0d7bcd91b28ddd6fc4bcd849f89348681e744891. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves auto-top-up attempt limits from the organization-limits configuration into rate-limit overrides.

**Key changes**
- **[Improvements]** Reads per-organization auto-top-up attempt limits from the shared rate-limit override store.
- **[API changes]** Exposes `auto_topup_attempts` and its default of two attempts per ten minutes through the admin rate-limit configuration endpoint.
- **[Improvements]** Removes the duplicate auto-top-up field from the organization-limits schema, store, types, and admin form.
- **[Bug fixes]** Updates the unit test to populate the new rate-limit override store.
- **[API changes]** Broadens rate-limit override keys from known rate-limit types to arbitrary strings.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because organizations with existing custom auto-top-up limits can silently receive the new default instead.

The existing migration finding remains unresolved: for example, an organization configured for one attempt per ten minutes has no fallback from the old setting and will now receive two attempts. The test-store finding is fully fixed. The override-key type-safety finding also remains outstanding because changing the type to `Record<string, number>` still permits misspelled keys to compile and be silently ignored.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/autoTopUp/helpers/limits/autoTopupRateLimitConfigs.ts | Moves attempt-limit lookup to rate-limit overrides, but existing organization-limit values still have no migration or fallback. |
| server/src/internal/misc/rateLimiter/rateLimitOverridesSchemas.ts | Allows the new override key by accepting arbitrary strings, leaving the previously reported loss of key type safety unresolved. |
| server/src/internal/admin/handleGetAdminRateLimitOverridesConfig.ts | Adds the auto-top-up attempt limit and its default settings to the admin response. |
| server/tests/unit/balances/auto-topup/auto-topup-rate-limit-configs.test.ts | Correctly updates test setup to use the new rate-limit override store. |
| vite/src/views/admin/components/OrgLimitsConfigForm.tsx | Removes the obsolete auto-top-up attempt field from the organization-limits form. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Auto-top-up request] --> B[Read organization rate-limit overrides]
  B --> C{auto_topup_attempts exists?}
  C -->|Yes| D[Use configured attempt limit]
  C -->|No| E[Use default: 2 attempts per 10 minutes]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["allow internal rate override keys"](https://github.com/useautumn/autumn/commit/0d7bcd91b28ddd6fc4bcd849f89348681e744891) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62085893)</sub>

<!-- /greptile_comment -->