### PR TITLE
fix(docker): copy the ax-evals workspace manifest into the deps stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,7 @@ COPY packages/agent-docs/package.json packages/agent-docs/
 COPY packages/atmn/package.json packages/atmn/
 COPY packages/atmn-nightly/package.json packages/atmn-nightly/
 COPY packages/atmn-generator/package.json packages/atmn-generator/
+COPY packages/ax-evals/package.json packages/ax-evals/
 COPY packages/atmn-tests/package.json packages/atmn-tests/
 COPY packages/auth/package.json packages/auth/
 COPY packages/autumn-js/package.json packages/autumn-js/


### PR DESCRIPTION
Follow-up to #3381. With the type check green again, the ECR workflow's "Build and Push Docker Image" job ran for the first time since Sep 10 and failed on the release PR (#3382):

```
error: Workspace not found "packages/ax-evals"
    at /app/package.json:22:4
```

`docker/Dockerfile`'s deps stage copies every workspace's `package.json` one by one before `bun install --frozen-lockfile`. `packages/ax-evals` was added to the root workspaces on Aug 28 (merged to dev Sep 10) without a matching `COPY`, so bun sees a declared workspace with no manifest. It was the only one missing out of the 31 declared workspaces; this adds it.

## Verified

- Every entry in root `package.json` `workspaces.packages` now has a `COPY <ws>/package.json` line.
- `docker build --target deps -f docker/Dockerfile .` completes locally and exports the image.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Docker deps stage build by copying `packages/ax-evals/package.json` alongside the other workspace manifests, so `bun install --frozen-lockfile` no longer fails with "Workspace not found".

<sup>Written for commit 5b1183cc4ff75067caf379eb2563c3bed28f65d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the Docker dependency-stage build by making the `ax-evals` workspace manifest available to Bun.

- **Bug fixes:** Copies `packages/ax-evals/package.json` before the frozen dependency installation, preventing the “Workspace not found” build failure.
- **Improvements:** Keeps the Docker dependency stage aligned with the root workspace declarations.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and directly fixes the reported Docker build failure.

The copied manifest exists, matches a declared workspace, is available in the Docker build context, and is placed before the frozen Bun installation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docker/Dockerfile | Adds the missing `ax-evals` workspace manifest to the dependency stage before Bun installs dependencies. |

<sub>Reviews (1): Last reviewed commit: ["fix(docker): copy the ax-evals workspace..."](https://github.com/useautumn/autumn/commit/5b1183cc4ff75067caf379eb2563c3bed28f65d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63049259)</sub>

<!-- /greptile_comment -->