### PR TITLE
feat: add overage_behavior to check.lock, honoured by finalize

### DIFF
--- a/server/src/_luaScriptsV2/fullSubjectDeduction/deductFromSubjectBalances.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/deductFromSubjectBalances.lua
@@ -383,6 +383,7 @@ then
       expires_at = lock.expires_at or cjson.null,
       created_at = lock.created_at or cjson.null,
       properties = lock.properties or cjson.null,
+      overage_behavior = lock.overage_behavior or cjson.null,
     },
     mutation_logs = mutation_logs,
     ttl_at = lock.ttl_at or cjson.null,

--- a/server/src/internal/balances/check/runCheckWithTrackV2.ts
+++ b/server/src/internal/balances/check/runCheckWithTrackV2.ts
@@ -107,7 +107,7 @@ export const runCheckWithTrackV2 = async ({
 		value: requiredBalance,
 		properties: body.properties,
 		skip_event: body.skip_event,
-		overage_behavior: "reject",
+		overage_behavior: body.lock?.overage_behavior ?? "reject",
 		lock: body.lock,
 	};
 

--- a/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
@@ -267,8 +267,9 @@ export const prepareFeatureDeductionV2 = ({
 					lockKey: lock.hashed_key ?? Bun.hash(lock.lock_id!).toString(),
 				}),
 				created_at: Date.now(),
-				// Persisted so an expiry-triggered finalize can reuse the check's metadata.
+				// Persisted so finalize can reuse the check's metadata and overage mode.
 				properties: options.eventProperties ?? null,
+				overage_behavior: overageBehaviour,
 				ttl_at: lock.expires_at
 					? Math.ceil(lock.expires_at / 1000) + oneHourSeconds
 					: Math.ceil(Date.now() / 1000) + oneDaySeconds,

--- a/server/src/internal/balances/utils/lock/fetchLockReceipt.ts
+++ b/server/src/internal/balances/utils/lock/fetchLockReceipt.ts
@@ -2,6 +2,7 @@ import { ErrCode, RecaseError } from "@autumn/shared";
 import { getRedisV2LockReceiptCandidates } from "@/external/redis/orgRedisUtils/orgRedisMigrationUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { fetchAndClaimLockReceiptV2 } from "@/internal/balances/utils/lockV2/fetchAndClaimLockReceiptV2.js";
+import type { DeductionOptions } from "@/internal/balances/utils/types/deductionTypes.js";
 import type { MutationLogItem } from "@/internal/balances/utils/types/mutationLogItem.js";
 
 export type LockReceipt = {
@@ -13,6 +14,7 @@ export type LockReceipt = {
 	region?: string | null;
 	overrideLockValue?: number | null;
 	properties?: Record<string, unknown> | null;
+	overage_behavior?: DeductionOptions["overageBehaviour"] | null;
 	items: MutationLogItem[];
 };
 

--- a/server/src/internal/balances/utils/lock/parseCheckParamsForLock.ts
+++ b/server/src/internal/balances/utils/lock/parseCheckParamsForLock.ts
@@ -49,6 +49,7 @@ export const parseCheckParamsForLock = ({
 		lock_id: lockId,
 		hashed_key: hashedKey,
 		expires_at: lock.expires_at ?? undefined,
+		overage_behavior: lock.overage_behavior ?? undefined,
 	};
 
 	return {

--- a/server/src/internal/balances/utils/lockV2/buildFinalizeLockContextV2.ts
+++ b/server/src/internal/balances/utils/lockV2/buildFinalizeLockContextV2.ts
@@ -8,6 +8,7 @@ import {
 	calculateLockValue,
 	calculateUnwindValue,
 } from "@/internal/balances/utils/lock/unwindLockUtils.js";
+import type { DeductionOptions } from "@/internal/balances/utils/types/deductionTypes.js";
 import type { FeatureDeduction } from "@/internal/balances/utils/types/featureDeduction.js";
 import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js";
 
@@ -26,6 +27,7 @@ export type FinalizeLockContextV2 = {
 	deductionOptions: {
 		triggerAutoTopUp: boolean;
 		eventProperties?: EventProperties;
+		overageBehaviour: NonNullable<DeductionOptions["overageBehaviour"]>;
 	};
 };
 
@@ -92,6 +94,11 @@ export const buildFinalizeLockContextV2 = async ({
 			unwindValue,
 			lockReceiptKey,
 		},
-		deductionOptions: { triggerAutoTopUp: true, eventProperties },
+		deductionOptions: {
+			triggerAutoTopUp: true,
+			eventProperties,
+			// Receipts written before this field existed were always locked under reject.
+			overageBehaviour: receipt.overage_behavior ?? "reject",
+		},
 	};
 };

--- a/server/src/internal/balances/utils/lockV2/saveLockReceiptV2.ts
+++ b/server/src/internal/balances/utils/lockV2/saveLockReceiptV2.ts
@@ -1,6 +1,7 @@
 import { ErrCode, RecaseError } from "@autumn/shared";
 import type { Redis } from "ioredis";
 import { currentRegion } from "@/external/redis/initRedis.js";
+import type { DeductionOptions } from "@/internal/balances/utils/types/deductionTypes.js";
 import type { MutationLogItem } from "@/internal/balances/utils/types/mutationLogItem.js";
 import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 
@@ -27,6 +28,7 @@ export const saveLockReceiptV2 = async ({
 		created_at: number;
 		ttl_at: number;
 		properties?: Record<string, unknown> | null;
+		overage_behavior?: DeductionOptions["overageBehaviour"];
 	};
 	customerId: string;
 	featureId: string;
@@ -46,6 +48,7 @@ export const saveLockReceiptV2 = async ({
 		expires_at: lock.expires_at ?? null,
 		created_at: lock.created_at,
 		properties: lock.properties ?? null,
+		overage_behavior: lock.overage_behavior ?? null,
 		overrideLockValue: overrideLockValue ?? null,
 		items,
 	});

--- a/server/src/internal/balances/utils/types/deductionTypes.ts
+++ b/server/src/internal/balances/utils/types/deductionTypes.ts
@@ -72,5 +72,6 @@ export type PreparedFeatureDeduction = {
 		created_at: number;
 		ttl_at: number;
 		properties?: Record<string, unknown> | null;
+		overage_behavior?: DeductionOptions["overageBehaviour"];
 	};
 };

--- a/server/tests/integration/balances/lock/check-with-lock-overage-behavior.test.ts
+++ b/server/tests/integration/balances/lock/check-with-lock-overage-behavior.test.ts
@@ -1,0 +1,492 @@
+/**
+ * TDD test for `overage_behavior` on `check.lock`.
+ *
+ * Contract under test:
+ *   New types/fields:
+ *     - check.lock.overage_behavior?: "reject" | "cap" | "overflow" (default "reject")
+ *     - lock receipt persists `overage_behavior`
+ *   New behaviors:
+ *     - omitted / "reject": short balance -> allowed: false, nothing deducted (unchanged)
+ *     - "cap": short balance -> deducts what fits, allowed: true
+ *     - "overflow": short balance -> deducts full value, balance negative, allowed: true
+ *     - finalize confirm with override_value above the lock re-uses the receipt's mode
+ *       for the additional deduction (cap clamps at 0, overflow goes negative)
+ *     - finalize release under overflow refunds the full negative lock
+ *     - "overflow" still honours the customer spend limit
+ *   Side effects:
+ *     - events carry the requested value (same as track), balances carry the clamped one
+ *
+ * Pre-impl red: `overage_behavior` is rejected by LockParamsSchema / ignored, so
+ * cap + overflow cases return allowed: false with no deduction.
+ * Post-impl green: lock mode flows check -> receipt -> finalize.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5, CheckResponseV3 } from "@autumn/shared";
+import { expectCustomerEventsCorrect } from "@tests/integration/balances/utils/events/expectCustomerEventsCorrect.js";
+import { deleteLock } from "@tests/integration/balances/utils/lockUtils/deleteLock.js";
+import { expectLockReceiptDeleted } from "@tests/integration/balances/utils/lockUtils/expectLockReceiptDeleted.js";
+import { setCustomerSpendLimit } from "@tests/integration/balances/utils/spend-limit-utils/customerSpendLimitUtils.js";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const makeFreeProd = () =>
+	products.base({
+		id: "free",
+		items: [items.monthlyMessages({ includedUsage: 20 })],
+	});
+
+// Usage-based overage: spend limits only apply to paid usage.
+const makeUsageProd = () =>
+	products.base({
+		id: "usage",
+		items: [items.consumableMessages({ includedUsage: 20, price: 1 })],
+	});
+
+const initLockCustomer = async ({ customerId }: { customerId: string }) => {
+	const prod = makeFreeProd();
+	const scenario = await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [prod] })],
+		actions: [s.attach({ productId: prod.id })],
+	});
+	await deleteLock({ ctx: scenario.ctx, lockId: customerId });
+	return scenario;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OB-1: omitted → reject (unchanged default). balance 20, lock 100 → allowed: false
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("lock-overage OB-1: omitted defaults to reject — allowed false, nothing deducted")}`,
+	async () => {
+		const customerId = "lock-overage-default-reject";
+		const { autumnV2_1 } = await initLockCustomer({ customerId });
+
+		const res = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 100,
+			lock: { enabled: true, lock_id: customerId },
+		});
+		expect(res.allowed).toBe(false);
+
+		const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			remaining: 20,
+		});
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OB-2: explicit reject behaves like OB-1
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("lock-overage OB-2: explicit reject — allowed false, nothing deducted")}`,
+	async () => {
+		const customerId = "lock-overage-explicit-reject";
+		const { autumnV2_1 } = await initLockCustomer({ customerId });
+
+		const res = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 100,
+			lock: { enabled: true, lock_id: customerId, overage_behavior: "reject" },
+		});
+		expect(res.allowed).toBe(false);
+
+		const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			remaining: 20,
+		});
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OB-3: cap. balance 20, lock 100 → allowed: true, remaining 0.
+// confirm (no override) → lockValue is 20 (what was actually deducted), nothing more happens.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("lock-overage OB-3: cap — partial reservation, allowed true, confirm keeps 20")}`,
+	async () => {
+		const customerId = "lock-overage-cap-confirm";
+		const { autumnV2_1, ctx } = await initLockCustomer({ customerId });
+
+		const res = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 100,
+			lock: { enabled: true, lock_id: customerId, overage_behavior: "cap" },
+		});
+		expect(res.allowed).toBe(true);
+
+		const afterLock = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: afterLock,
+			featureId: TestFeature.Messages,
+			remaining: 0,
+			usage: 20,
+		});
+
+		await autumnV2_1.balances.finalize({
+			lock_id: customerId,
+			action: "confirm",
+		});
+
+		const afterConfirm =
+			await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: afterConfirm,
+			featureId: TestFeature.Messages,
+			remaining: 0,
+			usage: 20,
+		});
+
+		// Event value is the requested amount, as with track under cap.
+		await expectCustomerEventsCorrect({
+			customerId,
+			events: [{ value: 100 }],
+		});
+		await expectLockReceiptDeleted({ ctx, lockId: customerId });
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OB-4: cap + finalize override above lock. balance 20, lock 5, confirm 50.
+// additional 45 runs under cap → clamps at 0 → remaining 0, usage 20.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("lock-overage OB-4: cap — finalize override above balance clamps at 0")}`,
+	async () => {
+		const customerId = "lock-overage-cap-override";
+		const { autumnV2_1, ctx } = await initLockCustomer({ customerId });
+
+		const res = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 5,
+			lock: { enabled: true, lock_id: customerId, overage_behavior: "cap" },
+		});
+		expect(res.allowed).toBe(true);
+
+		await autumnV2_1.balances.finalize({
+			lock_id: customerId,
+			action: "confirm",
+			override_value: 50,
+		});
+
+		const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			remaining: 0,
+			usage: 20,
+		});
+
+		// lock 5, then additional 45 requested (only 15 fit; event keeps the request)
+		await expectCustomerEventsCorrect({
+			customerId,
+			events: [{ value: 45 }, { value: 5 }],
+		});
+		await expectLockReceiptDeleted({ ctx, lockId: customerId });
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OB-5: overflow. balance 20, lock 100 → allowed: true, balance -80 (usage 100).
+// confirm (no override) → unchanged.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("lock-overage OB-5: overflow — full reservation goes negative, allowed true")}`,
+	async () => {
+		const customerId = "lock-overage-overflow-confirm";
+		const { autumnV2_1, ctx } = await initLockCustomer({ customerId });
+
+		const res = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 100,
+			lock: {
+				enabled: true,
+				lock_id: customerId,
+				overage_behavior: "overflow",
+			},
+		});
+		expect(res.allowed).toBe(true);
+
+		const afterLock = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: afterLock,
+			featureId: TestFeature.Messages,
+			remaining: 0,
+			usage: 100,
+		});
+
+		await autumnV2_1.balances.finalize({
+			lock_id: customerId,
+			action: "confirm",
+		});
+
+		const afterConfirm =
+			await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: afterConfirm,
+			featureId: TestFeature.Messages,
+			remaining: 0,
+			usage: 100,
+		});
+
+		await expectCustomerEventsCorrect({
+			customerId,
+			events: [{ value: 100 }],
+		});
+		await expectLockReceiptDeleted({ ctx, lockId: customerId });
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OB-6: overflow + finalize override above lock. balance 20, lock 30, confirm 80.
+// additional 50 must also overflow (mode read from receipt, not from finalize).
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("lock-overage OB-6: overflow — finalize override above lock keeps overflowing")}`,
+	async () => {
+		const customerId = "lock-overage-overflow-override";
+		const { autumnV2_1, ctx } = await initLockCustomer({ customerId });
+
+		const res = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 30,
+			lock: {
+				enabled: true,
+				lock_id: customerId,
+				overage_behavior: "overflow",
+			},
+		});
+		expect(res.allowed).toBe(true);
+
+		await autumnV2_1.balances.finalize({
+			lock_id: customerId,
+			action: "confirm",
+			override_value: 80,
+		});
+
+		const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			remaining: 0,
+			usage: 80,
+		});
+
+		await expectCustomerEventsCorrect({
+			customerId,
+			events: [{ value: 50 }, { value: 30 }],
+		});
+		await expectLockReceiptDeleted({ ctx, lockId: customerId });
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OB-7: overflow + release. balance 20, lock 100 → -80. release → back to 20.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("lock-overage OB-7: overflow — release refunds the full negative lock")}`,
+	async () => {
+		const customerId = "lock-overage-overflow-release";
+		const { autumnV2_1, ctx } = await initLockCustomer({ customerId });
+
+		await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 100,
+			lock: {
+				enabled: true,
+				lock_id: customerId,
+				overage_behavior: "overflow",
+			},
+		});
+
+		await autumnV2_1.balances.finalize({
+			lock_id: customerId,
+			action: "release",
+		});
+
+		const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			remaining: 20,
+			usage: 0,
+		});
+		await expectLockReceiptDeleted({ ctx, lockId: customerId });
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OB-8: overflow + confirm with smaller override. lock 100 (→ -80), confirm 50.
+// Unwind 50 → usage 50, remaining 0.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("lock-overage OB-8: overflow — confirm below lock unwinds the difference")}`,
+	async () => {
+		const customerId = "lock-overage-overflow-unwind";
+		const { autumnV2_1, ctx } = await initLockCustomer({ customerId });
+
+		await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 100,
+			lock: {
+				enabled: true,
+				lock_id: customerId,
+				overage_behavior: "overflow",
+			},
+		});
+
+		await autumnV2_1.balances.finalize({
+			lock_id: customerId,
+			action: "confirm",
+			override_value: 50,
+		});
+
+		const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			remaining: 0,
+			usage: 50,
+		});
+
+		await expectCustomerEventsCorrect({
+			customerId,
+			events: [{ value: -50 }, { value: 100 }],
+		});
+		await expectLockReceiptDeleted({ ctx, lockId: customerId });
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OB-9: overflow still honours the spend limit.
+// usage-based: 20 included @ $1/unit, spend limit $30 → max 50 units.
+// lock 100 → clamped to 50 (allowed true, partial), then confirm.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("lock-overage OB-9: overflow — spend limit still clamps the reservation")}`,
+	async () => {
+		const customerId = "lock-overage-overflow-spend-limit";
+		const usageProd = makeUsageProd();
+		const { autumnV2_1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [usageProd] }),
+			],
+			actions: [s.billing.attach({ productId: usageProd.id })],
+		});
+		await deleteLock({ ctx, lockId: customerId });
+
+		await setCustomerSpendLimit({
+			autumn: autumnV2_1,
+			customerId,
+			featureId: TestFeature.Messages,
+			overageLimit: 30,
+		});
+
+		const res = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 100,
+			lock: {
+				enabled: true,
+				lock_id: customerId,
+				overage_behavior: "overflow",
+			},
+		});
+		expect(res.allowed).toBe(true);
+
+		await autumnV2_1.balances.finalize({
+			lock_id: customerId,
+			action: "confirm",
+		});
+
+		const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			remaining: 0,
+			usage: 50,
+		});
+		await expectLockReceiptDeleted({ ctx, lockId: customerId });
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OB-10: Postgres path (skip_cache). The receipt is written by saveLockReceiptV2
+// instead of Lua, so the mode must survive that writer too.
+// balance 20, lock 30 overflow → -10, confirm 80 → additional 50 → usage 80.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("lock-overage OB-10: overflow — Postgres path persists the mode on the receipt")}`,
+	async () => {
+		const customerId = "lock-overage-overflow-postgres";
+		const { autumnV2_1, ctx } = await initLockCustomer({ customerId });
+
+		const res = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 30,
+			lock: {
+				enabled: true,
+				lock_id: customerId,
+				overage_behavior: "overflow",
+			},
+			skip_cache: true,
+		});
+		expect(res.allowed).toBe(true);
+
+		await autumnV2_1.balances.finalize(
+			{ lock_id: customerId, action: "confirm", override_value: 80 },
+			{ skipCache: true },
+		);
+
+		const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			remaining: 0,
+			usage: 80,
+		});
+
+		const customerDb = await autumnV2_1.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		expectBalanceCorrect({
+			customer: customerDb,
+			featureId: TestFeature.Messages,
+			remaining: 0,
+			usage: 80,
+		});
+		await expectLockReceiptDeleted({ ctx, lockId: customerId });
+	},
+);

--- a/shared/api/balances/check/checkParams.ts
+++ b/shared/api/balances/check/checkParams.ts
@@ -3,7 +3,10 @@ import { CustomerDataSchema } from "../../common/customerData";
 import { EntityDataSchema } from "../../common/entityData";
 import { queryStringArray } from "../../common/queryHelpers";
 import { BalanceParamsBaseSchema } from "../common/balanceParamsBase";
-import { LockParamsSchema, ParsedLockParamsSchema } from "../common/lockParams";
+import {
+	CheckLockParamsSchema,
+	ParsedLockParamsSchema,
+} from "../common/lockParams";
 import { CheckExpand } from "./enums/CheckExpand";
 
 export const CheckQuerySchema = z.object({
@@ -30,7 +33,7 @@ export const ExtCheckParamsSchema = BalanceParamsBaseSchema.extend({
 			"If true, atomically records a usage event while checking access. The required_balance value is used as the usage amount. Combines check + track in one call.",
 	}),
 
-	lock: LockParamsSchema.optional().meta({
+	lock: CheckLockParamsSchema.optional().meta({
 		description:
 			"Reserve units of a feature upfront by passing a lock_id, then call balances.finalize to confirm or release the hold.",
 	}),

--- a/shared/api/balances/common/lockParams.ts
+++ b/shared/api/balances/common/lockParams.ts
@@ -17,10 +17,28 @@ export const LockParamsSchema = z.object({
 	}),
 });
 
-export const ParsedLockParamsSchema = LockParamsSchema.extend({
+// "reject" is the default and stays internal like on track, so public docs
+// only surface "cap" and "overflow" as opt-ins.
+export const LockOverageBehaviorSchema = z
+	.union([
+		z.enum(["cap", "overflow"]),
+		z.enum(["reject"]).meta({ internal: true }),
+	])
+	.meta({
+		description:
+			'How to handle a lock that exceeds the available balance. "reject" (default) returns allowed: false and reserves nothing. "cap" reserves only what fits and returns allowed: true. "overflow" reserves the full value: the balance can go negative, though spend limits still apply. balances.finalize reuses the behavior chosen here.',
+	});
+
+export const CheckLockParamsSchema = LockParamsSchema.extend({
+	overage_behavior: LockOverageBehaviorSchema.optional(),
+});
+
+export const ParsedLockParamsSchema = CheckLockParamsSchema.extend({
 	lock_id: z.string().max(256),
 	hashed_key: z.string(),
 });
 
 export type LockParams = z.infer<typeof LockParamsSchema>;
+export type LockOverageBehavior = z.infer<typeof LockOverageBehaviorSchema>;
+export type CheckLockParams = z.infer<typeof CheckLockParamsSchema>;
 export type ParsedLockParams = z.infer<typeof ParsedLockParamsSchema>;

--- a/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
@@ -55,18 +55,22 @@ export function CheckBalanceSheet() {
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const requestSeq = useRef(0);
 
-	// A stale response for different inputs reads as the result of the next check.
+	// A stale or in-flight response for different inputs reads as the result of the next check.
+	const discardResponse = () => {
+		requestSeq.current += 1;
+		setResponse(null);
+	};
 	const updateRequiredBalance = (value: string) => {
 		setRequiredBalance(value);
-		setResponse(null);
+		discardResponse();
 	};
 	const updateLock = (next: CheckLockConfig) => {
 		setLock(next);
-		setResponse(null);
+		discardResponse();
 	};
 	const updateScope = (entityId: string | undefined) => {
 		setScopeEntityId(entityId);
-		setResponse(null);
+		discardResponse();
 	};
 
 	const handleSubmit = async () => {

--- a/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
@@ -1,8 +1,7 @@
 import type { Entity, FullCustomer } from "@autumn/shared";
 import { LATEST_VERSION } from "@autumn/shared";
 import { Button, FormLabel, Input, ShortcutButton } from "@autumn/ui";
-import { Spinner } from "@phosphor-icons/react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 import {
@@ -18,7 +17,6 @@ import {
 	SheetHeader,
 	SheetSection,
 } from "@/components/v2/sheets/SharedSheetComponents";
-import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useSheetScopeEntityId } from "@/hooks/useSheetScopeEntityId";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
@@ -40,7 +38,6 @@ export function CheckBalanceSheet() {
 	);
 	const axiosInstance = useAxiosInstance({ version: LATEST_VERSION });
 	const queryClient = useQueryClient();
-	const buildKey = useQueryKeyFactory();
 
 	const fullCustomer = customer as FullCustomer | null;
 	const entities = fullCustomer?.entities || [];
@@ -54,79 +51,56 @@ export function CheckBalanceSheet() {
 
 	const [requiredBalance, setRequiredBalance] = useState("1");
 	const [lock, setLock] = useState<CheckLockConfig>(DEFAULT_CHECK_LOCK_CONFIG);
-	const [lockResponse, setLockResponse] = useState<unknown>(null);
-	const [isLocking, setIsLocking] = useState(false);
+	const [response, setResponse] = useState<unknown>(null);
+	const [isSubmitting, setIsSubmitting] = useState(false);
 
-	const parsedRequiredBalance =
-		requiredBalance.trim() === "" ? 1 : Number.parseFloat(requiredBalance);
-	const requiredBalanceValid = !Number.isNaN(parsedRequiredBalance);
+	const handleSubmit = async () => {
+		if (!customerId || !featureId) return;
 
-	const buildParams = () => {
+		const parsedRequiredBalance =
+			requiredBalance.trim() === "" ? 1 : Number.parseFloat(requiredBalance);
+		if (Number.isNaN(parsedRequiredBalance)) {
+			toast.error("Please enter a valid number for required balance");
+			return;
+		}
+		if (lock.enabled && !lock.lockId.trim()) {
+			toast.error("Please enter a lock ID");
+			return;
+		}
+
 		const params: Record<string, unknown> = {
 			customer_id: customerId,
 			feature_id: featureId,
 			required_balance: parsedRequiredBalance,
 		};
 		if (scopeEntityId) params.entity_id = scopeEntityId;
-		return params;
-	};
-
-	// A plain check is read-only, so it runs on every input change. A lock
-	// reserves balance and only runs on an explicit submit.
-	const { data, isLoading, error } = useQuery({
-		queryKey: buildKey([
-			"check-balance",
-			customerId,
-			featureId,
-			scopeEntityId,
-			parsedRequiredBalance,
-		]),
-		queryFn: async () => {
-			const { data } = await axiosInstance.post("/v1/check", buildParams());
-			return data;
-		},
-		enabled:
-			!!customerId && !!featureId && requiredBalanceValid && !lock.enabled,
-		gcTime: 0,
-		staleTime: 0,
-	});
-
-	const handleLockCheck = async () => {
-		if (!customerId || !featureId) return;
-		if (!requiredBalanceValid) {
-			toast.error("Please enter a valid number for required balance");
-			return;
-		}
-		if (!lock.lockId.trim()) {
-			toast.error("Please enter a lock ID");
-			return;
+		if (lock.enabled) {
+			params.lock = {
+				enabled: true,
+				lock_id: lock.lockId.trim(),
+				overage_behavior: lock.overageBehavior,
+			};
 		}
 
-		setIsLocking(true);
+		setIsSubmitting(true);
 		try {
-			const { data } = await axiosInstance.post("/v1/check", {
-				...buildParams(),
-				lock: {
-					enabled: true,
-					lock_id: lock.lockId.trim(),
-					overage_behavior: lock.overageBehavior,
-				},
-			});
-			setLockResponse(data);
-			toast.success(
-				data?.allowed
-					? `Locked ${parsedRequiredBalance} with ID ${lock.lockId.trim()}`
-					: "Check denied, nothing was locked",
-			);
-			await queryClient.invalidateQueries({ queryKey: ["customer"] });
+			const { data } = await axiosInstance.post("/v1/check", params);
+			setResponse(data);
+			if (lock.enabled) {
+				toast.success(
+					data?.allowed
+						? `Locked ${parsedRequiredBalance} with ID ${lock.lockId.trim()}`
+						: "Check denied, nothing was locked",
+				);
+				await queryClient.invalidateQueries({ queryKey: ["customer"] });
+			}
 		} catch (err) {
 			toast.error(getBackendErr(err, "Failed to check balance"));
 		} finally {
-			setIsLocking(false);
+			setIsSubmitting(false);
 		}
 	};
 
-	const response = lock.enabled ? lockResponse : data;
 	const formattedJson = response ? JSON.stringify(response, null, 2) : "";
 
 	return (
@@ -162,26 +136,7 @@ export function CheckBalanceSheet() {
 				<CheckAdvancedSection lock={lock} onLockChange={setLock} />
 
 				<div className="flex-1 overflow-hidden flex flex-col px-4 py-4">
-					{!lock.enabled && isLoading && (
-						<div className="flex items-center justify-center py-12">
-							<Spinner className="size-6 animate-spin text-tertiary-foreground" />
-						</div>
-					)}
-
-					{!lock.enabled && error && (
-						<div className="p-4 rounded-md bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 text-sm">
-							{getBackendErr(error, "Failed to check balance")}
-						</div>
-					)}
-
-					{lock.enabled && !lockResponse && (
-						<p className="text-xs text-tertiary-foreground">
-							Running this check will reserve {parsedRequiredBalance} on the
-							balance until the lock is finalized.
-						</p>
-					)}
-
-					{response && (
+					{response ? (
 						<CodeGroup value="response" className="flex-1 h-0 flex flex-col">
 							<CodeGroupList>
 								<CodeGroupTab value="response">Response</CodeGroupTab>
@@ -193,30 +148,34 @@ export function CheckBalanceSheet() {
 								<CodeGroupCode language="json">{formattedJson}</CodeGroupCode>
 							</div>
 						</CodeGroup>
+					) : (
+						<p className="text-xs text-tertiary-foreground">
+							{lock.enabled
+								? "Running this check reserves the required balance until the lock is finalized."
+								: "Run the check to see the response."}
+						</p>
 					)}
 				</div>
 
-				{lock.enabled && (
-					<SheetFooter>
-						<Button
-							variant="secondary"
-							className="w-full"
-							onClick={closeSheet}
-							disabled={isLocking}
-						>
-							Cancel
-						</Button>
-						<ShortcutButton
-							variant="primary"
-							className="w-full"
-							onClick={handleLockCheck}
-							isLoading={isLocking}
-							metaShortcut="enter"
-						>
-							Check & lock
-						</ShortcutButton>
-					</SheetFooter>
-				)}
+				<SheetFooter>
+					<Button
+						variant="secondary"
+						className="w-full"
+						onClick={closeSheet}
+						disabled={isSubmitting}
+					>
+						Cancel
+					</Button>
+					<ShortcutButton
+						variant="primary"
+						className="w-full"
+						onClick={handleSubmit}
+						isLoading={isSubmitting}
+						metaShortcut="enter"
+					>
+						{lock.enabled ? "Check & lock" : "Check"}
+					</ShortcutButton>
+				</SheetFooter>
 			</div>
 		</LayoutGroup>
 	);

--- a/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
@@ -2,7 +2,7 @@ import type { Entity, FullCustomer } from "@autumn/shared";
 import { LATEST_VERSION } from "@autumn/shared";
 import { Button, FormLabel, Input, ShortcutButton } from "@autumn/ui";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import {
 	CodeGroup,
@@ -53,6 +53,21 @@ export function CheckBalanceSheet() {
 	const [lock, setLock] = useState<CheckLockConfig>(DEFAULT_CHECK_LOCK_CONFIG);
 	const [response, setResponse] = useState<unknown>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
+	const requestSeq = useRef(0);
+
+	// A stale response for different inputs reads as the result of the next check.
+	const updateRequiredBalance = (value: string) => {
+		setRequiredBalance(value);
+		setResponse(null);
+	};
+	const updateLock = (next: CheckLockConfig) => {
+		setLock(next);
+		setResponse(null);
+	};
+	const updateScope = (entityId: string | undefined) => {
+		setScopeEntityId(entityId);
+		setResponse(null);
+	};
 
 	const handleSubmit = async () => {
 		if (!customerId || !featureId) return;
@@ -82,9 +97,11 @@ export function CheckBalanceSheet() {
 			};
 		}
 
+		const seq = ++requestSeq.current;
 		setIsSubmitting(true);
 		try {
 			const { data } = await axiosInstance.post("/v1/check", params);
+			if (seq !== requestSeq.current) return;
 			setResponse(data);
 			if (lock.enabled) {
 				toast.success(
@@ -119,7 +136,7 @@ export function CheckBalanceSheet() {
 					<EntityScopeSelector
 						entities={entities}
 						scopeEntityId={scopeEntityId}
-						onScopeChange={setScopeEntityId}
+						onScopeChange={updateScope}
 					/>
 				)}
 
@@ -129,11 +146,11 @@ export function CheckBalanceSheet() {
 						placeholder="1"
 						type="number"
 						value={requiredBalance}
-						onChange={(e) => setRequiredBalance(e.target.value)}
+						onChange={(e) => updateRequiredBalance(e.target.value)}
 					/>
 				</SheetSection>
 
-				<CheckAdvancedSection lock={lock} onLockChange={setLock} />
+				<CheckAdvancedSection lock={lock} onLockChange={updateLock} />
 
 				<div className="flex-1 overflow-hidden flex flex-col px-4 py-4">
 					{response ? (

--- a/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
@@ -1,7 +1,10 @@
 import type { Entity, FullCustomer } from "@autumn/shared";
 import { LATEST_VERSION } from "@autumn/shared";
+import { Button, FormLabel, Input, ShortcutButton } from "@autumn/ui";
 import { Spinner } from "@phosphor-icons/react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
 import {
 	CodeGroup,
 	CodeGroupCode,
@@ -11,7 +14,9 @@ import {
 } from "@/components/v2/CodeGroup";
 import {
 	LayoutGroup,
+	SheetFooter,
 	SheetHeader,
+	SheetSection,
 } from "@/components/v2/sheets/SharedSheetComponents";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
@@ -20,14 +25,21 @@ import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { EntityScopeSelector } from "./EntityScopeSelector";
+import {
+	CheckAdvancedSection,
+	type CheckLockConfig,
+	DEFAULT_CHECK_LOCK_CONFIG,
+} from "./lock/CheckAdvancedSection";
 
 export function CheckBalanceSheet() {
+	const closeSheet = useSheetStore((s) => s.closeSheet);
 	const sheetData = useSheetStore((s) => s.data);
 	const { customer } = useCusQuery();
 	const [scopeEntityId, setScopeEntityId] = useSheetScopeEntityId(
 		customer as FullCustomer | undefined,
 	);
 	const axiosInstance = useAxiosInstance({ version: LATEST_VERSION });
+	const queryClient = useQueryClient();
 	const buildKey = useQueryKeyFactory();
 
 	const fullCustomer = customer as FullCustomer | null;
@@ -40,24 +52,82 @@ export function CheckBalanceSheet() {
 	const featureName = sheetData?.featureName as string | undefined;
 	const customerId = customer?.id || customer?.internal_id;
 
-	const { data, isLoading, error } = useQuery({
-		queryKey: buildKey(["check-balance", customerId, featureId, scopeEntityId]),
-		queryFn: async () => {
-			const params: Record<string, unknown> = {
-				customer_id: customerId,
-				feature_id: featureId,
-			};
-			if (scopeEntityId) params.entity_id = scopeEntityId;
+	const [requiredBalance, setRequiredBalance] = useState("1");
+	const [lock, setLock] = useState<CheckLockConfig>(DEFAULT_CHECK_LOCK_CONFIG);
+	const [lockResponse, setLockResponse] = useState<unknown>(null);
+	const [isLocking, setIsLocking] = useState(false);
 
-			const { data } = await axiosInstance.post("/v1/check", params);
+	const parsedRequiredBalance =
+		requiredBalance.trim() === "" ? 1 : Number.parseFloat(requiredBalance);
+	const requiredBalanceValid = !Number.isNaN(parsedRequiredBalance);
+
+	const buildParams = () => {
+		const params: Record<string, unknown> = {
+			customer_id: customerId,
+			feature_id: featureId,
+			required_balance: parsedRequiredBalance,
+		};
+		if (scopeEntityId) params.entity_id = scopeEntityId;
+		return params;
+	};
+
+	// A plain check is read-only, so it runs on every input change. A lock
+	// reserves balance and only runs on an explicit submit.
+	const { data, isLoading, error } = useQuery({
+		queryKey: buildKey([
+			"check-balance",
+			customerId,
+			featureId,
+			scopeEntityId,
+			parsedRequiredBalance,
+		]),
+		queryFn: async () => {
+			const { data } = await axiosInstance.post("/v1/check", buildParams());
 			return data;
 		},
-		enabled: !!customerId && !!featureId,
+		enabled:
+			!!customerId && !!featureId && requiredBalanceValid && !lock.enabled,
 		gcTime: 0,
 		staleTime: 0,
 	});
 
-	const formattedJson = data ? JSON.stringify(data, null, 2) : "";
+	const handleLockCheck = async () => {
+		if (!customerId || !featureId) return;
+		if (!requiredBalanceValid) {
+			toast.error("Please enter a valid number for required balance");
+			return;
+		}
+		if (!lock.lockId.trim()) {
+			toast.error("Please enter a lock ID");
+			return;
+		}
+
+		setIsLocking(true);
+		try {
+			const { data } = await axiosInstance.post("/v1/check", {
+				...buildParams(),
+				lock: {
+					enabled: true,
+					lock_id: lock.lockId.trim(),
+					overage_behavior: lock.overageBehavior,
+				},
+			});
+			setLockResponse(data);
+			toast.success(
+				data?.allowed
+					? `Locked ${parsedRequiredBalance} with ID ${lock.lockId.trim()}`
+					: "Check denied, nothing was locked",
+			);
+			await queryClient.invalidateQueries({ queryKey: ["customer"] });
+		} catch (err) {
+			toast.error(getBackendErr(err, "Failed to check balance"));
+		} finally {
+			setIsLocking(false);
+		}
+	};
+
+	const response = lock.enabled ? lockResponse : data;
+	const formattedJson = response ? JSON.stringify(response, null, 2) : "";
 
 	return (
 		<LayoutGroup>
@@ -79,20 +149,39 @@ export function CheckBalanceSheet() {
 					/>
 				)}
 
-				<div className="flex-1 overflow-hidden flex flex-col px-4 pb-4">
-					{isLoading && (
+				<SheetSection withSeparator>
+					<FormLabel>Required balance</FormLabel>
+					<Input
+						placeholder="1"
+						type="number"
+						value={requiredBalance}
+						onChange={(e) => setRequiredBalance(e.target.value)}
+					/>
+				</SheetSection>
+
+				<CheckAdvancedSection lock={lock} onLockChange={setLock} />
+
+				<div className="flex-1 overflow-hidden flex flex-col px-4 py-4">
+					{!lock.enabled && isLoading && (
 						<div className="flex items-center justify-center py-12">
 							<Spinner className="size-6 animate-spin text-tertiary-foreground" />
 						</div>
 					)}
 
-					{error && (
+					{!lock.enabled && error && (
 						<div className="p-4 rounded-md bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 text-sm">
 							{getBackendErr(error, "Failed to check balance")}
 						</div>
 					)}
 
-					{data && (
+					{lock.enabled && !lockResponse && (
+						<p className="text-xs text-tertiary-foreground">
+							Running this check will reserve {parsedRequiredBalance} on the
+							balance until the lock is finalized.
+						</p>
+					)}
+
+					{response && (
 						<CodeGroup value="response" className="flex-1 h-0 flex flex-col">
 							<CodeGroupList>
 								<CodeGroupTab value="response">Response</CodeGroupTab>
@@ -106,6 +195,28 @@ export function CheckBalanceSheet() {
 						</CodeGroup>
 					)}
 				</div>
+
+				{lock.enabled && (
+					<SheetFooter>
+						<Button
+							variant="secondary"
+							className="w-full"
+							onClick={closeSheet}
+							disabled={isLocking}
+						>
+							Cancel
+						</Button>
+						<ShortcutButton
+							variant="primary"
+							className="w-full"
+							onClick={handleLockCheck}
+							isLoading={isLocking}
+							metaShortcut="enter"
+						>
+							Check & lock
+						</ShortcutButton>
+					</SheetFooter>
+				)}
 			</div>
 		</LayoutGroup>
 	);

--- a/vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx
@@ -31,6 +31,11 @@ import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { getFeatureIcon } from "@/views/products/features/utils/getFeatureIcon";
 import { EntityScopeSelector } from "./EntityScopeSelector";
+import {
+	DEFAULT_FINALIZE_LOCK_CONFIG,
+	type FinalizeLockConfig,
+	TrackAdvancedSection,
+} from "./lock/TrackAdvancedSection";
 
 type TrackResponse = {
 	deductions?: { value: number }[];
@@ -137,6 +142,9 @@ export function RecordUsageSheet() {
 	const [properties, setProperties] = useState<
 		{ key: string; value: string }[]
 	>([]);
+	const [finalize, setFinalize] = useState<FinalizeLockConfig>(
+		DEFAULT_FINALIZE_LOCK_CONFIG,
+	);
 
 	const handleAddProperty = () => {
 		setProperties((prev) => [...prev, { key: "", value: "" }]);
@@ -162,7 +170,51 @@ export function RecordUsageSheet() {
 		);
 	};
 
+	const handleFinalize = async () => {
+		const lockId = finalize.lockId.trim();
+		if (!lockId) {
+			toast.error("Please enter a lock ID");
+			return;
+		}
+
+		const params: Record<string, unknown> = {
+			lock_id: lockId,
+			action: finalize.action,
+		};
+
+		if (finalize.action === "confirm" && finalize.overrideValue.trim()) {
+			const overrideValue = Number.parseFloat(finalize.overrideValue);
+			if (Number.isNaN(overrideValue)) {
+				toast.error("Please enter a valid number for override value");
+				return;
+			}
+			params.override_value = overrideValue;
+		}
+
+		setIsSubmitting(true);
+		try {
+			await axiosInstance.post("/v1/balances.finalize", params);
+			closeSheet();
+			toast.success(
+				finalize.action === "confirm"
+					? `Lock ${lockId} confirmed`
+					: `Lock ${lockId} released`,
+			);
+			await new Promise((resolve) => setTimeout(resolve, 500));
+			await queryClient.invalidateQueries({ queryKey: ["customer"] });
+			await queryClient.invalidateQueries({
+				queryKey: ["customer-timeseries-events"],
+			});
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to finalize lock"));
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
 	const handleSubmit = async () => {
+		if (finalize.enabled) return handleFinalize();
+
 		const customerId = customer?.id || customer?.internal_id;
 		if (!customerId || !trackingFeatureId) return;
 
@@ -283,74 +335,83 @@ export function RecordUsageSheet() {
 					</SheetSection>
 				)}
 
-				<SheetSection withSeparator>
-					<FormLabel>Value</FormLabel>
-					<Input
-						placeholder="1"
-						type="number"
-						value={value}
-						onChange={(e) => setValue(e.target.value)}
-					/>
-				</SheetSection>
+				{!finalize.enabled && (
+					<SheetSection withSeparator>
+						<FormLabel>Value</FormLabel>
+						<Input
+							placeholder="1"
+							type="number"
+							value={value}
+							onChange={(e) => setValue(e.target.value)}
+						/>
+					</SheetSection>
+				)}
 
-				<SheetSection withSeparator={false}>
-					<div className="flex flex-col gap-3">
-						<div className="flex items-center justify-between">
-							<FormLabel className="mb-0">Properties</FormLabel>
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={handleAddProperty}
-								className="h-6 gap-1 text-xs text-tertiary-foreground"
-							>
-								<PlusIcon size={12} />
-								Add
-							</Button>
-						</div>
-
-						{properties.length === 0 && (
-							<p className="text-xs text-tertiary-foreground">
-								No properties added. Click "Add" to attach metadata.
-							</p>
-						)}
-
-						{properties.map((property, index) => (
-							<div key={index} className="flex items-center gap-2">
-								<Input
-									placeholder="Key"
-									value={property.key}
-									onChange={(e) =>
-										handlePropertyChange({
-											index,
-											field: "key",
-											fieldValue: e.target.value,
-										})
-									}
-									className="flex-1"
-								/>
-								<Input
-									placeholder="Value"
-									value={property.value}
-									onChange={(e) =>
-										handlePropertyChange({
-											index,
-											field: "value",
-											fieldValue: e.target.value,
-										})
-									}
-									className="flex-1"
-								/>
-								<button
-									type="button"
-									onClick={() => handleRemoveProperty({ index })}
-									className="shrink-0 p-1 text-tertiary-foreground hover:text-destructive transition-colors"
+				{!finalize.enabled && (
+					<SheetSection withSeparator>
+						<div className="flex flex-col gap-3">
+							<div className="flex items-center justify-between">
+								<FormLabel className="mb-0">Properties</FormLabel>
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={handleAddProperty}
+									className="h-6 gap-1 text-xs text-tertiary-foreground"
 								>
-									<TrashIcon size={14} />
-								</button>
+									<PlusIcon size={12} />
+									Add
+								</Button>
 							</div>
-						))}
-					</div>
-				</SheetSection>
+
+							{properties.length === 0 && (
+								<p className="text-xs text-tertiary-foreground">
+									No properties added. Click "Add" to attach metadata.
+								</p>
+							)}
+
+							{properties.map((property, index) => (
+								<div key={index} className="flex items-center gap-2">
+									<Input
+										placeholder="Key"
+										value={property.key}
+										onChange={(e) =>
+											handlePropertyChange({
+												index,
+												field: "key",
+												fieldValue: e.target.value,
+											})
+										}
+										className="flex-1"
+									/>
+									<Input
+										placeholder="Value"
+										value={property.value}
+										onChange={(e) =>
+											handlePropertyChange({
+												index,
+												field: "value",
+												fieldValue: e.target.value,
+											})
+										}
+										className="flex-1"
+									/>
+									<button
+										type="button"
+										onClick={() => handleRemoveProperty({ index })}
+										className="shrink-0 p-1 text-tertiary-foreground hover:text-destructive transition-colors"
+									>
+										<TrashIcon size={14} />
+									</button>
+								</div>
+							))}
+						</div>
+					</SheetSection>
+				)}
+
+				<TrackAdvancedSection
+					finalize={finalize}
+					onFinalizeChange={setFinalize}
+				/>
 
 				<div className="flex-1" />
 
@@ -370,7 +431,11 @@ export function RecordUsageSheet() {
 						isLoading={isSubmitting}
 						metaShortcut="enter"
 					>
-						Record
+						{finalize.enabled
+							? finalize.action === "confirm"
+								? "Confirm lock"
+								: "Release lock"
+							: "Record"}
 					</ShortcutButton>
 				</SheetFooter>
 			</div>

--- a/vite/src/views/customers2/components/sheets/SubscriptionUpdateSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionUpdateSheet.tsx
@@ -30,9 +30,9 @@ import {
 	LayoutGroup,
 	SheetHeader,
 } from "@/components/v2/sheets/SharedSheetComponents";
+import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useLicenseProductsQuery } from "@/hooks/queries/useLicenseProductsQuery";
-import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
 import { useProductVersionQuery } from "@/hooks/queries/useProductVersionQuery";
 import { usePrepaidItems } from "@/hooks/stores/useProductStore";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";

--- a/vite/src/views/customers2/components/sheets/SubscriptionUpdateSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionUpdateSheet.tsx
@@ -30,9 +30,9 @@ import {
 	LayoutGroup,
 	SheetHeader,
 } from "@/components/v2/sheets/SharedSheetComponents";
-import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useLicenseProductsQuery } from "@/hooks/queries/useLicenseProductsQuery";
+import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
 import { useProductVersionQuery } from "@/hooks/queries/useProductVersionQuery";
 import { usePrepaidItems } from "@/hooks/stores/useProductStore";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";

--- a/vite/src/views/customers2/components/sheets/lock/CheckAdvancedSection.tsx
+++ b/vite/src/views/customers2/components/sheets/lock/CheckAdvancedSection.tsx
@@ -1,8 +1,13 @@
-import { Button, Input, SheetAccordion, SheetAccordionItem } from "@autumn/ui";
+import {
+	Button,
+	Input,
+	SheetAccordion,
+	SheetAccordionItem,
+	Switch,
+} from "@autumn/ui";
 import { ArrowsClockwiseIcon } from "@phosphor-icons/react";
 import { nanoid } from "nanoid";
 import { ConfigRow } from "@/components/forms/shared/advanced-section";
-import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import {
 	LOCK_OVERAGE_DESCRIPTIONS,
 	type LockOverageBehavior,
@@ -33,64 +38,66 @@ export function CheckAdvancedSection({
 	return (
 		<SheetAccordion>
 			<SheetAccordionItem value="advanced" title="Advanced">
-				<SheetSection
+				<ConfigRow
 					title="Lock balance"
-					description="Reserve the required balance upfront, then confirm or release it later with balances.finalize."
-					checked={lock.enabled}
-					setChecked={(enabled) =>
-						onLockChange({
-							...lock,
-							enabled,
-							lockId: enabled && !lock.lockId ? generateLockId() : lock.lockId,
-						})
+					description="Reserve the required balance upfront, then confirm or release it with balances.finalize"
+					expanded={lock.enabled}
+					action={
+						<Switch
+							checked={lock.enabled}
+							onCheckedChange={(enabled) =>
+								onLockChange({
+									...lock,
+									enabled,
+									lockId:
+										enabled && !lock.lockId ? generateLockId() : lock.lockId,
+								})
+							}
+						/>
 					}
-					withSeparator={false}
-					className="p-0"
 				>
-					{lock.enabled && (
-						<div className="space-y-4">
-							<ConfigRow
-								title="Lock ID"
-								description="Pass this ID to balances.finalize"
-							>
-								<div className="flex items-center gap-2">
-									<Input
-										placeholder="lck_..."
-										value={lock.lockId}
-										onChange={(e) =>
-											onLockChange({ ...lock, lockId: e.target.value })
-										}
-										className="flex-1 font-mono text-xs"
-									/>
-									<Button
-										variant="secondary"
-										size="sm"
-										onClick={() =>
-											onLockChange({ ...lock, lockId: generateLockId() })
-										}
-										className="shrink-0 gap-1 text-xs text-tertiary-foreground"
-									>
-										<ArrowsClockwiseIcon size={12} />
-										New
-									</Button>
-								</div>
-							</ConfigRow>
+					<div className="space-y-4 pt-2">
+						<ConfigRow
+							title="Lock ID"
+							description="Pass this ID to balances.finalize"
+						>
+							<div className="flex items-center gap-2">
+								<Input
+									placeholder="lck_..."
+									value={lock.lockId}
+									onChange={(e) =>
+										onLockChange({ ...lock, lockId: e.target.value })
+									}
+									className="flex-1 font-mono text-xs"
+								/>
+								<Button
+									variant="secondary"
+									size="sm"
+									onClick={() =>
+										onLockChange({ ...lock, lockId: generateLockId() })
+									}
+									className="shrink-0 gap-1 text-xs text-tertiary-foreground"
+								>
+									<ArrowsClockwiseIcon size={12} />
+									New
+								</Button>
+							</div>
+						</ConfigRow>
 
-							<ConfigRow
-								title="Overage behavior"
-								description={LOCK_OVERAGE_DESCRIPTIONS[lock.overageBehavior]}
-								action={
-									<LockOverageBehaviorToggle
-										value={lock.overageBehavior}
-										onChange={(overageBehavior) =>
-											onLockChange({ ...lock, overageBehavior })
-										}
-									/>
-								}
-							/>
-						</div>
-					)}
-				</SheetSection>
+						<ConfigRow
+							title="Overage behavior"
+							description={LOCK_OVERAGE_DESCRIPTIONS[lock.overageBehavior]}
+							action={
+								<LockOverageBehaviorToggle
+									value={lock.overageBehavior}
+									onChange={(overageBehavior) =>
+										onLockChange({ ...lock, overageBehavior })
+									}
+								/>
+							}
+						/>
+					</div>
+				</ConfigRow>
 			</SheetAccordionItem>
 		</SheetAccordion>
 	);

--- a/vite/src/views/customers2/components/sheets/lock/CheckAdvancedSection.tsx
+++ b/vite/src/views/customers2/components/sheets/lock/CheckAdvancedSection.tsx
@@ -44,6 +44,7 @@ export function CheckAdvancedSection({
 					expanded={lock.enabled}
 					action={
 						<Switch
+							aria-label="Lock balance"
 							checked={lock.enabled}
 							onCheckedChange={(enabled) =>
 								onLockChange({

--- a/vite/src/views/customers2/components/sheets/lock/CheckAdvancedSection.tsx
+++ b/vite/src/views/customers2/components/sheets/lock/CheckAdvancedSection.tsx
@@ -1,0 +1,97 @@
+import { Button, Input, SheetAccordion, SheetAccordionItem } from "@autumn/ui";
+import { ArrowsClockwiseIcon } from "@phosphor-icons/react";
+import { nanoid } from "nanoid";
+import { ConfigRow } from "@/components/forms/shared/advanced-section";
+import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
+import {
+	LOCK_OVERAGE_DESCRIPTIONS,
+	type LockOverageBehavior,
+	LockOverageBehaviorToggle,
+} from "./LockOverageBehaviorToggle";
+
+export type CheckLockConfig = {
+	enabled: boolean;
+	lockId: string;
+	overageBehavior: LockOverageBehavior;
+};
+
+export const DEFAULT_CHECK_LOCK_CONFIG: CheckLockConfig = {
+	enabled: false,
+	lockId: "",
+	overageBehavior: "reject",
+};
+
+export const generateLockId = () => `lck_${nanoid(12)}`;
+
+export function CheckAdvancedSection({
+	lock,
+	onLockChange,
+}: {
+	lock: CheckLockConfig;
+	onLockChange: (lock: CheckLockConfig) => void;
+}) {
+	return (
+		<SheetAccordion>
+			<SheetAccordionItem value="advanced" title="Advanced">
+				<SheetSection
+					title="Lock balance"
+					description="Reserve the required balance upfront, then confirm or release it later with balances.finalize."
+					checked={lock.enabled}
+					setChecked={(enabled) =>
+						onLockChange({
+							...lock,
+							enabled,
+							lockId: enabled && !lock.lockId ? generateLockId() : lock.lockId,
+						})
+					}
+					withSeparator={false}
+					className="p-0"
+				>
+					{lock.enabled && (
+						<div className="space-y-4">
+							<ConfigRow
+								title="Lock ID"
+								description="Pass this ID to balances.finalize"
+							>
+								<div className="flex items-center gap-2">
+									<Input
+										placeholder="lck_..."
+										value={lock.lockId}
+										onChange={(e) =>
+											onLockChange({ ...lock, lockId: e.target.value })
+										}
+										className="flex-1 font-mono text-xs"
+									/>
+									<Button
+										variant="secondary"
+										size="sm"
+										onClick={() =>
+											onLockChange({ ...lock, lockId: generateLockId() })
+										}
+										className="shrink-0 gap-1 text-xs text-tertiary-foreground"
+									>
+										<ArrowsClockwiseIcon size={12} />
+										New
+									</Button>
+								</div>
+							</ConfigRow>
+
+							<ConfigRow
+								title="Overage behavior"
+								description={LOCK_OVERAGE_DESCRIPTIONS[lock.overageBehavior]}
+								action={
+									<LockOverageBehaviorToggle
+										value={lock.overageBehavior}
+										onChange={(overageBehavior) =>
+											onLockChange({ ...lock, overageBehavior })
+										}
+									/>
+								}
+							/>
+						</div>
+					)}
+				</SheetSection>
+			</SheetAccordionItem>
+		</SheetAccordion>
+	);
+}

--- a/vite/src/views/customers2/components/sheets/lock/LockOverageBehaviorToggle.tsx
+++ b/vite/src/views/customers2/components/sheets/lock/LockOverageBehaviorToggle.tsx
@@ -1,0 +1,51 @@
+import { IconCheckbox } from "@autumn/ui";
+import { cn } from "@/lib/utils";
+
+export type LockOverageBehavior = "reject" | "cap" | "overflow";
+
+const OPTIONS: { value: LockOverageBehavior; label: string }[] = [
+	{ value: "reject", label: "Reject" },
+	{ value: "cap", label: "Cap" },
+	{ value: "overflow", label: "Overflow" },
+];
+
+export const LOCK_OVERAGE_DESCRIPTIONS: Record<LockOverageBehavior, string> = {
+	reject: "Deny the check and reserve nothing if the balance is short.",
+	cap: "Reserve whatever fits, stopping at zero.",
+	overflow: "Reserve the full amount, letting the balance go negative.",
+};
+
+export function LockOverageBehaviorToggle({
+	value,
+	onChange,
+}: {
+	value: LockOverageBehavior;
+	onChange: (value: LockOverageBehavior) => void;
+}) {
+	return (
+		<div className="flex">
+			{OPTIONS.map((option, index) => {
+				const isSelected = value === option.value;
+				const isFirst = index === 0;
+				const isLast = index === OPTIONS.length - 1;
+				return (
+					<IconCheckbox
+						key={option.value}
+						variant="secondary"
+						size="sm"
+						checked={isSelected}
+						onCheckedChange={() => onChange(option.value)}
+						className={cn(
+							"min-w-[72px] px-2 text-xs",
+							!isFirst && "rounded-l-none",
+							!isLast && "rounded-r-none",
+							!isSelected && !isLast && "border-r-0",
+						)}
+					>
+						{option.label}
+					</IconCheckbox>
+				);
+			})}
+		</div>
+	);
+}

--- a/vite/src/views/customers2/components/sheets/lock/TrackAdvancedSection.tsx
+++ b/vite/src/views/customers2/components/sheets/lock/TrackAdvancedSection.tsx
@@ -1,0 +1,132 @@
+import {
+	IconCheckbox,
+	Input,
+	SheetAccordion,
+	SheetAccordionItem,
+} from "@autumn/ui";
+import { ConfigRow } from "@/components/forms/shared/advanced-section";
+import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
+import { cn } from "@/lib/utils";
+
+export type FinalizeLockAction = "confirm" | "release";
+
+export type FinalizeLockConfig = {
+	enabled: boolean;
+	lockId: string;
+	action: FinalizeLockAction;
+	overrideValue: string;
+};
+
+export const DEFAULT_FINALIZE_LOCK_CONFIG: FinalizeLockConfig = {
+	enabled: false,
+	lockId: "",
+	action: "confirm",
+	overrideValue: "",
+};
+
+const ACTION_DESCRIPTIONS: Record<FinalizeLockAction, string> = {
+	confirm: "Commit the reserved balance, optionally at a different value.",
+	release: "Return the full reserved balance to the customer.",
+};
+
+export function TrackAdvancedSection({
+	finalize,
+	onFinalizeChange,
+}: {
+	finalize: FinalizeLockConfig;
+	onFinalizeChange: (finalize: FinalizeLockConfig) => void;
+}) {
+	const isConfirm = finalize.action === "confirm";
+
+	return (
+		<SheetAccordion withSeparator={false}>
+			<SheetAccordionItem value="advanced" title="Advanced">
+				<SheetSection
+					title="Finalize a lock"
+					description="Settle a balance reserved by a previous check with a lock instead of recording new usage."
+					checked={finalize.enabled}
+					setChecked={(enabled) => onFinalizeChange({ ...finalize, enabled })}
+					withSeparator={false}
+					className="p-0"
+				>
+					{finalize.enabled && (
+						<div className="space-y-4">
+							<ConfigRow
+								title="Lock ID"
+								description="The lock_id passed to the check call"
+							>
+								<Input
+									placeholder="lck_..."
+									value={finalize.lockId}
+									onChange={(e) =>
+										onFinalizeChange({ ...finalize, lockId: e.target.value })
+									}
+									className="font-mono text-xs"
+								/>
+							</ConfigRow>
+
+							<ConfigRow
+								title="Action"
+								description={ACTION_DESCRIPTIONS[finalize.action]}
+								action={
+									<div className="flex">
+										<IconCheckbox
+											variant="secondary"
+											size="sm"
+											checked={isConfirm}
+											onCheckedChange={() =>
+												onFinalizeChange({ ...finalize, action: "confirm" })
+											}
+											className={cn(
+												"min-w-[76px] px-2 text-xs rounded-r-none",
+												!isConfirm && "border-r-0",
+											)}
+										>
+											Confirm
+										</IconCheckbox>
+										<IconCheckbox
+											variant="secondary"
+											size="sm"
+											checked={!isConfirm}
+											onCheckedChange={() =>
+												onFinalizeChange({
+													...finalize,
+													action: "release",
+													overrideValue: "",
+												})
+											}
+											className={cn(
+												"min-w-[76px] px-2 text-xs rounded-l-none",
+												isConfirm && "border-l-0",
+											)}
+										>
+											Release
+										</IconCheckbox>
+									</div>
+								}
+							/>
+
+							<ConfigRow
+								title="Override value"
+								description="Leave empty to confirm the amount that was locked"
+								expanded={isConfirm}
+							>
+								<Input
+									placeholder="Same as locked"
+									type="number"
+									value={finalize.overrideValue}
+									onChange={(e) =>
+										onFinalizeChange({
+											...finalize,
+											overrideValue: e.target.value,
+										})
+									}
+								/>
+							</ConfigRow>
+						</div>
+					)}
+				</SheetSection>
+			</SheetAccordionItem>
+		</SheetAccordion>
+	);
+}

--- a/vite/src/views/customers2/components/sheets/lock/TrackAdvancedSection.tsx
+++ b/vite/src/views/customers2/components/sheets/lock/TrackAdvancedSection.tsx
@@ -47,6 +47,7 @@ export function TrackAdvancedSection({
 					expanded={finalize.enabled}
 					action={
 						<Switch
+							aria-label="Finalize a lock"
 							checked={finalize.enabled}
 							onCheckedChange={(enabled) =>
 								onFinalizeChange({ ...finalize, enabled })

--- a/vite/src/views/customers2/components/sheets/lock/TrackAdvancedSection.tsx
+++ b/vite/src/views/customers2/components/sheets/lock/TrackAdvancedSection.tsx
@@ -3,9 +3,9 @@ import {
 	Input,
 	SheetAccordion,
 	SheetAccordionItem,
+	Switch,
 } from "@autumn/ui";
 import { ConfigRow } from "@/components/forms/shared/advanced-section";
-import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import { cn } from "@/lib/utils";
 
 export type FinalizeLockAction = "confirm" | "release";
@@ -41,91 +41,94 @@ export function TrackAdvancedSection({
 	return (
 		<SheetAccordion withSeparator={false}>
 			<SheetAccordionItem value="advanced" title="Advanced">
-				<SheetSection
+				<ConfigRow
 					title="Finalize a lock"
-					description="Settle a balance reserved by a previous check with a lock instead of recording new usage."
-					checked={finalize.enabled}
-					setChecked={(enabled) => onFinalizeChange({ ...finalize, enabled })}
-					withSeparator={false}
-					className="p-0"
+					description="Settle a balance reserved by a previous check with a lock instead of recording new usage"
+					expanded={finalize.enabled}
+					action={
+						<Switch
+							checked={finalize.enabled}
+							onCheckedChange={(enabled) =>
+								onFinalizeChange({ ...finalize, enabled })
+							}
+						/>
+					}
 				>
-					{finalize.enabled && (
-						<div className="space-y-4">
-							<ConfigRow
-								title="Lock ID"
-								description="The lock_id passed to the check call"
-							>
-								<Input
-									placeholder="lck_..."
-									value={finalize.lockId}
-									onChange={(e) =>
-										onFinalizeChange({ ...finalize, lockId: e.target.value })
-									}
-									className="font-mono text-xs"
-								/>
-							</ConfigRow>
+					<div className="space-y-4 pt-2">
+						<ConfigRow
+							title="Lock ID"
+							description="The lock_id passed to the check call"
+						>
+							<Input
+								placeholder="lck_..."
+								value={finalize.lockId}
+								onChange={(e) =>
+									onFinalizeChange({ ...finalize, lockId: e.target.value })
+								}
+								className="font-mono text-xs"
+							/>
+						</ConfigRow>
 
-							<ConfigRow
-								title="Action"
-								description={ACTION_DESCRIPTIONS[finalize.action]}
-								action={
-									<div className="flex">
-										<IconCheckbox
-											variant="secondary"
-											size="sm"
-											checked={isConfirm}
-											onCheckedChange={() =>
-												onFinalizeChange({ ...finalize, action: "confirm" })
-											}
-											className={cn(
-												"min-w-[76px] px-2 text-xs rounded-r-none",
-												!isConfirm && "border-r-0",
-											)}
-										>
-											Confirm
-										</IconCheckbox>
-										<IconCheckbox
-											variant="secondary"
-											size="sm"
-											checked={!isConfirm}
-											onCheckedChange={() =>
-												onFinalizeChange({
-													...finalize,
-													action: "release",
-													overrideValue: "",
-												})
-											}
-											className={cn(
-												"min-w-[76px] px-2 text-xs rounded-l-none",
-												isConfirm && "border-l-0",
-											)}
-										>
-											Release
-										</IconCheckbox>
-									</div>
+						<ConfigRow
+							title="Action"
+							description={ACTION_DESCRIPTIONS[finalize.action]}
+							action={
+								<div className="flex">
+									<IconCheckbox
+										variant="secondary"
+										size="sm"
+										checked={isConfirm}
+										onCheckedChange={() =>
+											onFinalizeChange({ ...finalize, action: "confirm" })
+										}
+										className={cn(
+											"min-w-[76px] px-2 text-xs rounded-r-none",
+											!isConfirm && "border-r-0",
+										)}
+									>
+										Confirm
+									</IconCheckbox>
+									<IconCheckbox
+										variant="secondary"
+										size="sm"
+										checked={!isConfirm}
+										onCheckedChange={() =>
+											onFinalizeChange({
+												...finalize,
+												action: "release",
+												overrideValue: "",
+											})
+										}
+										className={cn(
+											"min-w-[76px] px-2 text-xs rounded-l-none",
+											isConfirm && "border-l-0",
+										)}
+									>
+										Release
+									</IconCheckbox>
+								</div>
+							}
+						/>
+
+						<ConfigRow
+							title="Override value"
+							description="Leave empty to confirm the amount that was locked"
+							expanded={isConfirm}
+						>
+							<Input
+								placeholder="Same as locked"
+								type="number"
+								value={finalize.overrideValue}
+								onChange={(e) =>
+									onFinalizeChange({
+										...finalize,
+										overrideValue: e.target.value,
+									})
 								}
 							/>
-
-							<ConfigRow
-								title="Override value"
-								description="Leave empty to confirm the amount that was locked"
-								expanded={isConfirm}
-							>
-								<Input
-									placeholder="Same as locked"
-									type="number"
-									value={finalize.overrideValue}
-									onChange={(e) =>
-										onFinalizeChange({
-											...finalize,
-											overrideValue: e.target.value,
-										})
-									}
-								/>
-							</ConfigRow>
-						</div>
-					)}
-				</SheetSection>
+						</ConfigRow>
+					</div>
+				</ConfigRow>
 			</SheetAccordionItem>
 		</SheetAccordion>
 	);


### PR DESCRIPTION
## What

`check.lock` now accepts `overage_behavior: "reject" | "cap" | "overflow"` inside the lock object. It defaults to `reject`, which is what locks have always done, so existing callers are unchanged.

```ts
await autumn.check({
  customer_id, feature_id, required_balance: 100,
  lock: { enabled: true, lock_id, overage_behavior: "overflow" },
});
```

| mode | short balance at check | finalize `override_value` above the lock |
|---|---|---|
| `reject` (default) | `allowed: false`, nothing reserved | extra deduction rejects |
| `cap` | reserves what fits, `allowed: true` | extra clamps at 0 |
| `overflow` | reserves the full value, balance goes negative, `allowed: true` | extra goes negative too |

`overflow` keeps the same semantics as on `track`: spend limits still clamp, usage windows are bypassed.

## How

- `runCheckWithTrackV2` no longer hardcodes `"reject"`; it uses the lock's mode.
- The resolved mode is stamped on the prepared lock and persisted on the lock receipt by both writers (Lua `deductFromSubjectBalances` and the Postgres-path `saveLockReceiptV2`).
- `buildFinalizeLockContextV2` reads the mode off the receipt into `deductionOptions`, so `finalize` needs no new params and expiry/queued-replay inherit it for free. Receipts without the field (written before deploy) resolve to `reject`.
- Schema-wise the field lives on a new `CheckLockParamsSchema`; `track.lock` keeps the base schema since `track` already has a top-level `overage_behavior`.

Paid-allocated features are unaffected: locks are already rejected for them and `prepareDeductionOptionsV2` forces `reject` regardless.

## Tests

New `check-with-lock-overage-behavior.test.ts` with 10 cases: default/explicit reject, cap (reserve + override), overflow (reserve, override above, override below, release, spend limit), and the Postgres `skip_cache` path. Full `tests/integration/balances/lock/` sweep run file-by-file: the only failures (`EQ-2`, the 500-pair stress test, and the SQS expiry test) fail identically on `dev` without this change.

OpenAPI/SDK regeneration is left for the usual regen commit; `bun api` produces the expected `overage_behavior` entry under `check.lock` but the SDK build step needs Speakeasy locally.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M22ZXQENFS5GV2K38SMGV7SM"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `overage_behavior` to `check.lock` so callers control what happens when a lock exceeds the available balance, and surfaces the option in the dashboard.

- `cap` reserves only what fits and returns `allowed: true`; `overflow` reserves the full value, letting the balance go negative, with spend limits still clamping. `reject` (the default) keeps existing behavior unchanged.
- `finalize` reuses the mode from the lock receipt, so no new params are needed; receipts written before this field existed resolve to `reject`.
- The Check Balance sheet gains a lock section with the overage behavior toggle and explicit submit; the Record Usage sheet gains a finalize-lock section for confirm/release. The Check Balance sheet now clears its response and ignores in-flight results whenever inputs change, so a stale result no longer appears for new inputs.

<sup>Written for commit 6e2c6e5f382155785f1e736ef98393060d73d162. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds configurable overage handling to balance locks and carries the selected behavior through finalization. It also adds dashboard controls for creating and finalizing locks.

## Key changes
- **[API changes]** Adds `reject`, `cap`, and `overflow` behavior options to `check.lock`, defaulting to the existing `reject` behavior.
- **[Improvements]** Persists the selected behavior in lock receipts across both Redis/Lua and Postgres paths so finalization, expiry, and queued replay use the original mode.
- **[Improvements]** Adds dashboard controls for reserving balances and confirming or releasing existing locks.
- **[Bug fixes]** Invalidates displayed check results when their form inputs change, including while a request is in flight.
- **[Improvements]** Adds integration coverage for default rejection, capped reservations, overflow, override values, release, spend limits, and the Postgres path.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no new actionable failures found and the previous stale-response issue fully addressed.

The selected overage behavior is validated, applied during reservation, persisted by both receipt writers, and restored during finalization with backward-compatible handling for older receipts. The latest dashboard change also invalidates in-flight results when inputs change, fully fixing the previous finding.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/balances/common/lockParams.ts | Defines the check-specific lock overage schema while preserving the base lock schema for track requests. |
| server/src/internal/balances/check/runCheckWithTrackV2.ts | Passes the requested lock overage behavior into the existing deduction pipeline with a reject default. |
| server/src/internal/balances/utils/lockV2/buildFinalizeLockContextV2.ts | Restores the persisted behavior during finalization and safely defaults older receipts to reject. |
| server/src/_luaScriptsV2/fullSubjectDeduction/deductFromSubjectBalances.lua | Persists the selected behavior in lock receipts written by the Lua deduction path. |
| server/src/internal/balances/utils/lockV2/saveLockReceiptV2.ts | Persists the selected behavior in lock receipts written by the Postgres path. |
| server/tests/integration/balances/lock/check-with-lock-overage-behavior.test.ts | Covers lock and finalize semantics for every behavior, including spend limits and skip-cache persistence. |
| vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx | Adds explicit check-and-lock controls and now discards stale or in-flight results when inputs change. |
| vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx | Adds a dashboard flow for confirming or releasing an existing lock. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Check
  participant Balance
  participant Receipt
  participant Finalize

  Client->>Check: check(lock, overage_behavior)
  Check->>Balance: reserve using reject/cap/overflow
  Balance->>Receipt: persist selected behavior
  Check-->>Client: allowed and balance result
  Client->>Finalize: confirm/release lock
  Finalize->>Receipt: claim receipt and read behavior
  Finalize->>Balance: settle using persisted behavior
  Finalize-->>Client: finalized result
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(dashboard): invalidate in-flight che..."](https://github.com/useautumn/autumn/commit/6e2c6e5f382155785f1e736ef98393060d73d162) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62099781)</sub>

<!-- /greptile_comment -->