### PR TITLE
fix(analytics): show billing-cycle options for mixed plans

### DIFF
--- a/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
@@ -2,7 +2,6 @@ import {
 	type CustomerDisplayInfo,
 	type EntityDisplayInfo,
 	ErrCode,
-	type FullCusProduct,
 	type FullCustomer,
 	type RangeEnum,
 	RecaseError,
@@ -98,14 +97,9 @@ export const handleInternalAggregateEvents = createRoute({
 				});
 			}
 
-			// Check for bcExclusionFlag only if we have a specific customer
-			if (customer.customer_products) {
-				customer.customer_products.forEach((product: FullCusProduct) => {
-					if (product.product.is_default) {
-						bcExclusionFlag = true;
-					}
-				});
-			}
+			bcExclusionFlag = customer.customer_products.every(
+				({ product }) => product.is_default,
+			);
 		}
 
 		// Filter out empty strings

--- a/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
@@ -3,6 +3,7 @@ import {
 	type EntityDisplayInfo,
 	ErrCode,
 	type FullCustomer,
+	filterCustomerProductsByActiveStatuses,
 	type RangeEnum,
 	RecaseError,
 	Scopes,
@@ -97,9 +98,9 @@ export const handleInternalAggregateEvents = createRoute({
 				});
 			}
 
-			bcExclusionFlag = customer.customer_products.every(
-				({ product }) => product.is_default,
-			);
+			bcExclusionFlag = filterCustomerProductsByActiveStatuses({
+				customerProducts: customer.customer_products,
+			}).every(({ product }) => product.is_default);
 		}
 
 		// Filter out empty strings

--- a/server/tests/unit/analytics/billing-cycle-exclusion.test.ts
+++ b/server/tests/unit/analytics/billing-cycle-exclusion.test.ts
@@ -1,7 +1,7 @@
 // A default plan used to hide billing-cycle options even alongside a non-default plan.
 // Mixed plans must leave the options visible; default-only customers remain excluded.
 import { afterEach, expect, mock, spyOn, test } from "bun:test";
-import type { FullCustomer } from "@autumn/shared";
+import { CusProductStatus, type FullCustomer } from "@autumn/shared";
 import { Hono } from "hono";
 import * as tinybirdUtils from "@/external/tinybird/tinybirdUtils.js";
 import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
@@ -25,10 +25,23 @@ test.each([
 	{ name: "default only", defaults: [true, true], excluded: true },
 	{ name: "non-default only", defaults: [false], excluded: false },
 	{ name: "no products", defaults: [], excluded: true },
-])("billing-cycle options: $name", async ({ defaults, excluded }) => {
+	{
+		name: "scheduled non-default alongside active default",
+		defaults: [true, false],
+		statuses: [CusProductStatus.Active, CusProductStatus.Scheduled],
+		excluded: true,
+	},
+	{
+		name: "past-due non-default alongside active default",
+		defaults: [true, false],
+		statuses: [CusProductStatus.Active, CusProductStatus.PastDue],
+		excluded: false,
+	},
+])("billing-cycle options: $name", async ({ defaults, statuses, excluded }) => {
 	const customer = {
 		id: "customer_123",
-		customer_products: defaults.map((is_default) => ({
+		customer_products: defaults.map((is_default, index) => ({
+			status: statuses?.[index] ?? CusProductStatus.Active,
 			product: { is_default },
 		})),
 	} as FullCustomer;

--- a/server/tests/unit/analytics/billing-cycle-exclusion.test.ts
+++ b/server/tests/unit/analytics/billing-cycle-exclusion.test.ts
@@ -1,0 +1,62 @@
+// A default plan used to hide billing-cycle options even alongside a non-default plan.
+// Mixed plans must leave the options visible; default-only customers remain excluded.
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import type { FullCustomer } from "@autumn/shared";
+import { Hono } from "hono";
+import * as tinybirdUtils from "@/external/tinybird/tinybirdUtils.js";
+import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { eventActions } from "@/internal/analytics/actions/eventActions.js";
+import { handleInternalAggregateEvents } from "@/internal/analytics/internalHandlers/handleInternalAggregateEvents.js";
+import { CusService } from "@/internal/customers/CusService.js";
+
+afterEach(() => mock.restore());
+
+test.each([
+	{
+		name: "default then non-default",
+		defaults: [true, false],
+		excluded: false,
+	},
+	{
+		name: "non-default then default",
+		defaults: [false, true],
+		excluded: false,
+	},
+	{ name: "default only", defaults: [true, true], excluded: true },
+	{ name: "non-default only", defaults: [false], excluded: false },
+	{ name: "no products", defaults: [], excluded: true },
+])("billing-cycle options: $name", async ({ defaults, excluded }) => {
+	const customer = {
+		id: "customer_123",
+		customer_products: defaults.map((is_default) => ({
+			product: { is_default },
+		})),
+	} as FullCustomer;
+	spyOn(CusService, "getFull").mockResolvedValue(customer);
+	spyOn(tinybirdUtils, "assertTinybirdAvailable").mockImplementation(() => {});
+	spyOn(eventActions, "aggregate").mockResolvedValue({
+		formatted: { data: [], meta: [], rows: 0 },
+		truncated: false,
+	});
+	spyOn(eventActions, "getCountAndSum").mockResolvedValue({});
+	const app = new Hono<HonoEnv>();
+	app.use("*", async (c, next) => {
+		const ctx: Pick<AutumnContext, "features"> = { features: [] };
+		c.set("ctx", ctx as AutumnContext);
+		await next();
+	});
+	app.post("/aggregate", ...handleInternalAggregateEvents);
+
+	const response = await app.request("/aggregate", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			customer_id: customer.id,
+			event_names: [],
+			interval: "30d",
+		}),
+	});
+
+	expect(response.status).toBe(200);
+	expect(await response.json()).toMatchObject({ bcExclusionFlag: excluded });
+});


### PR DESCRIPTION
Replace the any-default-product exclusion with an all-default check. An active or past-due non-default plan now keeps billing-cycle options visible even when a default plan is also attached; scheduled plans do not qualify. Default-only customers remain excluded, and customers with no products are now excluded as well.

Adds an isolated handler regression test with customer loading and analytics calls stubbed, covering mixed plans in both orders, default-only, non-default-only, empty product lists, scheduled plans, and past-due plans. No frontend or analytics-query changes.

Verified the mixed-plan regression failed before the fix and all seven visibility cases plus the existing billing-cycle range test pass afterward. Server typecheck and targeted Biome checks pass.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M28TYRXHWG0V20S7407RZRN6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes billing-cycle options being hidden for customers with a mix of default and non-default plans. Options now stay visible when an active or past-due non-default plan is attached, while scheduled plans don't count toward the check.

- Replaces the any-default-product exclusion with an all-default check over active and past-due products.
- Keeps customers with no products excluded from billing-cycle options.
- Adds regression tests for mixed plans in both orders, default-only, non-default-only, empty product lists, scheduled plans, and past-due plans.

<sup>Written for commit 356b9ad15d993b67d3d31b84e0c99bf69b9fab52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This update aligns billing-cycle option visibility with the plans that can determine a customer’s billing-cycle range.

- **[Bug fixes]** Mixed default and non-default plans now keep billing-cycle options visible.
- **[Bug fixes]** Scheduled plans are ignored while active and past-due plans are considered.
- **[Improvements]** Regression tests cover plan ordering, default-only, non-default-only, empty, scheduled, and past-due cases.
</details>


<h3>Confidence Score: 4/5</h3>

The PR should not merge until the existing limited-product loading issue is addressed, because customers with many plans can still receive the wrong billing-cycle option visibility.

The previous finding is only partially fixed: scheduled plans no longer affect visibility, but `CusService.getFull` still limits the loaded customer products to 15. For example, if an active non-default plan falls outside that limit, the handler can see only default plans and hide billing-cycle options incorrectly.

**Files Needing Attention:** server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts | Filters plans to active and past-due statuses before deciding whether every relevant plan is a default plan; the previously reported limited product loading remains. |
| server/tests/unit/analytics/billing-cycle-exclusion.test.ts | Adds focused handler regression coverage for mixed, empty, scheduled, and past-due plan combinations. |

<sub>Reviews (2): Last reviewed commit: ["fix(analytics): ignore scheduled plans i..."](https://github.com/useautumn/autumn/commit/356b9ad15d993b67d3d31b84e0c99bf69b9fab52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63200487)</sub>

**Context used:**

- Knowledge Base — [Analytics stores and data exports](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/analytics-and-data-exports.md)
- Knowledge Base — [Usage and billing API platform](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/api-platform.md)

<!-- /greptile_comment -->