### PR TITLE
fix(mcp): default top-level enable_plan_immediately under invoice mode for attach

### DIFF
--- a/packages/mcp/src/tools/billing.ts
+++ b/packages/mcp/src/tools/billing.ts
@@ -38,6 +38,13 @@ const createScheduleMcpSchema = CreateScheduleParamsV0Schema.check((ctx) => {
 	}
 });
 
+const attachMcpSchema = AttachParamsV1Schema.overwrite((data) =>
+	data.invoice_mode?.enabled === true &&
+	data.enable_plan_immediately === undefined
+		? { ...data, enable_plan_immediately: true }
+		: data,
+);
+
 const endpoints = {
 	previewAttach: "/v1/billing.preview_attach",
 	attach: "/v1/billing.attach",
@@ -48,8 +55,8 @@ const endpoints = {
 } as const;
 
 const schemas = {
-	previewAttach: AttachParamsV1Schema,
-	attach: AttachParamsV1Schema,
+	previewAttach: attachMcpSchema,
+	attach: attachMcpSchema,
 	previewUpdateSubscription: UpdateSubscriptionV1ParamsSchema,
 	updateSubscription: UpdateSubscriptionV1ParamsSchema,
 	previewCreateSchedule: createScheduleMcpSchema,

--- a/packages/mcp/tests/unit/tools/billing.test.ts
+++ b/packages/mcp/tests/unit/tools/billing.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod/v4";
+import { billing } from "../../../src/tools/billing.js";
+
+const attachRequest = {
+	customer_id: "cus_123",
+	plan_id: "pro",
+};
+
+describe("attach schemas", () => {
+	test("default top-level enable_plan_immediately to true under invoice mode", () => {
+		for (const schema of [
+			billing.schemas.attach,
+			billing.schemas.previewAttach,
+		]) {
+			const parsed = schema.parse({
+				...attachRequest,
+				invoice_mode: { enabled: true, finalize: false },
+			});
+			expect(parsed.enable_plan_immediately).toBe(true);
+		}
+	});
+
+	test("keep an explicit enable_plan_immediately under invoice mode", () => {
+		const parsed = billing.schemas.attach.parse({
+			...attachRequest,
+			enable_plan_immediately: false,
+			invoice_mode: { enabled: true, finalize: false },
+		});
+		expect(parsed.enable_plan_immediately).toBe(false);
+	});
+
+	test("leave enable_plan_immediately unset without invoice mode", () => {
+		expect(
+			billing.schemas.attach.parse(attachRequest).enable_plan_immediately,
+		).toBeUndefined();
+		expect(
+			billing.schemas.attach.parse({
+				...attachRequest,
+				invoice_mode: { enabled: false },
+			}).enable_plan_immediately,
+		).toBeUndefined();
+	});
+
+	test("still convert to JSON schema for tool discovery", () => {
+		const jsonSchema = z.toJSONSchema(billing.schemas.attach, { io: "input" });
+		expect(jsonSchema).toMatchObject({ type: "object" });
+	});
+});


### PR DESCRIPTION
Third follow-up for the release PR (#3382). The remaining red check is the Leaf eval `mcp-attach-approval` ("destructive attach waits for approval"), which has failed 7 of 9 PR-triggered runs since 2026-09-10 17:27 after passing 8 of 8 before.

## What fails

The case expects the attach body to carry top-level `enable_plan_immediately: true` alongside `invoice_mode: {enabled: true, finalize: false}` (body matching is subset, so the extra `proration_behavior` is not the problem). In failing runs the agent sends invoice mode but omits the top-level field.

## Why

The eval's generic Mastra agent is built from `listToolsetsWithErrors()` plus a two-sentence instruction. It never receives the MCP server instructions and has no tool to read `autumn://docs/billing`, and the tool descriptions and mocked agent rules don't state the default either. Both passing and failing runs make the identical five tool calls (`getAgentRules`, `listCustomers`, `listPlans`, `previewAttach`, `attach`) with no doc reads. So whether the top-level field got set was down to the model, and that stopped going our way after Sep 10. Nothing the agent consumes changed in that window (MCP instructions are byte-identical, attach schema, harness, drivers and fixtures untouched); only the concepts and catalog resource texts changed, which this agent can't read anyway.

## Fix

Default the field where it's deterministic. `attach` and `previewAttach` now use `AttachParamsV1Schema.overwrite(...)`: when `invoice_mode.enabled` is true and `enable_plan_immediately` was left unset, it becomes `true`. An explicit `false` is preserved, and nothing changes without invoice mode. This mirrors `createScheduleMcpSchema` in the same file, which already requires the field to be true under invoice mode, and matches the documented default in the billing resource ("grant access now" for operator-led invoice attaches). The request body is `schema.parse(...)` output, so the default reaches the API.

This is a behaviour change for MCP callers only (the public API is untouched): an MCP attach in invoice mode without an explicit `enable_plan_immediately` now grants access immediately. That is the behaviour the docs already promise.

Not changed: the nested `invoice_mode.enable_plan_immediately` description, because it's embedded in generated Mintlify and Python SDK artifacts and would pull a regeneration into this PR.

## Verified

- New unit test `packages/mcp/tests/unit/tools/billing.test.ts`: default applied for attach and previewAttach, explicit false kept, unset without invoice mode, JSON-schema conversion still works. 4 pass.
- `bun run ts` in `packages/mcp` clean; biome clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults `enable_plan_immediately` to `true` in the MCP `attach` and `previewAttach` schemas when `invoice_mode.enabled` is `true` and the caller left the field unset. Previously the top-level field was only sent when the model happened to include it, which is why the `mcp-attach-approval` eval started failing.

**Behavior change**
- MCP callers in invoice mode now grant access immediately when `enable_plan_immediately` is omitted, matching the documented billing default.
- An explicit `false` is preserved, and nothing changes outside invoice mode. The public API is unaffected.

<sup>Written for commit d461b32998f4773b00e36db9f26f1fdac9cdd71a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes MCP invoice-mode attach and preview requests grant plan access immediately when the top-level option is omitted, and adds focused schema tests.

- **[Bug fixes, API changes]** Defaults top-level `enable_plan_immediately` to `true` for MCP attach and preview-attach requests with invoice mode enabled.
- **[Improvements]** Preserves an explicit top-level `false` and leaves non-invoice requests unchanged.
- **[Improvements]** Adds unit coverage for defaulting, top-level overrides, non-invoice behavior, and JSON Schema conversion.

The implementation still needs to preserve the supported nested opt-out before it is safe to merge.
</details>


<h3>Confidence Score: 4/5</h3>

This PR is not safe to merge until an explicit nested request to defer access is preserved.

The new MCP default can convert a supported invoice request that explicitly asks to keep access pending into immediate plan activation because the inserted top-level true takes precedence over nested false.

**Files Needing Attention:** packages/mcp/src/tools/billing.ts; packages/mcp/tests/unit/tools/billing.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/mcp/src/tools/billing.ts | Adds the MCP invoice-mode immediate-access default, but it overrides the existing nested deferral option. |
| packages/mcp/tests/unit/tools/billing.test.ts | Covers the main defaulting paths and schema conversion, but omits the conflicting nested-false case. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[MCP attach request] --> B{Invoice mode enabled?}
  B -->|No| C[Leave top-level option unset]
  B -->|Yes| D{Top-level option supplied?}
  D -->|Yes| E[Preserve supplied value]
  D -->|No| F[Set top-level option to true]
  F --> G{Nested option explicitly false?}
  G -->|Yes| H[Current behavior: top-level true wins]
  H --> I[Access begins before invoice payment]
  G -->|No| I
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/mcp/src/tools/billing.ts:42-45
**Nested opt-out is overridden**

A caller can set `invoice_mode.enable_plan_immediately: false` to keep access pending until the invoice is paid. If the top-level field is omitted, this overwrite adds `enable_plan_immediately: true`, which takes precedence and grants access immediately. Preserve the supported nested opt-out when applying this default, and add a test for that case.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): default top-level enable\_plan\_..."](https://github.com/useautumn/autumn/commit/d461b32998f4773b00e36db9f26f1fdac9cdd71a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63059434)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Automation and external integrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/automation-and-external-integrations.md)
- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)

<!-- /greptile_comment -->