### PR TITLE
feat(analytics): add 6 and 12 month ranges to the internal events aggregate

### DIFF
--- a/server/src/internal/analytics/actions/listEventNames.ts
+++ b/server/src/internal/analytics/actions/listEventNames.ts
@@ -14,16 +14,18 @@ export const listEventNames = async ({
 	ctx,
 	limit,
 	interval,
+	binSize,
 	customRange,
 }: {
 	ctx: AutumnContext;
 	limit?: number;
 	interval?: string;
+	binSize?: string;
 	customRange?: { start: number; end: number };
 }): Promise<EventNameWithCount[]> => {
 	const { org, env } = ctx;
 	const pipes = getTinybirdPipes();
-	const window = getEventRankingWindow({ interval, customRange });
+	const window = getEventRankingWindow({ interval, binSize, customRange });
 
 	const result = await pipes.listEventNames({
 		org_id: org.id,

--- a/server/src/internal/analytics/actions/listRawEvents.ts
+++ b/server/src/internal/analytics/actions/listRawEvents.ts
@@ -2,20 +2,25 @@ import type {
 	BillingCycleResult,
 	ClickHouseResult,
 	FullCustomer,
-	MonthRangeEnum,
 	RawEventFromClickHouse,
 } from "@autumn/shared";
-import { MONTH_RANGES } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
-import { subMonths } from "date-fns";
+import { sub } from "date-fns";
 import {
 	getTinybirdPipes,
 	type ListEventsPaginatedPipeRow,
 } from "@/external/tinybird/initTinybird.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { getBillingCycleStartDate } from "../analyticsUtils.js";
+import {
+	getBillingCycleStartDate,
+	getStandardIntervalWindow,
+} from "../analyticsUtils.js";
 
 const DEFAULT_LIMIT = 1000;
+
+/** Lookback for ranges with no fixed window, e.g. billing-cycle ranges whose
+ * subscription lookup came up empty. */
+const FALLBACK_LOOKBACK_DAYS = 24;
 
 const formatJsDateToClickHouseDateTime = (date: Date): string => {
 	const year = date.getFullYear();
@@ -28,36 +33,15 @@ const formatJsDateToClickHouseDateTime = (date: Date): string => {
 	return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 };
 
-const calculateStartDateFromInterval = (interval: string): Date => {
-	const startDate = new Date();
-
-	const months =
-		interval in MONTH_RANGES
-			? MONTH_RANGES[interval as MonthRangeEnum]
-			: undefined;
-	if (months !== undefined) {
-		return subMonths(startDate, months);
-	}
-
-	switch (interval) {
-		case "24h":
-			startDate.setHours(startDate.getHours() - 24);
-			break;
-		case "7d":
-			startDate.setDate(startDate.getDate() - 7);
-			break;
-		case "30d":
-			startDate.setDate(startDate.getDate() - 30);
-			break;
-		case "90d":
-			startDate.setDate(startDate.getDate() - 90);
-			break;
-		default:
-			startDate.setDate(startDate.getDate() - 24);
-			break;
-	}
-
-	return startDate;
+const calculateStartDateFromInterval = ({
+	interval,
+	binSize,
+}: {
+	interval: string;
+	binSize?: string;
+}): UTCDate => {
+	const window = getStandardIntervalWindow({ interval, binSize });
+	return window?.start ?? sub(new UTCDate(), { days: FALLBACK_LOOKBACK_DAYS });
 };
 
 /** Converts pipe row to the expected ClickHouse format */
@@ -78,6 +62,7 @@ export type ListRawEventsParams = {
 	customer_id?: string;
 	entity_id?: string;
 	interval?: string;
+	bin_size?: string;
 	custom_range?: { start: number; end: number };
 	customer?: FullCustomer;
 	aggregateAll?: boolean;
@@ -112,7 +97,10 @@ export const listRawEvents = async ({
 			: null;
 
 	// Calculate date range
-	const startDate = calculateStartDateFromInterval(intervalType);
+	const startDate = calculateStartDateFromInterval({
+		interval: intervalType,
+		binSize: params.bin_size,
+	});
 
 	const finalStartDate = params.custom_range
 		? formatJsDateToClickHouseDateTime(new UTCDate(params.custom_range.start))
@@ -124,7 +112,7 @@ export const listRawEvents = async ({
 		? formatJsDateToClickHouseDateTime(new UTCDate(params.custom_range.end))
 		: isBillingCycle && billingCycleResult?.endDate
 			? billingCycleResult.endDate
-			: formatJsDateToClickHouseDateTime(new Date());
+			: formatJsDateToClickHouseDateTime(new UTCDate());
 
 	const eventNameFilter = (() => {
 		if (params.event_names && params.event_names.length > 0) {

--- a/server/src/internal/analytics/actions/listRawEvents.ts
+++ b/server/src/internal/analytics/actions/listRawEvents.ts
@@ -2,9 +2,12 @@ import type {
 	BillingCycleResult,
 	ClickHouseResult,
 	FullCustomer,
+	MonthRangeEnum,
 	RawEventFromClickHouse,
 } from "@autumn/shared";
+import { MONTH_RANGES } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
+import { subMonths } from "date-fns";
 import {
 	getTinybirdPipes,
 	type ListEventsPaginatedPipeRow,
@@ -27,6 +30,14 @@ const formatJsDateToClickHouseDateTime = (date: Date): string => {
 
 const calculateStartDateFromInterval = (interval: string): Date => {
 	const startDate = new Date();
+
+	const months =
+		interval in MONTH_RANGES
+			? MONTH_RANGES[interval as MonthRangeEnum]
+			: undefined;
+	if (months !== undefined) {
+		return subMonths(startDate, months);
+	}
 
 	switch (interval) {
 		case "24h":

--- a/server/src/internal/analytics/analyticsUtils.ts
+++ b/server/src/internal/analytics/analyticsUtils.ts
@@ -6,7 +6,6 @@ import {
 	type FullCustomer,
 	type FullProduct,
 	MONTH_RANGES,
-	type MonthRangeEnum,
 	RecaseError,
 	type Subscription,
 } from "@autumn/shared";
@@ -29,14 +28,33 @@ export const STANDARD_INTERVAL_DAYS: Record<string, number> = {
 
 const CLICKHOUSE_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 
+/** Own-property lookup: the interval is arbitrary caller input, so an inherited
+ * name like "toString" must not resolve to a range length. */
+const lookupRangeLength = ({
+	lengths,
+	interval,
+}: {
+	lengths: Record<string, number>;
+	interval?: string;
+}): number | undefined => {
+	if (interval === undefined) return undefined;
+	// biome-ignore lint/suspicious/noPrototypeBuiltins: Object.hasOwn needs lib ES2022; server targets ES2020.
+	if (!Object.prototype.hasOwnProperty.call(lengths, interval)) {
+		return undefined;
+	}
+	return lengths[interval];
+};
+
 const monthsForRange = ({
 	interval,
 }: {
 	interval?: string;
 }): number | undefined =>
-	interval !== undefined && interval in MONTH_RANGES
-		? MONTH_RANGES[interval as MonthRangeEnum]
-		: undefined;
+	lookupRangeLength({ lengths: MONTH_RANGES, interval });
+
+/** True when a range is measured in months rather than days. */
+export const isMonthRange = ({ interval }: { interval?: string }): boolean =>
+	monthsForRange({ interval }) !== undefined;
 
 /** Default bin for a range when the caller didn't pick one: month ranges are
  * built for monthly bins, and 24h is too short for anything but hours. */
@@ -63,7 +81,10 @@ export const getStandardIntervalWindow = ({
 	now?: UTCDate;
 }): { start: UTCDate; end: UTCDate } | undefined => {
 	const months = monthsForRange({ interval });
-	const days = interval ? STANDARD_INTERVAL_DAYS[interval] : undefined;
+	const days = lookupRangeLength({
+		lengths: STANDARD_INTERVAL_DAYS,
+		interval,
+	});
 	if (months === undefined && days === undefined) return undefined;
 
 	const bin = binSize ?? defaultBinSizeForRange({ interval });
@@ -84,14 +105,17 @@ export const getStandardIntervalWindow = ({
 
 /** Resolves the start/end window the event-name ranking should query so it
  * matches the chart's visible range. A custom range takes precedence; otherwise
- * the standard range resolves with the same boundary alignment the chart uses.
- * Returns undefined when neither applies (e.g. billing-cycle ranges), leaving
- * callers on all-time ranking. */
+ * the standard range resolves with the same boundary alignment the chart uses,
+ * which is why the chart's bin size belongs here too. Returns undefined when
+ * neither applies (e.g. billing-cycle ranges), leaving callers on all-time
+ * ranking. */
 export const getEventRankingWindow = ({
 	interval,
+	binSize,
 	customRange,
 }: {
 	interval?: string;
+	binSize?: string;
 	customRange?: { start: number; end: number };
 }): { startDate: string; endDate: string } | undefined => {
 	if (customRange) {
@@ -101,7 +125,7 @@ export const getEventRankingWindow = ({
 		};
 	}
 
-	const window = getStandardIntervalWindow({ interval });
+	const window = getStandardIntervalWindow({ interval, binSize });
 	if (!window) {
 		return undefined;
 	}

--- a/server/src/internal/analytics/analyticsUtils.ts
+++ b/server/src/internal/analytics/analyticsUtils.ts
@@ -5,11 +5,13 @@ import {
 	type FullCusProduct,
 	type FullCustomer,
 	type FullProduct,
+	MONTH_RANGES,
+	type MonthRangeEnum,
 	RecaseError,
 	type Subscription,
 } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
-import { format, startOfDay, startOfHour, sub } from "date-fns";
+import { format, startOfDay, startOfHour, startOfMonth, sub } from "date-fns";
 import type Stripe from "stripe";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
@@ -27,11 +29,64 @@ export const STANDARD_INTERVAL_DAYS: Record<string, number> = {
 
 const CLICKHOUSE_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 
+const monthsForRange = ({
+	interval,
+}: {
+	interval?: string;
+}): number | undefined =>
+	interval !== undefined && interval in MONTH_RANGES
+		? MONTH_RANGES[interval as MonthRangeEnum]
+		: undefined;
+
+/** Default bin for a range when the caller didn't pick one: month ranges are
+ * built for monthly bins, and 24h is too short for anything but hours. */
+export const defaultBinSizeForRange = ({
+	interval,
+}: {
+	interval?: string;
+}): "hour" | "day" | "month" => {
+	if (interval === "24h") return "hour";
+	return monthsForRange({ interval }) === undefined ? "day" : "month";
+};
+
+/** Resolves the UTC window a standard (non billing-cycle) range covers. The
+ * start is aligned down to the bin boundary so a chart's bucket filter and its
+ * totals' timestamp filter select the same events. Returns undefined when the
+ * range is unknown or billing-cycle based, which callers resolve per customer. */
+export const getStandardIntervalWindow = ({
+	interval,
+	binSize,
+	now = new UTCDate(),
+}: {
+	interval?: string;
+	binSize?: string;
+	now?: UTCDate;
+}): { start: UTCDate; end: UTCDate } | undefined => {
+	const months = monthsForRange({ interval });
+	const days = interval ? STANDARD_INTERVAL_DAYS[interval] : undefined;
+	if (months === undefined && days === undefined) return undefined;
+
+	const bin = binSize ?? defaultBinSizeForRange({ interval });
+
+	// A month range counts bins, not days: "12m" is the last 12 monthly bars, so
+	// the window opens on the 1st rather than leaving a partial leading bar.
+	if (months !== undefined && bin === "month") {
+		return { start: startOfMonth(sub(now, { months: months - 1 })), end: now };
+	}
+
+	const unaligned =
+		months !== undefined ? sub(now, { months }) : sub(now, { days });
+	return {
+		start: bin === "hour" ? startOfHour(unaligned) : startOfDay(unaligned),
+		end: now,
+	};
+};
+
 /** Resolves the start/end window the event-name ranking should query so it
  * matches the chart's visible range. A custom range takes precedence; otherwise
- * a standard interval is resolved with the same boundary alignment the chart
- * uses — hour for 24h, day for 7d/30d/90d. Returns undefined when neither
- * applies (e.g. billing-cycle intervals), leaving callers on all-time ranking. */
+ * the standard range resolves with the same boundary alignment the chart uses.
+ * Returns undefined when neither applies (e.g. billing-cycle ranges), leaving
+ * callers on all-time ranking. */
 export const getEventRankingWindow = ({
 	interval,
 	customRange,
@@ -46,18 +101,14 @@ export const getEventRankingWindow = ({
 		};
 	}
 
-	const days = interval ? STANDARD_INTERVAL_DAYS[interval] : undefined;
-	if (!days) {
+	const window = getStandardIntervalWindow({ interval });
+	if (!window) {
 		return undefined;
 	}
 
-	const now = new UTCDate();
-	const unaligned = sub(now, { days });
-	const start =
-		interval === "24h" ? startOfHour(unaligned) : startOfDay(unaligned);
 	return {
-		startDate: format(start, CLICKHOUSE_DATE_FORMAT),
-		endDate: format(now, CLICKHOUSE_DATE_FORMAT),
+		startDate: format(window.start, CLICKHOUSE_DATE_FORMAT),
+		endDate: format(window.end, CLICKHOUSE_DATE_FORMAT),
 	};
 };
 

--- a/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
@@ -4,7 +4,6 @@ import {
 	ErrCode,
 	type FullCusProduct,
 	type FullCustomer,
-	MONTH_RANGES,
 	type RangeEnum,
 	RecaseError,
 	Scopes,
@@ -23,6 +22,7 @@ import { eventActions } from "../actions/eventActions.js";
 import {
 	defaultBinSizeForRange,
 	getStandardIntervalWindow,
+	isMonthRange,
 } from "../analyticsUtils.js";
 import { collapsePlanIdGroups } from "./utils/collapsePlanIdGroups.js";
 
@@ -119,8 +119,7 @@ export const handleInternalAggregateEvents = createRoute({
 			bin_size || defaultBinSizeForRange({ interval: interval ?? undefined });
 
 		if (
-			interval &&
-			interval in MONTH_RANGES &&
+			isMonthRange({ interval: interval ?? undefined }) &&
 			(binSize === "day" || binSize === "hour")
 		) {
 			throw new RecaseError({

--- a/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
@@ -4,12 +4,12 @@ import {
 	ErrCode,
 	type FullCusProduct,
 	type FullCustomer,
+	MONTH_RANGES,
 	type RangeEnum,
 	RecaseError,
 	Scopes,
 } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
-import { sub } from "date-fns";
 import { StatusCodes } from "http-status-codes";
 import { z } from "zod/v4";
 import { assertTinybirdAvailable } from "@/external/tinybird/tinybirdUtils.js";
@@ -20,7 +20,10 @@ import { getEntityNames } from "@/internal/analytics/actions/getEntityNames.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { eventActions } from "../actions/eventActions.js";
-import { STANDARD_INTERVAL_DAYS } from "../analyticsUtils.js";
+import {
+	defaultBinSizeForRange,
+	getStandardIntervalWindow,
+} from "../analyticsUtils.js";
 import { collapsePlanIdGroups } from "./utils/collapsePlanIdGroups.js";
 
 const InternalAggregateEventsSchema = z.object({
@@ -111,42 +114,39 @@ export const handleInternalAggregateEvents = createRoute({
 		// Filter out empty strings
 		event_names = event_names.filter((name: string) => name !== "");
 
-		// Use provided bin_size, or default based on interval
-		const binSize = bin_size || (interval === "24h" ? "hour" : "day");
+		// Use provided bin_size, or the range's default.
+		const binSize =
+			bin_size || defaultBinSizeForRange({ interval: interval ?? undefined });
 
-		// For standard intervals, compute the window once here and pass it as
+		if (
+			interval &&
+			interval in MONTH_RANGES &&
+			(binSize === "day" || binSize === "hour")
+		) {
+			throw new RecaseError({
+				message: `bin_size "${binSize}" is not supported for the "${interval}" range; use "week" or "month"`,
+				code: ErrCode.InvalidRequest,
+				statusCode: StatusCodes.BAD_REQUEST,
+			});
+		}
+
+		// For standard ranges, compute the window once here and pass it as
 		// `custom_range` to both actions. This guarantees the chart (aggregate)
 		// and totals (getCountAndSum) use an identical window so their numbers
-		// stay aligned. Billing-cycle intervals fall through to each action's
-		// own resolution (both use the same `getBillingCycleStartDate`).
-		//
-		// The start is aligned down to the bin boundary (UTC) so the chart's
-		// `hour`-column filter and the totals' `timestamp`-column filter select
-		// the same events — otherwise the chart's first bucket would skip the
-		// sub-hour events the totals include.
-		const standardIntervalDays = interval
-			? STANDARD_INTERVAL_DAYS[interval]
-			: undefined;
+		// stay aligned. Billing-cycle ranges fall through to each action's own
+		// resolution (both use the same `getBillingCycleStartDate`).
 		const now = new UTCDate();
-		const customRange = (() => {
-			if (custom_range) return custom_range;
-			if (standardIntervalDays === undefined) return undefined;
-			const unaligned = sub(now, { days: standardIntervalDays });
-			const aligned =
-				binSize === "hour"
-					? new UTCDate(
-							unaligned.getFullYear(),
-							unaligned.getMonth(),
-							unaligned.getDate(),
-							unaligned.getHours(),
-						)
-					: new UTCDate(
-							unaligned.getFullYear(),
-							unaligned.getMonth(),
-							unaligned.getDate(),
-						);
-			return { start: aligned.getTime(), end: now.getTime() };
-		})();
+		const standardWindow = getStandardIntervalWindow({
+			interval: interval ?? undefined,
+			binSize,
+			now,
+		});
+		const customRange =
+			custom_range ??
+			(standardWindow && {
+				start: standardWindow.start.getTime(),
+				end: standardWindow.end.getTime(),
+			});
 
 		let resolvedGroupBy = group_by;
 		if (group_by === "$customer_id") {

--- a/server/src/internal/analytics/internalHandlers/handleInternalListRawEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalListRawEvents.ts
@@ -1,4 +1,9 @@
-import { ErrCode, type FullCustomer, RecaseError, Scopes } from "@autumn/shared";
+import {
+	ErrCode,
+	type FullCustomer,
+	RecaseError,
+	Scopes,
+} from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
 import { z } from "zod/v4";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
@@ -8,6 +13,7 @@ import { eventActions } from "../actions/eventActions.js";
 
 const InternalListRawEventsSchema = z.object({
 	interval: z.string().nullish(),
+	bin_size: z.enum(["day", "hour", "week", "month"]).optional(),
 	custom_range: z
 		.object({ start: z.number(), end: z.number() })
 		.refine((range) => range.start < range.end, {
@@ -28,8 +34,14 @@ export const handleInternalListRawEvents = createRoute({
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { db, org, env } = ctx;
-		const { interval, custom_range, event_names, customer_id, entity_id } =
-			c.req.valid("json");
+		const {
+			interval,
+			bin_size,
+			custom_range,
+			event_names,
+			customer_id,
+			entity_id,
+		} = c.req.valid("json");
 
 		let aggregateAll = false;
 		let customer: FullCustomer | undefined;
@@ -63,6 +75,7 @@ export const handleInternalListRawEvents = createRoute({
 					customer_id: customer?.id ?? undefined,
 					entity_id: entity_id,
 					interval: interval ?? undefined,
+					bin_size,
 					custom_range: custom_range ?? undefined,
 					event_names: event_names?.filter((name) => name !== ""),
 					customer,

--- a/server/src/internal/analytics/internalHandlers/handleListEventNames.ts
+++ b/server/src/internal/analytics/internalHandlers/handleListEventNames.ts
@@ -7,6 +7,7 @@ import { eventActions } from "../actions/eventActions.js";
 const ListEventNamesSchema = z.object({
 	limit: z.coerce.number().optional(),
 	interval: z.string().optional(),
+	bin_size: z.enum(["day", "hour", "week", "month"]).optional(),
 	start: z.coerce.number().optional(),
 	end: z.coerce.number().optional(),
 });
@@ -20,7 +21,7 @@ export const handleListEventNames = createRoute({
 	handler: async (c) => {
 		assertTinybirdAvailable();
 		const ctx = c.get("ctx");
-		const { limit, interval, start, end } = c.req.valid("query");
+		const { limit, interval, bin_size, start, end } = c.req.valid("query");
 
 		const customRange =
 			interval === "custom" && start !== undefined && end !== undefined
@@ -31,6 +32,7 @@ export const handleListEventNames = createRoute({
 			ctx,
 			limit,
 			interval,
+			binSize: bin_size,
 			customRange,
 		});
 

--- a/server/tests/unit/analytics/month-range-window.test.ts
+++ b/server/tests/unit/analytics/month-range-window.test.ts
@@ -73,8 +73,19 @@ test(`${chalk.yellowBright(
 	).toBe("2026-06-13T00:00:00.000Z");
 
 	expect(
-		getStandardIntervalWindow({ interval: "24h", now: NOW })?.start.toISOString(),
+		getStandardIntervalWindow({
+			interval: "24h",
+			now: NOW,
+		})?.start.toISOString(),
 	).toBe("2026-09-10T14:00:00.000Z");
 
-	expect(getStandardIntervalWindow({ interval: "1bc", now: NOW })).toBeUndefined();
+	expect(
+		getStandardIntervalWindow({ interval: "1bc", now: NOW }),
+	).toBeUndefined();
+
+	// The internal endpoint accepts any interval string, so an inherited
+	// Object.prototype name must not be mistaken for a month range.
+	expect(
+		getStandardIntervalWindow({ interval: "toString", now: NOW }),
+	).toBeUndefined();
 });

--- a/server/tests/unit/analytics/month-range-window.test.ts
+++ b/server/tests/unit/analytics/month-range-window.test.ts
@@ -1,0 +1,80 @@
+// Month ranges ("6m" / "12m") count monthly bins rather than days, so a
+// month-binned window must open on the 1st — otherwise the chart leads with a
+// partial bar the totals also under-count. Finer bins keep the full period.
+
+import { expect, test } from "bun:test";
+import { UTCDate } from "@date-fns/utc";
+import chalk from "chalk";
+import { generateAllPeriods } from "@/internal/analytics/actions/aggregate.js";
+import { getStandardIntervalWindow } from "@/internal/analytics/analyticsUtils.js";
+
+const NOW = new UTCDate("2026-09-11T14:37:12Z");
+
+test(`${chalk.yellowBright(
+	"analytics range window: month ranges on month bins start on the 1st",
+)}`, () => {
+	const twelveMonths = getStandardIntervalWindow({
+		interval: "12m",
+		binSize: "month",
+		now: NOW,
+	});
+	expect(twelveMonths?.start.toISOString()).toBe("2025-10-01T00:00:00.000Z");
+
+	const sixMonths = getStandardIntervalWindow({
+		interval: "6m",
+		binSize: "month",
+		now: NOW,
+	});
+	expect(sixMonths?.start.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+});
+
+test(`${chalk.yellowBright(
+	"analytics range window: a month range renders exactly that many monthly bars",
+)}`, () => {
+	const window = getStandardIntervalWindow({
+		interval: "12m",
+		binSize: "month",
+		now: NOW,
+	});
+
+	const periods = generateAllPeriods({
+		startDate: window?.start.toISOString() ?? "",
+		endDate: window?.end.toISOString() ?? "",
+		binSize: "month",
+		timezone: "UTC",
+	});
+
+	expect(periods).toHaveLength(12);
+	expect(periods[0]).toBe("2025-10-01 00:00:00");
+	expect(periods[11]).toBe("2026-09-01 00:00:00");
+});
+
+test(`${chalk.yellowBright(
+	"analytics range window: finer bins span the whole month range",
+)}`, () => {
+	const window = getStandardIntervalWindow({
+		interval: "6m",
+		binSize: "week",
+		now: NOW,
+	});
+
+	expect(window?.start.toISOString()).toBe("2026-03-11T00:00:00.000Z");
+});
+
+test(`${chalk.yellowBright(
+	"analytics range window: day and hour ranges keep their existing alignment",
+)}`, () => {
+	expect(
+		getStandardIntervalWindow({
+			interval: "90d",
+			binSize: "day",
+			now: NOW,
+		})?.start.toISOString(),
+	).toBe("2026-06-13T00:00:00.000Z");
+
+	expect(
+		getStandardIntervalWindow({ interval: "24h", now: NOW })?.start.toISOString(),
+	).toBe("2026-09-10T14:00:00.000Z");
+
+	expect(getStandardIntervalWindow({ interval: "1bc", now: NOW })).toBeUndefined();
+});

--- a/shared/api/events/components/rangeEnum.ts
+++ b/shared/api/events/components/rangeEnum.ts
@@ -11,3 +11,9 @@ export const RangeEnum = z.enum([
 ]);
 
 export type RangeEnum = z.infer<typeof RangeEnum>;
+
+/** Month-scale ranges the internal dashboard accepts on top of `RangeEnum`,
+ * mapped to the number of monthly bins each covers. Not on the public API. */
+export const MONTH_RANGES = { "6m": 6, "12m": 12 } as const;
+
+export type MonthRangeEnum = keyof typeof MONTH_RANGES;

--- a/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
@@ -20,66 +20,19 @@ import type { DateRange } from "react-day-picker";
 
 import { useAnalyticsContext } from "../AnalyticsContext";
 import { useAnalyticsQueryState } from "../hooks/useAnalyticsQueryState";
+import {
+	BILLING_CYCLE_INTERVALS,
+	CUSTOM_INTERVAL,
+	GRANULARITY_LABELS,
+	type Granularity,
+	getEffectiveBinSize,
+	granularitiesFor,
+	INTERVAL_LABELS,
+} from "../utils/intervals";
 import { CustomerComboBox } from "./CustomerComboBox";
 import { SelectEntityDropdown } from "./SelectEntityDropdown";
 import { SelectFeatureDropdown } from "./SelectFeatureDropdown";
 import { SelectGroupByDropdown } from "./SelectGroupByDropdown";
-
-// Time ranges shown in the dropdown, in display order.
-const INTERVAL_LABELS: Record<string, string> = {
-	"24h": "Last 24 hours",
-	"7d": "Last 7 days",
-	"30d": "Last 30 days",
-	"1bc": "Current billing cycle",
-	"90d": "Last 90 days",
-	"3bc": "Latest 3 billing cycles",
-};
-
-// Billing-cycle ranges, hidden when the customer has no billing cycle.
-const BILLING_CYCLE_INTERVALS = new Set(["1bc", "3bc"]);
-
-type Granularity = "hour" | "day" | "week" | "month";
-
-// Selectable granularities per range, in display order; the first is the
-// default. A single entry means the range has no choice, so the granularity
-// section is hidden for it.
-const INTERVAL_GRANULARITIES: Record<string, Granularity[]> = {
-	"24h": ["hour"],
-	"7d": ["day"],
-	"30d": ["day", "week"],
-	"1bc": ["day"],
-	"90d": ["day", "week", "month"],
-	"3bc": ["day", "week", "month"],
-	custom: ["day", "week", "month"],
-};
-
-const GRANULARITY_LABELS: Record<Granularity, string> = {
-	hour: "by hour",
-	day: "by day",
-	week: "by week",
-	month: "by month",
-};
-
-const CUSTOM_INTERVAL = "custom";
-const DEFAULT_GRANULARITIES: Granularity[] = ["day"];
-
-const granularitiesFor = (interval: string): Granularity[] =>
-	INTERVAL_GRANULARITIES[interval] ?? DEFAULT_GRANULARITIES;
-
-// The bin size in effect for a range: the viewer's choice when it's valid for
-// the range, otherwise the range's default (first) granularity.
-const getEffectiveBinSize = ({
-	interval,
-	binSize,
-}: {
-	interval: string;
-	binSize?: string | null;
-}): Granularity => {
-	const granularities = granularitiesFor(interval);
-	return binSize && granularities.some((g) => g === binSize)
-		? (binSize as Granularity)
-		: granularities[0];
-};
 
 const getDisplayLabel = ({
 	interval,

--- a/vite/src/views/customers/customer/analytics/components/SelectFeatureDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectFeatureDropdown.tsx
@@ -1,10 +1,5 @@
 import type { Feature } from "@autumn/shared";
 import { FeatureType } from "@autumn/shared";
-import { IconButton } from "@autumn/ui";
-import { CaretDownIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
-import { useMemo, useState } from "react";
-import { useLocation, useNavigate, useSearchParams } from "react-router";
-import { toast } from "sonner";
 import {
 	DropdownMenu,
 	DropdownMenuCheckboxItem,
@@ -12,11 +7,17 @@ import {
 	DropdownMenuGroup,
 	DropdownMenuLabel,
 	DropdownMenuTrigger,
+	IconButton,
 } from "@autumn/ui";
+import { CaretDownIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { useMemo, useState } from "react";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useAnalyticsContext } from "../AnalyticsContext";
 import { useAnalyticsQueryState } from "../hooks/useAnalyticsQueryState";
 import { useEventNames } from "../hooks/useEventNames";
+import { getEffectiveBinSize } from "../utils/intervals";
 
 const MAX_NUM_SELECTED = 10;
 
@@ -68,6 +69,10 @@ export const SelectFeatureDropdown = () => {
 	const { queryStates } = useAnalyticsQueryState();
 	const { eventNames: eventNamesData } = useEventNames({
 		interval: queryStates.interval,
+		binSize: getEffectiveBinSize({
+			interval: queryStates.interval,
+			binSize: queryStates.bin_size,
+		}),
 		start: queryStates.start,
 		end: queryStates.end,
 	});

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -157,6 +157,11 @@ export const useRawAnalyticsData = () => {
 
 	const { queryStates } = useAnalyticsQueryState();
 	const { interval, start, end } = queryStates;
+	// The table must cover the chart's window, so it resolves the bin the same way.
+	const binSize = getEffectiveBinSize({
+		interval,
+		binSize: queryStates.bin_size,
+	});
 	const customRange =
 		interval === "custom" && start && end ? { start, end } : undefined;
 
@@ -176,6 +181,7 @@ export const useRawAnalyticsData = () => {
 		customer_id: customerId || undefined,
 		entity_id: entityId || undefined,
 		interval: customRange ? undefined : interval,
+		bin_size: binSize,
 		custom_range: customRange,
 		event_names: tableEventNames,
 	};
@@ -187,6 +193,7 @@ export const useRawAnalyticsData = () => {
 			customerId,
 			entityId,
 			interval,
+			binSize,
 			String(start ?? ""),
 			String(end ?? ""),
 			...(tableEventNames ?? []).sort(),

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -9,6 +9,7 @@ import { useMemo } from "react";
 import { useSearchParams } from "react-router";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getEffectiveBinSize } from "../utils/intervals";
 import { useAnalyticsQueryState } from "./useAnalyticsQueryState";
 import { useSelectedEventNames } from "./useSelectedEventNames";
 
@@ -36,7 +37,13 @@ export const useAnalyticsData = ({
 	const maxGroups = Number(searchParams.get("max_groups")) || 10;
 
 	const { queryStates } = useAnalyticsQueryState();
-	const { interval, bin_size: binSize, start, end } = queryStates;
+	const { interval, start, end } = queryStates;
+	// Resolve the bin here rather than letting the server default it: a range's
+	// default granularity is a UI decision, and the two must not drift.
+	const binSize = getEffectiveBinSize({
+		interval,
+		binSize: queryStates.bin_size,
+	});
 	// The deduction rollup is keyed by customer, so it cannot run org-wide.
 	const aggregateOn =
 		queryStates.aggregate_on === "deducted" && customerId
@@ -77,7 +84,7 @@ export const useAnalyticsData = ({
 		custom_range: customRange,
 		event_names: selectedEventNames,
 		group_by: formattedGroupBy,
-		bin_size: binSize || undefined,
+		bin_size: binSize,
 		timezone: effectiveTimezone,
 		max_groups: formattedGroupBy ? maxGroups : undefined,
 		aggregate_on: aggregateOn,
@@ -92,7 +99,7 @@ export const useAnalyticsData = ({
 			customerId,
 			entityId,
 			interval,
-			binSize || "day",
+			binSize,
 			String(start ?? ""),
 			String(end ?? ""),
 			...selectedEventNames.sort(),

--- a/vite/src/views/customers/customer/analytics/hooks/useEventNames.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useEventNames.tsx
@@ -10,12 +10,14 @@ export type EventNameWithCount = {
 export const useEventNames = ({
 	limit,
 	interval,
+	binSize,
 	start,
 	end,
 	enabled = true,
 }: {
 	limit?: number;
 	interval?: string;
+	binSize?: string;
 	start?: number | null;
 	end?: number | null;
 	enabled?: boolean;
@@ -24,13 +26,21 @@ export const useEventNames = ({
 	const buildKey = useQueryKeyFactory();
 
 	const { data, isLoading, error } = useQuery({
-		queryKey: buildKey(["query-event-names-list", limit, interval, start, end]),
+		queryKey: buildKey([
+			"query-event-names-list",
+			limit,
+			interval,
+			binSize,
+			start,
+			end,
+		]),
 		enabled,
 		queryFn: async () => {
 			const { data } = await axiosInstance.get("/query/event_names/list", {
 				params: {
 					limit,
 					interval,
+					bin_size: binSize,
 					start: start ?? undefined,
 					end: end ?? undefined,
 				},

--- a/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
@@ -1,5 +1,6 @@
 import { parseAsArrayOf, parseAsString, useQueryStates } from "nuqs";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { getEffectiveBinSize } from "../utils/intervals";
 import { useAnalyticsQueryState } from "./useAnalyticsQueryState";
 import { type EventNameWithCount, useEventNames } from "./useEventNames";
 
@@ -16,9 +17,13 @@ export const useSelectedEventNames = () => {
 
 	const { queryStates } = useAnalyticsQueryState();
 	const { interval, start, end } = queryStates;
+	const binSize = getEffectiveBinSize({
+		interval,
+		binSize: queryStates.bin_size,
+	});
 
 	const { eventNames: cachedEventNames, isLoading: eventNamesLoading } =
-		useEventNames({ interval, start, end });
+		useEventNames({ interval, binSize, start, end });
 	const { features: featuresData, isLoading: featuresLoading } =
 		useFeaturesQuery();
 

--- a/vite/src/views/customers/customer/analytics/utils/chartGeometry.ts
+++ b/vite/src/views/customers/customer/analytics/utils/chartGeometry.ts
@@ -1,4 +1,6 @@
+import { MONTH_RANGES, type MonthRangeEnum } from "@autumn/shared";
 import type { CSSProperties } from "react";
+import { type Granularity, getEffectiveBinSize } from "./intervals";
 
 /**
  * Single source of truth for the usage chart's layout, shared between the real
@@ -135,33 +137,13 @@ export const niceCeil = (value: number): number => {
 	return niceFraction * magnitude;
 };
 
-type BinSize = "hour" | "day" | "week" | "month";
-
-const resolveBinSize = ({
-	interval,
-	binSize,
-}: {
-	interval: string;
-	binSize: string | null;
-}): BinSize => {
-	if (
-		binSize === "hour" ||
-		binSize === "day" ||
-		binSize === "week" ||
-		binSize === "month"
-	) {
-		return binSize;
-	}
-	return interval === "24h" ? "hour" : "day";
-};
-
 /** Truncates a timestamp down to the start of its bin, matching the backend. */
 const alignDown = ({
 	ms,
 	binSize,
 }: {
 	ms: number;
-	binSize: BinSize;
+	binSize: Granularity;
 }): number => {
 	const date = new Date(ms);
 	if (binSize === "hour") {
@@ -177,6 +159,27 @@ const alignDown = ({
 	} else {
 		date.setUTCHours(0, 0, 0, 0);
 	}
+	return date.getTime();
+};
+
+/** Start of a month range's window, mirroring the backend: month bins open on
+ * the 1st so the range renders exactly `months` bars. */
+const monthRangeStart = ({
+	rangeEnd,
+	months,
+	binSize,
+}: {
+	rangeEnd: number;
+	months: number;
+	binSize: Granularity;
+}): number => {
+	const date = new Date(rangeEnd);
+	if (binSize === "month") {
+		date.setUTCDate(1);
+		date.setUTCMonth(date.getUTCMonth() - (months - 1));
+		return date.getTime();
+	}
+	date.setUTCMonth(date.getUTCMonth() - months);
 	return date.getTime();
 };
 
@@ -196,12 +199,18 @@ export const predictBarCount = ({
 	start: number | null;
 	end: number | null;
 }): number => {
-	const bin = resolveBinSize({ interval, binSize });
+	const bin = getEffectiveBinSize({ interval, binSize });
 	const rangeEnd = interval === "custom" && end ? end : Date.now();
+	const months =
+		interval in MONTH_RANGES
+			? MONTH_RANGES[interval as MonthRangeEnum]
+			: undefined;
 	const rangeStart =
 		interval === "custom" && start
 			? start
-			: rangeEnd - (STANDARD_INTERVAL_DAYS[interval] ?? 30) * MS_PER_DAY;
+			: months !== undefined
+				? monthRangeStart({ rangeEnd, months, binSize: bin })
+				: rangeEnd - (STANDARD_INTERVAL_DAYS[interval] ?? 30) * MS_PER_DAY;
 
 	const alignedStart = alignDown({ ms: rangeStart, binSize: bin });
 

--- a/vite/src/views/customers/customer/analytics/utils/chartGeometry.ts
+++ b/vite/src/views/customers/customer/analytics/utils/chartGeometry.ts
@@ -173,14 +173,26 @@ const monthRangeStart = ({
 	months: number;
 	binSize: Granularity;
 }): number => {
-	const date = new Date(rangeEnd);
+	const end = new Date(rangeEnd);
+	const year = end.getUTCFullYear();
+	const month = end.getUTCMonth();
+
 	if (binSize === "month") {
-		date.setUTCDate(1);
-		date.setUTCMonth(date.getUTCMonth() - (months - 1));
-		return date.getTime();
+		return Date.UTC(year, month - (months - 1), 1);
 	}
-	date.setUTCMonth(date.getUTCMonth() - months);
-	return date.getTime();
+
+	// Clamp the day the way date-fns `sub` does on the server: day 0 of the
+	// following month is the last day of the target one.
+	const lastDayOfTarget = new Date(
+		Date.UTC(year, month - months + 1, 0),
+	).getUTCDate();
+	return Date.UTC(
+		year,
+		month - months,
+		Math.min(end.getUTCDate(), lastDayOfTarget),
+		end.getUTCHours(),
+		end.getUTCMinutes(),
+	);
 };
 
 /**
@@ -201,10 +213,9 @@ export const predictBarCount = ({
 }): number => {
 	const bin = getEffectiveBinSize({ interval, binSize });
 	const rangeEnd = interval === "custom" && end ? end : Date.now();
-	const months =
-		interval in MONTH_RANGES
-			? MONTH_RANGES[interval as MonthRangeEnum]
-			: undefined;
+	const months = Object.hasOwn(MONTH_RANGES, interval)
+		? MONTH_RANGES[interval as MonthRangeEnum]
+		: undefined;
 	const rangeStart =
 		interval === "custom" && start
 			? start

--- a/vite/src/views/customers/customer/analytics/utils/intervals.ts
+++ b/vite/src/views/customers/customer/analytics/utils/intervals.ts
@@ -1,0 +1,61 @@
+export type Granularity = "hour" | "day" | "week" | "month";
+
+export const CUSTOM_INTERVAL = "custom";
+
+// Time ranges shown in the dropdown, in display order.
+export const INTERVAL_LABELS: Record<string, string> = {
+	"24h": "Last 24 hours",
+	"7d": "Last 7 days",
+	"30d": "Last 30 days",
+	"1bc": "Current billing cycle",
+	"90d": "Last 90 days",
+	"3bc": "Latest 3 billing cycles",
+	"6m": "Last 6 months",
+	"12m": "Last 12 months",
+};
+
+// Billing-cycle ranges, hidden when the customer has no billing cycle.
+export const BILLING_CYCLE_INTERVALS = new Set(["1bc", "3bc"]);
+
+// Selectable granularities per range, in display order; the first is the
+// default. A single entry means the range has no choice, so the granularity
+// section is hidden for it. Month ranges omit "day" — hundreds of daily bars
+// are unreadable and miss the monthly rollups that make those ranges fast.
+export const INTERVAL_GRANULARITIES: Record<string, Granularity[]> = {
+	"24h": ["hour"],
+	"7d": ["day"],
+	"30d": ["day", "week"],
+	"1bc": ["day"],
+	"90d": ["day", "week", "month"],
+	"3bc": ["day", "week", "month"],
+	"6m": ["month", "week"],
+	"12m": ["month", "week"],
+	custom: ["day", "week", "month"],
+};
+
+export const GRANULARITY_LABELS: Record<Granularity, string> = {
+	hour: "by hour",
+	day: "by day",
+	week: "by week",
+	month: "by month",
+};
+
+const DEFAULT_GRANULARITIES: Granularity[] = ["day"];
+
+export const granularitiesFor = (interval: string): Granularity[] =>
+	INTERVAL_GRANULARITIES[interval] ?? DEFAULT_GRANULARITIES;
+
+/** The bin size in effect for a range: the viewer's choice when it's valid for
+ * the range, otherwise the range's default (first) granularity. */
+export const getEffectiveBinSize = ({
+	interval,
+	binSize,
+}: {
+	interval: string;
+	binSize?: string | null;
+}): Granularity => {
+	const granularities = granularitiesFor(interval);
+	return binSize && granularities.some((g) => g === binSize)
+		? (binSize as Granularity)
+		: granularities[0];
+};


### PR DESCRIPTION
Adds "Last 6 months" and "Last 12 months" to the internal events aggregate endpoint and the analytics range picker. Both default to monthly granularity and drop the by-day option — hundreds of daily bars are unreadable, and month bins are what hit the monthly rollups that make long ranges fast. Weekly stays available.

## Range window resolution

`getStandardIntervalWindow` in `analyticsUtils.ts` now owns resolving a standard range into an aligned UTC window, replacing the inline alignment that lived in the aggregate handler and the duplicated day math in `getEventRankingWindow`.

Month ranges count bins rather than days: `12m` on a month bin opens on the 1st of the month 11 back, so the chart renders exactly 12 full bars instead of 13 with a partial leader. Finer bins span the full period. Day and hour ranges keep their existing alignment, verified by unit tests.

The handler also rejects `day` / `hour` bin sizes for month ranges with a 400 rather than silently serving a 365-bar window off the hourly path.

## Frontend

The range labels, per-range granularities, and effective-bin resolution move out of `QueryTopbar` into `analytics/utils/intervals.ts`, so the request hook and the loading skeleton resolve the bin the same way the dropdown does. Previously `useAnalyticsData` sent whatever raw `bin_size` was in the URL and let the server default it, which would have defaulted month ranges to daily.

## Raw events

`listRawEvents` resolves month ranges too, so the events table under the chart covers the same window as the chart.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M28MKW2FR2D87YCR0AFBQQGM"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds "Last 6 months" and "Last 12 months" to the internal events aggregate and the analytics range picker. Both default to monthly granularity and drop the by-day option; week stays available, and day or hour bins on these ranges now fail with a 400 instead of rendering hundreds of unreadable bars.

**New Features**
- Month ranges open on the 1st, so a chart renders exactly as many monthly bars as the range name says.
- Raw events and event-name ranking now cover the same month window as the chart.

**Refactors**
- Range-window resolution is centralized in `getStandardIntervalWindow`, replacing duplicated alignment in the aggregate handler, raw-events, and event-ranking windows.
- Frontend range config moves into `analytics/utils/intervals.ts`, so the aggregate, raw events, event-name queries, feature dropdown, and loading skeleton resolve the same effective bin.

<sup>Written for commit 6a59b3422d166e3205f4b4f7334fbd04ed390356. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds six- and twelve-month analytics ranges and centralizes range, granularity, and UTC-window resolution across charts, event rankings, raw-event tables, and loading geometry.

- **[API changes]** Adds `6m` and `12m` internal analytics ranges, with monthly defaults and weekly alternatives.
- **[Improvements]** Centralizes standard interval-window calculation so charts, totals, event rankings, raw events, and loading skeletons use consistent boundaries.
- **[Bug fixes]** Aligns month-binned ranges to the first day of the opening month and safely handles month-end subtraction.
- **[Bug fixes]** Uses own-property range lookup so unsupported names such as `toString` are not interpreted as valid ranges.
- **[Improvements]** Consolidates analytics filter URL state through the shared query-state adapter.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the previous raw-window, month-overflow, and inherited-property findings are fully addressed.

Month-range windows are now shared across analytics consumers, frontend month subtraction is clamped to valid calendar dates, and range lookup checks only explicit object properties. No new actionable failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/analyticsUtils.ts | Centralizes safe range lookup, default granularity, and aligned UTC-window resolution. |
| server/src/internal/analytics/actions/listRawEvents.ts | Reuses the standard window resolver so raw events match the chart’s selected range. |
| server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts | Applies range-specific bin defaults and rejects unsupported fine-grained bins for month ranges. |
| vite/src/views/customers/customer/analytics/utils/intervals.ts | Defines shared range labels, available granularities, and effective-bin selection. |
| vite/src/views/customers/customer/analytics/utils/chartGeometry.ts | Mirrors backend month arithmetic when predicting loading-skeleton bar counts. |
| vite/src/views/customers/customer/analytics/hooks/useAnalyticsFilterState.tsx | Consolidates analytics filter parameters into shared URL-synchronized state. |
| server/tests/unit/analytics/month-range-window.test.ts | Covers month-bin alignment, exact bar counts, finer-bin windows, standard ranges, and inherited property names. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    UI[Analytics range picker] --> BIN[Resolve effective bin]
    BIN --> CHART[Aggregate events request]
    BIN --> RAW[Raw events request]
    BIN --> NAMES[Event-name ranking request]
    BIN --> SKELETON[Loading bar prediction]
    CHART --> WINDOW[Standard UTC window resolver]
    RAW --> WINDOW
    NAMES --> WINDOW
    WINDOW --> RANGE{Range type}
    RANGE -->|6m or 12m + month| MONTH[Align opening month to day 1]
    RANGE -->|Finer bin| FULL[Use full month duration]
    RANGE -->|Day/hour range| STANDARD[Align to day/hour boundary]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/useautumn/autumn/commit/6a59b3422d166e3205f4b4f7334fbd04ed390356) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63151052)</sub>

<!-- /greptile_comment -->