### PR TITLE
fix(atmn): avoid pull history name collisions

### DIFF
--- a/packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts
+++ b/packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts
@@ -1,5 +1,5 @@
 import { dirname, relative, resolve } from "node:path";
-import { Lang, parse } from "@ast-grep/napi";
+import { Lang, parse, type SgNode } from "@ast-grep/napi";
 import { appendToBinding } from "../../surgery/appendToBinding";
 import { appendToCollection } from "../../surgery/appendToCollection";
 import { ensureBuilderImport } from "../../surgery/ensureBuilderImport";
@@ -161,17 +161,95 @@ const declaresName = ({
 	name: string;
 }): boolean => {
 	const root = parse(Lang.TypeScript, source).root();
-	const variable = root
+	const variableBinding = root
 		.findAll({ rule: { kind: "variable_declarator" } })
-		.some((node) => node.field("name")?.text() === name);
-	if (variable) return true;
-	return root.findAll({ rule: { kind: "import_specifier" } }).some((node) => {
-		const names = node
-			.text()
-			.trim()
-			.split(/\s+as\s+/);
-		return names[names.length - 1] === name;
-	});
+		.some((node) => {
+			if (!bindsTopLevel({ node })) return false;
+			const pattern = node.field("name");
+			if (pattern === null) return false;
+			if (pattern.text() === name) return true;
+			return pattern
+				.findAll({ rule: { kind: "identifier", pattern: name } })
+				.some((identifier) => identifier.text() === name);
+		});
+	if (variableBinding) return true;
+	const namedDeclarationKinds = [
+		"function_declaration",
+		"generator_function_declaration",
+		"function_signature",
+		"class_declaration",
+		"abstract_class_declaration",
+		"enum_declaration",
+		"internal_module",
+	];
+	for (const kind of namedDeclarationKinds) {
+		if (
+			root
+				.findAll({ rule: { kind } })
+				.some(
+					(node) =>
+						bindsTopLevel({ node }) && node.field("name")?.text() === name,
+				)
+		)
+			return true;
+	}
+	const importBinding = root
+		.findAll({ rule: { kind: "import_specifier" } })
+		.some((node) => {
+			const names = node
+				.text()
+				.trim()
+				.split(/\s+as\s+/);
+			return names[names.length - 1] === name;
+		});
+	if (importBinding) return true;
+	const importClauseBinding = root
+		.findAll({ rule: { kind: "import_clause" } })
+		.some((clause) =>
+			clause
+				.children()
+				.some(
+					(child) =>
+						(child.kind() === "identifier" ||
+							child.kind() === "namespace_import") &&
+						child.text().replace(/^\*\s+as\s+/, "") === name,
+				),
+		);
+	if (importClauseBinding) return true;
+	const importRequireBinding = root
+		.findAll({ rule: { kind: "import_require_clause" } })
+		.some((clause) =>
+			clause
+				.findAll({ rule: { kind: "identifier", pattern: name } })
+				.some((identifier) => identifier.text() === name),
+		);
+	if (importRequireBinding) return true;
+	return root
+		.findAll({ rule: { kind: "export_specifier" } })
+		.some((specifier) => {
+			const names = specifier
+				.text()
+				.trim()
+				.split(/\s+as\s+/);
+			return names[names.length - 1] === name;
+		});
+};
+
+const bindsTopLevel = ({ node }: { node: SgNode }): boolean => {
+	const wrappers = new Set<string | number>([
+		"lexical_declaration",
+		"variable_declaration",
+		"export_statement",
+		"ambient_declaration",
+		"expression_statement",
+	]);
+	let current = node;
+	while (current.parent() !== null && current.parent()?.kind() !== "program") {
+		const parent = current.parent();
+		if (parent === null || !wrappers.has(parent.kind())) return false;
+		current = parent;
+	}
+	return current.parent()?.kind() === "program";
 };
 
 export const appendPlanVersionFixture = ({

--- a/packages/atmn-nightly/src/actions/pull/applyPreview.ts
+++ b/packages/atmn-nightly/src/actions/pull/applyPreview.ts
@@ -186,20 +186,48 @@ export const applyPreview = ({
 		}
 		return join(dirname(configPath), "planVersions", `${id}.ts`);
 	};
-	const deleteExportReferences = ({ name }: { name: string }): void => {
-		const referenceFiles = new Set([configPath]);
-		for (const targetCollection of [collection, spec.historyKey]) {
-			if (targetCollection === undefined) continue;
-			const target = resolveCollectionTarget({
-				configPath,
-				files,
-				collection: targetCollection,
-			});
-			if (target !== null) referenceFiles.add(target.file);
-		}
-		for (const file of referenceFiles) {
-			files.set(file, deleteReference({ source: files.get(file) ?? "", name }));
-		}
+	const collectionForRemoval = ({
+		id,
+		entry,
+		fixtureFile,
+	}: {
+		id: string;
+		entry: PreviewEntry;
+		fixtureFile: string;
+	}): string => {
+		const collectionTargets = [collection, spec.historyKey].flatMap(
+			(targetCollection) => {
+				if (targetCollection === undefined) return [];
+				const target = resolveCollectionTarget({
+					configPath,
+					files,
+					collection: targetCollection,
+				});
+				return target?.file === fixtureFile ? [targetCollection] : [];
+			},
+		);
+		if (collectionTargets.length === 1) return collectionTargets[0];
+		return versioned && configActiveOf({ id, entry }) === false
+			? (spec.historyKey ?? collection)
+			: collection;
+	};
+	const deleteExportReference = ({
+		name,
+		targetCollection,
+	}: {
+		name: string;
+		targetCollection: string;
+	}): void => {
+		const target = resolveCollectionTarget({
+			configPath,
+			files,
+			collection: targetCollection,
+		});
+		if (target === null) return;
+		files.set(
+			target.file,
+			deleteReference({ source: files.get(target.file) ?? "", name }),
+		);
 	};
 
 	const removeFixture = ({
@@ -240,7 +268,14 @@ export const applyPreview = ({
 		if (removed === null) return;
 		files.set(located.file, removed.source);
 		if (removed.exportedName !== undefined)
-			deleteExportReferences({ name: removed.exportedName });
+			deleteExportReference({
+				name: removed.exportedName,
+				targetCollection: collectionForRemoval({
+					id,
+					entry,
+					fixtureFile: located.file,
+				}),
+			});
 		result.deleted.push(id);
 		result.lines.push(`- ${id}`);
 	};
@@ -519,7 +554,13 @@ export const applyPreview = ({
 				if (removed === null) return;
 				files.set(located.file, removed.source);
 				if (removed.exportedName !== undefined)
-					deleteExportReferences({ name: removed.exportedName });
+					deleteExportReference({
+						name: removed.exportedName,
+						targetCollection:
+							configActive === false
+								? (spec.historyKey ?? collection)
+								: collection,
+					});
 				const appended = appendRow({
 					id,
 					entry,

--- a/packages/atmn-nightly/test/pull-plan-version-placement.test.ts
+++ b/packages/atmn-nightly/test/pull-plan-version-placement.test.ts
@@ -30,6 +30,16 @@ test("colliding sanitized names use a reversible fallback", () => {
 	).toBe("pro_5f_summer_5f_sale");
 });
 
+test("function and class declarations advance to the next free name", () => {
+	expect(
+		planVersionExportName({
+			planId: "pro",
+			versionSlug: "v1",
+			takenSources: ["function pro_v1() {}\nclass pro_5f_v1 {}"],
+		}),
+	).toBe("pro_5f_v1_2");
+});
+
 test("a missing history fixture gets its own file and a root reference", async () => {
 	rmSync(directory, { recursive: true, force: true });
 	mkdirSync(join(directory, "planVersions"), { recursive: true });
@@ -125,19 +135,33 @@ test("deleting an exported history fixture cleans its imported array target", as
 	writeFileSync(
 		join(targetDirectory, "autumn.config.ts"),
 		[
-			'import { atmn, plan } from "atmn-nightly";',
+			'import { atmn } from "atmn-nightly";',
+			'import { activePlans } from "./plans";',
 			'import { proVersions } from "./planVersions/pro";',
 			"",
 			"export default atmn({",
-			"\tplans: [",
-			'\t\tplan({ planId: "pro", internalId: "prod_v2", versionSlug: "v2", name: "Pro" }),',
-			"\t],",
+			"\tplans: activePlans,",
 			"\tplanVersions: proVersions,",
 			"});",
 			"",
 		].join("\n"),
 		"utf8",
 	);
+	const activePlansPath = join(targetDirectory, "plans.ts");
+	const activePlansSource = [
+		'import { plan } from "atmn-nightly";',
+		"",
+		"export const pro_v1 = plan({",
+		'\tplanId: "pro",',
+		'\tinternalId: "prod_v2",',
+		'\tversionSlug: "v2",',
+		'\tname: "Pro",',
+		"});",
+		"",
+		"export const activePlans = [pro_v1];",
+		"",
+	].join("\n");
+	writeFileSync(activePlansPath, activePlansSource, "utf8");
 	const versionsPath = join(targetDirectory, "planVersions", "pro.ts");
 	writeFileSync(
 		versionsPath,
@@ -218,4 +242,5 @@ test("deleting an exported history fixture cleans its imported array target", as
 	const afterDelete = readFileSync(versionsPath, "utf8");
 	expect(afterDelete).not.toContain("pro_v1");
 	expect(afterDelete).toContain("export const proVersions = [];");
+	expect(readFileSync(activePlansPath, "utf8")).toBe(activePlansSource);
 });


### PR DESCRIPTION
Follow-up to #3392, from two review findings confirmed after it merged.

## Generated export names never declare over user code

`declaresName` only saw variable and import bindings, so a generated `export const pro_v1` could collide with a user's own top-level declaration. It now detects variable and destructuring bindings, function / signature / generator declarations, class and abstract class declarations, enums, namespaces, imports, import-require, and export bindings. On a collision the name advances deterministically through the reversible fallback and then numeric suffixes.

## Deletion only touches the collection that owns the reference

Cleanup scanned both the `plans` and `planVersions` targets, so an identical local name living in a separate imported array module could be removed along with the history reference. Deletion now resolves the owning collection target from the fixture's location and membership and removes the reference only there; a same-named reference in the other module stays byte-identical.

## Tests

Regressions in `packages/atmn-nightly/test/pull-plan-version-placement.test.ts` for both: a module where the user already declares the generated name as a function or class, and a delete where the `plans` and `planVersions` modules share a local name.

Gates: atmn-nightly typecheck clean, package suite 355/1 with the single failure (`pullStatesSlugs.test.ts`, fake client missing `previewUpdateOrganization`) reproducing on `dev`, placement tests 5/0, the pull scenario 1/0.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M20C2JKFA15VPKF6GKTGB55Z"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two regressions in pull history name handling: generated export names now avoid colliding with any top-level user declaration, and cleanup deletion only removes the reference from the collection that owns it.

- Name collision detection now covers function, class, enum, namespace, import-require, and export bindings; on a collision, the name advances through the reversible fallback and numeric suffixes.
- Deletion now resolves the owning collection target from the fixture location and leaves same-named references in the other module byte-identical.
- Adds regression tests for a user-declared function/class collision and a shared local name across `plans` and `planVersions` modules.

<sup>Written for commit 613c52f9bc4367df39b956ba5f91892c005b1f87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves generated-name collision handling and narrows deletion cleanup to one collection.

### Key changes
- **[Bug fixes]** Expands generated export-name collision detection across additional TypeScript declarations and imports.
- **[Bug fixes]** Resolves one collection before removing an exported fixture reference, preventing deletion of an identically named reference from another collection.
- **[Improvements]** Adds regression coverage for function/class name collisions and same-named references in separate collection modules.

Two edge cases remain: shorthand destructuring can still collide with generated exports, and deleting a by-reference draft can leave a dangling reference in `plans`.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because two realistic paths can produce invalid generated TypeScript.

Collision detection can reuse a name bound through shorthand destructuring, and deleting an exported draft can remove its declaration without removing the reference from the `plans` collection.

**Files Needing Attention:** packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts, packages/atmn-nightly/src/actions/pull/applyPreview.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts | Expands collision detection, but shorthand object-destructuring bindings remain undetected. |
| packages/atmn-nightly/src/actions/pull/applyPreview.ts | Narrows reference cleanup, but its inactive-entry fallback misroutes by-reference draft deletion. |
| packages/atmn-nightly/test/pull-plan-version-placement.test.ts | Adds useful regressions for declaration collisions and isolated collection cleanup, but does not cover shorthand destructuring or by-reference drafts. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Pull entry] --> B{Delete fixture?}
    B -->|Yes| C[Locate exported fixture]
    C --> D[Remove fixture declaration]
    D --> E{Collection target file matches fixture file?}
    E -->|Exactly one| F[Remove reference from matched collection]
    E -->|No match| G{Entry active flag}
    G -->|false| H[Select planVersions]
    G -->|true or missing| I[Select plans]
    H --> J[Draft may actually belong to plans]
    J --> K[Dangling import and array reference]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts:171-173
**Shorthand bindings remain undetected**

A top-level shorthand destructuring declaration such as `const { pro_v1 } = value` already binds `pro_v1`, but this code only searches its children for nodes whose kind is `identifier`. TypeScript represents this shorthand binding as `shorthand_property_identifier_pattern`, so the name is missed and the generator can append another `export const pro_v1`. That creates a duplicate declaration and causes typechecking to fail.

### Issue 2
packages/atmn-nightly/src/actions/pull/applyPreview.ts:209-212
**Draft deletion targets history**

Newer inactive plan versions are drafts stored in `plans`, but this fallback treats every inactive entry as history. For example, if a draft is exported from `plans.ts` and referenced by an inline `plans: [draft]` array, neither collection target matches the fixture file and deletion selects `planVersions`. The export is removed from `plans.ts`, while its import and array reference remain in the config, leaving generated code that no longer compiles.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(atmn): avoid pull history name colli..."](https://github.com/useautumn/autumn/commit/613c52f9bc4367df39b956ba5f91892c005b1f87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63193193)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->