### PR TITLE
fix: set Capy shell working directory on startup

### DIFF
--- a/scripts/capy/command.test.ts
+++ b/scripts/capy/command.test.ts
@@ -1,5 +1,57 @@
-import { describe, expect, test } from "bun:test";
-import { capyHandoffText } from "./command.ts";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { capyHandoffText, ensureCapyBashrc } from "./command.ts";
+
+describe("ensureCapyBashrc", () => {
+	const homes: string[] = [];
+	function createHome() {
+		const home = mkdtempSync(join(tmpdir(), "capy-bashrc-"));
+		homes.push(home);
+		return home;
+	}
+	afterEach(() => {
+		for (const home of homes.splice(0)) rmSync(home, { recursive: true });
+	});
+
+	test("leaves shells untouched without an existing Capy machine config", () => {
+		const home = createHome();
+		for (const machineConfig of ["", join(home, "missing.json")]) {
+			ensureCapyBashrc({ home, machineConfig });
+			expect(existsSync(join(home, ".bashrc"))).toBe(false);
+		}
+	});
+
+	test("preserves existing shell config and appends the directory once", () => {
+		const home = createHome();
+		const machineConfig = join(home, "machine.json");
+		writeFileSync(machineConfig, "{}");
+		const bashrc = join(home, ".bashrc");
+		writeFileSync(bashrc, "export EDITOR=vim");
+		ensureCapyBashrc({ home, machineConfig });
+		ensureCapyBashrc({ home, machineConfig });
+		expect(readFileSync(bashrc, "utf-8")).toBe(
+			"export EDITOR=vim\ncd /workspace/autumn\n",
+		);
+	});
+
+	test("creates a missing bashrc on a Capy machine", () => {
+		const home = createHome();
+		const machineConfig = join(home, "machine.json");
+		writeFileSync(machineConfig, "{}");
+		ensureCapyBashrc({ home, machineConfig });
+		expect(readFileSync(join(home, ".bashrc"), "utf-8").trim()).toBe(
+			"cd /workspace/autumn",
+		);
+	});
+});
 
 describe("capyHandoffText", () => {
 	test("describes the bounded Capy handoff", () => {

--- a/scripts/capy/command.ts
+++ b/scripts/capy/command.ts
@@ -1,4 +1,5 @@
 import {
+	appendFileSync,
 	chmodSync,
 	existsSync,
 	mkdirSync,
@@ -108,6 +109,21 @@ function ensureBunGlobalBin(): void {
 	}
 }
 
+export function ensureCapyBashrc({
+	machineConfig = process.env.CAPY_MACHINE_CONFIG,
+	home = process.env.HOME ?? "/home/user",
+}: {
+	machineConfig?: string;
+	home?: string;
+} = {}): void {
+	if (!machineConfig || !existsSync(machineConfig)) return;
+	const bashrc = join(home, ".bashrc");
+	const contents = readLog(bashrc) ?? "";
+	const command = "cd /workspace/autumn";
+	if (contents.split("\n").some((line) => line.trim() === command)) return;
+	appendFileSync(bashrc, `${contents.endsWith("\n") ? "" : "\n"}${command}\n`);
+}
+
 export function capyHandoffText(): string {
 	return [
 		"Capy is ready.",
@@ -182,6 +198,7 @@ function ensureAppProcess(): void {
 }
 
 export async function cmdCapy(): Promise<void> {
+	ensureCapyBashrc();
 	ensureAppProcess();
 	await waitForReady();
 	console.log(capyHandoffText());


### PR DESCRIPTION
`bun capy` now appends `cd /workspace/autumn` to `~/.bashrc` only when `CAPY_MACHINE_CONFIG` is set and its path exists. Normal local runs leave shell configuration untouched.

Preserves existing content and avoids duplicate entries on repeated startup or restart, including when the tmux session is already running.

Validated with the four tests in `scripts/capy/command.test.ts` and Biome checks on both changed files.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M23B8N91M9RQTMHG82P7C9WT"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`bun capy` now sets the Capy machine shell working directory on startup by appending `cd /workspace/autumn` to `~/.bashrc` when `CAPY_MACHINE_CONFIG` is set and its path exists. Local runs leave shell configuration untouched.

- Preserves existing `.bashrc` content and skips appending if the command is already present, so repeated startups or restarts don't create duplicates.
- Adds four tests in `scripts/capy/command.test.ts` covering untouched shells, existing config, and missing `.bashrc` cases.

<sup>Written for commit 30393ab0c94d88ec4835e73140acea0d6d4e639f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR configures Capy interactive shells to begin in the Autumn workspace while leaving ordinary local shell configuration unchanged.

- **[Bug fixes]** Conditionally appends `cd /workspace/autumn` to `.bashrc` when a valid Capy machine configuration is present.
- **[Improvements]** Preserves existing shell configuration and avoids duplicate entries during sequential startups.
- **[Improvements]** Adds tests for local runs, existing configuration, repeated calls, and missing `.bashrc` files.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking concurrency edge case that can leave duplicate `.bashrc` entries.

The normal and sequential restart paths are covered, but the read-check-append sequence is not atomic when two startup commands overlap.

**Files Needing Attention:** scripts/capy/command.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/capy/command.ts | Adds conditional `.bashrc` setup at Capy startup; concurrent invocations can still append duplicate commands. |
| scripts/capy/command.test.ts | Covers the main conditional, preservation, creation, and sequential-idempotency behaviors. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/capy/command.ts:121-124
**Concurrent starts duplicate entries**

If two `bun capy` commands start at the same time, both can read `.bashrc` before either writes to it. They can then each append `cd /workspace/autumn`, leaving duplicate entries despite the intended restart-safe behavior. Please make the update concurrency-safe or serialize startup, and add a test for overlapping starts.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: set Capy shell working directory on..."](https://github.com/useautumn/autumn/commit/30393ab0c94d88ec4835e73140acea0d6d4e639f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62149620)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->