### PR TITLE
fix(billing): omit redundant invoice-credit subscription items

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptionItems/customerProductToStripeItemSpecs.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptionItems/customerProductToStripeItemSpecs.ts
@@ -1,11 +1,15 @@
 import {
 	type BillingContext,
+	cusPriceToCusEntWithCusProduct,
 	type FullCusProduct,
+	isConsumablePrice,
+	isFixedPrice,
 	isOneOffPrice,
 	type StripeItemSpec,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { cusPriceToStripeItemSpec } from "@/internal/billing/v2/providers/stripe/utils/stripeItemSpec/cusPriceToStripeItemSpec/cusPriceToStripeItemSpec";
+import { isInvoiceCreditFeature } from "@/internal/features/creditSystemUtils.js";
 import { customerLicenseToStripeItemSpecs } from "./customerLicenseToStripeItemSpecs";
 
 /**
@@ -28,6 +32,7 @@ export const customerProductToStripeItemSpecs = ({
 } => {
 	const recurringItems: StripeItemSpec[] = [];
 	const oneOffItems: StripeItemSpec[] = [];
+	const invoiceCreditItems = new Set<StripeItemSpec>();
 
 	for (const cusPrice of customerProduct.customer_prices) {
 		const spec = cusPriceToStripeItemSpec({
@@ -39,6 +44,20 @@ export const customerProductToStripeItemSpecs = ({
 		});
 
 		if (!spec) continue;
+		if (isConsumablePrice(cusPrice.price)) {
+			const customerEntitlement = cusPriceToCusEntWithCusProduct({
+				cusProduct: customerProduct,
+				cusPrice,
+				cusEnts: customerProduct.customer_entitlements,
+			});
+			if (
+				isInvoiceCreditFeature({
+					feature: customerEntitlement?.entitlement.feature,
+				})
+			) {
+				invoiceCreditItems.add(spec);
+			}
+		}
 
 		if (isOneOffPrice(cusPrice.price)) {
 			oneOffItems.push(spec);
@@ -58,5 +77,22 @@ export const customerProductToStripeItemSpecs = ({
 		}
 	}
 
-	return { recurringItems, oneOffItems };
+	return {
+		recurringItems: recurringItems.filter((item) => {
+			if (!invoiceCreditItems.has(item)) return true;
+			const creditConfig = item.autumnPrice!.config;
+			// Source debits settle credits; retain the meter only when it supplies the renewal cadence.
+			return !recurringItems.some((candidate) => {
+				const price = candidate.autumnPrice;
+				return (
+					price &&
+					isFixedPrice(price) &&
+					price.config.interval === creditConfig.interval &&
+					(price.config.interval_count ?? 1) ===
+						(creditConfig.interval_count ?? 1)
+				);
+			});
+		}),
+		oneOffItems,
+	};
 };

--- a/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-invoice-credits.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-invoice-credits.test.ts
@@ -2,99 +2,122 @@ import { expect, test } from "bun:test";
 import type { ApiCustomerV5 } from "@autumn/shared";
 import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement.js";
 import { expectInvoiceLineItemsCorrect } from "@tests/integration/billing/utils/expectInvoiceLineItemsCorrect.js";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect/expectStripeSubscriptionCorrect.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 
-test.concurrent(
-	`${chalk.yellowBright("invoice.created invoice credits: renders attribution without changing the funded invoice total")}`,
-	async () => {
-		const invoiceCreditItem = items.consumable({
-			featureId: TestFeature.InvoiceCredits,
-			includedUsage: 100,
-			price: 1,
-		});
-		const product = products.pro({
-			id: "invoice-credit-renewal",
-			items: [invoiceCreditItem],
-		});
-
-		const { customerId, autumnV2_3, ctx } = await initScenario({
-			customerId: "invoice-credit-renewal",
-			setup: [
-				s.customer({ paymentMethod: "success" }),
-				s.products({ list: [product] }),
-			],
-			actions: [
-				s.billing.attach({ productId: product.id }),
-				s.track({ featureId: TestFeature.Action1, value: 50 }),
-				s.track({ featureId: TestFeature.Action2, value: 50 }),
-				s.advanceToNextInvoice({ withPause: true }),
-			],
-		});
-
-		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
-		const renewalInvoice = customer.invoices?.[0];
-		expect(renewalInvoice?.stripe_id).toBeDefined();
-		expect(renewalInvoice?.total).toBe(20);
-
-		const storedLineItems = await expectInvoiceLineItemsCorrect({
-			stripeInvoiceId: renewalInvoice!.stripe_id,
-			expectedCount: 4,
-			expectedTotal: 20,
-			expectedLineItems: [
-				{ isBasePrice: true, direction: "charge", amount: 20 },
-				{
-					featureId: TestFeature.Action1,
-					direction: "charge",
-					billingTiming: "in_arrear",
-					amount: 10,
-				},
-				{
-					featureId: TestFeature.Action2,
-					direction: "charge",
-					billingTiming: "in_arrear",
-					amount: 30,
-				},
-				{
-					featureId: TestFeature.InvoiceCredits,
-					direction: "refund",
-					billingTiming: "in_arrear",
-					amount: -40,
-				},
-			],
-		});
-		expect(
-			storedLineItems.find(
-				(lineItem) => lineItem.feature_id === TestFeature.InvoiceCredits,
-			)?.description,
-		).toBe("Credits applied");
-
-		const stripeInvoice = await ctx.stripeCli.invoices.retrieve(
-			renewalInvoice!.stripe_id,
-		);
-		expect(stripeInvoice.total).toBe(2_000);
-		const action1Line = stripeInvoice.lines.data.find(
-			(line) => line.description === "Action1, 50 units",
-		);
-		const action2Line = stripeInvoice.lines.data.find(
-			(line) => line.description === "Action2, 50 units",
-		);
-		expect(action1Line?.quantity).toBe(1);
-		expect(action2Line?.quantity).toBe(1);
-		expect(stripeInvoice.lines.data.map((line) => line.description)).toContain(
-			"Credits applied",
-		);
-
-		expect(customer.balances[TestFeature.InvoiceCredits].remaining).toBe(100);
-		const resetCustomerEntitlement = await findCustomerEntitlement({
-			ctx,
-			customerId,
-			featureId: TestFeature.InvoiceCredits,
-		});
-		expect(resetCustomerEntitlement?.usage_attribution).toEqual({});
+for (const scenario of [
+	{
+		name: "funded",
+		usage: 50,
+		action1Amount: 10,
+		action2Amount: 30,
+		creditsApplied: 40,
+		total: 20,
 	},
-	{ timeout: 120_000 },
-);
+	{
+		name: "overage",
+		usage: 250,
+		action1Amount: 50,
+		action2Amount: 150,
+		creditsApplied: 100,
+		total: 120,
+	},
+]) {
+	test.concurrent(
+		`${chalk.yellowBright(`invoice.created invoice credits: ${scenario.name} renewal omits the empty credit row`)}`,
+		async () => {
+			const invoiceCreditItem = items.consumable({
+				featureId: TestFeature.InvoiceCredits,
+				includedUsage: 100,
+				price: 1,
+			});
+			const product = products.pro({
+				id: `invoice-credit-renewal-${scenario.name}`,
+				items: [invoiceCreditItem],
+			});
+
+			const { customerId, autumnV2_3, ctx } = await initScenario({
+				customerId: `invoice-credit-renewal-${scenario.name}`,
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.products({ list: [product] }),
+				],
+				actions: [
+					s.billing.attach({ productId: product.id }),
+					s.track({ featureId: TestFeature.Action1, value: scenario.usage }),
+					s.track({ featureId: TestFeature.Action2, value: scenario.usage }),
+					s.advanceToNextInvoice({ withPause: true }),
+				],
+			});
+
+			const customer =
+				await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+			const renewalInvoice = customer.invoices?.[0];
+			expect(renewalInvoice?.stripe_id).toBeDefined();
+			expect(renewalInvoice?.total).toBe(scenario.total);
+
+			const storedLineItems = await expectInvoiceLineItemsCorrect({
+				stripeInvoiceId: renewalInvoice!.stripe_id,
+				expectedCount: 4,
+				expectedTotal: scenario.total,
+				expectedLineItems: [
+					{ isBasePrice: true, direction: "charge", amount: 20 },
+					{
+						featureId: TestFeature.Action1,
+						direction: "charge",
+						billingTiming: "in_arrear",
+						amount: scenario.action1Amount,
+					},
+					{
+						featureId: TestFeature.Action2,
+						direction: "charge",
+						billingTiming: "in_arrear",
+						amount: scenario.action2Amount,
+					},
+					{
+						featureId: TestFeature.InvoiceCredits,
+						direction: "refund",
+						billingTiming: "in_arrear",
+						amount: -scenario.creditsApplied,
+					},
+				],
+			});
+			expect(
+				storedLineItems.find(
+					(lineItem) => lineItem.feature_id === TestFeature.InvoiceCredits,
+				)?.description,
+			).toBe("Credits applied");
+
+			const stripeInvoice = await ctx.stripeCli.invoices.retrieve(
+				renewalInvoice!.stripe_id,
+			);
+			await expectStripeSubscriptionCorrect({ ctx, customerId });
+			expect(stripeInvoice.total).toBe(scenario.total * 100);
+			expect(stripeInvoice.lines.data).toHaveLength(4);
+			const action1Line = stripeInvoice.lines.data.find(
+				(line) => line.description === `Action1, ${scenario.usage} units`,
+			);
+			const action2Line = stripeInvoice.lines.data.find(
+				(line) => line.description === `Action2, ${scenario.usage} units`,
+			);
+			expect(action1Line?.quantity).toBe(1);
+			expect(action2Line?.quantity).toBe(1);
+			expect(
+				stripeInvoice.lines.data.map((line) => line.description),
+			).toContain("Credits applied");
+
+			expect(customer.balances[TestFeature.InvoiceCredits].remaining).toBe(100);
+			const resetCustomerEntitlement = await findCustomerEntitlement({
+				ctx,
+				customerId,
+				featureId: TestFeature.InvoiceCredits,
+			});
+			expect(resetCustomerEntitlement?.usage_attribution).toEqual({});
+		},
+		{ timeout: 120_000 },
+	);
+}

--- a/server/tests/unit/billing/invoice-credit-subscription-items.test.ts
+++ b/server/tests/unit/billing/invoice-credit-subscription-items.test.ts
@@ -1,0 +1,155 @@
+// Red: paid invoice-credit plans include an empty credit subscription row.
+// Green: the paid base drives renewals; source charges and credit resets remain intact.
+import { describe, expect, test } from "bun:test";
+import {
+	BillingInterval,
+	FeatureType,
+	type FixedPriceConfig,
+} from "@autumn/shared";
+import { contexts } from "@tests/utils/fixtures/db/contexts.js";
+import { customerEntitlements } from "@tests/utils/fixtures/db/customerEntitlements.js";
+import { customerProducts } from "@tests/utils/fixtures/db/customerProducts.js";
+import { features } from "@tests/utils/fixtures/db/features.js";
+import { prices } from "@tests/utils/fixtures/db/prices.js";
+import { products } from "@tests/utils/fixtures/db/products.js";
+import { stripeSubscriptions } from "@tests/utils/fixtures/stripe/subscriptions.js";
+import { buildStripeSubscriptionItemsUpdate } from "@/internal/billing/v2/providers/stripe/utils/subscriptionItems/buildStripeSubscriptionItemsUpdate.js";
+import { customerProductToStripeItemSpecs } from "@/internal/billing/v2/providers/stripe/utils/subscriptionItems/customerProductToStripeItemSpecs.js";
+import { customerProductToArrearLineItems } from "@/internal/billing/v2/utils/lineItems/customerProductToArrearLineItems.js";
+
+const makeFixture = ({
+	invoiceCredit = true,
+	baseInterval = BillingInterval.Month,
+	baseIntervalCount = 1,
+	baseAmount = 5_000,
+	includeBase = true,
+}: {
+	invoiceCredit?: boolean;
+	baseInterval?: BillingInterval;
+	baseIntervalCount?: number;
+	baseAmount?: number;
+	includeBase?: boolean;
+} = {}) => {
+	const source = features.create({ id: "voice", name: "Voice Minute" });
+	const customerEntitlement = customerEntitlements.create({
+		id: "customer_entitlement_credits",
+		featureId: "credits",
+		featureName: "Credits - Tier A",
+		featureType: FeatureType.CreditSystem,
+		featureConfig: { invoice_credit: invoiceCredit, schema: [] },
+		allowance: 5_000,
+		balance: -10_000,
+	});
+	customerEntitlement.usage_attribution = {
+		[source.internal_id]: { units: 100_000, credits: 15_000 },
+	};
+	const creditPrice = prices.createConsumable({
+		id: "credit_price",
+		featureId: "credits",
+		entitlementId: customerEntitlement.entitlement.id,
+	});
+	const basePrice = prices.createFixed({ id: "base_price" });
+	basePrice.config = {
+		...basePrice.config,
+		amount: baseAmount,
+		interval: baseInterval,
+		interval_count: baseIntervalCount,
+	} as FixedPriceConfig;
+	const productPrices = includeBase ? [creditPrice, basePrice] : [creditPrice];
+	const customerProduct = customerProducts.create({
+		product: products.createFull({
+			id: "enterprise",
+			name: "Enterprise - Tier A",
+			prices: productPrices,
+			entitlements: [customerEntitlement.entitlement],
+		}),
+		customerPrices: productPrices.map((price) =>
+			prices.createCustomer({ price }),
+		),
+		customerEntitlements: [customerEntitlement],
+	});
+	const ctx = contexts.create({
+		features: [source, customerEntitlement.entitlement.feature],
+	});
+	const billingContext = contexts.createBilling({
+		customerProducts: [customerProduct],
+	});
+	return { ctx, billingContext, customerProduct };
+};
+
+describe("invoice-credit subscription items", () => {
+	test("omits the credit pool row when the paid base supplies its renewal interval", () => {
+		const fixture = makeFixture();
+		const { recurringItems } = customerProductToStripeItemSpecs(fixture);
+		expect(recurringItems.map((item) => item.stripePriceId)).toEqual([
+			"stripe_price_base_price",
+		]);
+
+		const settlement = customerProductToArrearLineItems({
+			...fixture,
+			options: { invoiceCredits: { idempotencyScope: "invoice_test" } },
+		});
+		expect(
+			settlement.invoiceCreditLineItems.map((item) => ({
+				amount: item.amount,
+				description: item.description,
+			})),
+		).toEqual([
+			{ amount: 15_000, description: "Voice Minute, 100,000 units" },
+			{ amount: -5_000, description: "Credits applied" },
+		]);
+		expect(settlement.updateCustomerEntitlements[0]?.updates).toMatchObject({
+			balance: 5_000,
+			usage_attribution: {},
+		});
+	});
+
+	test("keeps the metered item for classic credit systems", () => {
+		const { recurringItems } = customerProductToStripeItemSpecs(
+			makeFixture({ invoiceCredit: false }),
+		);
+		expect(recurringItems.map((item) => item.stripePriceId)).toEqual([
+			"stripe_price_credit_price",
+			"stripe_price_base_price",
+		]);
+	});
+
+	test("removes the redundant item when an existing subscription is updated", () => {
+		const fixture = makeFixture();
+		const stripeSubscription = stripeSubscriptions.create({
+			id: "sub_credits",
+			items: [
+				{ id: "si_base", priceId: "stripe_price_base_price", quantity: 1 },
+				{ id: "si_credits", priceId: "stripe_price_credit_price", quantity: 0 },
+			],
+		});
+		fixture.customerProduct.subscription_ids = [stripeSubscription.id];
+		fixture.billingContext.stripeSubscription = stripeSubscription;
+		expect(
+			buildStripeSubscriptionItemsUpdate({
+				ctx: fixture.ctx,
+				billingContext: fixture.billingContext,
+				autumnBillingPlan: { customerId: "test", insertCustomerProducts: [] },
+				finalCustomerProducts: [fixture.customerProduct],
+			}),
+		).toEqual([{ id: "si_credits", deleted: true }]);
+	});
+
+	test.each([
+		{ includeBase: false },
+		{ baseAmount: 0 },
+		{ baseInterval: BillingInterval.OneOff },
+		{ baseInterval: BillingInterval.Year },
+		{ baseIntervalCount: 2 },
+	])(
+		"keeps the credit item when the base cannot supply monthly renewals: %j",
+		(options) => {
+			const { recurringItems } = customerProductToStripeItemSpecs(
+				makeFixture(options),
+			);
+			expect(recurringItems.map((item) => item.stripePriceId)).toContain(
+				"stripe_price_credit_price",
+			);
+		},
+	);
+});


### PR DESCRIPTION
Paid invoice-credit plans currently add an empty metered credit row to Stripe renewal invoices alongside the source charges and `Credits applied` deduction. Omit that redundant subscription item when a fixed recurring item on the same customer product supplies the same interval and interval count.

Credit-only plans, zero-price or one-off bases, differing renewal intervals, and ordinary credit systems retain their metered items. The shared builder applies this to subscription creation and updates, schedule phases, and Checkout. Existing subscriptions pick up the removal on their next subscription-item update; this does not backfill existing subscriptions or alter historical invoices.

Validation:

- TDD: the new omission and existing-subscription removal unit assertions fail with the original builder and pass with the fix. Eight regression cases cover cadence preservation, classic credits, settlement charges, and balance resets.
- 17 integration tests / 539 assertions passed on the isolated worktree through real Stripe sandbox webhooks, Autumn's API, Redis, workers, and Postgres. Includes funded and overage invoice credits, ordinary consumables, mixed-feature/entity/multi-product renewals, completed Stripe Checkout, and schedule transitions/proration. Both invoice-credit renewals have four lines, correct totals, restored balances, and cleared attribution.
- Focused billing unit run: 66 passed / 156 assertions. Server typecheck, scoped Biome, and `git diff --check` pass.
- Full unit suite: 4,206 passed, 14 failed, 9 skipped. Thirteen Redis-related failures reproduce with the original builder; the additional timing failure passes in isolation. The original-builder control also fails the two new regression assertions. These unrelated failures remain outside this change.

[Slack report](https://autumnpricing.slack.com/archives/C0AM2CY6BB8/p1789065230039699)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paid invoice-credit plans now omit the redundant metered credit row on Stripe renewal invoices when a fixed recurring item on the same product supplies the same interval and interval count. Credit-only plans, zero-price or one-off bases, differing renewal intervals, and ordinary credit systems retain their metered items. Existing subscriptions pick up the removal on their next subscription-item update; this does not backfill existing subscriptions or alter historical invoices.

<sup>Written for commit a071b008cc1a36f6daa98bac5a32a72f49c38a1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes a redundant metered credit row from Stripe subscriptions when a paid fixed item already provides the same renewal cadence.

**Key changes**
- **[Bug fixes]** Omits invoice-credit subscription items when a paid recurring fixed item on the same customer product has the same interval and interval count.
- **[Improvements]** Allows existing subscriptions to delete the redundant item during their next subscription-item update.
- **[Improvements]** Expands unit and integration coverage for funded and overage renewals, cadence mismatches, free and one-off bases, ordinary credit systems, settlement lines, and balance resets.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the redundant item is removed only when another billable recurring item preserves the same renewal cadence.

No actionable failures remain. Settlement and balance-reset behavior is independent of the omitted Stripe item, while the added tests cover both removal and the important cases where the meter must be retained.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/subscriptionItems/customerProductToStripeItemSpecs.ts | Detects invoice-credit metered items and removes them only when a billable fixed recurring item supplies the same cadence. |
| server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-invoice-credits.test.ts | Verifies funded and overage renewals omit the empty Stripe row while preserving invoice totals, settlement attribution, and balance resets. |
| server/tests/unit/billing/invoice-credit-subscription-items.test.ts | Covers omission, existing-item deletion, ordinary credits, and cases where the credit meter must remain. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Build Stripe item specifications] --> B{Consumable invoice-credit item?}
  B -- No --> C[Keep item]
  B -- Yes --> D{Matching paid recurring fixed item?}
  D -- No --> C
  D -- Yes --> E[Omit redundant credit meter]
  C --> F[Create or update Stripe subscription]
  E --> F
  F --> G[Fixed item drives renewal cadence]
  G --> H[Autumn settlement applies credits and resets balance]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): omit redundant invoice-cre..."](https://github.com/useautumn/autumn/commit/a071b008cc1a36f6daa98bac5a32a72f49c38a1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62855074)</sub>

<!-- /greptile_comment -->