### PR TITLE
fix(admin): repair impersonation and mobile controls

### DIFF
--- a/vite/src/views/admin/AdminOrgColumns.tsx
+++ b/vite/src/views/admin/AdminOrgColumns.tsx
@@ -1,7 +1,7 @@
 import type { OrgClaimState } from "@autumn/shared";
 import { Button, MiniCopyButton } from "@autumn/ui";
 import type { ColumnDef, Row } from "@tanstack/react-table";
-import type { User } from "better-auth";
+import type { UserWithRole } from "better-auth/plugins";
 import { format } from "date-fns";
 import { AdminOrgNameCell } from "./components/AdminOrgNameCell";
 import { AdminOrgStatusCell } from "./components/AdminOrgStatusCell";
@@ -14,7 +14,7 @@ export type AdminOrg = {
 	slug: string;
 	createdAt: string;
 	claim_state: OrgClaimState | null;
-	users: User[];
+	users: UserWithRole[];
 	requestBlockSummary: {
 		blockAll: boolean;
 		ruleCount: number;
@@ -133,7 +133,10 @@ export const createAdminOrgColumns = ({
 						Redis
 					</Button>
 					{firstNonAdminUser && (
-						<ImpersonateButton userId={firstNonAdminUser.id} />
+						<ImpersonateButton
+							userId={firstNonAdminUser.id}
+							organizationId={row.original.id}
+						/>
 					)}
 				</div>
 			);

--- a/vite/src/views/admin/AdminOrgColumns.tsx
+++ b/vite/src/views/admin/AdminOrgColumns.tsx
@@ -25,9 +25,6 @@ export type AdminOrg = {
 	} | null;
 };
 
-// AdminOrgNameCell renders the whole mobile card, so nothing else joins it.
-const hiddenOnMobile = { mobileCard: "hidden" as const };
-
 export const createAdminOrgColumns = ({
 	onManageRequestBlocks,
 	onManageRedis,
@@ -49,7 +46,7 @@ export const createAdminOrgColumns = ({
 		header: "Users",
 		accessorKey: "users",
 		size: 300,
-		meta: hiddenOnMobile,
+		meta: { mobileCard: "hidden" },
 		cell: ({ row }: { row: Row<AdminOrg> }) => (
 			<AdminOrgUsersCell users={row.original.users} />
 		),
@@ -59,7 +56,6 @@ export const createAdminOrgColumns = ({
 		header: "Status",
 		size: 120,
 		enableSorting: false,
-		meta: hiddenOnMobile,
 		cell: ({ row }: { row: Row<AdminOrg> }) => (
 			<AdminOrgStatusCell org={row.original} />
 		),
@@ -69,7 +65,6 @@ export const createAdminOrgColumns = ({
 		header: "Slug",
 		accessorKey: "slug",
 		size: 150,
-		meta: hiddenOnMobile,
 		cell: ({ row }: { row: Row<AdminOrg> }) => (
 			<MiniCopyButton text={row.original.slug} innerClassName="text-xs" />
 		),
@@ -79,7 +74,6 @@ export const createAdminOrgColumns = ({
 		header: "Created",
 		accessorKey: "createdAt",
 		size: 92,
-		meta: hiddenOnMobile,
 		cell: ({ row }: { row: Row<AdminOrg> }) => (
 			<span className="whitespace-nowrap text-subtle text-xs">
 				{format(new Date(row.original.createdAt), "dd MMM HH:mm")}
@@ -91,7 +85,6 @@ export const createAdminOrgColumns = ({
 		header: "ID",
 		accessorKey: "id",
 		size: 140,
-		meta: hiddenOnMobile,
 		cell: ({ row }: { row: Row<AdminOrg> }) => (
 			<div className="group flex w-full font-mono">
 				<MiniCopyButton text={row.original.id} innerClassName="text-xs" />
@@ -106,7 +99,7 @@ export const createAdminOrgColumns = ({
 		size: 200,
 		enableSorting: false,
 		enableHiding: false,
-		meta: hiddenOnMobile,
+		meta: { mobileCard: "full" },
 		cell: ({ row }: { row: Row<AdminOrg> }) => {
 			const firstNonAdminUser = row.original.users.find(
 				(user) => user.role !== "admin",
@@ -117,7 +110,10 @@ export const createAdminOrgColumns = ({
 			// would silently hide them. Only `ImpersonateButton` requires a
 			// non-admin user to target.
 			return (
-				<div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
+				<div
+					className="flex flex-wrap gap-2"
+					onClick={(e) => e.stopPropagation()}
+				>
 					<Button
 						variant="secondary"
 						size="sm"

--- a/vite/src/views/admin/AdminOrgColumns.tsx
+++ b/vite/src/views/admin/AdminOrgColumns.tsx
@@ -53,6 +53,7 @@ export const createAdminOrgColumns = ({
 	},
 	{
 		id: "status",
+		meta: { mobileCard: "hidden" },
 		header: "Status",
 		size: 120,
 		enableSorting: false,
@@ -62,6 +63,7 @@ export const createAdminOrgColumns = ({
 	},
 	{
 		id: "slug",
+		meta: { mobileCard: "hidden" },
 		header: "Slug",
 		accessorKey: "slug",
 		size: 150,
@@ -71,6 +73,7 @@ export const createAdminOrgColumns = ({
 	},
 	{
 		id: "createdAt",
+		meta: { mobileCard: "hidden" },
 		header: "Created",
 		accessorKey: "createdAt",
 		size: 92,
@@ -82,6 +85,7 @@ export const createAdminOrgColumns = ({
 	},
 	{
 		id: "id",
+		meta: { mobileCard: "hidden" },
 		header: "ID",
 		accessorKey: "id",
 		size: 140,

--- a/vite/src/views/admin/AdminUserColumns.tsx
+++ b/vite/src/views/admin/AdminUserColumns.tsx
@@ -11,7 +11,7 @@ export type AdminUser = {
 	createdAt: string;
 };
 
-// AdminUserEmailCell renders the whole mobile card, so nothing else joins it.
+// The mobile summary already includes the name and creation time.
 const hiddenOnMobile = { mobileCard: "hidden" as const };
 
 export const createAdminUserColumns = (): ColumnDef<AdminUser, unknown>[] => [
@@ -51,7 +51,6 @@ export const createAdminUserColumns = (): ColumnDef<AdminUser, unknown>[] => [
 		header: "ID",
 		accessorKey: "id",
 		size: 140,
-		meta: hiddenOnMobile,
 		cell: ({ row }: { row: Row<AdminUser> }) => (
 			<div className="group flex w-full font-mono">
 				<MiniCopyButton text={row.original.id} innerClassName="text-xs" />

--- a/vite/src/views/admin/AdminView.tsx
+++ b/vite/src/views/admin/AdminView.tsx
@@ -95,7 +95,7 @@ export const AdminView = () => {
 				value={activeTab}
 				onValueChange={(value) => setActiveTab(value as AdminTab)}
 			>
-				<TabsList className="max-w-full overflow-x-auto">
+				<TabsList className="max-w-full justify-start overflow-x-auto">
 					<TabsTrigger value="orgs">Organizations</TabsTrigger>
 					<TabsTrigger value="users">Users</TabsTrigger>
 					<TabsTrigger value="slack-bot">Slack Bot</TabsTrigger>

--- a/vite/src/views/admin/AdminView.tsx
+++ b/vite/src/views/admin/AdminView.tsx
@@ -61,7 +61,7 @@ export const AdminView = () => {
 
 	return (
 		<div className="flex flex-col p-6 gap-8">
-			<div className="flex justify-end absolute top-10 right-10 gap-2">
+			<div className="flex flex-wrap justify-end gap-2 md:absolute md:top-10 md:right-10">
 				<CreateUser />
 				<Button
 					onClick={() => navigate(`${adminBasePath}/edge-config`)}
@@ -95,7 +95,7 @@ export const AdminView = () => {
 				value={activeTab}
 				onValueChange={(value) => setActiveTab(value as AdminTab)}
 			>
-				<TabsList>
+				<TabsList className="max-w-full overflow-x-auto">
 					<TabsTrigger value="orgs">Organizations</TabsTrigger>
 					<TabsTrigger value="users">Users</TabsTrigger>
 					<TabsTrigger value="slack-bot">Slack Bot</TabsTrigger>

--- a/vite/src/views/admin/adminUtils.ts
+++ b/vite/src/views/admin/adminUtils.ts
@@ -49,23 +49,18 @@ export const impersonateUser = async ({
 }: {
 	userId: string;
 	organizationId?: string;
-	/**
-	 * When true, await stopImpersonating first — the active session is the
-	 * impersonated user's (non-admin) session, so impersonateUser would
-	 * otherwise fail the permission check. When false, skip the call entirely.
-	 */
 	isCurrentlyImpersonating?: boolean;
 }) => {
 	if (isCurrentlyImpersonating) {
-		try {
-			await authClient.admin.stopImpersonating();
-		} catch (error) {
-			console.error(error);
+		const { error } = await authClient.admin.stopImpersonating();
+		if (error) {
+			toast.error(error.message || "Failed to restore admin session");
+			return;
 		}
 	}
 	const res = await authClient.admin.impersonateUser({ userId });
 	if (res.error) {
-		toast.error("Something went wrong");
+		toast.error(res.error.message || "Failed to impersonate user");
 		return;
 	}
 

--- a/vite/src/views/admin/components/AdminOrgMobileSummary.tsx
+++ b/vite/src/views/admin/components/AdminOrgMobileSummary.tsx
@@ -2,10 +2,6 @@ import { OrgClaimState } from "@autumn/shared";
 import type { AdminOrg } from "../AdminOrgColumns";
 import { AdminOrgUnclaimedDot } from "./AdminOrgUnclaimedDot";
 
-/**
- * Whole mobile card body: org name over its emails, and nothing else. Rendered
- * from the title cell so the card stays two lines tall for fast scanning.
- */
 export const AdminOrgMobileSummary = ({ org }: { org: AdminOrg }) => (
 	<div className="flex min-w-0 flex-col gap-0.5">
 		<div className="flex min-w-0 items-center gap-1.5">

--- a/vite/src/views/admin/components/AdminOrgMobileSummary.tsx
+++ b/vite/src/views/admin/components/AdminOrgMobileSummary.tsx
@@ -1,5 +1,14 @@
 import { OrgClaimState } from "@autumn/shared";
+import {
+	Button,
+	MiniCopyButton,
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@autumn/ui";
+import { format } from "date-fns";
 import type { AdminOrg } from "../AdminOrgColumns";
+import { AdminOrgStatusCell } from "./AdminOrgStatusCell";
 import { AdminOrgUnclaimedDot } from "./AdminOrgUnclaimedDot";
 
 export const AdminOrgMobileSummary = ({ org }: { org: AdminOrg }) => (
@@ -7,6 +16,33 @@ export const AdminOrgMobileSummary = ({ org }: { org: AdminOrg }) => (
 		<div className="flex min-w-0 items-center gap-1.5">
 			<span className="truncate">{org.name}</span>
 			{org.claim_state === OrgClaimState.Pending && <AdminOrgUnclaimedDot />}
+			<Popover>
+				<PopoverTrigger asChild>
+					<Button variant="ghost" size="sm" className="ml-auto">
+						Details
+					</Button>
+				</PopoverTrigger>
+				<PopoverContent align="end" aria-label="Organization details">
+					<dl className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-4 gap-y-3 text-xs">
+						<dt>Status</dt>
+						<dd>
+							<AdminOrgStatusCell org={org} />
+						</dd>
+						<dt>Slug</dt>
+						<dd className="min-w-0">
+							<MiniCopyButton text={org.slug} innerClassName="text-xs" />
+						</dd>
+						<dt>Created</dt>
+						<dd className="tabular-nums">
+							{format(new Date(org.createdAt), "dd MMM HH:mm")}
+						</dd>
+						<dt>ID</dt>
+						<dd className="min-w-0 font-mono">
+							<MiniCopyButton text={org.id} innerClassName="text-xs" />
+						</dd>
+					</dl>
+				</PopoverContent>
+			</Popover>
 		</div>
 		<div className="flex flex-col font-normal text-tertiary-foreground text-xs">
 			{org.users.length === 0 && <span>No members</span>}

--- a/vite/src/views/admin/components/AdminOrgNameCell.tsx
+++ b/vite/src/views/admin/components/AdminOrgNameCell.tsx
@@ -5,8 +5,6 @@ import { AdminOrgMobileSummary } from "./AdminOrgMobileSummary";
 import { AdminOrgUnclaimedDot } from "./AdminOrgUnclaimedDot";
 
 export const AdminOrgNameCell = ({ org }: { org: AdminOrg }) => {
-	// The mobile card builds itself from the title cell, so it needs the emails
-	// too; every other column opts out of the card entirely.
 	const isMobile = useIsMobile();
 	if (isMobile) return <AdminOrgMobileSummary org={org} />;
 

--- a/vite/src/views/admin/components/ImpersonateBtn.tsx
+++ b/vite/src/views/admin/components/ImpersonateBtn.tsx
@@ -2,9 +2,17 @@ import { Button } from "@autumn/ui";
 import { useState } from "react";
 import { toast } from "sonner";
 import { impersonateUser } from "../adminUtils";
+import { useAdmin } from "../hooks/useAdmin";
 
-export const ImpersonateButton = ({ userId }: { userId?: string }) => {
+export const ImpersonateButton = ({
+	userId,
+	organizationId,
+}: {
+	userId?: string;
+	organizationId?: string;
+}) => {
 	const [loading, setLoading] = useState(false);
+	const { isCurrentlyImpersonating } = useAdmin();
 	if (!userId) {
 		return null;
 	}
@@ -16,7 +24,11 @@ export const ImpersonateButton = ({ userId }: { userId?: string }) => {
 			onClick={async () => {
 				setLoading(true);
 				try {
-					await impersonateUser({ userId });
+					await impersonateUser({
+						userId,
+						organizationId,
+						isCurrentlyImpersonating,
+					});
 				} catch (error: unknown) {
 					const errorMessage =
 						error instanceof Error ? error.message : "Unknown error";

--- a/vite/tests/views/admin/impersonate-user.test.ts
+++ b/vite/tests/views/admin/impersonate-user.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const calls: string[] = [];
+let stopError: { message: string } | null = null;
+const stopImpersonating = mock(async () => {
+	calls.push("stop");
+	return { error: stopError };
+});
+const startImpersonating = mock(async (_params: { userId: string }) => {
+	calls.push("impersonate");
+	return { error: null };
+});
+const setActiveOrg = mock(async (_orgId: string) => {
+	calls.push("set-org");
+	return { error: null };
+});
+const getSession = mock(async () => {
+	calls.push("get-session");
+	return { data: { session: { activeOrganizationId: "org_123" } } };
+});
+const reload = mock(() => {
+	calls.push("reload");
+});
+const toastError = mock((_message: string) => {});
+
+const originalAuthModule = { ...(await import("@/lib/auth-client")) };
+const originalOrgModule = { ...(await import("@/lib/orgSync")) };
+const originalSonnerModule = { ...(await import("sonner")) };
+
+mock.module("@/lib/auth-client", () => ({
+	authClient: {
+		admin: { stopImpersonating, impersonateUser: startImpersonating },
+		getSession,
+	},
+}));
+mock.module("@/lib/orgSync", () => ({ setActiveOrg }));
+mock.module("sonner", () => ({ toast: { error: toastError } }));
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+Object.defineProperty(globalThis, "window", {
+	value: { location: { reload } },
+	configurable: true,
+});
+
+afterAll(() => {
+	mock.module("@/lib/auth-client", () => originalAuthModule);
+	mock.module("@/lib/orgSync", () => originalOrgModule);
+	mock.module("sonner", () => originalSonnerModule);
+	if (originalWindow)
+		Object.defineProperty(globalThis, "window", originalWindow);
+	else Reflect.deleteProperty(globalThis, "window");
+});
+
+const { impersonateUser } = await import("../../../src/views/admin/adminUtils");
+
+beforeEach(() => {
+	calls.length = 0;
+	stopError = null;
+	stopImpersonating.mockClear();
+	startImpersonating.mockClear();
+	setActiveOrg.mockClear();
+	getSession.mockClear();
+	reload.mockClear();
+	toastError.mockClear();
+});
+
+describe("admin impersonation", () => {
+	test("restores admin before switching user and selected organization", async () => {
+		await impersonateUser({
+			userId: "user_123",
+			organizationId: "org_123",
+			isCurrentlyImpersonating: true,
+		});
+		expect(calls).toEqual([
+			"stop",
+			"impersonate",
+			"set-org",
+			"get-session",
+			"reload",
+		]);
+		expect(startImpersonating).toHaveBeenCalledWith({ userId: "user_123" });
+		expect(setActiveOrg).toHaveBeenCalledWith("org_123");
+	});
+
+	test("does not start another impersonation when restoring admin fails", async () => {
+		stopError = { message: "Unable to restore admin session" };
+		await impersonateUser({
+			userId: "user_123",
+			isCurrentlyImpersonating: true,
+		});
+		expect(calls).toEqual(["stop"]);
+		expect(toastError).toHaveBeenCalledWith("Unable to restore admin session");
+	});
+
+	test("does not stop a regular admin session", async () => {
+		await impersonateUser({ userId: "user_123" });
+		expect(calls).toEqual(["impersonate", "reload"]);
+	});
+});


### PR DESCRIPTION
Hotfix targeting `main`.

The admin-table impersonation button now passes the current impersonation state to the shared helper, restoring the admin session before switching users. Organization rows also pass the selected organization ID so the new session opens the intended organization. Stop failures abort the transition, and auth failures show the returned message instead of a generic toast.

Mobile organization cards retain the compact name/email/action layout, with status, slug, creation time, and copyable ID in a Details popover. Block, Redis, and Impersonate remain accessible; user cards include copyable IDs. The mobile toolbar no longer overlaps the tabs, and left-aligned scrolling keeps the first tab reachable.

Validation: three focused impersonation regression tests; browser reproduction failed before the fix and passes with the expected stop → impersonate → set-organization request sequence using intercepted synthetic auth responses. Responsive controls checked at 320, 390, 768, and 1440px. Biome and the repository `ts` command pass; React Doctor reports no diagnostics. The deeper `tsc -p tsconfig.app.json` check exposes unrelated repository errors and is not green.

![Compact mobile admin card with synthetic data](https://api.capy.ai/pr-assets/TZeMaLQVS6G5Jsen7IB2aTkWCuS7x_sN7N28sILE7cc)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This hotfix repairs transitions between impersonated admin sessions and improves access to admin controls on narrow screens.

**Key changes**
- **[Bug fixes]** Restores the administrator session before impersonating another user and aborts the transition if restoration fails.
- **[Bug fixes]** Opens organization-row impersonation in the selected organization and verifies the active organization before reloading.
- **[Improvements]** Shows authentication error messages returned by the server.
- **[Improvements]** Keeps organization actions and details accessible in compact mobile cards.
- **[Bug fixes]** Left-aligns the scrollable tab list so its first tabs remain reachable on narrow screens.
- **[Improvements]** Adds focused regression tests for impersonation sequencing and restoration failures.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the previous mobile-tab issue is fixed and no actionable new regression remains.

The resolved tab issue is fully addressed by left-aligning the overflowing list, while the impersonation flow now aborts failed restoration, verifies the selected organization before reload, and has focused regression coverage.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/admin/adminUtils.ts | Restores the administrator session before switching users, surfaces returned errors, and verifies organization selection before reload. |
| vite/src/views/admin/components/ImpersonateBtn.tsx | Supplies current impersonation state and optional organization context to the shared transition helper. |
| vite/src/views/admin/AdminOrgColumns.tsx | Preserves mobile organization actions and passes the selected organization to impersonation. |
| vite/src/views/admin/AdminView.tsx | Makes the mobile toolbar flow naturally and keeps the beginning of the tab list reachable. |
| vite/src/views/admin/components/AdminOrgMobileSummary.tsx | Adds a compact details popover for organization metadata on mobile. |
| vite/tests/views/admin/impersonate-user.test.ts | Covers stop-before-switch sequencing, restoration failure, organization selection, and normal admin impersonation. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor Admin
    participant UI as Admin table
    participant Auth as Auth client
    participant Org as Organization client
    Admin->>UI: Select Impersonate
    alt Already impersonating
        UI->>Auth: Stop impersonating
        Auth-->>UI: Restore result
    end
    UI->>Auth: Impersonate selected user
    Auth-->>UI: New session
    opt Organization row selected
        UI->>Org: Set selected organization
        UI->>Auth: Refresh session without cookie cache
        Auth-->>UI: Active organization
    end
    UI->>UI: Reload after verification
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(admin): restore admin session before..."](https://github.com/useautumn/autumn/commit/f854a52d5daf5fd641a2bb0cf91fd88227d0df73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63076930)</sub>

<!-- /greptile_comment -->