### PR TITLE
Auto-advance invoice-mode draft invoices for one-off products

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -106,6 +106,9 @@ export const createInvoiceForBilling = async ({
 			? undefined
 			: billingContextToCurrency({ org: ctx.org, billingContext }),
 		collectionMethod,
+		// Invoice mode drafts: let Stripe auto-finalize and email the invoice
+		// (~1 hour after creation), matching subscription-generated drafts.
+		autoAdvance: isInvoiceMode,
 		daysUntilDue: invoiceMode?.daysUntilDue,
 		paymentMethodTypes: invoiceMode?.paymentMethodTypes,
 		footer: invoiceMode?.footer,

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps.ts
@@ -15,6 +15,7 @@ type CreateInvoiceParams = {
 	currency?: string;
 	discounts?: Stripe.InvoiceCreateParams["discounts"];
 	collectionMethod?: "charge_automatically" | "send_invoice";
+	autoAdvance?: boolean;
 	daysUntilDue?: number;
 	paymentMethodTypes?: InvoicePaymentMethod[];
 	description?: string;
@@ -30,6 +31,7 @@ export const createStripeInvoice = async ({
 	stripeSubId,
 	currency,
 	collectionMethod = "charge_automatically",
+	autoAdvance = false,
 	daysUntilDue,
 	paymentMethodTypes,
 	description,
@@ -44,7 +46,7 @@ export const createStripeInvoice = async ({
 	const invoice = await stripeCli.invoices.create(
 		{
 			customer: stripeCusId,
-			auto_advance: false,
+			auto_advance: autoAdvance,
 			...(stripeSubId ? { subscription: stripeSubId } : {}),
 			...(currency ? { currency } : {}),
 			...(description ? { description } : {}),


### PR DESCRIPTION
## Summary

Reported by AthenaHQ: clicking "Draft and edit in Stripe" for a one-off add-on (e.g. "Credits Add-on One Time") left the invoice sitting in draft forever, while the same button on a subscription plan produced an invoice that Stripe finalized and sent about an hour later.

**Cause:** subscription invoices are created by Stripe with `auto_advance` on by default, so Stripe finalizes and emails them after ~1 hour. One-off invoices are created by Autumn in `createInvoiceForBilling` with `auto_advance: false`, so Stripe never touches them.

**Fix:** `createStripeInvoice` now accepts an `autoAdvance` flag, and `createInvoiceForBilling` sets it to `true` whenever the billing context is in invoice mode. Behavior is now the same for one-offs and subscriptions:

- `finalize: true` → finalized immediately with auto-advance on, Stripe emails it right away.
- `finalize: false` → stays in draft for ~1 hour so it can be edited, then Stripe finalizes and emails it.

The card-charging path (`charge_automatically`) is unchanged and still passes `false`.

## Testing

- `bun ts` in `server/` passes.
- Biome check on the two touched files passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oL885ZZh96r3Hm2ZUxHrY

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes Stripe invoice creation behavior to configure whether draft invoices automatically advance.

**Key changes**
- **Bug fixes:** Adds an `autoAdvance` option to the shared Stripe invoice-creation helper.
- **Improvements:** Passes an explicit `auto_advance` value to Stripe when creating invoices.
- **Bug fixes:** Attempts to align standalone invoice-mode behavior with subscription-generated invoices, but currently also auto-advances drafts whose finalization was explicitly deferred.

</details>


<h3>Confidence Score: 4/5</h3>

The PR is not safe to merge because invoice-mode drafts can still be finalized and emailed by Stripe without the merchant explicitly finalizing them.

The new creation setting enables Stripe auto-advance whenever invoice mode is present, even when `finalizeInvoice` is false, defeating the manual-review workflow the PR is intended to protect. The previous invoice-lifecycle testing finding also remains outstanding because no assertion was added for the new `auto_advance` behavior.

**Files Needing Attention:** server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts | Enables auto-advance for all invoice-mode drafts, including drafts explicitly configured not to finalize. |
| server/src/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps.ts | Adds optional plumbing for Stripe's `auto_advance` creation parameter while retaining a safe false default. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App as Autumn
    participant Stripe
    participant Merchant
    App->>Stripe: "Create invoice-mode invoice (auto_advance=true)"
    Stripe-->>App: Return draft invoice
    App-->>Merchant: Report draft for editing
    Stripe->>Stripe: Automatically finalize later
    Stripe-->>Merchant: Email invoice without explicit finalization
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts:109-111
**Drafts Automatically Finalize**

Setting `autoAdvance` for every invoice-mode invoice ignores `finalizeInvoice: false`, which is also the default. For example, a merchant choosing “Draft and edit in Stripe” for a one-off purchase receives a draft initially, but Stripe can automatically finalize and email it about an hour later without approval. Only enable auto-advance when finalization was requested.

```suggestion
		// Finalized invoice-mode invoices should let Stripe send the invoice.
		autoAdvance: isInvoiceMode && shouldFinalizeInvoice,
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["Auto-advance invoice-mode draft invoices..."](https://github.com/useautumn/autumn/commit/b0bae3cf6386eab30274aa07680602c53296df46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62708383)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)

<!-- /greptile_comment -->