### PR TITLE
Hide pending plan entitlements from dashboard balances

### DIFF
--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts
@@ -34,8 +34,10 @@ export function filterCustomerFeatureUsage({
 			if (ent.customer_product.status === CusProductStatus.Expired) {
 				return showExpired;
 			}
-			// Scheduled products stay hidden from balance views.
-			if (ent.customer_product.status === CusProductStatus.Scheduled) {
+			const hidesFromBalanceView =
+				ent.customer_product.status === CusProductStatus.Scheduled ||
+				ent.customer_product.status === CusProductStatus.Pending;
+			if (hidesFromBalanceView) {
 				return false;
 			}
 			return showActive;

--- a/vite/tests/views/customers2/customer-feature-usage.test.ts
+++ b/vite/tests/views/customers2/customer-feature-usage.test.ts
@@ -11,10 +11,12 @@ const buildCustomerEntitlement = ({
 	id,
 	pooled,
 	isPooledBalance = false,
+	status = CusProductStatus.Active,
 }: {
 	id: string;
 	pooled: boolean;
 	isPooledBalance?: boolean;
+	status?: CusProductStatus;
 }) =>
 	({
 		id,
@@ -25,7 +27,7 @@ const buildCustomerEntitlement = ({
 			feature: { id: "messages" },
 		},
 		customer_product: {
-			status: CusProductStatus.Active,
+			status,
 		},
 	}) as FullCusEntWithFullCusProduct;
 
@@ -103,5 +105,72 @@ describe("customer feature usage pooled balances", () => {
 		expect(flattened.id).toBe("pool");
 		expect(flattened.is_pooled_balance).toBe(true);
 		expect(flattened.customer_product).toBeNull();
+	});
+});
+
+describe("customer feature usage product statuses", () => {
+	test("hides pending entitlements from the active balance view", () => {
+		const pending = buildCustomerEntitlement({
+			id: "pending",
+			pooled: false,
+			status: CusProductStatus.Pending,
+		});
+
+		const filtered = filterCustomerFeatureUsage({
+			entitlements: [pending],
+			statuses: ["active"],
+		});
+
+		expect(filtered).toEqual([]);
+	});
+
+	test("hides pending entitlements from the expired balance view", () => {
+		const pending = buildCustomerEntitlement({
+			id: "pending",
+			pooled: false,
+			status: CusProductStatus.Pending,
+		});
+
+		const filtered = filterCustomerFeatureUsage({
+			entitlements: [pending],
+			statuses: ["expired"],
+		});
+
+		expect(filtered).toEqual([]);
+	});
+
+	test("keeps the active grant when the same feature also has a pending grant", () => {
+		const active = buildCustomerEntitlement({
+			id: "active",
+			pooled: false,
+			status: CusProductStatus.Active,
+		});
+		const pending = buildCustomerEntitlement({
+			id: "pending",
+			pooled: false,
+			status: CusProductStatus.Pending,
+		});
+
+		const filtered = filterCustomerFeatureUsage({
+			entitlements: [active, pending],
+			statuses: ["active"],
+		});
+
+		expect(filtered.map(({ id }) => id)).toEqual(["active"]);
+	});
+
+	test("hides scheduled entitlements from the active balance view", () => {
+		const scheduled = buildCustomerEntitlement({
+			id: "scheduled",
+			pooled: false,
+			status: CusProductStatus.Scheduled,
+		});
+
+		const filtered = filterCustomerFeatureUsage({
+			entitlements: [scheduled],
+			statuses: ["active"],
+		});
+
+		expect(filtered).toEqual([]);
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Unpaid checkout inserts the new plan as a `pending` customer product while the current plan stays `active`. Dashboard Features / Balances treated pending entitlements as active, so grants were summed (for example two daily allowances on the same feature).

The public API already excludes pending (`Active` / `PastDue` only). Spend was never affected.

## Change

`filterCustomerFeatureUsage` now hides entitlements whose customer product is `pending`, the same way it already hides `scheduled`.

- Pending plans still appear in the Plans table
- Features / Balances only show entitlements from non-pending, non-scheduled products
- Active grants remain when the same feature also has a pending grant

## Tests

Unit coverage in `vite/tests/views/customers2/customer-feature-usage.test.ts`:

- pending hidden from the active view
- pending hidden from the expired view
- only the active grant remains when the same feature also has a pending grant
- scheduled remains hidden

Browser check on a synthetic customer with an active free plan (100 messages) and a pending paid plan (200 messages): Plans still lists both; Features shows `100 / 100 left`, not 300.

[Customer page with pending plan listed and only the active 100-message balance](https://cursor.com/agents/bc-ce0b4ba4-5a1b-4c1e-aaad-89af3ba6adc5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcustomer_pending_plan_hidden_from_balances.webp)

[dashboard_hides_pending_plan_balances.mp4](https://cursor.com/agents/bc-ce0b4ba4-5a1b-4c1e-aaad-89af3ba6adc5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_hides_pending_plan_balances.mp4)

## Out of scope

- Public API `orgToInStatuses`
- Spend / check / track
- Plans table “active” filter (`status <> expired`)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce0b4ba4-5a1b-4c1e-aaad-89af3ba6adc5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce0b4ba4-5a1b-4c1e-aaad-89af3ba6adc5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides pending plan entitlements from the dashboard Features/Balances views so grants are no longer summed twice when a checkout is pending. Pending plans still appear in the Plans table, and active grants on the same feature remain visible.

- Pending entitlements are now filtered the same way scheduled entitlements already are.
- Public API, spend, check, and track behavior are unchanged.
- Unit tests cover pending and scheduled filtering, including mixed active/pending cases.

<sup>Written for commit dac57231b97409da1489d9d86699af786a599f63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents pending plan entitlements from inflating balances shown on customer dashboards.

**Key changes**
- **Bug fixes:** Excludes entitlements belonging to pending customer products from active and expired balance views.
- **Bug fixes:** Preserves an active grant when the same feature also has a pending grant.
- **Improvements:** Adds focused unit coverage for pending, mixed active/pending, and scheduled product states.
</details>


<h3>Confidence Score: 5/5</h3>

The current PR appears safe to merge because pending entitlements are consistently excluded and the intended status combinations are covered by tests.

No actionable defects or repository-rule violations remain in the current PR diff.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts | Extends the existing scheduled-product exclusion to pending products without changing active or expired handling. |
| vite/tests/views/customers2/customer-feature-usage.test.ts | Adds coverage confirming that pending and scheduled grants remain hidden while valid active grants remain visible. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into cursor/hide-pen..."](https://github.com/useautumn/autumn/commit/dac57231b97409da1489d9d86699af786a599f63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63118201)</sub>

<!-- /greptile_comment -->