### PR TITLE
fix(ci): unblock dev type check and public skills check

### DIFF
--- a/packages/agent-docs/scripts/checkPublicSkills.ts
+++ b/packages/agent-docs/scripts/checkPublicSkills.ts
@@ -1,17 +1,25 @@
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import config from "../agent-docs.config.js";
+import { parseFrontmatter } from "../src/translate/ingest/frontmatter.js";
 import { publishedSkillName } from "../src/translate/publishedSkillName.js";
 import { validateGeneratedSkillDirectory } from "./publicSkills.js";
+
+const contentRoot = resolve(import.meta.dir, "../content");
 
 const expectedSkillNames = Object.values(config)
 	.map((entry) => entry.formats.skill?.file)
 	.filter((file): file is string => Boolean(file))
 	.map((file) => {
-		const sourceName = file.split("/").at(-2);
-		if (!sourceName) {
-			throw new Error(`Cannot derive public skill name from "${file}"`);
+		const path = resolve(contentRoot, file);
+		const { data } = parseFrontmatter({
+			path,
+			text: readFileSync(path, "utf8"),
+		});
+		if (!data.name) {
+			throw new Error(`Skill ${file} is missing frontmatter name`);
 		}
-		return publishedSkillName({ name: sourceName });
+		return publishedSkillName({ name: data.name });
 	});
 
 validateGeneratedSkillDirectory({

--- a/packages/atmn-generator/src/emit/emitEmitModule.ts
+++ b/packages/atmn-generator/src/emit/emitEmitModule.ts
@@ -63,7 +63,7 @@ export const emitEmitModule = ({
 		Object.fromEntries(
 			[...allDefaults]
 				.filter(([path]) => path.startsWith(prefix))
-				.map(([path, value]) => [path.slice(prefix.length), value])
+				.map(([path, value]) => [path.slice(prefix.length), value] as const)
 				.sort(([left], [right]) => left.localeCompare(right)),
 		);
 	const lines: string[] = [


### PR DESCRIPTION
Fixes two of the three red checks on the current dev → main release PR (#3371). Both have been failing on every dev push since 2026-09-10 17:27.

## Type Check (Build and Push to ECR)

`packages/atmn-generator/src/emit/emitEmitModule.ts:67` fails `tsgo --build` with `'left' is of type 'unknown'`. The `.map(([path, value]) => [path.slice(...), value])` returns `unknown[]`, so the `.sort(([left], [right]) => left.localeCompare(right))` after it has no string type to work with. Narrowed with `as const`.

This came in with 6bbfdaaa on Sep 10 and PR CI didn't catch it because pull requests only run Server Type Check. Because this job gates "Build and Push Docker Image", the dev image hasn't built since then, and merging dev to main as-is would break the main build too.

## publish (Publish Public Skills)

`skills:check` derived expected skill names from the mdx folder (`skills/billing-steps/` → `autumn-billing-steps`), but the generator names output folders from the frontmatter `name` (`billing` → `autumn-billing`). The folder was renamed on Sep 1 while the published name stayed `autumn-billing`, which is what the instructions, the integrate skill and `agent.test.ts` all reference, so the checker is the thing that's wrong. It now reads the frontmatter through `parseFrontmatter` and `publishedSkillName`, the same path the generator uses.

## Not in this PR

The Leaf eval `mcp-attach-approval` ("destructive attach waits for approval") is agent behaviour, not code: the model nests `enable_plan_immediately: false` under `invoice_mode` and adds `proration_behavior: "none"` on a new customer, against the billing skill's own rules. It has failed 3 of the last 4 PR-triggered runs since the Sep 10 skill rewrite; the push-triggered runs that show green skipped the eval job. Needs a prompt or eval decision rather than a fix here.

## Verified

- `bun run ts` in `packages/atmn-generator`: clean.
- `bun -F @autumn/agent-docs gen && bun -F @autumn/agent-docs skills:check`: `Validated 9 generated public skills`, and gen produced no other diffs.
- `bunx biome check` clean on both files.
- `publicSkills.test.ts` fails locally on both this branch and untouched dev with `column "claim_state" does not exist` from the test preload against a local DB, so that is environment, not this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two of the three failing CI checks on dev: the ECR type check and the public skills check.

**Bug Fixes**
- Fixed `atmn-generator` type error: the mapped tuple widened to `unknown[]`, breaking `tsgo --build`; narrow it with `as const`.
- Fixed `agent-docs` `skills:check`: it derived expected skill names from folder names, but the generator uses frontmatter names. The billing skill folder is `billing-steps` but its name is `billing`, so the check failed. Now it reads frontmatter like the generator.

<sup>Written for commit d68cd39cc34734719039dd3608cb411622cc3e91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes two CI failures without changing generated output or public APIs.

Key changes:
- **[Bug fixes]** Derives expected public skill names from source frontmatter, matching the generator. For example, the billing-steps source folder correctly produces autumn-billing.
- **[Bug fixes]** Preserves tuple types when sorting generator defaults so TypeScript recognizes the keys as strings.

Static review found no actionable issues. Tests were not rerun during this review.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; both changes address the reported CI failures without introducing an actionable regression.

The skill checker uses the same source paths and naming rules as generation, and the tuple assertion restores string inference while remaining compatible with sorting and Object.fromEntries.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agent-docs/scripts/checkPublicSkills.ts | Aligns expected skill names with the generator’s frontmatter-based naming and existing CI environment. |
| packages/atmn-generator/src/emit/emitEmitModule.ts | Adds a const tuple assertion to fix key type inference without changing runtime behavior. |

<sub>Reviews (1): Last reviewed commit: ["fix(ci): unblock dev type check and publ..."](https://github.com/useautumn/autumn/commit/d68cd39cc34734719039dd3608cb411622cc3e91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63045417)</sub>

<!-- /greptile_comment -->