### PR TITLE
fix(dashboard): keep analytics filters in sync and make entity names readable

### DIFF
--- a/vite/src/views/customers/customer/analytics/components/CustomerComboBox.tsx
+++ b/vite/src/views/customers/customer/analytics/components/CustomerComboBox.tsx
@@ -18,23 +18,12 @@ import { CaretDownIcon } from "@phosphor-icons/react";
 import { debounce } from "lodash";
 import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router";
-import { useEnv } from "@/utils/envUtils";
-import { navigateTo } from "@/utils/genUtils";
 import { useCusSearchQueryV2 } from "@/views/customers/hooks/useCusSearchQuery";
 import { useAnalyticsContext } from "../AnalyticsContext";
-
-interface CustomerSearchResult {
-	id: string;
-	internal_id?: string;
-	name?: string;
-	email?: string;
-}
+import { useAnalyticsFilterState } from "../hooks/useAnalyticsFilterState";
 
 export function CustomerComboBox() {
-	const env = useEnv();
-	const navigate = useNavigate();
-	const location = useLocation();
+	const { setFilterStates } = useAnalyticsFilterState();
 	const { customer, setHasCleared } = useAnalyticsContext();
 	const [open, setOpen] = useState(false);
 	const [value, setValue] = useState("");
@@ -120,13 +109,7 @@ export function CustomerComboBox() {
 										size="sm"
 										className="mx-auto"
 										onClick={() => {
-											const params = new URLSearchParams(location.search);
-											params.delete("customer_id");
-											const queryString = params.toString();
-											const path = queryString
-												? `/analytics?${queryString}`
-												: "/analytics";
-											navigateTo(path, navigate, env);
+											setFilterStates({ customer_id: null });
 											setOpen(false);
 											setHasCleared(false);
 										}}
@@ -145,13 +128,9 @@ export function CustomerComboBox() {
 													key={idx}
 													value={c.id || c.internal_id}
 													onSelect={() => {
-														const params = new URLSearchParams(location.search);
-														params.set(
-															"customer_id",
-															c.id || c.internal_id || "",
-														);
-														const path = `/analytics?${params.toString()}`;
-														navigateTo(path, navigate, env);
+														setFilterStates({
+															customer_id: c.id || c.internal_id || "",
+														});
 														setOpen(false);
 													}}
 													className="w-full"

--- a/vite/src/views/customers/customer/analytics/components/SelectEntityDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectEntityDropdown.tsx
@@ -1,26 +1,24 @@
 import type { Entity } from "@autumn/shared";
-import { IconButton } from "@autumn/ui";
-import { CaretDownIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
-import { Check } from "lucide-react";
-import { useState } from "react";
-import { useLocation, useNavigate, useSearchParams } from "react-router";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
+	IconButton,
 } from "@autumn/ui";
+import { CaretDownIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { Check } from "lucide-react";
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { useAnalyticsContext } from "../AnalyticsContext";
+import { useAnalyticsFilterState } from "../hooks/useAnalyticsFilterState";
 
 export const SelectEntityDropdown = () => {
 	const [open, setOpen] = useState(false);
 	const [searchValue, setSearchValue] = useState("");
 
-	const [searchParams] = useSearchParams();
-	const navigate = useNavigate();
-	const location = useLocation();
+	const { filterStates, setFilterStates } = useAnalyticsFilterState();
 
 	const { customer } = useAnalyticsContext();
 
@@ -30,19 +28,7 @@ export const SelectEntityDropdown = () => {
 		return null;
 	}
 
-	const currentEntityId = searchParams.get("entity_id") || "";
-
-	const updateQueryParams = ({ entityId }: { entityId: string | null }) => {
-		const params = new URLSearchParams(location.search);
-
-		if (entityId) {
-			params.set("entity_id", entityId);
-		} else {
-			params.delete("entity_id");
-		}
-
-		navigate(`${location.pathname}?${params.toString()}`);
-	};
+	const currentEntityId = filterStates.entity_id ?? "";
 
 	const filteredEntities = entities.filter((entity) => {
 		const label = entity.name || entity.id || "";
@@ -50,7 +36,7 @@ export const SelectEntityDropdown = () => {
 	});
 
 	const handleSelect = ({ entityId }: { entityId: string | null }) => {
-		updateQueryParams({ entityId });
+		setFilterStates({ entity_id: entityId });
 		setOpen(false);
 	};
 

--- a/vite/src/views/customers/customer/analytics/components/SelectFeatureDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectFeatureDropdown.tsx
@@ -1,10 +1,5 @@
 import type { Feature } from "@autumn/shared";
 import { FeatureType } from "@autumn/shared";
-import { IconButton } from "@autumn/ui";
-import { CaretDownIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
-import { useMemo, useState } from "react";
-import { useLocation, useNavigate, useSearchParams } from "react-router";
-import { toast } from "sonner";
 import {
 	DropdownMenu,
 	DropdownMenuCheckboxItem,
@@ -12,9 +7,14 @@ import {
 	DropdownMenuGroup,
 	DropdownMenuLabel,
 	DropdownMenuTrigger,
+	IconButton,
 } from "@autumn/ui";
+import { CaretDownIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useAnalyticsContext } from "../AnalyticsContext";
+import { useAnalyticsFilterState } from "../hooks/useAnalyticsFilterState";
 import { useAnalyticsQueryState } from "../hooks/useAnalyticsQueryState";
 import { useEventNames } from "../hooks/useEventNames";
 
@@ -74,14 +74,8 @@ export const SelectFeatureDropdown = () => {
 	const [open, setOpen] = useState(false);
 	const [searchValue, setSearchValue] = useState("");
 
-	const [searchParams] = useSearchParams();
-	const navigate = useNavigate();
-	const location = useLocation();
-
-	// Read current selected event names from query parameters
-	const currentEventNames =
-		searchParams.get("event_names")?.split(",").filter(Boolean) || [];
-
+	const { filterStates, setFilterStates } = useAnalyticsFilterState();
+	const currentEventNames = filterStates.event_names ?? [];
 	// Show every ingested event; feature linkage only drives the optional label, not visibility
 	const eventOptions: EventOption[] = useMemo(() => {
 		return eventNamesData.map((item) => ({
@@ -107,40 +101,32 @@ export const SelectFeatureDropdown = () => {
 		);
 	}, [eventOptions, searchValue]);
 
-	// Helper function to update query parameters
-	const updateQueryParams = (eventNames: string[]) => {
-		const params = new URLSearchParams(location.search);
-
-		// Clear feature_ids since we're now only using event_names
-		params.delete("feature_ids");
-
-		if (eventNames.length > 0) {
-			params.set("event_names", eventNames.join(","));
-		} else {
-			params.delete("event_names");
-		}
-
-		navigate(`${location.pathname}?${params.toString()}`);
+	// Selecting events supersedes the legacy feature_ids param, so clear it.
+	const updateSelection = (eventNames: string[]) => {
+		setFilterStates({
+			event_names: eventNames.length > 0 ? eventNames : null,
+			feature_ids: null,
+		});
 	};
 
 	const numSelected = currentEventNames.length;
 
 	const handleToggleItem = (option: EventOption) => {
 		if (option.selected) {
-			updateQueryParams(
+			updateSelection(
 				currentEventNames.filter((name) => name !== option.eventName),
 			);
 		} else {
 			if (numSelected >= MAX_NUM_SELECTED) {
 				toast.error(`You can only select up to ${MAX_NUM_SELECTED} events`);
 			} else {
-				updateQueryParams([...currentEventNames, option.eventName]);
+				updateSelection([...currentEventNames, option.eventName]);
 			}
 		}
 	};
 
 	const handleClear = () => {
-		updateQueryParams([]);
+		updateSelection([]);
 		setHasCleared(true);
 	};
 

--- a/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
@@ -27,7 +27,10 @@ import { Check } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { useAnalyticsContext } from "../AnalyticsContext";
-import { useAnalyticsFilterState } from "../hooks/useAnalyticsFilterState";
+import {
+	clampMaxGroups,
+	useAnalyticsFilterState,
+} from "../hooks/useAnalyticsFilterState";
 import { useAnalyticsQueryState } from "../hooks/useAnalyticsQueryState";
 import { groupValueLabel } from "../utils/displayLabels";
 
@@ -112,7 +115,7 @@ export const SelectGroupByDropdown = ({
 	};
 
 	const updateMaxGroups = ({ value }: { value: number }) => {
-		setFilterStates({ max_groups: Math.min(250, Math.max(1, value)) });
+		setFilterStates({ max_groups: clampMaxGroups(value) });
 	};
 
 	const filteredOptions = propertyKeys.filter((key) =>

--- a/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
@@ -25,9 +25,9 @@ import {
 } from "@phosphor-icons/react";
 import { Check } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { useLocation, useNavigate, useSearchParams } from "react-router";
 import { cn } from "@/lib/utils";
 import { useAnalyticsContext } from "../AnalyticsContext";
+import { useAnalyticsFilterState } from "../hooks/useAnalyticsFilterState";
 import { useAnalyticsQueryState } from "../hooks/useAnalyticsQueryState";
 import { groupValueLabel } from "../utils/displayLabels";
 
@@ -39,9 +39,7 @@ export const SelectGroupByDropdown = ({
 	const [open, setOpen] = useState(false);
 	const [searchValue, setSearchValue] = useState("");
 
-	const [searchParams] = useSearchParams();
-	const navigate = useNavigate();
-	const location = useLocation();
+	const { filterStates, setFilterStates } = useAnalyticsFilterState();
 
 	const {
 		groupFilter,
@@ -75,10 +73,10 @@ export const SelectGroupByDropdown = ({
 		setPlanDeselected(new Set());
 	};
 
-	const currentGroupBy = searchParams.get("group_by") || "";
-	const customerId = searchParams.get("customer_id");
+	const currentGroupBy = filterStates.group_by ?? "";
+	const customerId = filterStates.customer_id;
 	const showCustomerIdOption = !customerId;
-	const maxGroups = Number(searchParams.get("max_groups")) || 10;
+	const maxGroups = filterStates.max_groups;
 
 	const { queryStates, setQueryStates } = useAnalyticsQueryState();
 	// Without a customer the hook never sends aggregate_on, so the chart shows
@@ -89,7 +87,7 @@ export const SelectGroupByDropdown = ({
 	// it, but the combination can also arrive via URL load or back-navigation.
 	useEffect(() => {
 		if (isDeducted && currentGroupBy === "plan_id") {
-			updateQueryParams({ groupBy: null });
+			updateGroupBy({ groupBy: null });
 		}
 	});
 
@@ -102,33 +100,19 @@ export const SelectGroupByDropdown = ({
 		// Plan grouping isn't served in deducted mode — drop it rather than
 		// leave the chart pointing at a grouping that returns nothing.
 		if (mode === "deductions" && currentGroupBy === "plan_id") {
-			updateQueryParams({ groupBy: null });
+			updateGroupBy({ groupBy: null });
 		}
 	};
 
-	// Built from window.location, NOT react-router's `location.search`: the
-	// Values/Deductions tab writes aggregate_on through nuqs, whose history push
-	// react-router may not have observed yet. Rebuilding from a stale snapshot
-	// silently dropped that param (picking a group-by kicked you out of deducted
-	// mode). window.location is always the real current URL, whoever wrote last.
-	const updateQueryParams = ({ groupBy }: { groupBy: string | null }) => {
-		const params = new URLSearchParams(window.location.search);
-
-		if (groupBy) {
-			params.set("group_by", groupBy);
-		} else {
-			params.delete("group_by");
-			params.delete("max_groups");
-		}
-
-		navigate(`${location.pathname}?${params.toString()}`);
+	// Max groups only means something alongside a grouping, so it leaves with it.
+	const updateGroupBy = ({ groupBy }: { groupBy: string | null }) => {
+		setFilterStates(
+			groupBy ? { group_by: groupBy } : { group_by: null, max_groups: null },
+		);
 	};
 
 	const updateMaxGroups = ({ value }: { value: number }) => {
-		const clamped = Math.min(250, Math.max(1, value));
-		const params = new URLSearchParams(window.location.search);
-		params.set("max_groups", String(clamped));
-		navigate(`${location.pathname}?${params.toString()}`);
+		setFilterStates({ max_groups: Math.min(250, Math.max(1, value)) });
 	};
 
 	const filteredOptions = propertyKeys.filter((key) =>
@@ -136,7 +120,7 @@ export const SelectGroupByDropdown = ({
 	);
 
 	const handleSelect = ({ property }: { property: string | null }) => {
-		updateQueryParams({ groupBy: property });
+		updateGroupBy({ groupBy: property });
 		setOpen(false);
 	};
 

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -6,9 +6,9 @@ import type {
 import { ErrCode } from "@autumn/shared";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { useSearchParams } from "react-router";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { useAnalyticsFilterState } from "./useAnalyticsFilterState";
 import { useAnalyticsQueryState } from "./useAnalyticsQueryState";
 import { useSelectedEventNames } from "./useSelectedEventNames";
 
@@ -29,11 +29,13 @@ export const useAnalyticsData = ({
 	const axiosInstance = useAxiosInstance();
 	const buildKey = useQueryKeyFactory();
 
-	const [searchParams] = useSearchParams();
-	const customerId = searchParams.get("customer_id");
-	const entityId = searchParams.get("entity_id");
-	const groupBy = searchParams.get("group_by");
-	const maxGroups = Number(searchParams.get("max_groups")) || 10;
+	const { filterStates } = useAnalyticsFilterState();
+	const {
+		customer_id: customerId,
+		entity_id: entityId,
+		group_by: groupBy,
+		max_groups: maxGroups,
+	} = filterStates;
 
 	const { queryStates } = useAnalyticsQueryState();
 	const { interval, bin_size: binSize, start, end } = queryStates;
@@ -141,9 +143,8 @@ export const useRawAnalyticsData = () => {
 	const axiosInstance = useAxiosInstance();
 	const buildKey = useQueryKeyFactory();
 
-	const [searchParams] = useSearchParams();
-	const customerId = searchParams.get("customer_id");
-	const entityId = searchParams.get("entity_id");
+	const { filterStates } = useAnalyticsFilterState();
+	const { customer_id: customerId, entity_id: entityId } = filterStates;
 
 	const { queryStates } = useAnalyticsQueryState();
 	const { interval, start, end } = queryStates;

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsFilterState.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsFilterState.tsx
@@ -1,11 +1,26 @@
 import {
+	createParser,
 	parseAsArrayOf,
-	parseAsInteger,
 	parseAsString,
 	useQueryStates,
 } from "nuqs";
 
 const DEFAULT_MAX_GROUPS = 10;
+const MIN_MAX_GROUPS = 1;
+const MAX_MAX_GROUPS = 250;
+
+// The aggregate endpoint rejects anything outside 1-250, so a hand-edited or
+// bookmarked URL is clamped on the way in rather than failing the request.
+export const clampMaxGroups = (value: number) =>
+	Math.min(MAX_MAX_GROUPS, Math.max(MIN_MAX_GROUPS, value));
+
+const parseAsMaxGroups = createParser({
+	parse: (query) => {
+		const parsed = Number.parseInt(query, 10);
+		return Number.isNaN(parsed) ? null : clampMaxGroups(parsed);
+	},
+	serialize: String,
+}).withDefault(DEFAULT_MAX_GROUPS);
 
 /**
  * URL-synced state for the analytics filter controls. Every analytics reader
@@ -20,7 +35,7 @@ export const useAnalyticsFilterState = () => {
 			customer_id: parseAsString,
 			entity_id: parseAsString,
 			group_by: parseAsString,
-			max_groups: parseAsInteger.withDefault(DEFAULT_MAX_GROUPS),
+			max_groups: parseAsMaxGroups,
 			event_names: parseAsArrayOf(parseAsString),
 			feature_ids: parseAsArrayOf(parseAsString),
 		},

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsFilterState.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsFilterState.tsx
@@ -1,0 +1,30 @@
+import {
+	parseAsArrayOf,
+	parseAsInteger,
+	parseAsString,
+	useQueryStates,
+} from "nuqs";
+
+const DEFAULT_MAX_GROUPS = 10;
+
+/**
+ * URL-synced state for the analytics filter controls. Every analytics reader
+ * and writer goes through nuqs: it applies each change to the live URL, whereas
+ * react-router rebuilds the query string from a `useLocation` snapshot that
+ * nuqs' shallow history push never reaches — which silently dropped whichever
+ * param the other control had just written.
+ */
+export const useAnalyticsFilterState = () => {
+	const [filterStates, setFilterStates] = useQueryStates(
+		{
+			customer_id: parseAsString,
+			entity_id: parseAsString,
+			group_by: parseAsString,
+			max_groups: parseAsInteger.withDefault(DEFAULT_MAX_GROUPS),
+			event_names: parseAsArrayOf(parseAsString),
+			feature_ids: parseAsArrayOf(parseAsString),
+		},
+		{ history: "push" },
+	);
+	return { filterStates, setFilterStates };
+};

--- a/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
@@ -1,5 +1,5 @@
-import { parseAsArrayOf, parseAsString, useQueryStates } from "nuqs";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { useAnalyticsFilterState } from "./useAnalyticsFilterState";
 import { useAnalyticsQueryState } from "./useAnalyticsQueryState";
 import { type EventNameWithCount, useEventNames } from "./useEventNames";
 
@@ -7,12 +7,8 @@ import { type EventNameWithCount, useEventNames } from "./useEventNames";
  * selection (event_names / feature_ids) or the top events by count in the
  * active window by default. Shared by the chart and the events table. */
 export const useSelectedEventNames = () => {
-	const [{ feature_ids: featureIds, event_names: eventNames }] = useQueryStates(
-		{
-			feature_ids: parseAsArrayOf(parseAsString),
-			event_names: parseAsArrayOf(parseAsString),
-		},
-	);
+	const { filterStates } = useAnalyticsFilterState();
+	const { feature_ids: featureIds, event_names: eventNames } = filterStates;
 
 	const { queryStates } = useAnalyticsQueryState();
 	const { interval, start, end } = queryStates;

--- a/vite/src/views/customers2/customer/components/SelectedEntityDetails.tsx
+++ b/vite/src/views/customers2/customer/components/SelectedEntityDetails.tsx
@@ -1,4 +1,12 @@
-import { Button, CopyButton, SearchableSelect } from "@autumn/ui";
+import {
+	Button,
+	CopyButton,
+	MiniCopyButton,
+	SearchableSelect,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@autumn/ui";
 import { PlusIcon, TrashIcon, XIcon } from "@phosphor-icons/react";
 import { CheckIcon } from "lucide-react";
 import { useState } from "react";
@@ -8,6 +16,27 @@ import { CreateEntity } from "./CreateEntity";
 import { DeleteEntity } from "./DeleteEntity";
 
 const PLACEHOLDER = "PENDING";
+
+/** One value in an entity row: truncates in place, reveals the full string on
+ *  hover, and copies it on click of the icon. */
+const EntityValue = ({
+	value,
+	className,
+	widthClassName,
+}: {
+	value: string;
+	className?: string;
+	widthClassName?: string;
+}) => (
+	<Tooltip>
+		<TooltipTrigger asChild>
+			<div className={cn("min-w-0 max-w-full", widthClassName)}>
+				<MiniCopyButton text={value} innerClassName={className} />
+			</div>
+		</TooltipTrigger>
+		<TooltipContent className="max-w-xs break-all">{value}</TooltipContent>
+	</Tooltip>
+);
 
 export const SelectedEntityDetails = () => {
 	const [isDeleteOpen, setDeleteOpen] = useState(false);
@@ -47,27 +76,42 @@ export const SelectedEntityDetails = () => {
 						triggerClassName="w-full sm:w-72"
 						onSearchChange={setSearch}
 						isLoading={isLoading}
-						renderValue={(entity) => (
-							<span
-								className={cn(
-									"truncate",
-									entity ? "text-muted-foreground" : "text-tertiary-foreground",
-								)}
-							>
-								{entity
-									? entity.name || entity.id || PLACEHOLDER
-									: "Select entity"}
-							</span>
-						)}
+						renderValue={(entity) => {
+							const label = entity
+								? entity.name || entity.id || PLACEHOLDER
+								: "Select entity";
+							return (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<span
+											className={cn(
+												"truncate",
+												entity
+													? "text-muted-foreground"
+													: "text-tertiary-foreground",
+											)}
+										>
+											{label}
+										</span>
+									</TooltipTrigger>
+									<TooltipContent className="max-w-xs break-all">
+										{label}
+									</TooltipContent>
+								</Tooltip>
+							);
+						}}
 						renderOption={(entity, isSelected) => (
 							<>
 								<div className="flex gap-2 items-center min-w-0 flex-1">
 									{entity.name && (
-										<span className="text-sm shrink-0">{entity.name}</span>
+										<EntityValue value={entity.name} className="text-sm" />
 									)}
-									<span className="truncate text-tertiary-foreground font-mono text-xs min-w-0">
-										{entity.id || PLACEHOLDER}
-									</span>
+									{/* The opaque id yields width to the readable name first. */}
+									<EntityValue
+										value={entity.id || PLACEHOLDER}
+										className="font-mono text-xs"
+										widthClassName="shrink-[4]"
+									/>
 								</div>
 								{isSelected && <CheckIcon className="size-4 shrink-0" />}
 							</>


### PR DESCRIPTION
Two dashboard fixes reported from the analytics and customer views.

## Usage date filter no longer resets

Changing the date range and then picking events (or a customer, entity, or grouping) snapped the range back to **Last 30 days**.

The analytics view wrote its URL through two systems. The date controls use nuqs, which — with the react-router adapter and shallow updates — calls `history.pushState` directly and never notifies the router. The event, entity, and customer dropdowns rebuilt the query string from react-router's `useLocation`, which by then held a snapshot from before the nuqs push, so `interval` was dropped on the next `navigate()` and fell back to its `30d` default. `SelectGroupByDropdown` already carried a comment about hitting the same trap, patched locally by reading `window.location.search`.

The whole analytics URL surface now goes through one nuqs hook, `useAnalyticsFilterState`, covering `customer_id`, `entity_id`, `group_by`, `max_groups`, `event_names`, and `feature_ids`. Every reader and writer applies changes against the live URL, so one control can no longer clobber another's param, and the `window.location` workaround in the group-by dropdown is gone.

## Entity list shows full names

Long entity names overflowed their row: the name had `shrink-0`, so it pushed the id out of the row entirely and ran underneath the selected checkmark.

Both the name and the id now truncate, with the id yielding width to the readable name first. Hovering a row reveals the full value in a tooltip, and each value carries a hover copy button, so a truncated name or id can be read and pasted without leaving the dropdown. The collapsed trigger gets the same tooltip.

## Verification

Reproduced the date-filter reset against the current `dev` code in the local dashboard (set Last 90 days, pick a customer, range reverts to Last 30 days and `interval` disappears from the URL), then confirmed on this branch that `interval`, `bin_size`, and the new filter param all survive. Entity dropdown checked visually with long synthetic names.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M26EW03Z5DYW3FY3K0HWX2SZ"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two analytics dashboard bugs: changing filters no longer resets the date range to Last 30 days, and long entity names no longer overflow their dropdown rows.

**Bug Fixes**
- All analytics filter params now share one URL-synced state hook, so dropdown updates no longer drop the `interval` and `bin_size` params set by the date controls.
- `max_groups` from the URL is clamped to the API's 1-250 range, so bookmarked or hand-edited values load instead of failing the request.
- Entity dropdown values truncate with hover tooltips and copy buttons instead of pushing IDs out of the row.

<sup>Written for commit f4fdf3176eda0701c4d666d91bcdd10cbe088874. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR keeps analytics filters synchronized through a shared URL-state hook and improves how long entity names and IDs are displayed.

- **[Bug fixes]** Routes analytics customer, entity, event, feature, and grouping filters through shared live URL state so changing one filter no longer resets the selected date range.
- **[Bug fixes]** Clamps the maximum group count from bookmarked or manually edited URLs to the API-supported range.
- **[Improvements]** Truncates long entity names and IDs while providing tooltips and copy controls for their complete values.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable new defects or outstanding repository-rule violations identified.

The changes since the previous review consistently reuse the new range clamp for maximum group counts, and the full implementation preserves analytics URL parameters while improving entity-value presentation without introducing a blocking failure.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/hooks/useAnalyticsFilterState.tsx | Centralizes analytics filter query parameters and constrains maximum group counts to the supported range. |
| vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx | Moves grouping updates to shared URL state and clears the group limit when grouping is removed. |
| vite/src/views/customers/customer/analytics/components/SelectFeatureDropdown.tsx | Updates event selections atomically through shared URL state while clearing the superseded feature filter. |
| vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx | Reads analytics request filters from the consolidated URL-state hook. |
| vite/src/views/customers2/customer/components/SelectedEntityDetails.tsx | Makes long entity values readable through truncation, tooltips, and copy controls. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Date[Date controls] --> URL[Shared nuqs URL state]
    Customer[Customer filter] --> URL
    Entity[Entity filter] --> URL
    Events[Event filters] --> URL
    Grouping[Grouping controls] --> URL
    URL --> Query[Analytics request]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(analytics): clamp max\_groups from th..."](https://github.com/useautumn/autumn/commit/f4fdf3176eda0701c4d666d91bcdd10cbe088874) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62785473)</sub>

<!-- /greptile_comment -->