### PR TITLE
fix(analytics): request UTC months so month bins hit the monthly rollups

### DIFF
--- a/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
@@ -50,6 +50,7 @@ const INTERVAL_GRANULARITIES: Record<string, Granularity[]> = {
 	"1bc": ["day"],
 	"90d": ["day", "week", "month"],
 	"3bc": ["day", "week", "month"],
+	custom: ["day", "week", "month"],
 };
 
 const GRANULARITY_LABELS: Record<Granularity, string> = {

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -53,6 +53,9 @@ export const useAnalyticsData = ({
 	} = useSelectedEventNames();
 
 	const timezone = useMemo(() => getUserTimezone(), []);
+	// Month bins are requested in UTC so they can be served from the monthly
+	// rollups, which key on UTC month starts; a local month never aligns with one.
+	const effectiveTimezone = binSize === "month" ? "UTC" : timezone;
 
 	// Deducted mode defaults to splitting by which tracked feature caused the
 	// deduction — the story the mode exists to tell. An explicit group_by wins.
@@ -75,7 +78,7 @@ export const useAnalyticsData = ({
 		event_names: selectedEventNames,
 		group_by: formattedGroupBy,
 		bin_size: binSize || undefined,
-		timezone,
+		timezone: effectiveTimezone,
 		max_groups: formattedGroupBy ? maxGroups : undefined,
 		aggregate_on: aggregateOn,
 	};


### PR DESCRIPTION
The dashboard sends the viewer's browser timezone, so month bins were bucketed with `toStartOfMonth(hour, 'America/New_York')` and friends. The monthly rollups added in #3376 key on UTC month starts, and a local month is offset from one (New York February runs `Feb 1 05:00 UTC → Mar 1 05:00 UTC`), so every non-UTC viewer fell back to scanning hourly rows.

Month bins now request `timezone: "UTC"`; every other bin size keeps the viewer's zone.

Period labels are unchanged: `formatPeriodLabel` parses a month bucket's label string as local wall-clock ([parseTimestamp.ts:16](vite/src/views/customers/customer/analytics/utils/parseTimestamp.ts:16)), so `"2026-07-01 00:00:00"` still renders as "1 Jul" — no epoch arithmetic involved.

The tradeoff: a New York viewer's July bar now covers `Jul 1 00:00 UTC → Aug 1 00:00 UTC`, starting 5 hours before their local July. Five hours out of ~720 per bar, against month-over-month comparisons that currently can't use the rollups at all.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M25QK1KXW8H4A0JASM1GZPWW"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the analytics dashboard so month bins request UTC, letting them hit the monthly rollups instead of falling back to hourly scans. Also lets custom date ranges pick week and month granularity instead of forcing day-only.

- Month bins now send `timezone: "UTC"`; other bin sizes keep the viewer's browser timezone.
- Custom ranges previously had no granularity entry, so the picker hid itself; they now offer day, week, and month.
- Period labels are unchanged — `formatPeriodLabel` still parses month labels as local wall-clock.
- Side effect: a custom month selection in a non-UTC zone can span two UTC month bars and show an extra partial bar.

<sup>Written for commit 29e918b72319463bec54e6a9ac0cf2ca0f770976. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns monthly analytics requests with UTC-keyed monthly rollups and adds granularity controls for custom date ranges.

- **Bug fixes:** Requests monthly analytics buckets in UTC so non-UTC viewers can use monthly rollups instead of scanning hourly data.
- **Improvements:** Allows custom date ranges to be grouped by day, week, or month.
- **Bug fixes:** The existing custom-range issue remains: for example, a New York selection covering July can extend into August in UTC and display a small second month bar.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because custom monthly ranges can produce an unexpected extra month bar for non-UTC viewers.

The previous blocking finding remains outstanding. Custom ranges still use browser-local start and end timestamps while monthly buckets use UTC boundaries; the new custom month option now exposes this mismatch directly. For example, a New York July range reaches into August in UTC, so the chart can show July plus a small August bar.

**Files Needing Attention:** vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx, vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx | Uses UTC for monthly requests, but custom ranges retain local boundaries and can therefore span an extra UTC month bucket. |
| vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx | Adds day, week, and month grouping choices to custom date ranges, making the existing custom-month boundary mismatch directly selectable. |

<sub>Reviews (2): Last reviewed commit: ["feat(analytics): offer week and month gr..."](https://github.com/useautumn/autumn/commit/29e918b72319463bec54e6a9ac0cf2ca0f770976) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62749008)</sub>

**Context used:**

- Knowledge Base — [Operational web applications and UI primitives](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/operational-web-applications.md)

<!-- /greptile_comment -->