### PR TITLE
fix(catalog-v2): a variant's active row is never historical under an unpromoted draft

### DIFF
--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleVariantErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleVariantErrors.ts
@@ -4,6 +4,7 @@ import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCa
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { editedBaseInternalIds } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/editedBaseInternalIds";
 import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
+import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
 import { mintedVariantPins } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/mintedVariantPins";
 import { rowHasVersionableCustomers } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/rowHasVersionableCustomers";
 import { variantPinKey } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/variantEntryMintsRow";
@@ -272,11 +273,16 @@ export const handleVariantErrors = ({
 				statusCode: StatusCodes.BAD_REQUEST,
 			});
 		}
-		// "Historical" means not the active row: a draft version above the active
-		// one must not make the active row look old.
+		// Historical = inactive AND below the latest version: the active row stays
+		// mintable under a draft above it, and a latest-but-inactive draft still mints.
 		if (
 			mintSource &&
 			!targetRow.active &&
+			targetRow.version <
+				maxVersionForPlan({
+					planId: target.plan_id,
+					productStatesContext,
+				}) &&
 			rowHasVersionableCustomers({ row: targetRow, productStatesContext })
 		) {
 			throw new RecaseError({

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleVariantErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleVariantErrors.ts
@@ -4,7 +4,6 @@ import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCa
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { editedBaseInternalIds } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/editedBaseInternalIds";
 import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
-import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
 import { mintedVariantPins } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/mintedVariantPins";
 import { rowHasVersionableCustomers } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/rowHasVersionableCustomers";
 import { variantPinKey } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/variantEntryMintsRow";
@@ -273,13 +272,11 @@ export const handleVariantErrors = ({
 				statusCode: StatusCodes.BAD_REQUEST,
 			});
 		}
+		// "Historical" means not the active row: a draft version above the active
+		// one must not make the active row look old.
 		if (
 			mintSource &&
-			targetRow.version <
-				maxVersionForPlan({
-					planId: target.plan_id,
-					productStatesContext,
-				}) &&
+			!targetRow.active &&
 			rowHasVersionableCustomers({ row: targetRow, productStatesContext })
 		) {
 			throw new RecaseError({

--- a/server/tests/integration/catalog-v2/plans/variants/versioning/propagate-new-version-over-draft.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/versioning/propagate-new-version-over-draft.test.ts
@@ -1,0 +1,91 @@
+/**
+ * catalogV2.update — a second new_version while an unpromoted draft exists.
+ *
+ * Red (before): the follower guard called the variant's ACTIVE v1 "historical"
+ * because a draft v2 sat above it, and refused with "historical version has
+ * customers". Green (after): historical means not active, so v3 drafts mint.
+ */
+import { test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import {
+	dashboardItem,
+	messagesItem,
+	withCatalogPlans,
+} from "../../licenses/utils/seedLicensePlans.js";
+import { seedVersionableCustomer } from "../../migrations/utils/seedVersionableCustomer.js";
+import { expectVersionIdentityCorrect } from "../../utils/expectVersionIdentity.js";
+import { seedBaseWithVariant } from "../utils/seedVariantPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants: new_version from the active row mints again while a draft sits above it")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_draft_above");
+		const variantId = uniqueTestId("cv2_var_draft_above_eu");
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId],
+			run: async () => {
+				await seedBaseWithVariant({
+					autumn: autumnV2_3,
+					baseId,
+					variantId,
+				});
+				await seedVersionableCustomer({ ctx, planId: variantId, version: 1 });
+
+				// First versioning: v2 drafts for the base and its follower, never promoted.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: baseId,
+							items: [messagesItem(100), dashboardItem()],
+							versioning: "new_version",
+							propagate: { variants: [{ plan_id: variantId }] },
+						},
+					],
+				});
+
+				// Second versioning from the still-active v1: must mint v3 drafts, not 400.
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: baseId,
+							items: [messagesItem(80), dashboardItem()],
+							versioning: "new_version",
+							propagate: { variants: [{ plan_id: variantId }] },
+						},
+					],
+				});
+
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: baseId,
+					version: 1,
+					active: true,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: baseId,
+					version: 3,
+					active: false,
+					isDefault: false,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: variantId,
+					version: 1,
+					active: true,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: variantId,
+					version: 3,
+					active: false,
+					isDefault: false,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/variants/versioning/propagate-new-version-over-draft.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/versioning/propagate-new-version-over-draft.test.ts
@@ -15,7 +15,10 @@ import {
 	withCatalogPlans,
 } from "../../licenses/utils/seedLicensePlans.js";
 import { seedVersionableCustomer } from "../../migrations/utils/seedVersionableCustomer.js";
-import { expectVersionIdentityCorrect } from "../../utils/expectVersionIdentity.js";
+import {
+	expectExactlyOneActiveVersion,
+	expectVersionIdentityCorrect,
+} from "../../utils/expectVersionIdentity.js";
 import { seedBaseWithVariant } from "../utils/seedVariantPlans.js";
 
 test.concurrent(
@@ -46,6 +49,17 @@ test.concurrent(
 						},
 					],
 				});
+
+				// The premise: v2 drafts exist above the still-active v1.
+				for (const planId of [baseId, variantId]) {
+					await expectVersionIdentityCorrect({
+						ctx,
+						planId,
+						version: 2,
+						active: false,
+						isDefault: false,
+					});
+				}
 
 				// Second versioning from the still-active v1: must mint v3 drafts, not 400.
 				await autumnV2_3.catalogV2.update({
@@ -85,6 +99,8 @@ test.concurrent(
 					active: false,
 					isDefault: false,
 				});
+				await expectExactlyOneActiveVersion({ ctx, planId: baseId });
+				await expectExactlyOneActiveVersion({ ctx, planId: variantId });
 			},
 		});
 	},


### PR DESCRIPTION
Creating a new version of a base plan with propagate.variants failed with `Cannot propagate a new version onto <variant>@v1: historical version has customers` whenever an unpromoted draft version sat above the active row: the follower guard defined "historical" as `version < max version`, so the active v1 read as old once a draft v2 existed. Historical now means `!active`, mirroring the license-parent guard.

Test: active v1 with a customer, draft v2 minted and never promoted, second `new_version` push mints v3 drafts (red before, green after); the existing propagate guard file stays 6/6.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes variant propagation failing when an unpromoted draft version sits above the active row. Previously the follower guard treated the active v1 as historical because a draft v2 existed, and refused with "historical version has customers". Now "historical" means inactive and below the latest version, so the active row can mint new versions again and a latest-but-inactive draft still propagates. Adds an integration test covering the draft-above-active scenario.

<sup>Written for commit d177bfafbc3ef4b9ca8c01153f817b3acda5cf54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects variant version propagation when drafts and customer-bearing versions coexist.

Key changes:
- [Bug fixes] Defines a historical variant row as inactive and below the plan lineage’s latest version, allowing both an active row beneath a draft and a latest inactive draft to mint a new version.
- [Improvements] Adds integration coverage showing that a second propagated update creates v3 drafts while v1 remains the sole active version.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the revised guard preserves both valid minting cases while retaining protection for customer-bearing historical rows.

No new actionable issues remain. The previous finding was manually resolved, and the current implementation now distinguishes the latest inactive row from older inactive rows as requested.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleVariantErrors.ts | Refines the customer-bearing historical-row guard so active and latest inactive variant targets remain eligible for minting. |
| server/tests/integration/catalog-v2/plans/variants/versioning/propagate-new-version-over-draft.test.ts | Verifies repeated propagation over an unpromoted draft creates new drafts without changing the single active version. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Propagate a new base-plan version] --> B{Variant target active?}
    B -->|Yes| C[Allow minting a new variant version]
    B -->|No| D{Target below latest version?}
    D -->|No| C
    D -->|Yes| E{Target has customers?}
    E -->|Yes| F[Reject historical-row propagation]
    E -->|No| C
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: 🐛 historical means inactive and be..."](https://github.com/useautumn/autumn/commit/d177bfafbc3ef4b9ca8c01153f817b3acda5cf54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62169047)</sub>

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)

<!-- /greptile_comment -->