### PR TITLE
feat(atmn): pull writes plan history into planVersions/&lt;planId&gt;.ts

### DIFF
--- a/packages/atmn-nightly/src/actions/pull.ts
+++ b/packages/atmn-nightly/src/actions/pull.ts
@@ -1,5 +1,11 @@
-import { readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import { ConfigNotFoundError, loadConfig } from "../config/loadConfig";
 import { loadEnvFiles } from "../env/loadEnv";
 import type { AutumnClient } from "../generated/client";
@@ -227,7 +233,12 @@ export const runPull = async ({
 
 	for (const [file, source] of files) {
 		if (source === originals.get(file)) continue;
+		mkdirSync(dirname(file), { recursive: true });
 		writeFileSync(file, source, "utf8");
+		if (!originals.has(file)) {
+			const keep = join(dirname(file), ".gitkeep");
+			if (existsSync(keep)) unlinkSync(keep);
+		}
 	}
 
 	// Fixtures the catalog already knows get their stable id and slug, even

--- a/packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts
+++ b/packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts
@@ -1,0 +1,200 @@
+import { dirname, relative } from "node:path";
+import { Lang, parse } from "@ast-grep/napi";
+import { appendToBinding } from "../../surgery/appendToBinding";
+import { appendToCollection } from "../../surgery/appendToCollection";
+import { ensureBuilderImport } from "../../surgery/ensureBuilderImport";
+import { lineStartOf } from "../../surgery/fixtureEdit";
+import type { CollectionTarget } from "./resolveCollectionTarget";
+
+const NAMED_IMPORT = /import\s+\{([^}]*)\}\s*from\s*["']([^"']+)["']/;
+
+const importSpecifierForBuilder = ({
+	source,
+	builder,
+}: {
+	source: string;
+	builder: string;
+}): string | null => {
+	const root = parse(Lang.TypeScript, source).root();
+	for (const statement of root.findAll({
+		rule: { kind: "import_statement" },
+	})) {
+		const match = NAMED_IMPORT.exec(statement.text());
+		if (match === null) continue;
+		const importsBuilder = match[1].split(",").some((entry) => {
+			const [imported] = entry.trim().split(/\s+as\s+/);
+			return imported === builder;
+		});
+		if (importsBuilder) return match[2];
+	}
+	return null;
+};
+
+const referenceSpecifier = ({
+	from,
+	fixtureFile,
+}: {
+	from: string;
+	fixtureFile: string;
+}): string => {
+	const path = relative(dirname(from), fixtureFile)
+		.replaceAll("\\", "/")
+		.replace(/\.ts$/, "");
+	return path.startsWith(".") ? path : `./${path}`;
+};
+
+const ensureReferenceImport = ({
+	source,
+	name,
+	specifier,
+}: {
+	source: string;
+	name: string;
+	specifier: string;
+}): string => {
+	const root = parse(Lang.TypeScript, source).root();
+	for (const statement of root.findAll({
+		rule: { kind: "import_statement" },
+	})) {
+		const match = NAMED_IMPORT.exec(statement.text());
+		if (match === null || match[2] !== specifier) continue;
+		const names = match[1]
+			.split(",")
+			.map((entry) => entry.trim())
+			.filter(Boolean);
+		if (names.includes(name)) return source;
+		if (match[1].includes("\n")) break;
+		const updated = statement
+			.text()
+			.replace(`{${match[1]}}`, `{ ${[...names, name].join(", ")} }`);
+		return root.commitEdits([
+			{
+				startPos: statement.range().start.index,
+				endPos: statement.range().end.index,
+				insertedText: updated,
+			},
+		]);
+	}
+	return `import { ${name} } from "${specifier}";\n${source}`;
+};
+
+const addExport = ({
+	source,
+	declaration,
+	beforeBinding,
+}: {
+	source: string;
+	declaration: string;
+	beforeBinding?: string;
+}): string => {
+	if (beforeBinding === undefined)
+		return `${source.trimEnd()}${source.trim() === "" ? "" : "\n\n"}${declaration}\n`;
+
+	const root = parse(Lang.TypeScript, source).root();
+	const declarator = root
+		.findAll({ rule: { kind: "variable_declarator" } })
+		.find((node) => node.field("name")?.text() === beforeBinding);
+	if (declarator === undefined)
+		return `${source.trimEnd()}\n\n${declaration}\n`;
+	let statement = declarator;
+	while (
+		statement.parent() !== null &&
+		statement.parent()?.kind() !== "program"
+	)
+		statement = statement.parent() ?? statement;
+	const insertAt = lineStartOf(source, statement.range().start.index);
+	return `${source.slice(0, insertAt)}${declaration}\n\n${source.slice(insertAt)}`;
+};
+
+export const planVersionExportName = ({
+	planId,
+	versionSlug,
+}: {
+	planId: string;
+	versionSlug: string;
+}): string => {
+	const sanitized = `${planId}_${versionSlug}`.replace(/[^A-Za-z0-9]/g, "_");
+	return /^[A-Za-z_]/.test(sanitized) ? sanitized : `_${sanitized}`;
+};
+
+export const appendPlanVersionFixture = ({
+	configPath,
+	files,
+	target,
+	fixtureFile,
+	exportName,
+	fixture,
+	builder,
+	targetCollection,
+	builderCollection,
+}: {
+	configPath: string;
+	files: Map<string, string>;
+	target: CollectionTarget;
+	fixtureFile: string;
+	exportName: string;
+	fixture: string;
+	builder: string;
+	targetCollection: string;
+	builderCollection: string;
+}): boolean => {
+	const configSource = files.get(configPath) ?? "";
+	const originalFixtureSource = files.get(fixtureFile);
+	const builderSpecifier = importSpecifierForBuilder({
+		source: configSource,
+		builder,
+	});
+	const seededFixtureSource =
+		originalFixtureSource ??
+		(builderSpecifier === null
+			? ""
+			: `import { ${builder} } from "${builderSpecifier}";\n`);
+	const withExport = addExport({
+		source: seededFixtureSource,
+		declaration: `export const ${exportName} = ${fixture};`,
+		...(target.file === fixtureFile && target.kind === "binding"
+			? { beforeBinding: target.name }
+			: {}),
+	});
+	const fixtureSource = ensureBuilderImport({
+		source: withExport,
+		builder,
+		collection: builderCollection,
+	});
+	const targetSource =
+		target.file === fixtureFile
+			? fixtureSource
+			: (files.get(target.file) ?? "");
+	const withReference =
+		target.kind === "inline"
+			? appendToCollection({
+					source: targetSource,
+					collection: targetCollection,
+					text: exportName,
+				})
+			: appendToBinding({
+					source: targetSource,
+					name: target.name,
+					text: exportName,
+				});
+	if (withReference === null) return false;
+
+	files.set(
+		fixtureFile,
+		target.file === fixtureFile ? withReference : fixtureSource,
+	);
+	if (target.file !== fixtureFile) {
+		files.set(
+			target.file,
+			ensureReferenceImport({
+				source: withReference,
+				name: exportName,
+				specifier: referenceSpecifier({
+					from: target.file,
+					fixtureFile,
+				}),
+			}),
+		);
+	}
+	return true;
+};

--- a/packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts
+++ b/packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts
@@ -1,4 +1,4 @@
-import { dirname, relative } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { Lang, parse } from "@ast-grep/napi";
 import { appendToBinding } from "../../surgery/appendToBinding";
 import { appendToCollection } from "../../surgery/appendToCollection";
@@ -42,6 +42,22 @@ const referenceSpecifier = ({
 		.replace(/\.ts$/, "");
 	return path.startsWith(".") ? path : `./${path}`;
 };
+
+const builderSpecifierForFixture = ({
+	configPath,
+	fixtureFile,
+	specifier,
+}: {
+	configPath: string;
+	fixtureFile: string;
+	specifier: string;
+}): string =>
+	specifier.startsWith(".")
+		? referenceSpecifier({
+				from: fixtureFile,
+				fixtureFile: resolve(dirname(configPath), specifier),
+			})
+		: specifier;
 
 const ensureReferenceImport = ({
 	source,
@@ -109,12 +125,54 @@ const addExport = ({
 export const planVersionExportName = ({
 	planId,
 	versionSlug,
+	takenSources = [],
 }: {
 	planId: string;
 	versionSlug: string;
+	takenSources?: string[];
 }): string => {
-	const sanitized = `${planId}_${versionSlug}`.replace(/[^A-Za-z0-9]/g, "_");
-	return /^[A-Za-z_]/.test(sanitized) ? sanitized : `_${sanitized}`;
+	const raw = `${planId}_${versionSlug}`;
+	const sanitized = raw.replace(/[^A-Za-z0-9]/g, "_");
+	const preferred = /^[A-Za-z_]/.test(sanitized) ? sanitized : `_${sanitized}`;
+	if (!takenSources.some((source) => declaresName({ source, name: preferred })))
+		return preferred;
+
+	const encoded = raw.replace(
+		/[^A-Za-z0-9]/gu,
+		(character) => `_${character.codePointAt(0)?.toString(16)}_`,
+	);
+	const fallback = /^[A-Za-z_]/.test(encoded) ? encoded : `_${encoded}`;
+	let available = fallback;
+	let suffix = 2;
+	while (
+		takenSources.some((source) => declaresName({ source, name: available }))
+	) {
+		available = `${fallback}_${suffix}`;
+		suffix += 1;
+	}
+	return available;
+};
+
+const declaresName = ({
+	source,
+	name,
+}: {
+	source: string;
+	name: string;
+}): boolean => {
+	const root = parse(Lang.TypeScript, source).root();
+	const variable = root
+		.findAll({ rule: { kind: "variable_declarator" } })
+		.some((node) => node.field("name")?.text() === name);
+	if (variable) return true;
+	return root.findAll({ rule: { kind: "import_specifier" } }).some(
+		(node) =>
+			node
+				.text()
+				.trim()
+				.split(/\s+as\s+/)
+				.at(-1) === name,
+	);
 };
 
 export const appendPlanVersionFixture = ({
@@ -122,7 +180,8 @@ export const appendPlanVersionFixture = ({
 	files,
 	target,
 	fixtureFile,
-	exportName,
+	planId,
+	versionSlug,
 	fixture,
 	builder,
 	targetCollection,
@@ -132,7 +191,8 @@ export const appendPlanVersionFixture = ({
 	files: Map<string, string>;
 	target: CollectionTarget;
 	fixtureFile: string;
-	exportName: string;
+	planId: string;
+	versionSlug: string;
 	fixture: string;
 	builder: string;
 	targetCollection: string;
@@ -140,6 +200,12 @@ export const appendPlanVersionFixture = ({
 }): boolean => {
 	const configSource = files.get(configPath) ?? "";
 	const originalFixtureSource = files.get(fixtureFile);
+	const targetSourceBefore = files.get(target.file) ?? "";
+	const exportName = planVersionExportName({
+		planId,
+		versionSlug,
+		takenSources: [targetSourceBefore, originalFixtureSource ?? ""],
+	});
 	const builderSpecifier = importSpecifierForBuilder({
 		source: configSource,
 		builder,
@@ -148,7 +214,7 @@ export const appendPlanVersionFixture = ({
 		originalFixtureSource ??
 		(builderSpecifier === null
 			? ""
-			: `import { ${builder} } from "${builderSpecifier}";\n`);
+			: `import { ${builder} } from "${builderSpecifierForFixture({ configPath, fixtureFile, specifier: builderSpecifier })}";\n`);
 	const withExport = addExport({
 		source: seededFixtureSource,
 		declaration: `export const ${exportName} = ${fixture};`,

--- a/packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts
+++ b/packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts
@@ -165,14 +165,13 @@ const declaresName = ({
 		.findAll({ rule: { kind: "variable_declarator" } })
 		.some((node) => node.field("name")?.text() === name);
 	if (variable) return true;
-	return root.findAll({ rule: { kind: "import_specifier" } }).some(
-		(node) =>
-			node
-				.text()
-				.trim()
-				.split(/\s+as\s+/)
-				.at(-1) === name,
-	);
+	return root.findAll({ rule: { kind: "import_specifier" } }).some((node) => {
+		const names = node
+			.text()
+			.trim()
+			.split(/\s+as\s+/);
+		return names[names.length - 1] === name;
+	});
 };
 
 export const appendPlanVersionFixture = ({

--- a/packages/atmn-nightly/src/actions/pull/applyPreview.ts
+++ b/packages/atmn-nightly/src/actions/pull/applyPreview.ts
@@ -21,10 +21,7 @@ import {
 	patchFixtureProperty,
 } from "../../surgery/patchFixtureProperty";
 import { replaceFixture } from "../../surgery/replaceFixture";
-import {
-	appendPlanVersionFixture,
-	planVersionExportName,
-} from "./appendPlanVersionFixture";
+import { appendPlanVersionFixture } from "./appendPlanVersionFixture";
 import { changedFixtureKeys } from "./changedFixtureKeys";
 import { type FixtureConstraint, locateFixture } from "./locateFixture";
 import { resolveCollectionTarget } from "./resolveCollectionTarget";
@@ -187,6 +184,21 @@ export const applyPreview = ({
 		}
 		return join(dirname(configPath), "planVersions", `${id}.ts`);
 	};
+	const deleteExportReferences = ({ name }: { name: string }): void => {
+		const referenceFiles = new Set([configPath]);
+		for (const targetCollection of [collection, spec.historyKey]) {
+			if (targetCollection === undefined) continue;
+			const target = resolveCollectionTarget({
+				configPath,
+				files,
+				collection: targetCollection,
+			});
+			if (target !== null) referenceFiles.add(target.file);
+		}
+		for (const file of referenceFiles) {
+			files.set(file, deleteReference({ source: files.get(file) ?? "", name }));
+		}
+	};
 
 	const removeFixture = ({
 		id,
@@ -225,14 +237,8 @@ export const applyPreview = ({
 		});
 		if (removed === null) return;
 		files.set(located.file, removed.source);
-		// A removed export leaves the config importing it — drop those too.
-		if (removed.exportedName !== undefined) {
-			const configSource = files.get(configPath) ?? "";
-			files.set(
-				configPath,
-				deleteReference({ source: configSource, name: removed.exportedName }),
-			);
-		}
+		if (removed.exportedName !== undefined)
+			deleteExportReferences({ name: removed.exportedName });
 		result.deleted.push(id);
 		result.lines.push(`- ${id}`);
 	};
@@ -334,7 +340,8 @@ export const applyPreview = ({
 				files,
 				target: resolved,
 				fixtureFile: historyFileFor({ id, row }),
-				exportName: planVersionExportName({ planId: id, versionSlug }),
+				planId: id,
+				versionSlug,
 				fixture: emitFixture({
 					spec,
 					row: emitted,
@@ -507,16 +514,8 @@ export const applyPreview = ({
 				});
 				if (removed === null) return;
 				files.set(located.file, removed.source);
-				if (removed.exportedName !== undefined) {
-					const configSource = files.get(configPath) ?? "";
-					files.set(
-						configPath,
-						deleteReference({
-							source: configSource,
-							name: removed.exportedName,
-						}),
-					);
-				}
+				if (removed.exportedName !== undefined)
+					deleteExportReferences({ name: removed.exportedName });
 				const appended = appendRow({
 					id,
 					entry,

--- a/packages/atmn-nightly/src/actions/pull/applyPreview.ts
+++ b/packages/atmn-nightly/src/actions/pull/applyPreview.ts
@@ -1,3 +1,4 @@
+import { dirname, join } from "node:path";
 import {
 	branchSpecs,
 	type CollectionSpec,
@@ -20,6 +21,10 @@ import {
 	patchFixtureProperty,
 } from "../../surgery/patchFixtureProperty";
 import { replaceFixture } from "../../surgery/replaceFixture";
+import {
+	appendPlanVersionFixture,
+	planVersionExportName,
+} from "./appendPlanVersionFixture";
 import { changedFixtureKeys } from "./changedFixtureKeys";
 import { type FixtureConstraint, locateFixture } from "./locateFixture";
 import { resolveCollectionTarget } from "./resolveCollectionTarget";
@@ -139,6 +144,49 @@ export const applyPreview = ({
 			: undefined;
 	const internalIdOf = (entry: PreviewEntry): string | null =>
 		typeof entry.internalId === "string" ? entry.internalId : null;
+	const historyFileFor = ({
+		id,
+		row,
+	}: {
+		id: string;
+		row: Record<string, unknown>;
+	}): string => {
+		const planRows = rowsByPlan.get(id) ?? [];
+		const activeVersion = activeVersionOf({
+			rows: planRows as { active?: boolean; version?: number }[],
+		});
+		const nonRootFiles = new Map(
+			[...files].filter(([file]) => file !== configPath),
+		);
+		for (const sibling of planRows) {
+			if (sibling === row) continue;
+			const route = routePlanRow({
+				row: sibling as { active?: boolean; version?: number },
+				activeVersion,
+			});
+			if (route.collection !== "planVersions") continue;
+			const siblingId = idOfRow(sibling);
+			if (typeof siblingId !== "string") continue;
+			const located = locateFixture({
+				configPath: "",
+				files: nonRootFiles,
+				builder: specFor(sibling).builder,
+				idField: specFor(sibling).idField,
+				id: siblingId,
+				internalId:
+					typeof sibling.internalId === "string" ? sibling.internalId : null,
+				where: [
+					{
+						field: "versionSlug",
+						equals: slugOf(sibling),
+						absentMeans: "v1",
+					},
+				],
+			});
+			if (located !== null) return located.file;
+		}
+		return join(dirname(configPath), "planVersions", `${id}.ts`);
+	};
 
 	const removeFixture = ({
 		id,
@@ -202,6 +250,26 @@ export const applyPreview = ({
 		const key = keyOf({ id, slug: slugOf(entry) });
 		const row = rowsById.get(key);
 		if (row === undefined) return false;
+		const rowSpec = specFor(row);
+		const locatedEntry =
+			typeof row.internalId === "string"
+				? { ...entry, internalId: row.internalId }
+				: entry;
+		if (
+			versioned &&
+			locateFixture({
+				configPath,
+				files,
+				builder: rowSpec.builder,
+				idField: rowSpec.idField,
+				id,
+				internalId: internalIdOf(locatedEntry),
+				where: constraintsFor(locatedEntry),
+			}) !== null
+		) {
+			replaceRow({ id, entry: locatedEntry });
+			return true;
+		}
 		let target = collection;
 		let emitted: Record<string, unknown> = row;
 		if (versioned) {
@@ -259,7 +327,35 @@ export const applyPreview = ({
 			return false;
 		}
 		// The surgery indents the first line; the emitter indents the rest.
-		const rowSpec = specFor(row);
+		if (versioned && target === spec.historyKey) {
+			const versionSlug = slugOf(row);
+			const appended = appendPlanVersionFixture({
+				configPath,
+				files,
+				target: resolved,
+				fixtureFile: historyFileFor({ id, row }),
+				exportName: planVersionExportName({ planId: id, versionSlug }),
+				fixture: emitFixture({
+					spec,
+					row: emitted,
+					includeMappings,
+					indent: "",
+				}),
+				builder: rowSpec.builder,
+				targetCollection: target,
+				builderCollection: collection,
+			});
+			if (!appended) {
+				result.unlocated.push({
+					id: key,
+					action: `append to \`${target}\` by hand: it is not an array literal`,
+				});
+				return false;
+			}
+			result.appended.push(key);
+			result.lines.push(`+ ${key}`);
+			return true;
+		}
 		const text = (elementIndent: string) =>
 			emitFixture({
 				spec,

--- a/packages/atmn-nightly/test/pull-plan-version-placement.test.ts
+++ b/packages/atmn-nightly/test/pull-plan-version-placement.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { runPull } from "../src/actions/pull";
+import { planVersionExportName } from "../src/actions/pull/appendPlanVersionFixture";
+import type { AutumnClient } from "../src/generated/client";
+
+const directory = join(import.meta.dir, ".tmp", "pull-plan-version-placement");
+const configPath = join(directory, "autumn.config.ts");
+
+test("history export names are valid identifiers", () => {
+	expect(
+		planVersionExportName({ planId: "123-pro.plan", versionSlug: "v-1" }),
+	).toBe("_123_pro_plan_v_1");
+});
+
+test("a missing history fixture gets its own file and a root reference", async () => {
+	rmSync(directory, { recursive: true, force: true });
+	mkdirSync(join(directory, "planVersions"), { recursive: true });
+	writeFileSync(join(directory, "planVersions", ".gitkeep"), "", "utf8");
+	writeFileSync(
+		configPath,
+		[
+			'import { atmn, plan } from "atmn-nightly";',
+			"",
+			"export default atmn({",
+			"\tplans: [],",
+			"\tplanVersions: [],",
+			"});",
+			"",
+		].join("\n"),
+		"utf8",
+	);
+	const client = {
+		previewUpdateOrganization: async () => ({ config: { changes: [] } }),
+		previewUpdate: async () => ({
+			features: [],
+			plans: [
+				{
+					planId: "pro",
+					versionSlug: "v1",
+					action: "delete",
+					internalId: "prod_v1",
+				},
+			],
+		}),
+		update: async () => ({}),
+		get: async () => ({
+			features: [],
+			plans: [
+				{
+					id: "pro",
+					internalId: "prod_v1",
+					name: "Pro",
+					version: 1,
+					versionSlug: "v1",
+					active: false,
+					archived: false,
+					items: [],
+				},
+			],
+		}),
+	} as unknown as AutumnClient;
+
+	const result = await runPull({ client, cwd: directory, write: () => {} });
+
+	expect(result.appended).toEqual(["pro@v1"]);
+	expect(readFileSync(configPath, "utf8")).toBe(
+		[
+			'import { pro_v1 } from "./planVersions/pro";',
+			'import { atmn, plan } from "atmn-nightly";',
+			"",
+			"export default atmn({",
+			"\tplans: [],",
+			"\tplanVersions: [",
+			"\t\tpro_v1,",
+			"\t],",
+			"});",
+			"",
+		].join("\n"),
+	);
+	expect(readFileSync(join(directory, "planVersions", "pro.ts"), "utf8")).toBe(
+		[
+			'import { plan } from "atmn-nightly";',
+			"",
+			"export const pro_v1 = plan({",
+			'\tplanId: "pro",',
+			'\tinternalId: "prod_v1",',
+			'\tname: "Pro",',
+			"\titems: [],",
+			'\tversionSlug: "v1",',
+			"});",
+			"",
+		].join("\n"),
+	);
+	expect(existsSync(join(directory, "planVersions", ".gitkeep"))).toBe(false);
+});

--- a/packages/atmn-nightly/test/pull-plan-version-placement.test.ts
+++ b/packages/atmn-nightly/test/pull-plan-version-placement.test.ts
@@ -20,6 +20,16 @@ test("history export names are valid identifiers", () => {
 	).toBe("_123_pro_plan_v_1");
 });
 
+test("colliding sanitized names use a reversible fallback", () => {
+	expect(
+		planVersionExportName({
+			planId: "pro",
+			versionSlug: "summer_sale",
+			takenSources: ["export const pro_summer_sale = {};"],
+		}),
+	).toBe("pro_5f_summer_5f_sale");
+});
+
 test("a missing history fixture gets its own file and a root reference", async () => {
 	rmSync(directory, { recursive: true, force: true });
 	mkdirSync(join(directory, "planVersions"), { recursive: true });
@@ -27,7 +37,8 @@ test("a missing history fixture gets its own file and a root reference", async (
 	writeFileSync(
 		configPath,
 		[
-			'import { atmn, plan } from "atmn-nightly";',
+			'import { plan } from "../../../src/generated/plans";',
+			'import { atmn } from "../../../src/generated/wire";',
 			"",
 			"export default atmn({",
 			"\tplans: [],",
@@ -74,7 +85,8 @@ test("a missing history fixture gets its own file and a root reference", async (
 	expect(readFileSync(configPath, "utf8")).toBe(
 		[
 			'import { pro_v1 } from "./planVersions/pro";',
-			'import { atmn, plan } from "atmn-nightly";',
+			'import { plan } from "../../../src/generated/plans";',
+			'import { atmn } from "../../../src/generated/wire";',
 			"",
 			"export default atmn({",
 			"\tplans: [],",
@@ -87,7 +99,7 @@ test("a missing history fixture gets its own file and a root reference", async (
 	);
 	expect(readFileSync(join(directory, "planVersions", "pro.ts"), "utf8")).toBe(
 		[
-			'import { plan } from "atmn-nightly";',
+			'import { plan } from "../../../../src/generated/plans";',
 			"",
 			"export const pro_v1 = plan({",
 			'\tplanId: "pro",',
@@ -100,4 +112,110 @@ test("a missing history fixture gets its own file and a root reference", async (
 		].join("\n"),
 	);
 	expect(existsSync(join(directory, "planVersions", ".gitkeep"))).toBe(false);
+});
+
+test("deleting an exported history fixture cleans its imported array target", async () => {
+	const targetDirectory = join(
+		import.meta.dir,
+		".tmp",
+		"pull-plan-version-imported-target",
+	);
+	rmSync(targetDirectory, { recursive: true, force: true });
+	mkdirSync(join(targetDirectory, "planVersions"), { recursive: true });
+	writeFileSync(
+		join(targetDirectory, "autumn.config.ts"),
+		[
+			'import { atmn, plan } from "atmn-nightly";',
+			'import { proVersions } from "./planVersions/pro";',
+			"",
+			"export default atmn({",
+			"\tplans: [",
+			'\t\tplan({ planId: "pro", internalId: "prod_v2", versionSlug: "v2", name: "Pro" }),',
+			"\t],",
+			"\tplanVersions: proVersions,",
+			"});",
+			"",
+		].join("\n"),
+		"utf8",
+	);
+	const versionsPath = join(targetDirectory, "planVersions", "pro.ts");
+	writeFileSync(
+		versionsPath,
+		[
+			'import { plan } from "atmn-nightly";',
+			"",
+			"export const proVersions = [];",
+			"",
+		].join("\n"),
+		"utf8",
+	);
+	const catalog = {
+		features: [],
+		plans: [
+			{
+				id: "pro",
+				internalId: "prod_v1",
+				name: "Pro",
+				version: 1,
+				versionSlug: "v1",
+				active: false,
+				archived: false,
+				items: [],
+			},
+			{
+				id: "pro",
+				internalId: "prod_v2",
+				name: "Pro",
+				version: 2,
+				versionSlug: "v2",
+				active: true,
+				archived: false,
+				items: [],
+			},
+		],
+	};
+	const clientFor = ({ action }: { action: "create" | "delete" }) =>
+		({
+			previewUpdateOrganization: async () => ({ config: { changes: [] } }),
+			previewUpdate: async () => ({
+				features: [],
+				plans: [
+					{
+						planId: "pro",
+						versionSlug: "v1",
+						action,
+						internalId: "prod_v1",
+					},
+					{
+						planId: "pro",
+						versionSlug: "v2",
+						action: "none",
+						internalId: "prod_v2",
+					},
+				],
+			}),
+			update: async () => ({}),
+			get: async () => catalog,
+		}) as unknown as AutumnClient;
+
+	await runPull({
+		client: clientFor({ action: "delete" }),
+		cwd: targetDirectory,
+		write: () => {},
+	});
+	expect(readFileSync(versionsPath, "utf8")).toContain(
+		"export const pro_v1 = plan({",
+	);
+	expect(readFileSync(versionsPath, "utf8")).toContain(
+		"export const proVersions = [\n\tpro_v1,\n];",
+	);
+
+	await runPull({
+		client: clientFor({ action: "create" }),
+		cwd: targetDirectory,
+		write: () => {},
+	});
+	const afterDelete = readFileSync(versionsPath, "utf8");
+	expect(afterDelete).not.toContain("pro_v1");
+	expect(afterDelete).toContain("export const proVersions = [];");
 });

--- a/packages/atmn-nightly/test/pullPlans.test.ts
+++ b/packages/atmn-nightly/test/pullPlans.test.ts
@@ -12,7 +12,7 @@ import { runPull } from "../src/actions/pull";
 const dir = `${import.meta.dir}/.tmp/pull-plans`;
 const imports = [
 	'import { feature } from "../../../src/generated/features";',
-	`import { plan } from "${import.meta.dir}/../src/generated/plans";`,
+	'import { plan } from "../../../src/generated/plans";',
 	'import { atmn } from "../../../src/generated/wire";',
 	"",
 ].join("\n");

--- a/packages/atmn-nightly/test/pullPlans.test.ts
+++ b/packages/atmn-nightly/test/pullPlans.test.ts
@@ -12,7 +12,7 @@ import { runPull } from "../src/actions/pull";
 const dir = `${import.meta.dir}/.tmp/pull-plans`;
 const imports = [
 	'import { feature } from "../../../src/generated/features";',
-	'import { plan } from "../../../src/generated/plans";',
+	`import { plan } from "${import.meta.dir}/../src/generated/plans";`,
 	'import { atmn } from "../../../src/generated/wire";',
 	"",
 ].join("\n");

--- a/server/tests/integration/atmn/scenarios/pull/plan-versions-get-their-own-file.test.ts
+++ b/server/tests/integration/atmn/scenarios/pull/plan-versions-get-their-own-file.test.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { uniqueTestId } from "@tests/integration/catalog-v2/utils/uniqueTestId.js";
+import { paidMonthly } from "@tests/utils/atmnUtils/baseConfigs.js";
+import {
+	initAtmnScenario,
+	runCli,
+	TMP_ROOT,
+} from "@tests/utils/atmnUtils/initAtmnScenario.js";
+import { s } from "@tests/utils/testInitUtils/initScenario.js";
+
+test.concurrent(
+	"plan versions get their own file and keep its user-chosen location",
+	async () => {
+		const planId = uniqueTestId("atmn_version_file");
+		const scenario = await initAtmnScenario({
+			setup: [
+				s.platform.create({ userEmail: `${uniqueTestId("atmn")}@autumn.test` }),
+			],
+			config: `{
+	plans: [${paidMonthly({ planId })}
+	],
+}`,
+		});
+		const freshDirectory = join(TMP_ROOT, uniqueTestId("atmn_version_pull"));
+		mkdirSync(freshDirectory, { recursive: true });
+
+		try {
+			await scenario.push();
+			await scenario.client.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "new_version",
+						active: true,
+						name: "Pro v2",
+						price: { amount: 59, interval: "month" },
+					},
+				],
+			});
+
+			const firstOutput = runCli({
+				cwd: freshDirectory,
+				args: ["pull"],
+				secretKey: scenario.secretKey,
+				baseUrl: scenario.baseUrl,
+			});
+			expect(firstOutput).toContain(`+ ${planId}@v1`);
+			const rootPath = join(freshDirectory, "autumn.config.ts");
+			const versionPath = join(freshDirectory, "planVersions", `${planId}.ts`);
+			const root = readFileSync(rootPath, "utf8");
+			const version = readFileSync(versionPath, "utf8");
+			const v1Export = `${planId}_v1`.replace(/[^A-Za-z0-9]/g, "_");
+			expect(root).toContain(
+				`import { ${v1Export} } from "./planVersions/${planId}";`,
+			);
+			expect(root).toContain(`planVersions: [\n\t\t${v1Export},`);
+			expect(root).toContain('versionSlug: "v2"');
+			expect(version).toContain(`export const ${v1Export} = plan({`);
+			expect(version).toContain('versionSlug: "v1"');
+
+			const secondOutput = runCli({
+				cwd: freshDirectory,
+				args: ["pull"],
+				secretKey: scenario.secretKey,
+				baseUrl: scenario.baseUrl,
+			});
+			expect(secondOutput).toBe("Nothing to pull.\n");
+			expect(readFileSync(rootPath, "utf8")).toBe(root);
+			expect(readFileSync(versionPath, "utf8")).toBe(version);
+			const dryRunOutput = runCli({
+				cwd: freshDirectory,
+				args: ["push", "--dry-run"],
+				secretKey: scenario.secretKey,
+				baseUrl: scenario.baseUrl,
+			});
+			expect(dryRunOutput).toContain("No changes");
+
+			const legacyPath = join(freshDirectory, "planVersions", "legacy.ts");
+			const legacyExport = "userNamedLegacy";
+			const renamedPlanId = `${planId}_renamed`;
+			writeFileSync(
+				versionPath,
+				version
+					.replaceAll(v1Export, legacyExport)
+					.replace(`planId: "${planId}"`, `planId: "${renamedPlanId}"`),
+				"utf8",
+			);
+			renameSync(versionPath, legacyPath);
+			writeFileSync(
+				rootPath,
+				root
+					.replaceAll(v1Export, legacyExport)
+					.replace(`./planVersions/${planId}`, "./planVersions/legacy")
+					.replaceAll(`planId: "${planId}"`, `planId: "${renamedPlanId}"`),
+				"utf8",
+			);
+
+			await scenario.client.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "new_version",
+						active: true,
+						name: "Pro v3",
+						price: { amount: 69, interval: "month" },
+					},
+				],
+			});
+			runCli({
+				cwd: freshDirectory,
+				args: ["pull"],
+				secretKey: scenario.secretKey,
+				baseUrl: scenario.baseUrl,
+			});
+
+			const finalRoot = readFileSync(rootPath, "utf8");
+			const finalLegacy = readFileSync(legacyPath, "utf8");
+			expect(existsSync(versionPath)).toBe(false);
+			expect(finalRoot).toContain("./planVersions/legacy");
+			expect(finalLegacy).toContain(`export const ${legacyExport} = plan({`);
+			expect(finalLegacy).toContain(`planId: "${planId}"`);
+			expect(finalLegacy).not.toContain(`planId: "${renamedPlanId}"`);
+			expect(finalLegacy).toContain('versionSlug: "v2"');
+		} finally {
+			rmSync(freshDirectory, { recursive: true, force: true });
+			scenario.cleanup();
+		}
+	},
+);


### PR DESCRIPTION
## Problem

`atmn pull` scaffolded an empty `planVersions/` directory and then wrote history rows as literals inside the root `autumn.config.ts`, so the folder never held anything:

```
autumn.config.ts        plans: [plan({...v2})]  and  planVersions: [plan({...v1})]
planVersions/.gitkeep   empty, never used
```

## Change

A history row with no existing fixture anywhere in the config now gets its own module, and the root config references it:

```
autumn.config.ts        import { pro_v1 } from "./planVersions/pro";
                        plans: [plan({...v2})]
                        planVersions: [pro_v1]
planVersions/pro.ts     export const pro_v1 = plan({...v1});
```

`.gitkeep` is removed once a real module lands, and later versions of the same plan append another export and another reference to that same file.

Placement is decided once, on first write. Lookup stays keyed on `internalId`, so a user who moves the file, renames the export, or renames the `planId` keeps getting in-place edits and never a duplicate; nothing reads the filename. Active rows in `plans[]` are untouched and stay inline in the root config.

## Tests

- `packages/atmn-nightly/test/pull-plan-version-placement.test.ts`: the module, the import line, and the reference are written for a history row with no existing fixture.
- `server/tests/integration/atmn/scenarios/pull/plan-versions-get-their-own-file.test.ts`: pull into a fresh dir after a server-side version mint produces the layout above, a second pull is byte-identical, and `push --dry-run` reports no changes; then a user-moved and renamed history module is still edited in place when a third version arrives.

Gates: placement unit 2/0, the scenario 1/0, `bun run ts` clean, atmn-nightly unit suite 350/1 where the single failure (`pullStatesSlugs.test.ts`, fake client missing `previewUpdateOrganization`) reproduces on `dev` without this change.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M20C2JKFA15VPKF6GKTGB55Z"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`atmn pull` now writes plan history rows to their own modules under `planVersions/` instead of keeping them as literals in the root `autumn.config.ts`. The root config references each history module by import, and `.gitkeep` is removed once a real module lands. Generated export names that collide after sanitizing (for example `summer-sale` and `summer_sale`) get a reversible encoded fallback, and deleting a version now cleans references from imported plan-versions arrays, not just the root config.

**Placement**
- File location is decided once, on first write; later versions of the same plan append to that file.
- Lookup stays keyed on `internalId`, so user-moved or renamed history modules are still edited in place.
- Active rows in `plans[]` are untouched and stay inline in the root config.

<sup>Written for commit 590caa2415b3ee52756ada8e2655314429204217. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves pulled plan-history fixtures into dedicated `planVersions/<planId>.ts` modules while retaining references from the configured history collection.

Key changes:
- **[Improvements, API changes]** New plan-history rows are exported from dedicated modules, with imports and collection references inserted into the appropriate configuration files.
- **[Improvements]** Existing history fixtures continue to be located by internal ID, preserving user-selected filenames and export names.
- **[Bug fixes]** Generated names now use encoded fallbacks after sanitized-name collisions, and relative builder imports are rewritten for the history module's location.
- **[Bug fixes]** Version deletion attempts to clean references from imported collection targets as well as the root configuration.
- **[Improvements]** Pull creates required directories and removes `.gitkeep` after writing the first real module.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because history deletion can remove an unrelated active-plan reference, and generated exports can still collide with user-defined value declarations.

Two changed paths can leave the configuration incorrect or unloadable: deletion applies broad identifier cleanup to both active and history collection modules, while export-name collision detection omits functions and classes. The two previous findings were manually resolved and are not outstanding.

**Files Needing Attention:** packages/atmn-nightly/src/actions/pull/applyPreview.ts; packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts | Adds history-module generation, import rewriting, and collision fallback, but collision detection misses some value declarations. |
| packages/atmn-nightly/src/actions/pull/applyPreview.ts | Routes new history rows into modules and expands deletion cleanup, but cleanup can remove unrelated active-plan references with the same local name. |
| packages/atmn-nightly/src/actions/pull.ts | Creates parent directories before writes and removes placeholder `.gitkeep` files when a new module is created. |
| packages/atmn-nightly/test/pull-plan-version-placement.test.ts | Covers initial module placement, sanitized-name collisions, relative imports, and deletion from an imported history array. |
| server/tests/integration/atmn/scenarios/pull/plan-versions-get-their-own-file.test.ts | Verifies pull idempotence, push compatibility, and preservation of a user-moved and renamed history module. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Pull receives catalog rows] --> B{Existing fixture found by internal ID?}
    B -- Yes --> C[Edit fixture in its existing file]
    B -- No --> D{History row?}
    D -- No --> E[Append inline to active collection]
    D -- Yes --> F[Choose planVersions module]
    F --> G[Generate exported plan fixture]
    G --> H[Add import and reference to history collection]
    H --> I[Write changed files and remove .gitkeep]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/atmn-nightly/src/actions/pull/applyPreview.ts:194-199
**Deletion Removes Unrelated References**

When a history version is removed, this code searches both the history and active-plan modules and deletes every array reference with the same name. For example, deleting history export `pro_v1` would also remove an unrelated active-plan reference named `pro_v1`, silently changing the user's active configuration. Cleanup should be limited to the collection that referenced the removed export.

### Issue 2
packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts:163-168
**Declaration Collisions Remain**

The collision check only recognizes variable declarations and imports. If a user already has `function pro_v1() {}` or a class with that name in the module, pull still adds `export const pro_v1 = plan(...)`. The duplicate declaration then prevents the configuration from compiling.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(atmn): support server TypeScript tar..."](https://github.com/useautumn/autumn/commit/590caa2415b3ee52756ada8e2655314429204217) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63167943)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->