### PR TITLE
Share credit dimension schemas as OpenAPI components

### DIFF
--- a/packages/openapi/latest/openapi.ts
+++ b/packages/openapi/latest/openapi.ts
@@ -1,6 +1,10 @@
 import { writeFileSync } from "node:fs";
 import { SuccessResponseSchema } from "@api/common/commonResponses.js";
 import {
+	ApiCreditDimensionSchema,
+	ApiCreditTierSchema,
+} from "@api/features/creditRateCard.js";
+import {
 	ApiBalanceV1Schema,
 	ApiCustomerV5Schema,
 	ApiEventsListV2_3ParamsSchema,
@@ -140,6 +144,18 @@ async function generateOpenApiDocument({
 			Balance: {
 				schema: ApiBalanceV1Schema,
 				strategy: "output",
+			},
+			CreditDimension: {
+				schema: ApiCreditDimensionSchema,
+				strategy: "input",
+			},
+			CreditDimensionResponse: {
+				schema: ApiCreditDimensionSchema,
+				strategy: "output",
+			},
+			CreditTier: {
+				schema: ApiCreditTierSchema,
+				strategy: "input",
 			},
 		},
 		servers: [


### PR DESCRIPTION
Fixes `bun api` failing in Python SDK generation.

Every plan item's `feature_override.credit_schema[].dimensions` inlined the credit dimension union (`credit_cost` vs graduated `tiers`) once per branch of the outer item union, so Speakeasy cloned the branch classes per occurrence (`UpdatePlanDimensionsUpsertLicense1–4`) and emitted one type alias above its own clone. Python evaluates the alias at import, so mypy fails with `used-before-def` and the run exits before our patch hooks.

The generator already exposes ORPC's `commonSchemas` for reusable components. This registers the dimension union and its tier object there so the spec emits a single `$ref` everywhere instead of inline copies. The dimension `match` map differs between input (string, number or boolean) and output (transformed to string), so the union is registered twice: `CreditDimension` for request bodies and `CreditDimensionResponse` for responses. ORPC only shares one component across both when the two renderings are identical.

Verified with `speakeasy run -t autumn-python` on the regenerated stripped spec:
- Without this change: exit 1, `updateplan_response.py:2004` and `:2012` `used-before-def`.
- With it: exit 0; `updateplan_response.py` has no `Dimensions*` clones, and the shared classes are generated once (`creditdimension_union.py`, `creditdimensionresponse_union.py`, `credittier.py`).

Generated specs and SDKs are not committed here; `bun api` regenerates them at release as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `bun api` failing in Python SDK generation by sharing credit dimension schemas as reusable OpenAPI components. The spec now emits a single `$ref` for the credit dimension union and its tier object instead of inlining copies per branch, which caused `used-before-def` errors in generated Python.

- Registers the union twice: `CreditDimension` for request bodies and `CreditDimensionResponse` for responses, since the `match` map differs between input and output.
- Generated specs and SDKs are not committed; `bun api` regenerates them at release as before.

<sup>Written for commit dc45273d5d7296b8981e41f81a7205da2233beaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes Python SDK generation by publishing credit-dimension schemas as reusable OpenAPI components rather than repeatedly inlining their unions.

## Key changes
- **[Bug fixes] [Improvements]** Registers separate reusable credit-dimension components for request and response rendering.
- **[Improvements] [API changes]** Registers graduated credit tiers as a shared OpenAPI component.
- **[Bug fixes]** Allows generated SDK models to reference shared schemas, avoiding duplicate Python classes and import-order errors.

No actionable issues were identified.

The SDK-delivery documentation confirms that OpenAPI generation is the shared source for TypeScript and Python clients and that both generation paths must remain successful.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; it deduplicates existing schema representations without changing their validation or API shape.

The registered components use the same schema instances already embedded in plan feature overrides, their input and output distinctions are handled explicitly, and no naming collision or contract mismatch was found.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/openapi/latest/openapi.ts | Registers existing credit-dimension and tier schemas as reusable OpenAPI components for stable SDK generation. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Z[Credit schemas] --> G[OpenAPI generator]
  G --> DI[CreditDimension input component]
  G --> DO[CreditDimensionResponse output component]
  G --> T[CreditTier component]
  P[Plan feature overrides] --> DI
  P --> DO
  DI --> T
  DO --> T
  DI --> S[Generated SDK models]
  DO --> S
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Share credit dimension schemas as OpenAP..."](https://github.com/useautumn/autumn/commit/dc45273d5d7296b8981e41f81a7205da2233beaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62232794)</sub>

**Context used:**

- Knowledge Base — [SDKs and API contract delivery](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/sdk-and-api-contract-delivery.md)

<!-- /greptile_comment -->