### PR TITLE
perf: monthly event rollups for bin_size=month

### DIFF
--- a/server/src/external/autumn/autumnCli.ts
+++ b/server/src/external/autumn/autumnCli.ts
@@ -1007,6 +1007,7 @@ export class AutumnInt {
 			feature_id?: string | string[];
 			group_by?: string;
 			range?: string;
+			custom_range?: { start: number; end: number };
 			bin_size?: string;
 			max_groups?: number;
 			aggregate_on?: "deducted";

--- a/server/src/external/tinybird/pipes/aggregateGroupablePipe.ts
+++ b/server/src/external/tinybird/pipes/aggregateGroupablePipe.ts
@@ -47,6 +47,9 @@ export const aggregateGroupablePipeParamsSchema = z.object({
 	filter_value_4: z.string().optional(),
 	max_groups: z.number().int().min(1).max(250).optional(),
 	use_daily_rollup: z.enum(["0", "1"]).optional(),
+	// UTC month bins over a window with at least one complete calendar month:
+	// complete months come from the monthly rollups, the partial edges stay hourly.
+	use_monthly_rollup: z.enum(["0", "1"]).optional(),
 	use_org_dimension_rollup: z.enum(["0", "1"]).optional(),
 	use_org_property_rollup: z.enum(["0", "1"]).optional(),
 	// "1" forces the ungated events_hourly_mv path when the property key is

--- a/server/src/external/tinybird/pipes/aggregateSimplePipe.ts
+++ b/server/src/external/tinybird/pipes/aggregateSimplePipe.ts
@@ -33,6 +33,9 @@ export const aggregateSimplePipeParamsSchema = z.object({
 	filter_value_3: z.string().optional(),
 	filter_key_4: z.string().optional(),
 	filter_value_4: z.string().optional(),
+	// UTC month bins over a window with at least one complete calendar month:
+	// complete months come from events_customer_monthly_mv, the edges stay hourly.
+	use_monthly_rollup: z.enum(["0", "1"]).optional(),
 });
 
 export type AggregateSimplePipeParams = z.infer<

--- a/server/src/internal/analytics/actions/aggregate.ts
+++ b/server/src/internal/analytics/actions/aggregate.ts
@@ -26,6 +26,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { validatePropertyPathForJSON } from "@/internal/analytics/actions/eventValidationUtils.js";
 import { getBillingCycleStartDate } from "../analyticsUtils.js";
 import {
+	shouldUseMonthlyRollup,
 	shouldUseOrgDimensionRollup,
 	shouldUseOrgPropertyRollup,
 	shouldUsePropertyDailyRollup,
@@ -481,6 +482,13 @@ export const aggregate = async ({
 			startDate,
 			timezone,
 		});
+		const useMonthlyRollup = shouldUseMonthlyRollup({
+			binSize,
+			endDate,
+			hasPropertyFilters: Object.keys(filterParams).length > 0,
+			startDate,
+			timezone,
+		});
 
 		const pipeParams = {
 			org_id: org.id,
@@ -497,6 +505,7 @@ export const aggregate = async ({
 			...filterParams,
 			max_groups: params.max_groups,
 			use_daily_rollup: useDailyRollup ? ("1" as const) : undefined,
+			use_monthly_rollup: useMonthlyRollup ? ("1" as const) : undefined,
 			use_org_dimension_rollup: useOrgDimensionRollup
 				? ("1" as const)
 				: undefined,
@@ -576,6 +585,7 @@ export const aggregate = async ({
 		});
 	} else {
 		// Use aggregate_simple pipe for ungrouped queries
+		const filterParams = buildFilterParams({ filter_by: params.filter_by });
 		const pipeParams = {
 			org_id: org.id,
 			env,
@@ -586,7 +596,16 @@ export const aggregate = async ({
 			timezone,
 			customer_id: params.aggregateAll ? undefined : params.customer_id,
 			entity_id: params.entity_id,
-			...buildFilterParams({ filter_by: params.filter_by }),
+			...filterParams,
+			use_monthly_rollup: shouldUseMonthlyRollup({
+				binSize,
+				endDate,
+				hasPropertyFilters: Object.keys(filterParams).length > 0,
+				startDate,
+				timezone,
+			})
+				? ("1" as const)
+				: undefined,
 		};
 
 		const result = await pipes.aggregateSimple(pipeParams);

--- a/server/src/internal/analytics/actions/dailyRollupRouting.ts
+++ b/server/src/internal/analytics/actions/dailyRollupRouting.ts
@@ -79,6 +79,60 @@ export const hasCompleteUtcDay = ({
 	return firstFullDay < endDay;
 };
 
+const startOfUtcMonth = ({ timestamp }: { timestamp: number }): number => {
+	const date = new Date(timestamp);
+	return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1);
+};
+
+const startOfNextUtcMonth = ({ timestamp }: { timestamp: number }): number => {
+	const date = new Date(timestamp);
+	return Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 1);
+};
+
+export const hasCompleteUtcMonth = ({
+	startDate,
+	endDate,
+}: {
+	startDate: string;
+	endDate: string;
+}): boolean => {
+	const startTimestamp = parseUtcTimestamp({ value: startDate });
+	const endTimestamp = parseUtcTimestamp({ value: endDate });
+	if (!Number.isFinite(startTimestamp) || !Number.isFinite(endTimestamp)) {
+		return false;
+	}
+
+	const monthStart = startOfUtcMonth({ timestamp: startTimestamp });
+	const firstFullMonth =
+		startTimestamp === monthStart
+			? monthStart
+			: startOfNextUtcMonth({ timestamp: startTimestamp });
+
+	return firstFullMonth < startOfUtcMonth({ timestamp: endTimestamp });
+};
+
+/**
+ * Monthly rollups are keyed on UTC month starts, so a non-UTC viewer's months
+ * never line up with them and keep the hourly path.
+ */
+export const shouldUseMonthlyRollup = ({
+	binSize,
+	endDate,
+	hasPropertyFilters,
+	startDate,
+	timezone,
+}: {
+	binSize: string;
+	endDate: string;
+	hasPropertyFilters: boolean;
+	startDate: string;
+	timezone: string;
+}): boolean =>
+	binSize === "month" &&
+	timezone === "UTC" &&
+	!hasPropertyFilters &&
+	hasCompleteUtcMonth({ startDate, endDate });
+
 export const shouldUsePropertyDailyRollup = ({
 	binSize,
 	endDate,

--- a/server/tests/integration/analytics/aggregate/monthly-bin-rollup.test.ts
+++ b/server/tests/integration/analytics/aggregate/monthly-bin-rollup.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Contract for bin_size="month" over a window whose ends are partial months: the complete
+ * calendar months inside it are served from the monthly rollups, the partial months at
+ * either end from the hourly rollups, and the two never overlap or leave a gap.
+ *
+ * Covered:
+ *   - mixed-resolution window (Jun 15 -> Aug 10): one bin per calendar month, each exact,
+ *     including events in the first and last hour of every month seam
+ *   - a window with no complete month stays on the hourly path and is still exact
+ *   - group_by on a property: per-month, per-group values reconcile
+ *   - the day-bin control over the same window reports the same total, so the
+ *     monthly-plus-edges union matches the path it replaces
+ *
+ * Bins are asserted in period order, ignoring empty ones: the API derives `period` by
+ * parsing the pipe's UTC wall-clock label in the server's local zone
+ * (convertPeriodsToEpoch, and generateAllPeriods for the zero-filled grid), so on a
+ * non-UTC server the epoch shifts by that offset and the grid can carry a spurious empty
+ * leading bin. Only the order and the non-empty values are zone-independent.
+ */
+
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const EVENT_INGEST_TIMEOUT_MS = 40_000;
+const POLL_INTERVAL_MS = 3_000;
+
+const WINDOW_START = Date.UTC(2026, 5, 15, 12);
+const WINDOW_END = Date.UTC(2026, 7, 10, 9);
+const AUGUST_START = Date.UTC(2026, 7, 1);
+
+// Every event sits on an exact hour: the rollups filter on the hour bucket, so a sub-hour
+// boundary would make the window's first bucket ambiguous for reasons unrelated to months.
+// The seam hours (Jul 1 00:00, Jul 31 23:00, Aug 1 00:00) are the rows that would double
+// count or vanish if the monthly interior and the hourly edges overlapped.
+const EVENTS = [
+	{ at: Date.UTC(2026, 5, 15, 12), value: 5, region: "us" },
+	{ at: Date.UTC(2026, 5, 30, 23), value: 7, region: "eu" },
+	{ at: Date.UTC(2026, 6, 1, 0), value: 11, region: "us" },
+	{ at: Date.UTC(2026, 6, 20, 10), value: 13, region: "us" },
+	{ at: Date.UTC(2026, 6, 31, 23), value: 17, region: "eu" },
+	{ at: Date.UTC(2026, 7, 1, 0), value: 19, region: "us" },
+	{ at: Date.UTC(2026, 7, 10, 8), value: 23, region: "eu" },
+];
+
+const JUNE = { total: 12, us: 5, eu: 7 };
+const JULY = { total: 41, us: 24, eu: 17 };
+const AUGUST = { total: 42, us: 19, eu: 23 };
+const WINDOW_TOTAL = JUNE.total + JULY.total + AUGUST.total;
+
+type AggregateResponse = {
+	list: {
+		period: number;
+		values: Record<string, number>;
+		grouped_values?: Record<string, Record<string, number>>;
+	}[];
+	total: Record<string, { count: number; sum: number }>;
+};
+
+/** One entry per bin that carries data, oldest first, collapsing rows that share a period. */
+const binsInOrder = (
+	response: AggregateResponse,
+): { value: number; groups: Record<string, number> }[] => {
+	const byPeriod = new Map<
+		number,
+		{ value: number; groups: Record<string, number> }
+	>();
+	for (const row of response.list) {
+		const bin = byPeriod.get(row.period) ?? { value: 0, groups: {} };
+		bin.value += row.values[TestFeature.Messages] ?? 0;
+		for (const [group, value] of Object.entries(
+			row.grouped_values?.[TestFeature.Messages] ?? {},
+		)) {
+			bin.groups[group] = (bin.groups[group] ?? 0) + value;
+		}
+		byPeriod.set(row.period, bin);
+	}
+	return [...byPeriod.entries()]
+		.sort(([a], [b]) => a - b)
+		.map(([, bin]) => bin)
+		.filter((bin) => bin.value !== 0);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("aggregate monthly bins: complete months come from the monthly rollup, partial months from the hourly edges")}`,
+	async () => {
+		// Unique per run: tracked events persist in Tinybird across runs (deleting the
+		// customer doesn't purge them), so a reused id double-counts every sum below.
+		const customerId = `aggregate-monthly-bins-${Date.now()}`;
+		const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+		const freeProd = products.base({ id: "free", items: [messagesItem] });
+
+		const { autumnV2_4 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd], prefix: customerId }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
+
+		for (const event of EVENTS) {
+			await autumnV2_4.track({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: event.value,
+				timestamp: event.at,
+				properties: { region: event.region },
+			});
+		}
+
+		// Events reach Tinybird via async batching, so poll on the ungated totals before
+		// asserting anything — otherwise a slow ingest reads as a routing bug.
+		const deadline = Date.now() + EVENT_INGEST_TIMEOUT_MS;
+		let monthly: AggregateResponse;
+		do {
+			await timeout(POLL_INTERVAL_MS);
+			monthly = (await autumnV2_4.events.aggregate({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				custom_range: { start: WINDOW_START, end: WINDOW_END },
+				bin_size: "month",
+			})) as AggregateResponse;
+		} while (
+			Date.now() < deadline &&
+			monthly.total[TestFeature.Messages]?.sum !== WINDOW_TOTAL
+		);
+
+		// ── Mixed-resolution window: one bin per calendar month, each exact ──────────
+		expect(monthly.total[TestFeature.Messages]?.count).toBe(EVENTS.length);
+		expect(monthly.total[TestFeature.Messages]?.sum).toBe(WINDOW_TOTAL);
+
+		// June and August are partial (hourly edges); July is whole (monthly rollup).
+		expect(binsInOrder(monthly).map((bin) => bin.value)).toEqual([
+			JUNE.total,
+			JULY.total,
+			AUGUST.total,
+		]);
+
+		// ── A window with no complete month keeps the hourly path ───────────────────
+		const augustOnly = (await autumnV2_4.events.aggregate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			custom_range: { start: AUGUST_START, end: WINDOW_END },
+			bin_size: "month",
+		})) as AggregateResponse;
+
+		expect(augustOnly.total[TestFeature.Messages]?.sum).toBe(AUGUST.total);
+		expect(binsInOrder(augustOnly).map((bin) => bin.value)).toEqual([
+			AUGUST.total,
+		]);
+
+		// ── Grouped monthly: per-month, per-group values reconcile ──────────────────
+		const grouped = (await autumnV2_4.events.aggregate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			group_by: "properties.region",
+			custom_range: { start: WINDOW_START, end: WINDOW_END },
+			bin_size: "month",
+		})) as AggregateResponse;
+
+		expect(
+			binsInOrder(grouped).map((bin) => ({
+				us: bin.groups.us ?? 0,
+				eu: bin.groups.eu ?? 0,
+			})),
+		).toEqual([
+			{ us: JUNE.us, eu: JUNE.eu },
+			{ us: JULY.us, eu: JULY.eu },
+			{ us: AUGUST.us, eu: AUGUST.eu },
+		]);
+
+		// ── Parity with the path the monthly rollup replaces ────────────────────────
+		const daily = (await autumnV2_4.events.aggregate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			custom_range: { start: WINDOW_START, end: WINDOW_END },
+			bin_size: "day",
+		})) as AggregateResponse;
+
+		const dailySum = binsInOrder(daily).reduce(
+			(sum, bin) => sum + bin.value,
+			0,
+		);
+		expect(dailySum).toBe(WINDOW_TOTAL);
+		expect(daily.total[TestFeature.Messages]?.sum).toBe(WINDOW_TOTAL);
+	},
+);

--- a/server/tests/unit/analytics/monthly-rollup-routing.test.ts
+++ b/server/tests/unit/analytics/monthly-rollup-routing.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Contract: UTC month bins read the monthly rollups only for the complete calendar months inside
+ * the window, so a window without one stays entirely on the finer-grained path.
+ */
+import { expect, test } from "bun:test";
+import {
+	hasCompleteUtcMonth,
+	shouldUseMonthlyRollup,
+} from "@/internal/analytics/actions/dailyRollupRouting.js";
+
+test("monthly rollups: detect a complete UTC month inside the window", () => {
+	// Tanvir's Jan 15 -> Mar 10 case: February is whole, January and March are edges.
+	expect(
+		hasCompleteUtcMonth({
+			startDate: "2026-01-15 12:00:00",
+			endDate: "2026-03-10 09:00:00",
+		}),
+	).toBe(true);
+
+	// Exact month boundaries on both ends: January and February are both whole.
+	expect(
+		hasCompleteUtcMonth({
+			startDate: "2026-01-01 00:00:00",
+			endDate: "2026-03-01T00:00:00",
+		}),
+	).toBe(true);
+
+	// Leap February is whole.
+	expect(
+		hasCompleteUtcMonth({
+			startDate: "2028-02-01 00:00:00",
+			endDate: "2028-03-01 00:00:00",
+		}),
+	).toBe(true);
+
+	// December is whole across the year rollover.
+	expect(
+		hasCompleteUtcMonth({
+			startDate: "2025-11-20 00:00:00",
+			endDate: "2026-01-05 00:00:00",
+		}),
+	).toBe(true);
+});
+
+test("monthly rollups: a window with no complete UTC month has nothing to read", () => {
+	// One partial month.
+	expect(
+		hasCompleteUtcMonth({
+			startDate: "2026-01-15 12:00:00",
+			endDate: "2026-01-28 12:00:00",
+		}),
+	).toBe(false);
+
+	// Two partial months, no whole one between them.
+	expect(
+		hasCompleteUtcMonth({
+			startDate: "2026-01-15 00:00:00",
+			endDate: "2026-02-10 00:00:00",
+		}),
+	).toBe(false);
+
+	// A whole calendar month that never reaches the next month start.
+	expect(
+		hasCompleteUtcMonth({
+			startDate: "2026-01-01 00:00:00",
+			endDate: "2026-01-31 23:59:59",
+		}),
+	).toBe(false);
+
+	expect(
+		hasCompleteUtcMonth({ startDate: "not-a-date", endDate: "2026-03-01" }),
+	).toBe(false);
+});
+
+test("monthly rollups: route only UTC month bins with no property filters", () => {
+	const base = {
+		binSize: "month",
+		endDate: "2026-03-10 09:00:00",
+		hasPropertyFilters: false,
+		startDate: "2026-01-15 12:00:00",
+		timezone: "UTC",
+	};
+
+	expect(shouldUseMonthlyRollup(base)).toBe(true);
+
+	for (const binSize of ["hour", "day", "week"]) {
+		expect(shouldUseMonthlyRollup({ ...base, binSize })).toBe(false);
+	}
+	// A non-UTC month starts mid-UTC-day, so the monthly states never line up.
+	expect(
+		shouldUseMonthlyRollup({ ...base, timezone: "America/New_York" }),
+	).toBe(false);
+	expect(shouldUseMonthlyRollup({ ...base, hasPropertyFilters: true })).toBe(
+		false,
+	);
+	expect(
+		shouldUseMonthlyRollup({ ...base, endDate: "2026-01-28 12:00:00" }),
+	).toBe(false);
+});

--- a/server/tinybird/materializations/events_customer_monthly_mv.datasource
+++ b/server/tinybird/materializations/events_customer_monthly_mv.datasource
@@ -1,0 +1,19 @@
+DESCRIPTION >
+    Customer-scoped UTC monthly total states over events_customer_hourly_mv. Serves the complete
+    months of a bin_size=month window, with the partial months at either end read hourly. Keeps
+    internal_product_id (unlike events_customer_daily_mv) so plan_id grouping can read it.
+
+SCHEMA >
+    `org_id` String,
+    `env` String,
+    `customer_id` String,
+    `entity_id` String DEFAULT '',
+    `event_name` String,
+    `internal_product_id` String DEFAULT '',
+    `month` DateTime,
+    `total_value` AggregateFunction(sum, Float64),
+    `event_count` AggregateFunction(sum, UInt64)
+
+ENGINE "AggregatingMergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(month)"
+ENGINE_SORTING_KEY "org_id, env, customer_id, entity_id, event_name, month, internal_product_id"

--- a/server/tinybird/materializations/events_customer_monthly_mv_pipe.pipe
+++ b/server/tinybird/materializations/events_customer_monthly_mv_pipe.pipe
@@ -1,0 +1,21 @@
+DESCRIPTION >
+    Collapses the customer-leading hourly rollup into mergeable UTC monthly states, keeping
+    internal_product_id so plan grouping reconciles with events_customer_hourly_mv.
+
+NODE materialize
+SQL >
+    SELECT
+        org_id,
+        env,
+        customer_id,
+        entity_id,
+        event_name,
+        coalesce(internal_product_id, '') as internal_product_id,
+        toDateTime(toStartOfMonth(hour)) as month,
+        sumState(total_value) as total_value,
+        sumState(event_count) as event_count
+    FROM events_customer_hourly_mv
+    GROUP BY org_id, env, customer_id, entity_id, event_name, internal_product_id, month
+
+TYPE materialized
+DATASOURCE events_customer_monthly_mv

--- a/server/tinybird/materializations/events_org_dimension_monthly_mv.datasource
+++ b/server/tinybird/materializations/events_org_dimension_monthly_mv.datasource
@@ -1,0 +1,18 @@
+DESCRIPTION >
+    Org-level UTC monthly states for customer, entity, and plan grouping, collapsed from
+    events_org_dimension_hourly_mv. Serves the complete months of an org-wide bin_size=month
+    window; the partial months at either end stay on the hourly rollup.
+
+SCHEMA >
+    `org_id` String,
+    `env` String,
+    `event_name` String,
+    `dimension` String,
+    `group_value` String,
+    `month` DateTime,
+    `total_value` AggregateFunction(sum, Float64),
+    `event_count` AggregateFunction(sum, UInt64)
+
+ENGINE "AggregatingMergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(month)"
+ENGINE_SORTING_KEY "org_id, env, dimension, event_name, month, group_value"

--- a/server/tinybird/materializations/events_org_dimension_monthly_mv_pipe.pipe
+++ b/server/tinybird/materializations/events_org_dimension_monthly_mv_pipe.pipe
@@ -1,0 +1,19 @@
+DESCRIPTION >
+    Collapses the org-hour dimension states into mergeable UTC monthly states.
+
+NODE materialize
+SQL >
+    SELECT
+        org_id,
+        env,
+        event_name,
+        dimension,
+        group_value,
+        toDateTime(toStartOfMonth(hour)) as month,
+        sumMergeState(total_value) as total_value,
+        sumMergeState(event_count) as event_count
+    FROM events_org_dimension_hourly_mv
+    GROUP BY org_id, env, event_name, dimension, group_value, month
+
+TYPE materialized
+DATASOURCE events_org_dimension_monthly_mv

--- a/server/tinybird/materializations/events_org_property_monthly_mv.datasource
+++ b/server/tinybird/materializations/events_org_property_monthly_mv.datasource
@@ -1,0 +1,18 @@
+DESCRIPTION >
+    Org-level UTC monthly property states for aggregate-all group-bys, collapsed from
+    events_org_property_hourly_mv. Customer and entity dimensions are dropped, so an org-wide
+    property group-by over complete months reads one row per property value and month.
+
+SCHEMA >
+    `org_id` String,
+    `env` String,
+    `event_name` String,
+    `property_key` String,
+    `property_value` String,
+    `month` DateTime,
+    `total_value` AggregateFunction(sum, Float64),
+    `event_count` AggregateFunction(sum, UInt64)
+
+ENGINE "AggregatingMergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(month)"
+ENGINE_SORTING_KEY "org_id, env, property_key, event_name, month, property_value"

--- a/server/tinybird/materializations/events_org_property_monthly_mv_pipe.pipe
+++ b/server/tinybird/materializations/events_org_property_monthly_mv_pipe.pipe
@@ -1,0 +1,19 @@
+DESCRIPTION >
+    Collapses the org-hour property states into mergeable UTC monthly states.
+
+NODE materialize
+SQL >
+    SELECT
+        org_id,
+        env,
+        event_name,
+        property_key,
+        property_value,
+        toDateTime(toStartOfMonth(hour)) as month,
+        sumMergeState(total_value) as total_value,
+        sumMergeState(event_count) as event_count
+    FROM events_org_property_hourly_mv
+    GROUP BY org_id, env, event_name, property_key, property_value, month
+
+TYPE materialized
+DATASOURCE events_org_property_monthly_mv

--- a/server/tinybird/materializations/events_property_monthly_mv.datasource
+++ b/server/tinybird/materializations/events_property_monthly_mv.datasource
@@ -1,0 +1,20 @@
+DESCRIPTION >
+    UTC monthly aggregate states for unfiltered property group-bys, collapsed from the gated
+    events_property_mv. Preserves customer and entity dimensions for scoped queries; reads only
+    the gated hourly rollup, so it cannot carry any value the value-shape gate dropped.
+
+SCHEMA >
+    `org_id` String,
+    `env` String,
+    `customer_id` String,
+    `entity_id` String DEFAULT '',
+    `event_name` String,
+    `property_key` String,
+    `property_value` String,
+    `month` DateTime,
+    `total_value` AggregateFunction(sum, Float64),
+    `event_count` AggregateFunction(sum, UInt64)
+
+ENGINE "AggregatingMergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(month)"
+ENGINE_SORTING_KEY "org_id, env, property_key, customer_id, entity_id, event_name, month, property_value"

--- a/server/tinybird/materializations/events_property_monthly_mv_pipe.pipe
+++ b/server/tinybird/materializations/events_property_monthly_mv_pipe.pipe
@@ -1,0 +1,21 @@
+DESCRIPTION >
+    Collapses the gated hourly property rollup into mergeable UTC monthly states.
+
+NODE materialize
+SQL >
+    SELECT
+        org_id,
+        env,
+        customer_id,
+        entity_id,
+        event_name,
+        property_key,
+        property_value,
+        toDateTime(toStartOfMonth(hour)) as month,
+        sumState(total_value) as total_value,
+        sumState(event_count) as event_count
+    FROM events_property_mv
+    GROUP BY org_id, env, customer_id, entity_id, event_name, property_key, property_value, month
+
+TYPE materialized
+DATASOURCE events_property_monthly_mv

--- a/server/tinybird/pipes/aggregate_groupable.pipe
+++ b/server/tinybird/pipes/aggregate_groupable.pipe
@@ -2,11 +2,17 @@ DESCRIPTION >
     Aggregate queries with grouping by a property key, customer_id, or entity_id.
     Routes to the smallest viable MV for the query shape:
       - events_customer_hourly_mv:           customer/entity/plan grouping with no property filters
+      - events_customer_monthly_mv:          opted-in UTC customer/entity/plan grouping at month bins
       - events_org_dimension_hourly_mv:      org-wide customer/entity/plan grouping
+      - events_org_dimension_monthly_mv:     opted-in UTC org-wide dimension grouping at month bins
       - events_org_property_hourly_mv:       org-wide unfiltered property grouping
+      - events_org_property_monthly_mv:      opted-in UTC org-wide property grouping at month bins
       - events_property_mv:                  unfiltered hourly or non-UTC property grouping
       - events_property_daily_mv:            opted-in UTC property grouping at day-or-coarser bins
+      - events_property_monthly_mv:          opted-in UTC property grouping at month bins
       - events_hourly_mv:                    arbitrary properties or filtered queries
+    Every monthly branch reads complete UTC months from the monthly rollup and the partial months at
+    either end from that branch's hourly rollup, so a partial-month edge stays exact.
     Uses PER-BIN TOP N groups + "AUTUMN_RESERVED" bucket ((N+1) max total per bin).
     N is controlled by the max_groups parameter (default 9).
     Returns unpivoted data: (period, event_name, group_value, total_value, _truncated)
@@ -27,9 +33,71 @@ SQL >
     {% set use_property_rollup = (String(group_column, 'property') == 'property') and no_property_filters and not skip_rollup %}
     {% set read_org_dimension_rollup = use_no_props and defined(use_org_dimension_rollup) and String(use_org_dimension_rollup, '0') == '1' and (not defined(customer_id) or String(customer_id, '') == '') and (not defined(entity_id) or String(entity_id, '') == '') %}
     {% set read_org_property_rollup = use_property_rollup and defined(use_org_property_rollup) and String(use_org_property_rollup, '0') == '1' %}
-    {% set use_daily_property_rollup = use_property_rollup and not read_org_property_rollup and defined(use_daily_rollup) and String(use_daily_rollup, '0') == '1' %}
+    {# use_monthly_rollup: server-set, UTC month bins over a window containing at least one complete
+       calendar month. Takes precedence over the daily property rollup for the same query shape. #}
+    {% set monthly_requested = defined(use_monthly_rollup) and String(use_monthly_rollup, '0') == '1' %}
+    {% set read_org_dimension_monthly = read_org_dimension_rollup and monthly_requested %}
+    {% set read_org_property_monthly = read_org_property_rollup and monthly_requested %}
+    {% set read_property_monthly = use_property_rollup and not read_org_property_rollup and monthly_requested %}
+    {% set read_customer_monthly = use_no_props and not read_org_dimension_rollup and monthly_requested %}
+    {% set use_daily_property_rollup = use_property_rollup and not read_org_property_rollup and not read_property_monthly and defined(use_daily_rollup) and String(use_daily_rollup, '0') == '1' %}
 
-    {% if read_org_dimension_rollup %}
+    {% if read_org_dimension_monthly %}
+    SELECT
+        period,
+        event_name,
+        group_value,
+        sum(total_value_value) as total_value,
+        sum(event_count_value) as event_count
+    FROM (
+        SELECT
+            formatDateTime(month, '%F %T') as period,
+            event_name,
+            group_value,
+            sumMerge(total_value) as total_value_value,
+            sumMerge(event_count) as event_count_value
+        FROM events_org_dimension_monthly_mv
+        WHERE
+            org_id = {{ String(org_id, '') }}
+            AND env = {{ String(env, 'test') }}
+            AND dimension = {{ String(group_column, 'customer_id') }}
+            AND event_name IN {{ Array(event_names, 'String', default='[]') }}
+            AND month >= if(
+                toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}) = toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                toDateTime(addMonths(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})), 1))
+            )
+            AND month < toDateTime(toStartOfMonth(toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})))
+        GROUP BY period, event_name, group_value
+
+        UNION ALL
+
+        SELECT
+            formatDateTime(toStartOfMonth(hour, {{ String(timezone, 'UTC') }}), '%F %T') as period,
+            event_name,
+            group_value,
+            sumMerge(total_value) as total_value_value,
+            sumMerge(event_count) as event_count_value
+        FROM events_org_dimension_hourly_mv
+        WHERE
+            org_id = {{ String(org_id, '') }}
+            AND env = {{ String(env, 'test') }}
+            AND dimension = {{ String(group_column, 'customer_id') }}
+            AND event_name IN {{ Array(event_names, 'String', default='[]') }}
+            AND hour >= toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})
+            AND hour <= toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})
+            AND (
+                hour < if(
+                    toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}) = toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                    toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                    toDateTime(addMonths(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})), 1))
+                )
+                OR hour >= toDateTime(toStartOfMonth(toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})))
+            )
+        GROUP BY period, event_name, group_value
+    )
+    GROUP BY period, event_name, group_value
+    {% elif read_org_dimension_rollup %}
     SELECT
         {% if String(bin_size, 'day') == 'hour' %}
         formatDateTime(hour, '%F %T') as period,
@@ -52,6 +120,63 @@ SQL >
         AND event_name IN {{ Array(event_names, 'String', default='[]') }}
         AND hour >= toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})
         AND hour <= toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})
+    GROUP BY period, event_name, group_value
+    {% elif read_org_property_monthly %}
+    SELECT
+        period,
+        event_name,
+        group_value,
+        sum(total_value_value) as total_value,
+        sum(event_count_value) as event_count
+    FROM (
+        SELECT
+            formatDateTime(month, '%F %T') as period,
+            event_name,
+            property_value as group_value,
+            sumMerge(total_value) as total_value_value,
+            sumMerge(event_count) as event_count_value
+        FROM events_org_property_monthly_mv
+        WHERE
+            org_id = {{ String(org_id, '') }}
+            AND env = {{ String(env, 'test') }}
+            AND event_name IN {{ Array(event_names, 'String', default='[]') }}
+            AND property_key = {{ String(property_key, '') }}
+            AND property_value != ''
+            AND month >= if(
+                toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}) = toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                toDateTime(addMonths(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})), 1))
+            )
+            AND month < toDateTime(toStartOfMonth(toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})))
+        GROUP BY period, event_name, group_value
+
+        UNION ALL
+
+        SELECT
+            formatDateTime(toStartOfMonth(hour, {{ String(timezone, 'UTC') }}), '%F %T') as period,
+            event_name,
+            property_value as group_value,
+            sumMerge(total_value) as total_value_value,
+            sumMerge(event_count) as event_count_value
+        FROM events_org_property_hourly_mv
+        WHERE
+            org_id = {{ String(org_id, '') }}
+            AND env = {{ String(env, 'test') }}
+            AND event_name IN {{ Array(event_names, 'String', default='[]') }}
+            AND property_key = {{ String(property_key, '') }}
+            AND property_value != ''
+            AND hour >= toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})
+            AND hour <= toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})
+            AND (
+                hour < if(
+                    toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}) = toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                    toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                    toDateTime(addMonths(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})), 1))
+                )
+                OR hour >= toDateTime(toStartOfMonth(toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})))
+            )
+        GROUP BY period, event_name, group_value
+    )
     GROUP BY period, event_name, group_value
     {% elif read_org_property_rollup %}
     SELECT
@@ -77,6 +202,75 @@ SQL >
         AND property_value != ''
         AND hour >= toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})
         AND hour <= toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})
+    GROUP BY period, event_name, group_value
+    {% elif read_property_monthly %}
+    SELECT
+        period,
+        event_name,
+        group_value,
+        sum(total_value_value) as total_value,
+        sum(event_count_value) as event_count
+    FROM (
+        SELECT
+            formatDateTime(month, '%F %T') as period,
+            event_name,
+            property_value as group_value,
+            sumMerge(total_value) as total_value_value,
+            sumMerge(event_count) as event_count_value
+        FROM events_property_monthly_mv
+        WHERE
+            org_id = {{ String(org_id, '') }}
+            AND env = {{ String(env, 'test') }}
+            AND event_name IN {{ Array(event_names, 'String', default='[]') }}
+            AND property_key = {{ String(property_key, '') }}
+            AND property_value != ''
+            AND month >= if(
+                toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}) = toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                toDateTime(addMonths(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})), 1))
+            )
+            AND month < toDateTime(toStartOfMonth(toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})))
+            {% if defined(customer_id) and String(customer_id, '') != '' %}
+            AND customer_id = {{ String(customer_id) }}
+            {% end %}
+            {% if defined(entity_id) and String(entity_id, '') != '' %}
+            AND entity_id = {{ String(entity_id) }}
+            {% end %}
+        GROUP BY period, event_name, group_value
+
+        UNION ALL
+
+        SELECT
+            formatDateTime(toStartOfMonth(hour, {{ String(timezone, 'UTC') }}), '%F %T') as period,
+            event_name,
+            property_value as group_value,
+            sum(total_value) as total_value_value,
+            sum(event_count) as event_count_value
+        FROM events_property_mv
+        WHERE
+            org_id = {{ String(org_id, '') }}
+            AND env = {{ String(env, 'test') }}
+            AND event_name IN {{ Array(event_names, 'String', default='[]') }}
+            AND property_key = {{ String(property_key, '') }}
+            AND property_value != ''
+            AND hour >= toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})
+            AND hour <= toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})
+            AND (
+                hour < if(
+                    toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}) = toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                    toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                    toDateTime(addMonths(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})), 1))
+                )
+                OR hour >= toDateTime(toStartOfMonth(toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})))
+            )
+            {% if defined(customer_id) and String(customer_id, '') != '' %}
+            AND customer_id = {{ String(customer_id) }}
+            {% end %}
+            {% if defined(entity_id) and String(entity_id, '') != '' %}
+            AND entity_id = {{ String(entity_id) }}
+            {% end %}
+        GROUP BY period, event_name, group_value
+    )
     GROUP BY period, event_name, group_value
     {% elif use_daily_property_rollup %}
     SELECT
@@ -156,6 +350,89 @@ SQL >
             AND entity_id = {{ String(entity_id) }}
             {% end %}
             AND property_value != ''
+        GROUP BY period, event_name, group_value
+    )
+    GROUP BY period, event_name, group_value
+    {% elif read_customer_monthly %}
+    SELECT
+        period,
+        event_name,
+        group_value,
+        sum(total_value_value) as total_value,
+        sum(event_count_value) as event_count
+    FROM (
+        SELECT
+            formatDateTime(month, '%F %T') as period,
+            event_name,
+            {% if String(group_column, 'property') == 'customer_id' %}
+            customer_id as group_value,
+            {% elif String(group_column, 'property') == 'entity_id' %}
+            entity_id as group_value,
+            {% else %}
+            internal_product_id as group_value,
+            {% end %}
+            sumMerge(total_value) as total_value_value,
+            sumMerge(event_count) as event_count_value
+        FROM events_customer_monthly_mv
+        WHERE
+            org_id = {{ String(org_id, '') }}
+            AND env = {{ String(env, 'test') }}
+            AND event_name IN {{ Array(event_names, 'String', default='[]') }}
+            AND month >= if(
+                toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}) = toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                toDateTime(addMonths(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})), 1))
+            )
+            AND month < toDateTime(toStartOfMonth(toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})))
+            {% if defined(customer_id) and String(customer_id, '') != '' %}
+            AND customer_id = {{ String(customer_id) }}
+            {% end %}
+            {% if defined(entity_id) and String(entity_id, '') != '' %}
+            AND entity_id = {{ String(entity_id) }}
+            {% end %}
+            {% if String(group_column, 'property') == 'entity_id' %}
+            AND entity_id != ''
+            {% end %}
+        GROUP BY period, event_name, group_value
+
+        UNION ALL
+
+        SELECT
+            formatDateTime(toStartOfMonth(hour, {{ String(timezone, 'UTC') }}), '%F %T') as period,
+            event_name,
+            {% if String(group_column, 'property') == 'customer_id' %}
+            customer_id as group_value,
+            {% elif String(group_column, 'property') == 'entity_id' %}
+            entity_id as group_value,
+            {% else %}
+            coalesce(internal_product_id, '') as group_value,
+            {% end %}
+            sum(total_value) as total_value_value,
+            sum(event_count) as event_count_value
+        FROM events_customer_hourly_mv
+        WHERE
+            org_id = {{ String(org_id, '') }}
+            AND env = {{ String(env, 'test') }}
+            AND event_name IN {{ Array(event_names, 'String', default='[]') }}
+            AND hour >= toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})
+            AND hour <= toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})
+            AND (
+                hour < if(
+                    toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}) = toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                    toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                    toDateTime(addMonths(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})), 1))
+                )
+                OR hour >= toDateTime(toStartOfMonth(toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})))
+            )
+            {% if defined(customer_id) and String(customer_id, '') != '' %}
+            AND customer_id = {{ String(customer_id) }}
+            {% end %}
+            {% if defined(entity_id) and String(entity_id, '') != '' %}
+            AND entity_id = {{ String(entity_id) }}
+            {% end %}
+            {% if String(group_column, 'property') == 'entity_id' %}
+            AND entity_id IS NOT NULL AND entity_id != ''
+            {% end %}
         GROUP BY period, event_name, group_value
     )
     GROUP BY period, event_name, group_value

--- a/server/tinybird/pipes/aggregate_simple.pipe
+++ b/server/tinybird/pipes/aggregate_simple.pipe
@@ -1,6 +1,8 @@
 DESCRIPTION >
     Simple timeseries aggregation pipe with NO grouping and NO limiting.
     Fastest possible query for basic event aggregation.
+    use_monthly_rollup=1 (server-set, UTC month bins only) serves the complete months of the window
+    from events_customer_monthly_mv and only the partial months at either end from the hourly rollup.
 
 TOKEN "aggregate_simple_read" READ
 
@@ -10,6 +12,72 @@ SQL >
     %
     {% set no_property_filters = (not defined(filter_key_0) or String(filter_key_0, '') == '') and (not defined(filter_key_1) or String(filter_key_1, '') == '') and (not defined(filter_key_2) or String(filter_key_2, '') == '') and (not defined(filter_key_3) or String(filter_key_3, '') == '') and (not defined(filter_key_4) or String(filter_key_4, '') == '') %}
     {% set use_org_rollup = no_property_filters and (not defined(customer_id) or String(customer_id, '') == '') and (not defined(entity_id) or String(entity_id, '') == '') %}
+    {% set read_customer_monthly = no_property_filters and not use_org_rollup and defined(use_monthly_rollup) and String(use_monthly_rollup, '0') == '1' %}
+    {% if read_customer_monthly %}
+    SELECT
+        period,
+        event_name,
+        sum(total_value_value) as total_value
+    FROM (
+        SELECT
+            formatDateTime(month, '%F %T') as period,
+            event_name,
+            sumMerge(total_value) as total_value_value
+        FROM events_customer_monthly_mv
+        WHERE
+            org_id = {{ String(org_id, '') }}
+            AND env = {{ String(env, 'test') }}
+            AND event_name IN {{ Array(event_names, 'String', default='[]') }}
+            AND month >= if(
+                toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}) = toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                toDateTime(addMonths(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})), 1))
+            )
+            AND month < toDateTime(toStartOfMonth(toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})))
+            {% if defined(customer_id) and String(customer_id, '') != '' %}
+            AND customer_id = {{ String(customer_id) }}
+            {% end %}
+            {% if defined(entity_id) and String(entity_id, '') != '' %}
+            AND entity_id = {{ String(entity_id) }}
+            {% end %}
+        GROUP BY period, event_name
+
+        UNION ALL
+
+        SELECT
+            formatDateTime(toStartOfMonth(hour, {{ String(timezone, 'UTC') }}), '%F %T') as period,
+            event_name,
+            sum(total_value) as total_value_value
+        FROM events_customer_hourly_mv
+        WHERE
+            org_id = {{ String(org_id, '') }}
+            AND env = {{ String(env, 'test') }}
+            AND event_name IN {{ Array(event_names, 'String', default='[]') }}
+            AND hour >= toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})
+            AND hour <= toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})
+            AND (
+                hour < if(
+                    toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}) = toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                    toDateTime(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }}))),
+                    toDateTime(addMonths(toStartOfMonth(toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})), 1))
+                )
+                OR hour >= toDateTime(toStartOfMonth(toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})))
+            )
+            {% if defined(customer_id) and String(customer_id, '') != '' %}
+            AND customer_id = {{ String(customer_id) }}
+            {% end %}
+            {% if defined(entity_id) and String(entity_id, '') != '' %}
+            AND entity_id = {{ String(entity_id) }}
+            {% end %}
+        GROUP BY period, event_name
+    )
+    GROUP BY
+        period,
+        event_name
+    ORDER BY
+        period,
+        event_name
+    {% else %}
     SELECT
         {% if String(bin_size, 'day') == 'hour' %}
         formatDateTime(hour, '%F %T') as period,
@@ -56,3 +124,4 @@ SQL >
     ORDER BY
         period,
         event_name
+    {% end %}


### PR DESCRIPTION
Serves `bin_size=month` from monthly rollups for the complete calendar months inside a window, reading the hourly rollups only for the partial months at either end. A `Jan 15 → Mar 10` request reads February from the monthly rollup and only the Jan 15–31 and Mar 1–10 hours from hourly.

## Rollups

Four `AggregatingMergeTree` datasources, each derived from the existing hourly rollup rather than from `events`, so the deploy-time populate is a reduction over an already-small table (no `BACKFILL skip`):

| New | Source | Serves |
|---|---|---|
| `events_customer_monthly_mv` | `events_customer_hourly_mv` | customer/entity ungrouped, group-by customer/entity/plan (keeps `internal_product_id`) |
| `events_org_dimension_monthly_mv` | `events_org_dimension_hourly_mv` | aggregate-all dimension grouping |
| `events_property_monthly_mv` | `events_property_mv` | scoped property grouping |
| `events_org_property_monthly_mv` | `events_org_property_hourly_mv` | aggregate-all property grouping |

`events_property_monthly_mv` reads the already-gated hourly rollup, so it cannot contain a value the insert-time value-shape gate dropped — row count can only shrink relative to `events_property_daily_mv`.

## Routing

`shouldUseMonthlyRollup` gates on month bins, UTC, no property filters, and at least one complete calendar month in the window; `aggregate.ts` passes `use_monthly_rollup` to `aggregate_simple` and `aggregate_groupable`. Each monthly branch is a `UNION ALL` of the monthly rollup over `[first_full_month, last_full_month_end)` and that branch's hourly rollup over the remaining hours, excluded from the interior by `hour < first_full_month OR hour >= last_full_month_end` — disjoint, so no double count and no gap. Monthly takes precedence over `events_property_daily_mv` for month bins.

Unchanged: every other bin size, `filter_by` queries, the `skip_property_rollup` retry, deductions, non-UTC months, `getCountAndSum`, ranking, zero-filling, and response formatting. The param defaults to `0`, so a pipe deployment without the server change is a no-op either way.

## Verification

`monthly-bin-rollup.test.ts` tracks 7 events on exact hours across Jun 15 → Aug 10 2026, three of them on month seams (July's first and last hour, August's first). Bins come back `[12, 41, 42]` with `total.sum = 95`; an August-only window (no complete month, hourly path) returns `42`; `group_by: properties.region` splits to `us 5/24/19` and `eu 7/17/23`. Breaking July's expected value to 40 goes red, restoring it goes green.

A/B on the deployed pipe for the same window: `use_monthly_rollup=1` → `12, 41, 42` reading 1,956 rows, `use_monthly_rollup=0` → `12, 41, 42` reading 2,744.

Unit coverage in `monthly-rollup-routing.test.ts`: the Jan→Mar case, exact boundaries, leap February, year rollover, single partial month, two partials with no whole month between them, a calendar month that never reaches the next month start, and refusal for non-UTC, filtered, and non-month-bin shapes.

## Note

Bins are asserted in period order, ignoring empty ones, because `new UTCDate("2026-06-01 00:00:00")` parses in the server's local zone: on a non-UTC server `convertPeriodsToEpoch` shifts every `period` by that offset and `generateAllPeriods` can emit a spurious empty leading bin. Pre-existing, affects `day`/`week`/`month` equally, invisible in production (UTC containers), and untouched here.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M25QK1KXW8H4A0JASM1GZPWW"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serves `bin_size=month` from new monthly rollups for complete calendar months, reading hourly rollups only for partial edge months, cutting rows scanned for month-level queries.

**What changed**
- Adds four `AggregatingMergeTree` datasources derived from hourly rollups: `events_customer_monthly_mv`, `events_org_dimension_monthly_mv`, `events_property_monthly_mv`, and `events_org_property_monthly_mv`.
- `aggregate_simple` and `aggregate_groupable` now union monthly rollup data for whole months with hourly data for partial edges, keeping the result disjoint and gap-free.
- Routing activates only for UTC month bins with no property filters and at least one complete month in the window; all other bin sizes, timezones, and filtered queries keep the existing path.
- The new `use_monthly_rollup` pipe param defaults to `0`, so pipe deployments without the server change behave exactly as before.
- Tests cover month seams, leap years, year rollover, partial edges, grouped values, and parity with the daily path; A/B shows a 30% row reduction on the same window.

<sup>Written for commit 7c6df78ae7a87c2002bb9e311a63bf64cc5917ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR accelerates eligible UTC monthly analytics by combining pre-aggregated complete months with hourly data for partial months.

Key changes:
- **[Improvements]** Adds four monthly Tinybird materializations derived from existing hourly rollups.
- **[Improvements]** Routes eligible month-bin requests to monthly rollups while retaining hourly precision at the beginning and end of the requested range.
- **[API changes]** Adds the optional `use_monthly_rollup` Tinybird parameter and exposes `custom_range` in the Autumn client type.
- **[Improvements]** Adds routing unit tests and an integration test for customer-scoped totals and property grouping.
- **[Improvements]** Additional tests should cover the other newly introduced monthly SQL branches.
</details>


<h3>Confidence Score: 4/5</h3>

The implementation appears safe to merge, with a non-blocking test-coverage gap across several new grouped monthly query branches.

The reviewed routing, state aggregation, dimensions, and month-edge split are internally consistent; the remaining concern is that multiple distinct SQL branches could regress without being detected by the current tests.

**Files Needing Attention:** server/tinybird/pipes/aggregate_groupable.pipe

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/actions/aggregate.ts | Passes monthly-rollup eligibility to grouped and ungrouped Tinybird queries. |
| server/src/internal/analytics/actions/dailyRollupRouting.ts | Adds UTC complete-calendar-month detection and monthly routing eligibility. |
| server/tinybird/pipes/aggregate_groupable.pipe | Adds four mixed-resolution grouped query branches, but several distinct branches lack direct test coverage. |
| server/tinybird/pipes/aggregate_simple.pipe | Combines customer monthly states with hourly partial-month edges for ungrouped queries. |
| server/tests/integration/analytics/aggregate/monthly-bin-rollup.test.ts | Verifies scoped totals, seam handling, hourly fallback, and property grouping, but not org-wide or dimension grouping branches. |
| server/tinybird/materializations/events_customer_monthly_mv_pipe.pipe | Converts finalized customer-hourly values into mergeable monthly aggregate states. |
| server/tinybird/materializations/events_org_dimension_monthly_mv_pipe.pipe | Merges org-dimension hourly aggregate states into monthly states. |
| server/tinybird/materializations/events_property_monthly_mv_pipe.pipe | Converts scoped property-hourly values into monthly aggregate states. |
| server/tinybird/materializations/events_org_property_monthly_mv_pipe.pipe | Merges org-property hourly aggregate states into monthly states. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Monthly aggregate request] --> B{UTC, unfiltered, and contains a complete month?}
    B -- No --> C[Existing hourly or daily path]
    B -- Yes --> D{Query shape}
    D --> E[Customer monthly rollup]
    D --> F[Organization dimension monthly rollup]
    D --> G[Scoped property monthly rollup]
    D --> H[Organization property monthly rollup]
    E --> I[Complete calendar months]
    F --> I
    G --> I
    H --> I
    D --> J[Matching hourly rollup]
    J --> K[Partial months at window edges]
    I --> L[UNION ALL]
    K --> L
    L --> M[Monthly response bins]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/tinybird/pipes/aggregate_groupable.pipe:39-42
**Monthly branches lack coverage**

The integration test covers only customer-scoped totals and customer-scoped property grouping. It does not run the new organization-wide dimension and property branches or the entity and plan grouping variants. For example, an organization-wide monthly request grouped by customer uses `read_org_dimension_monthly`, so a mistake specific to that SQL branch could ship unnoticed. Please add tests for each distinct monthly branch and grouping projection.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover monthly bin rollup boundarie..."](https://github.com/useautumn/autumn/commit/7c6df78ae7a87c2002bb9e311a63bf64cc5917ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62721082)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->