### PR TITLE
fix(atmn): resolve plan history ownership by membership

### DIFF
--- a/packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts
+++ b/packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts
@@ -167,10 +167,7 @@ const declaresName = ({
 			if (!bindsTopLevel({ node })) return false;
 			const pattern = node.field("name");
 			if (pattern === null) return false;
-			if (pattern.text() === name) return true;
-			return pattern
-				.findAll({ rule: { kind: "identifier", pattern: name } })
-				.some((identifier) => identifier.text() === name);
+			return bindingPatternHasName({ pattern, name });
 		});
 	if (variableBinding) return true;
 	const namedDeclarationKinds = [
@@ -233,6 +230,39 @@ const declaresName = ({
 				.split(/\s+as\s+/);
 			return names[names.length - 1] === name;
 		});
+};
+
+const bindingPatternHasName = ({
+	pattern,
+	name,
+}: {
+	pattern: SgNode;
+	name: string;
+}): boolean => {
+	if (
+		(pattern.kind() === "identifier" ||
+			pattern.kind() === "shorthand_property_identifier_pattern") &&
+		pattern.text() === name
+	)
+		return true;
+	const children = pattern.namedChildren();
+	if (
+		pattern.kind() === "pair_pattern" ||
+		pattern.kind() === "assignment_pattern" ||
+		pattern.kind() === "object_assignment_pattern" ||
+		pattern.kind() === "rest_pattern"
+	) {
+		const binding =
+			pattern.kind() === "pair_pattern"
+				? children[children.length - 1]
+				: children[0];
+		return binding === undefined
+			? false
+			: bindingPatternHasName({ pattern: binding, name });
+	}
+	return children.some((child) =>
+		bindingPatternHasName({ pattern: child, name }),
+	);
 };
 
 const bindsTopLevel = ({ node }: { node: SgNode }): boolean => {

--- a/packages/atmn-nightly/src/actions/pull/applyPreview.ts
+++ b/packages/atmn-nightly/src/actions/pull/applyPreview.ts
@@ -25,7 +25,7 @@ import { appendPlanVersionFixture } from "./appendPlanVersionFixture";
 import { changedFixtureKeys } from "./changedFixtureKeys";
 import { type FixtureConstraint, locateFixture } from "./locateFixture";
 import {
-	collectionTargetReferencesName,
+	collectionTargetReferenceName,
 	resolveCollectionTarget,
 } from "./resolveCollectionTarget";
 import { activeVersionOf, routePlanRow } from "./routePlanRow";
@@ -195,7 +195,7 @@ export const applyPreview = ({
 	}: {
 		name: string;
 		fixtureFile: string;
-	}): string => {
+	}): { targetCollection: string; referenceName: string } | null => {
 		const collectionTargets = [collection, spec.historyKey].flatMap(
 			(targetCollection) => {
 				if (targetCollection === undefined) return [];
@@ -207,23 +207,27 @@ export const applyPreview = ({
 				return target === null ? [] : [{ targetCollection, target }];
 			},
 		);
-		const membershipMatches = collectionTargets.filter(
-			({ targetCollection, target }) =>
-				collectionTargetReferencesName({
+		const membershipMatches = collectionTargets.flatMap(
+			({ targetCollection, target }) => {
+				const referenceName = collectionTargetReferenceName({
 					target,
 					files,
 					collection: targetCollection,
 					name,
-				}),
+					fixtureFile,
+				});
+				return referenceName === null
+					? []
+					: [{ targetCollection, referenceName }];
+			},
 		);
-		if (membershipMatches.length === 1)
-			return membershipMatches[0].targetCollection;
+		if (membershipMatches.length === 1) return membershipMatches[0];
 		const locationMatches = collectionTargets.filter(
 			({ target }) => target.file === fixtureFile,
 		);
 		if (locationMatches.length === 1)
-			return locationMatches[0].targetCollection;
-		return collection;
+			return { ...locationMatches[0], referenceName: name };
+		return null;
 	};
 	const deleteExportReference = ({
 		name,
@@ -280,14 +284,26 @@ export const applyPreview = ({
 			where: located.where,
 		});
 		if (removed === null) return;
+		const ownership =
+			removed.exportedName === undefined
+				? null
+				: collectionForRemoval({
+						name: removed.exportedName,
+						fixtureFile: located.file,
+					});
+		if (removed.exportedName !== undefined && ownership === null) {
+			result.unlocated.push({
+				id,
+				action:
+					"remove its exported reference by hand: collection ownership is ambiguous",
+			});
+			return;
+		}
 		files.set(located.file, removed.source);
-		if (removed.exportedName !== undefined)
+		if (ownership !== null)
 			deleteExportReference({
-				name: removed.exportedName,
-				targetCollection: collectionForRemoval({
-					name: removed.exportedName,
-					fixtureFile: located.file,
-				}),
+				name: ownership.referenceName,
+				targetCollection: ownership.targetCollection,
 			});
 		result.deleted.push(id);
 		result.lines.push(`- ${id}`);
@@ -565,14 +581,26 @@ export const applyPreview = ({
 					where: located.where,
 				});
 				if (removed === null) return;
+				const ownership =
+					removed.exportedName === undefined
+						? null
+						: collectionForRemoval({
+								name: removed.exportedName,
+								fixtureFile: located.file,
+							});
+				if (removed.exportedName !== undefined && ownership === null) {
+					result.unlocated.push({
+						id,
+						action:
+							"move its exported reference by hand: collection ownership is ambiguous",
+					});
+					return;
+				}
 				files.set(located.file, removed.source);
-				if (removed.exportedName !== undefined)
+				if (ownership !== null)
 					deleteExportReference({
-						name: removed.exportedName,
-						targetCollection: collectionForRemoval({
-							name: removed.exportedName,
-							fixtureFile: located.file,
-						}),
+						name: ownership.referenceName,
+						targetCollection: ownership.targetCollection,
 					});
 				const appended = appendRow({
 					id,

--- a/packages/atmn-nightly/src/actions/pull/applyPreview.ts
+++ b/packages/atmn-nightly/src/actions/pull/applyPreview.ts
@@ -24,7 +24,10 @@ import { replaceFixture } from "../../surgery/replaceFixture";
 import { appendPlanVersionFixture } from "./appendPlanVersionFixture";
 import { changedFixtureKeys } from "./changedFixtureKeys";
 import { type FixtureConstraint, locateFixture } from "./locateFixture";
-import { resolveCollectionTarget } from "./resolveCollectionTarget";
+import {
+	collectionTargetReferencesName,
+	resolveCollectionTarget,
+} from "./resolveCollectionTarget";
 import { activeVersionOf, routePlanRow } from "./routePlanRow";
 
 export type PreviewEntry = { action?: string } & Record<string, unknown>;
@@ -187,12 +190,10 @@ export const applyPreview = ({
 		return join(dirname(configPath), "planVersions", `${id}.ts`);
 	};
 	const collectionForRemoval = ({
-		id,
-		entry,
+		name,
 		fixtureFile,
 	}: {
-		id: string;
-		entry: PreviewEntry;
+		name: string;
 		fixtureFile: string;
 	}): string => {
 		const collectionTargets = [collection, spec.historyKey].flatMap(
@@ -203,13 +204,26 @@ export const applyPreview = ({
 					files,
 					collection: targetCollection,
 				});
-				return target?.file === fixtureFile ? [targetCollection] : [];
+				return target === null ? [] : [{ targetCollection, target }];
 			},
 		);
-		if (collectionTargets.length === 1) return collectionTargets[0];
-		return versioned && configActiveOf({ id, entry }) === false
-			? (spec.historyKey ?? collection)
-			: collection;
+		const membershipMatches = collectionTargets.filter(
+			({ targetCollection, target }) =>
+				collectionTargetReferencesName({
+					target,
+					files,
+					collection: targetCollection,
+					name,
+				}),
+		);
+		if (membershipMatches.length === 1)
+			return membershipMatches[0].targetCollection;
+		const locationMatches = collectionTargets.filter(
+			({ target }) => target.file === fixtureFile,
+		);
+		if (locationMatches.length === 1)
+			return locationMatches[0].targetCollection;
+		return collection;
 	};
 	const deleteExportReference = ({
 		name,
@@ -271,8 +285,7 @@ export const applyPreview = ({
 			deleteExportReference({
 				name: removed.exportedName,
 				targetCollection: collectionForRemoval({
-					id,
-					entry,
+					name: removed.exportedName,
 					fixtureFile: located.file,
 				}),
 			});
@@ -556,10 +569,10 @@ export const applyPreview = ({
 				if (removed.exportedName !== undefined)
 					deleteExportReference({
 						name: removed.exportedName,
-						targetCollection:
-							configActive === false
-								? (spec.historyKey ?? collection)
-								: collection,
+						targetCollection: collectionForRemoval({
+							name: removed.exportedName,
+							fixtureFile: located.file,
+						}),
 					});
 				const appended = appendRow({
 					id,

--- a/packages/atmn-nightly/src/actions/pull/resolveCollectionTarget.ts
+++ b/packages/atmn-nightly/src/actions/pull/resolveCollectionTarget.ts
@@ -7,6 +7,34 @@ export type CollectionTarget =
 	| { kind: "inline"; file: string }
 	| { kind: "binding"; file: string; name: string };
 
+export const collectionTargetReferencesName = ({
+	target,
+	files,
+	collection,
+	name,
+}: {
+	target: CollectionTarget;
+	files: Map<string, string>;
+	collection: string;
+	name: string;
+}): boolean => {
+	const source = files.get(target.file);
+	if (source === undefined) return false;
+	const root = parse(Lang.TypeScript, source).root();
+	const array =
+		target.kind === "binding"
+			? findLiteralBinding({ root, name: target.name, kind: "array" })
+			: collectionValue({ root, collection });
+	return (
+		array?.kind() === "array" &&
+		array
+			.namedChildren()
+			.some(
+				(element) => element.kind() === "identifier" && element.text() === name,
+			)
+	);
+};
+
 const NAMED_IMPORT =
 	/import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*["']([^"']+)["']/;
 

--- a/packages/atmn-nightly/src/actions/pull/resolveCollectionTarget.ts
+++ b/packages/atmn-nightly/src/actions/pull/resolveCollectionTarget.ts
@@ -7,32 +7,44 @@ export type CollectionTarget =
 	| { kind: "inline"; file: string }
 	| { kind: "binding"; file: string; name: string };
 
-export const collectionTargetReferencesName = ({
+export const collectionTargetReferenceName = ({
 	target,
 	files,
 	collection,
 	name,
+	fixtureFile,
 }: {
 	target: CollectionTarget;
 	files: Map<string, string>;
 	collection: string;
 	name: string;
-}): boolean => {
+	fixtureFile: string;
+}): string | null => {
 	const source = files.get(target.file);
-	if (source === undefined) return false;
+	if (source === undefined) return null;
 	const root = parse(Lang.TypeScript, source).root();
 	const array =
 		target.kind === "binding"
 			? findLiteralBinding({ root, name: target.name, kind: "array" })
 			: collectionValue({ root, collection });
-	return (
-		array?.kind() === "array" &&
-		array
-			.namedChildren()
-			.some(
-				(element) => element.kind() === "identifier" && element.text() === name,
-			)
-	);
+	if (array?.kind() !== "array") return null;
+	for (const element of array.namedChildren()) {
+		if (element.kind() !== "identifier") continue;
+		const localName = element.text();
+		const imported = importedFrom({ root, name: localName });
+		if (imported !== null) {
+			const importedFile = moduleFileOf({
+				from: target.file,
+				specifier: imported.specifier,
+				files,
+			});
+			if (importedFile === fixtureFile && imported.exportedName === name)
+				return localName;
+			continue;
+		}
+		if (target.file === fixtureFile && localName === name) return localName;
+	}
+	return null;
 };
 
 const NAMED_IMPORT =

--- a/packages/atmn-nightly/src/surgery/deleteReference.ts
+++ b/packages/atmn-nightly/src/surgery/deleteReference.ts
@@ -30,7 +30,11 @@ export const deleteReference = ({
 	for (const specifier of root.findAll({
 		rule: { kind: "import_specifier" },
 	})) {
-		if (specifier.text() !== name) continue;
+		const names = specifier
+			.text()
+			.trim()
+			.split(/\s+as\s+/);
+		if (names[names.length - 1] !== name) continue;
 		const imports = specifier.parent();
 		if (imports !== null && imports.namedChildren().length === 1) {
 			const statement = importStatementOf(specifier);

--- a/packages/atmn-nightly/test/pull-plan-version-placement.test.ts
+++ b/packages/atmn-nightly/test/pull-plan-version-placement.test.ts
@@ -149,6 +149,103 @@ test("draft membership cleans plans even though the draft is inactive", () => {
 	expect(files.get(history)).toBe(historySource);
 });
 
+test("aliased history membership resolves to the exported fixture", () => {
+	const root = "/catalog/autumn.config.ts";
+	const fixture = "/catalog/legacy.ts";
+	const history = "/catalog/history.ts";
+	const files = new Map([
+		[
+			root,
+			'import { historyPlans } from "./history";\nexport default atmn({ plans: [plan({ planId: "pro", internalId: "prod_v2", versionSlug: "v2" })], planVersions: historyPlans });\n',
+		],
+		[
+			fixture,
+			'export const pro_v1 = plan({ planId: "pro", internalId: "prod_v1", versionSlug: "v1" });\n',
+		],
+		[
+			history,
+			'import { pro_v1 as oldPro } from "./legacy";\nexport const historyPlans = [oldPro];\n',
+		],
+	]);
+
+	const result = applyPreview({
+		collection: "plans",
+		spec: COLLECTIONS.plans,
+		entries: [
+			{
+				planId: "pro",
+				versionSlug: "v1",
+				internalId: "prod_v1",
+				action: "create",
+			},
+		],
+		catalogRows: [],
+		statedRows: [],
+		configPath: root,
+		files,
+		includeMappings: false,
+	});
+
+	expect(result.unlocated).toEqual([]);
+	expect(files.get(fixture)).not.toContain("pro_v1");
+	expect(files.get(history)).toBe("export const historyPlans = [];\n");
+	expect(files.get(root)).toContain('internalId: "prod_v2"');
+});
+
+test("duplicate local member names resolve through their import sources", () => {
+	const root = "/catalog/autumn.config.ts";
+	const activeFixture = "/catalog/active-fixture.ts";
+	const historyFixture = "/catalog/history-fixture.ts";
+	const activeCollection = "/catalog/active-collection.ts";
+	const historyCollection = "/catalog/history-collection.ts";
+	const activeCollectionSource =
+		'import { pro_v1 } from "./active-fixture";\nexport const activePlans = [pro_v1];\n';
+	const files = new Map([
+		[
+			root,
+			'import { activePlans } from "./active-collection";\nimport { historyPlans } from "./history-collection";\nexport default atmn({ plans: activePlans, planVersions: historyPlans });\n',
+		],
+		[
+			activeFixture,
+			'export const pro_v1 = plan({ planId: "pro", internalId: "prod_v2", versionSlug: "v2" });\n',
+		],
+		[
+			historyFixture,
+			'export const pro_v1 = plan({ planId: "pro", internalId: "prod_v1", versionSlug: "v1" });\n',
+		],
+		[activeCollection, activeCollectionSource],
+		[
+			historyCollection,
+			'import { pro_v1 } from "./history-fixture";\nexport const historyPlans = [pro_v1];\n',
+		],
+	]);
+
+	const result = applyPreview({
+		collection: "plans",
+		spec: COLLECTIONS.plans,
+		entries: [
+			{
+				planId: "pro",
+				versionSlug: "v1",
+				internalId: "prod_v1",
+				action: "create",
+			},
+		],
+		catalogRows: [],
+		statedRows: [],
+		configPath: root,
+		files,
+		includeMappings: false,
+	});
+
+	expect(result.unlocated).toEqual([]);
+	expect(files.get(activeCollection)).toBe(activeCollectionSource);
+	expect(files.get(historyCollection)).toBe(
+		"export const historyPlans = [];\n",
+	);
+	expect(files.get(historyFixture)).not.toContain("pro_v1");
+});
+
 test("a missing history fixture gets its own file and a root reference", async () => {
 	rmSync(directory, { recursive: true, force: true });
 	mkdirSync(join(directory, "planVersions"), { recursive: true });

--- a/packages/atmn-nightly/test/pull-plan-version-placement.test.ts
+++ b/packages/atmn-nightly/test/pull-plan-version-placement.test.ts
@@ -9,7 +9,9 @@ import {
 import { join } from "node:path";
 import { runPull } from "../src/actions/pull";
 import { planVersionExportName } from "../src/actions/pull/appendPlanVersionFixture";
+import { applyPreview } from "../src/actions/pull/applyPreview";
 import type { AutumnClient } from "../src/generated/client";
+import { COLLECTIONS } from "../src/generated/emit";
 
 const directory = join(import.meta.dir, ".tmp", "pull-plan-version-placement");
 const configPath = join(directory, "autumn.config.ts");
@@ -38,6 +40,113 @@ test("function and class declarations advance to the next free name", () => {
 			takenSources: ["function pro_v1() {}\nclass pro_5f_v1 {}"],
 		}),
 	).toBe("pro_5f_v1_2");
+});
+
+test("shorthand destructuring reserves its bound name", () => {
+	expect(
+		planVersionExportName({
+			planId: "pro",
+			versionSlug: "v1",
+			takenSources: ["const { pro_v1 } = value;"],
+		}),
+	).toBe("pro_5f_v1");
+});
+
+test("history membership beats a declaration beside the plans binding", () => {
+	const root = "/catalog/autumn.config.ts";
+	const plans = "/catalog/plans.ts";
+	const history = "/catalog/history.ts";
+	const files = new Map([
+		[
+			root,
+			'import { activePlans } from "./plans";\nimport { historyPlans } from "./history";\nexport default atmn({ plans: activePlans, planVersions: historyPlans });\n',
+		],
+		[
+			plans,
+			'export const activeV2 = plan({ planId: "pro", internalId: "prod_v2", versionSlug: "v2" });\nexport const pro_v1 = plan({ planId: "pro", internalId: "prod_v1", versionSlug: "v1" });\nexport const activePlans = [activeV2];\n',
+		],
+		[
+			history,
+			'import { pro_v1 } from "./plans";\nexport const historyPlans = [pro_v1];\n',
+		],
+	]);
+
+	applyPreview({
+		collection: "plans",
+		spec: COLLECTIONS.plans,
+		entries: [
+			{
+				planId: "pro",
+				versionSlug: "v1",
+				internalId: "prod_v1",
+				action: "create",
+			},
+		],
+		catalogRows: [],
+		statedRows: [
+			{
+				plan_id: "pro",
+				version_slug: "v1",
+				internal_id: "prod_v1",
+				active: false,
+			},
+		],
+		configPath: root,
+		files,
+		includeMappings: false,
+	});
+
+	expect(files.get(plans)).toContain("export const activePlans = [activeV2]");
+	expect(files.get(plans)).not.toContain("export const pro_v1");
+	expect(files.get(history)).toBe("export const historyPlans = [];\n");
+});
+
+test("draft membership cleans plans even though the draft is inactive", () => {
+	const root = "/catalog/autumn.config.ts";
+	const draft = "/catalog/draft.ts";
+	const history = "/catalog/history.ts";
+	const historySource = "export const historyPlans = [];\n";
+	const files = new Map([
+		[
+			root,
+			'import { pro_v3 } from "./draft";\nimport { historyPlans } from "./history";\nexport default atmn({ plans: [plan({ planId: "pro", versionSlug: "v2" }), pro_v3], planVersions: historyPlans });\n',
+		],
+		[
+			draft,
+			'export const pro_v3 = plan({ planId: "pro", internalId: "prod_v3", versionSlug: "v3", active: false });\n',
+		],
+		[history, historySource],
+	]);
+
+	applyPreview({
+		collection: "plans",
+		spec: COLLECTIONS.plans,
+		entries: [
+			{
+				planId: "pro",
+				versionSlug: "v3",
+				internalId: "prod_v3",
+				active: false,
+				action: "create",
+			},
+		],
+		catalogRows: [],
+		statedRows: [
+			{
+				plan_id: "pro",
+				version_slug: "v3",
+				internal_id: "prod_v3",
+				active: false,
+			},
+		],
+		configPath: root,
+		files,
+		includeMappings: false,
+	});
+
+	expect(files.get(root)).not.toContain("pro_v3");
+	expect(files.get(root)).toContain('versionSlug: "v2"');
+	expect(files.get(history)).toBe(historySource);
 });
 
 test("a missing history fixture gets its own file and a root reference", async () => {

--- a/packages/atmn-nightly/test/pullStatesSlugs.test.ts
+++ b/packages/atmn-nightly/test/pullStatesSlugs.test.ts
@@ -68,6 +68,7 @@ const catalog = {
 };
 
 const client = {
+	previewUpdateOrganization: async () => ({ config: { changes: [] } }),
 	previewUpdate: async () => unchangedPreview,
 	update: async () => ({}),
 	get: async () => catalog,


### PR DESCRIPTION
Follow-up to #3394, from three review findings confirmed after it merged.

## Ownership comes from membership, not co-location

A history export can be declared beside the `plans` binding while being referenced from a different `planVersions` module, so matching on the declaration's file could pick the wrong collection. Removal now inspects the resolved collection arrays and takes the one that actually holds the exported reference; declaration co-location is only a fallback when membership cannot decide.

## Every binding-pattern kind is detected

Shorthand object bindings (`const { pro_v1 } = …`) use `shorthand_property_identifier_pattern`, which the identifier-only walk missed. Traversal now covers shorthand, pair, assignment, object-assignment, rest, array, and nested patterns.

## A draft is not history

Drafts are inactive but live in `plans`, so inferring history from the active flag could clean `planVersions` and leave the draft's real import and reference dangling. Inactive state no longer decides ownership: a draft reference found in `plans` is cleaned from `plans`, and the history target is untouched.

## Also

`packages/atmn-nightly/test/pullStatesSlugs.test.ts` has been red on `dev` because its fake client predates `previewUpdateOrganization`. The second commit adds that method to the fake and nothing else; the test itself is unchanged and now passes, so the package suite is fully green.

## Tests

One regression per finding in `pull-plan-version-placement.test.ts`: a history export declared beside the `plans` binding but referenced from a `planVersions` module, a shorthand-destructured binding, and a draft in `plans` whose reference must survive a history delete.

Gates: typecheck clean, package suite 359/0, placement and ownership tests 8/0, the pull scenario 1/0.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M20C2JKFA15VPKF6GKTGB55Z"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plan history removal so a deleted version is cleaned from the collection that actually holds its reference, not just the one co-located with the declaration. Also resolves aliased imports (`pro_v1 as oldPro`), detects all shorthand and binding pattern kinds, and treats inactive drafts as live plans rather than history.

**Bug fixes**
- Ownership is decided by which resolved collection array holds the exported reference, with declaration co-location only as a fallback; alias names are traced back to their exported fixture and removed correctly.
- Traversal covers shorthand, pair, assignment, object-assignment, rest, array, and nested binding patterns when finding a plan's exported name.
- A draft reference is cleaned from the plans collection; history is left untouched.

**Tests**
- `pullStatesSlugs.test.ts` adds the missing `previewUpdateOrganization` method to its fake client so the suite passes.

<sup>Written for commit d702e02f674204105c0bb503cfdf227fe4a4ad86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes plan-version removal determine ownership from the collection that actually contains the fixture reference, including references imported under aliases. It also improves binding-pattern detection and repairs an outdated test client.

- **Bug fixes:** Resolve plan and history ownership through actual array membership and imported fixture identity rather than declaration location or inactive state.
- **Bug fixes:** Remove aliased collection references and their corresponding imports using the local binding name.
- **Improvements:** Detect names reserved by shorthand, nested, assignment, rest, object, and array binding patterns.
- **Improvements:** Add the missing organization-preview method to the pull-state test client.
- **Improvements:** Add regression coverage for co-located history declarations, drafts, aliases, duplicate local names, and shorthand destructuring.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the alias-related ownership finding is resolved and no new actionable defect was identified.

Collection ownership now verifies both the fixture source file and exported name, returns the local alias for cleanup, and refuses ambiguous edits before mutating source files. The previous alias finding was manually resolved.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/atmn-nightly/src/actions/pull/applyPreview.ts | Determines removal and move ownership from resolved collection membership and safely stops when ownership remains ambiguous. |
| packages/atmn-nightly/src/actions/pull/resolveCollectionTarget.ts | Resolves collection members through their import source and returns the local alias used by the target array. |
| packages/atmn-nightly/src/surgery/deleteReference.ts | Removes aliased named imports by matching the local import binding. |
| packages/atmn-nightly/src/actions/pull/appendPlanVersionFixture.ts | Recursively detects reserved names across supported JavaScript and TypeScript binding patterns. |
| packages/atmn-nightly/test/pull-plan-version-placement.test.ts | Adds regression coverage for membership ownership, drafts, aliases, duplicate names, and shorthand bindings. |
| packages/atmn-nightly/test/pullStatesSlugs.test.ts | Updates the fake client with the organization-preview operation now required by the pull workflow. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Locate exported plan fixture] --> B[Resolve plans and planVersions arrays]
    B --> C[Inspect each array member]
    C --> D[Resolve local import alias to source export]
    D --> E{Exactly one collection owns fixture?}
    E -- Yes --> F[Delete local array reference and import]
    F --> G[Delete or move fixture]
    E -- No --> H{Exactly one declaration-location fallback?}
    H -- Yes --> F
    H -- No --> I[Report ambiguous ownership for manual handling]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(atmn): resolve imported collection o..."](https://github.com/useautumn/autumn/commit/d702e02f674204105c0bb503cfdf227fe4a4ad86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63221045)</sub>

**Context used:**

- Knowledge Base — [Declarative catalog configuration CLI](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/declarative-catalog-cli.md)

<!-- /greptile_comment -->