### PR TITLE
hotfix(sync): skip sub.updated back-sync when an Autumn-owned schedule advances

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/isAutumnScheduledPhaseChange.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/isAutumnScheduledPhaseChange.ts
@@ -1,0 +1,17 @@
+import { isAutumnManagedStripeSchedule } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata";
+import { isSchedulePhaseChange } from "./isSchedulePhaseChange";
+import type { StripeSubscriptionUpdatedContext } from "./stripeSubscriptionUpdatedContext";
+
+/**
+ * An Autumn-owned schedule advancing is Autumn's own plan playing out, not an
+ * external edit. Schedules the customer built in Stripe still back-sync.
+ */
+export const isAutumnScheduledPhaseChange = ({
+	subscriptionUpdatedContext,
+}: {
+	subscriptionUpdatedContext: StripeSubscriptionUpdatedContext;
+}): boolean =>
+	isSchedulePhaseChange({ subscriptionUpdatedContext }) &&
+	isAutumnManagedStripeSchedule({
+		schedule: subscriptionUpdatedContext.stripeSubscription.schedule,
+	});

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/isSchedulePhaseChange.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/isSchedulePhaseChange.ts
@@ -1,0 +1,15 @@
+import { notNullish } from "@autumn/shared";
+import type { StripeSubscriptionUpdatedContext } from "./stripeSubscriptionUpdatedContext";
+
+/** Stripe's only signal that a schedule advanced: items changed while a schedule is attached. */
+export const isSchedulePhaseChange = ({
+	subscriptionUpdatedContext,
+}: {
+	subscriptionUpdatedContext: StripeSubscriptionUpdatedContext;
+}): boolean => {
+	const { stripeSubscription, previousAttributes } = subscriptionUpdatedContext;
+	return (
+		notNullish(previousAttributes?.items) &&
+		notNullish(stripeSubscription.schedule)
+	);
+};

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
@@ -12,6 +12,7 @@ import { isAutumnManagedSubscriptionMetadata } from "@/internal/billing/v2/provi
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import type { StripeWebhookContext } from "../../../webhookMiddlewares/stripeWebhookContext";
 import { trackCustomerProductUpdate } from "../../common/trackCustomerProductUpdate";
+import { isAutumnScheduledPhaseChange } from "../isAutumnScheduledPhaseChange";
 import type { StripeSubscriptionUpdatedContext } from "../stripeSubscriptionUpdatedContext";
 
 const stripeProductId = (
@@ -87,6 +88,14 @@ export const autoSyncUpdatedSubscription = async ({
 		subscriptionUpdatedContext;
 
 	if (!priceOrProductChanged({ subscriptionUpdatedContext })) return;
+
+	if (isAutumnScheduledPhaseChange({ subscriptionUpdatedContext })) {
+		logger.info(
+			`sub.updated auto-sync skipping ${stripeSubscription.id}: autumn-managed schedule advanced`,
+		);
+		return;
+	}
+
 	const metadataDecision = isAutumnManagedSubscriptionMetadata({
 		metadata: stripeSubscription.metadata,
 		requireRecent: true,

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
@@ -96,6 +96,14 @@ export const autoSyncUpdatedSubscription = async ({
 		return;
 	}
 
+	// Pre-stamp schedules: Autumn already applied this phase (ended_at / activate).
+	if (subscriptionUpdatedContext.billingChangeTags.has("phase_changed")) {
+		logger.info(
+			`sub.updated auto-sync skipping ${stripeSubscription.id}: schedule phase already applied`,
+		);
+		return;
+	}
+
 	const metadataDecision = isAutumnManagedSubscriptionMetadata({
 		metadata: stripeSubscription.metadata,
 		requireRecent: true,

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleSchedulePhaseChanges/handleSchedulePhaseChanges.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleSchedulePhaseChanges/handleSchedulePhaseChanges.ts
@@ -1,9 +1,10 @@
-import { formatMs, notNullish } from "@autumn/shared";
+import { formatMs } from "@autumn/shared";
 import { isAutumnOriginatedStripeEvent } from "@/external/stripe/common/autumnStripeIdempotency.js";
 import { stripeSubscriptionScheduleToPhaseIndex } from "@/external/stripe/subscriptionSchedules/utils/convertStripeSubscriptionScheduleUtils";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
 import { reconcileLicenseStateForCustomer } from "@/internal/licenses/actions/reconcile/reconcileLicenseState";
 import { addBillingChangeTag } from "../../../common";
+import { isSchedulePhaseChange } from "../../isSchedulePhaseChange";
 import type { StripeSubscriptionUpdatedContext } from "../../stripeSubscriptionUpdatedContext";
 import { activateScheduledCustomerProducts } from "./activateScheduledCustomerProducts";
 import { expireEndedCustomerProducts } from "./expireEndedCustomerProducts";
@@ -24,7 +25,7 @@ export const handleSchedulePhaseChanges = async ({
 	ctx: StripeWebhookContext;
 	eventContext: StripeSubscriptionUpdatedContext;
 }): Promise<void> => {
-	const { stripeSubscription, previousAttributes, nowMs } = eventContext;
+	const { stripeSubscription, nowMs } = eventContext;
 	const { logger } = ctx;
 
 	if (isAutumnOriginatedStripeEvent({ event: ctx.stripeEvent })) {
@@ -42,16 +43,13 @@ export const handleSchedulePhaseChanges = async ({
 	// Step 1: Activate scheduled products; checkout trial-end updates have no schedule phase change.
 	await activateScheduledCustomerProducts({ ctx, eventContext });
 
-	// Check if phase possibly changed (items changed and schedule exists)
-	const phasePossiblyChanged =
-		notNullish(previousAttributes?.items) &&
-		notNullish(stripeSubscription.schedule);
-
 	// `activateScheduledCustomerProducts` can still mutate cusProducts on
 	// non-phase-change events (e.g. checkout trial-end flows). Those are
 	// NOT phase changes — only tag `phase_changed` once the canonical
 	// Stripe-schedule advance signal is confirmed below.
-	if (!phasePossiblyChanged) return;
+	if (!isSchedulePhaseChange({ subscriptionUpdatedContext: eventContext })) {
+		return;
+	}
 
 	const stripeSubscriptionSchedule = stripeSubscription.schedule;
 

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionScheduleAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionScheduleAction.ts
@@ -6,6 +6,7 @@ import { createStripeCli } from "@server/external/connect/createStripeCli";
 import { autumnStripeRequestOptions } from "@server/external/stripe/common/autumnStripeIdempotency";
 import type { AutumnContext } from "@server/honoUtils/HonoEnv";
 import type Stripe from "stripe";
+import { buildAutumnSubscriptionMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata";
 import { findMatchingInlinePriceIdForPhaseItem } from "@/internal/billing/v2/providers/stripe/utils/matchUtils/matchStripeInlinePrice";
 import { logSubscriptionScheduleAction } from "@/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/logSubscriptionScheduleAction";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
@@ -141,11 +142,13 @@ const createScheduleFromSubscription = async ({
 	subscriptionId,
 	params,
 	stripeSubscription,
+	autumnMetadata,
 }: {
 	stripeCli: Stripe;
 	subscriptionId: string;
 	params: Stripe.SubscriptionScheduleUpdateParams;
 	stripeSubscription?: Stripe.Subscription;
+	autumnMetadata: Stripe.MetadataParam;
 }): Promise<Stripe.SubscriptionSchedule> => {
 	const schedule = await stripeCli.subscriptionSchedules.create(
 		{
@@ -165,6 +168,7 @@ const createScheduleFromSubscription = async ({
 		{
 			phases,
 			end_behavior: params.end_behavior,
+			metadata: autumnMetadata,
 		},
 		autumnStripeRequestOptions({ source: "schedule" }),
 	);
@@ -203,6 +207,10 @@ export const executeStripeSubscriptionScheduleAction = async ({
 }): Promise<Stripe.SubscriptionSchedule | null> => {
 	const { org, env } = ctx;
 	const stripeCli = createStripeCli({ org, env });
+	// Marks the schedule as Autumn-owned so its phase advances are never back-synced.
+	const autumnMetadata = buildAutumnSubscriptionMetadata({
+		actionSource: billingContext.actionSource,
+	});
 
 	logSubscriptionScheduleAction({
 		ctx,
@@ -225,6 +233,7 @@ export const executeStripeSubscriptionScheduleAction = async ({
 					subscriptionId: stripeSubscription.id,
 					params,
 					stripeSubscription,
+					autumnMetadata,
 				});
 			}
 
@@ -236,6 +245,7 @@ export const executeStripeSubscriptionScheduleAction = async ({
 					phases: params.phases?.map(toCreatePhase) ?? [],
 					end_behavior: params.end_behavior,
 					start_date: startDate,
+					metadata: autumnMetadata,
 					...getStandaloneScheduleDefaults({ billingContext }),
 				},
 				autumnStripeRequestOptions({ source: billingContext.actionSource }),
@@ -254,7 +264,7 @@ export const executeStripeSubscriptionScheduleAction = async ({
 				// Update them in place instead of releasing and recreating from a sub.
 				return await stripeCli.subscriptionSchedules.update(
 					stripeSubscriptionScheduleId,
-					params,
+					{ ...params, metadata: autumnMetadata },
 					autumnStripeRequestOptions({ source: billingContext.actionSource }),
 				);
 			}
@@ -275,6 +285,7 @@ export const executeStripeSubscriptionScheduleAction = async ({
 						: subscriptionId.id,
 				params,
 				stripeSubscription,
+				autumnMetadata,
 			});
 
 			// Update existing customer products with the new schedule ID

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata.ts
@@ -26,6 +26,14 @@ export const buildAutumnSubscriptionMetadata = ({
 	return meta;
 };
 
+/** Ownership, not recency: a schedule Autumn wrote stays Autumn's for its whole life. */
+export const isAutumnManagedStripeSchedule = ({
+	schedule,
+}: {
+	schedule: Stripe.SubscriptionSchedule | null | undefined;
+}): boolean =>
+	Boolean(schedule?.metadata?.[AUTUMN_STRIPE_METADATA_KEYS.managedAt]);
+
 /**
  * @param requireRecent — when true (default), `autumn_managed_at` only counts
  *   if it falls within `windowMs`. Used by sub.updated where a stale stamp

--- a/server/src/internal/customers/attach/mergeUtils/updateCurSchedule.ts
+++ b/server/src/internal/customers/attach/mergeUtils/updateCurSchedule.ts
@@ -1,5 +1,6 @@
 import type Stripe from "stripe";
 import { autumnStripeRequestOptions } from "@/external/stripe/common/autumnStripeIdempotency.js";
+import { buildAutumnSubscriptionMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata.js";
 import type { AutumnContext } from "../../../../honoUtils/HonoEnv.js";
 import type { AttachParams } from "../../cusProducts/AttachParams.js";
 
@@ -33,6 +34,7 @@ export const updateCurSchedule = async ({
 		schedule.id,
 		{
 			phases: newPhases,
+			metadata: buildAutumnSubscriptionMetadata({ actionSource: "v1Attach" }),
 		},
 		autumnStripeRequestOptions({ source: "attach.schedule_update" }),
 	);

--- a/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-scheduled-addon-drop-keeps-version.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-scheduled-addon-drop-keeps-version.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression: an add-on canceled at end of cycle drops off via an Autumn-built
+ * Stripe schedule. When that phase advances, sub.updated back-sync must not
+ * re-match the surviving base price and swap the customer's plan version.
+ *
+ * Setup: pro v1 + add-on on one sub → pro v2 published → add-on canceled EOC.
+ * Red (pre-fix): after the cycle turns, pro is replaced by v2.
+ * Green: add-on gone, pro still v1, and the schedule carries Autumn's stamp.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { BillingInterval, ResetInterval } from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { getSubscriptionId } from "@tests/integration/billing/utils/stripe/getSubscriptionId";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import {
+	WEBHOOK_SETTLE_TIMEOUT_MS,
+	WEBHOOK_TEST_TIMEOUT_MS,
+} from "@tests/utils/pollableCustomerExpect";
+import { advanceToNextInvoice } from "@tests/utils/testAttachUtils/testAttachUtils";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { AUTUMN_STRIPE_METADATA_KEYS } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata";
+
+const attachedVersion = ({
+	customer,
+	planId,
+}: {
+	customer: ApiCustomerV3;
+	planId: string;
+}) => customer.products.find((product) => product.id === planId)?.version;
+
+test(
+	chalk.yellowBright(
+		"sub.updated: Autumn-scheduled add-on drop keeps the customer's plan version",
+	),
+	async () => {
+		const customerId = "sub-updated-sched-addon-drop-version";
+		const pro = products.pro({
+			id: "sched-addon-drop-pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const addon = products.base({
+			id: "sched-addon-drop-addon",
+			isAddOn: true,
+			items: [
+				items.monthlyPrice({ price: 10 }),
+				items.monthlyUsers({ includedUsage: 5 }),
+			],
+		});
+
+		const { autumnV1, autumnV2_3, ctx, testClockId } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, addon] }),
+			],
+			actions: [
+				s.billing.attach({ productId: pro.id }),
+				s.billing.attach({ productId: addon.id }),
+			],
+		});
+
+		// A newer pro version sharing the same base price — the bait for back-sync.
+		await autumnV2_3.catalogV2.update({
+			plans: [
+				{
+					plan_id: pro.id,
+					versioning: "new_version",
+					active: true,
+					price: { amount: 20, interval: BillingInterval.Month },
+					items: [
+						{
+							feature_id: TestFeature.Messages,
+							included: 500,
+							reset: { interval: ResetInterval.Month },
+						},
+					],
+				},
+			],
+		});
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: addon.id,
+			cancel_action: "cancel_end_of_cycle",
+		});
+
+		const subscriptionId = await getSubscriptionId({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+		const subscription = await ctx.stripeCli.subscriptions.retrieve(
+			subscriptionId,
+			{ expand: ["schedule"] },
+		);
+		const schedule = subscription.schedule as Stripe.SubscriptionSchedule;
+		expect(
+			schedule?.metadata?.[AUTUMN_STRIPE_METADATA_KEYS.managedAt],
+		).toBeDefined();
+
+		// In production the cycle turns weeks after the cancel, long past the
+		// 10-minute recency window on the subscription stamp. Age it to match.
+		await ctx.stripeCli.subscriptions.update(subscriptionId, {
+			metadata: { [AUTUMN_STRIPE_METADATA_KEYS.managedAt]: "1" },
+		});
+
+		await advanceToNextInvoice({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId!,
+		});
+
+		const customer = (await expectCustomerProducts({
+			autumn: autumnV1,
+			customerId,
+			settleTimeoutMs: WEBHOOK_SETTLE_TIMEOUT_MS,
+			active: [pro.id],
+			notPresent: [addon.id],
+		})) as ApiCustomerV3;
+		expect(attachedVersion({ customer, planId: pro.id })).toBe(1);
+	},
+	WEBHOOK_TEST_TIMEOUT_MS,
+);

--- a/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-scheduled-addon-drop-keeps-version.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-scheduled-addon-drop-keeps-version.test.ts
@@ -34,95 +34,150 @@ const attachedVersion = ({
 	planId: string;
 }) => customer.products.find((product) => product.id === planId)?.version;
 
+const setupAddonDropWithNewerVersion = async ({
+	customerId,
+}: {
+	customerId: string;
+}) => {
+	const pro = products.pro({
+		id: "sched-addon-drop-pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const addon = products.base({
+		id: "sched-addon-drop-addon",
+		isAddOn: true,
+		items: [
+			items.monthlyPrice({ price: 10 }),
+			items.monthlyUsers({ includedUsage: 5 }),
+		],
+	});
+
+	const { autumnV1, autumnV2_3, ctx, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, addon] }),
+		],
+		actions: [
+			s.billing.attach({ productId: pro.id }),
+			s.billing.attach({ productId: addon.id }),
+		],
+	});
+
+	// A newer pro version sharing the same base price — the bait for back-sync.
+	await autumnV2_3.catalogV2.update({
+		plans: [
+			{
+				plan_id: pro.id,
+				versioning: "new_version",
+				active: true,
+				price: { amount: 20, interval: BillingInterval.Month },
+				items: [
+					{
+						feature_id: TestFeature.Messages,
+						included: 500,
+						reset: { interval: ResetInterval.Month },
+					},
+				],
+			},
+		],
+	});
+
+	await autumnV1.subscriptions.update({
+		customer_id: customerId,
+		product_id: addon.id,
+		cancel_action: "cancel_end_of_cycle",
+	});
+
+	const subscriptionId = await getSubscriptionId({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+	const subscription = await ctx.stripeCli.subscriptions.retrieve(
+		subscriptionId,
+		{ expand: ["schedule"] },
+	);
+	const schedule = subscription.schedule as Stripe.SubscriptionSchedule;
+
+	// Cycle turns weeks later — the subscription recency window is already stale.
+	await ctx.stripeCli.subscriptions.update(subscriptionId, {
+		metadata: { [AUTUMN_STRIPE_METADATA_KEYS.managedAt]: "1" },
+	});
+
+	return { autumnV1, ctx, testClockId, pro, addon, subscriptionId, schedule };
+};
+
+const expectAddonDroppedProKeptAtV1 = async ({
+	autumnV1,
+	customerId,
+	proId,
+	addonId,
+}: {
+	autumnV1: Awaited<ReturnType<typeof initScenario>>["autumnV1"];
+	customerId: string;
+	proId: string;
+	addonId: string;
+}) => {
+	const customer = (await expectCustomerProducts({
+		autumn: autumnV1,
+		customerId,
+		settleTimeoutMs: WEBHOOK_SETTLE_TIMEOUT_MS,
+		active: [proId],
+		notPresent: [addonId],
+	})) as ApiCustomerV3;
+	expect(attachedVersion({ customer, planId: proId })).toBe(1);
+};
+
 test(
 	chalk.yellowBright(
 		"sub.updated: Autumn-scheduled add-on drop keeps the customer's plan version",
 	),
 	async () => {
 		const customerId = "sub-updated-sched-addon-drop-version";
-		const pro = products.pro({
-			id: "sched-addon-drop-pro",
-			items: [items.monthlyMessages({ includedUsage: 100 })],
-		});
-		const addon = products.base({
-			id: "sched-addon-drop-addon",
-			isAddOn: true,
-			items: [
-				items.monthlyPrice({ price: 10 }),
-				items.monthlyUsers({ includedUsage: 5 }),
-			],
-		});
-
-		const { autumnV1, autumnV2_3, ctx, testClockId } = await initScenario({
-			customerId,
-			setup: [
-				s.customer({ paymentMethod: "success" }),
-				s.products({ list: [pro, addon] }),
-			],
-			actions: [
-				s.billing.attach({ productId: pro.id }),
-				s.billing.attach({ productId: addon.id }),
-			],
-		});
-
-		// A newer pro version sharing the same base price — the bait for back-sync.
-		await autumnV2_3.catalogV2.update({
-			plans: [
-				{
-					plan_id: pro.id,
-					versioning: "new_version",
-					active: true,
-					price: { amount: 20, interval: BillingInterval.Month },
-					items: [
-						{
-							feature_id: TestFeature.Messages,
-							included: 500,
-							reset: { interval: ResetInterval.Month },
-						},
-					],
-				},
-			],
-		});
-
-		await autumnV1.subscriptions.update({
-			customer_id: customerId,
-			product_id: addon.id,
-			cancel_action: "cancel_end_of_cycle",
-		});
-
-		const subscriptionId = await getSubscriptionId({
-			ctx,
-			customerId,
-			productId: pro.id,
-		});
-		const subscription = await ctx.stripeCli.subscriptions.retrieve(
-			subscriptionId,
-			{ expand: ["schedule"] },
-		);
-		const schedule = subscription.schedule as Stripe.SubscriptionSchedule;
+		const { autumnV1, ctx, testClockId, pro, addon, schedule } =
+			await setupAddonDropWithNewerVersion({ customerId });
 		expect(
 			schedule?.metadata?.[AUTUMN_STRIPE_METADATA_KEYS.managedAt],
 		).toBeDefined();
 
-		// In production the cycle turns weeks after the cancel, long past the
-		// 10-minute recency window on the subscription stamp. Age it to match.
-		await ctx.stripeCli.subscriptions.update(subscriptionId, {
-			metadata: { [AUTUMN_STRIPE_METADATA_KEYS.managedAt]: "1" },
+		await advanceToNextInvoice({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId!,
+		});
+		await expectAddonDroppedProKeptAtV1({
+			autumnV1,
+			customerId,
+			proId: pro.id,
+			addonId: addon.id,
+		});
+	},
+	WEBHOOK_TEST_TIMEOUT_MS,
+);
+
+test(
+	chalk.yellowBright(
+		"sub.updated: unstamped (pre-existing) schedule add-on drop still keeps the plan version",
+	),
+	async () => {
+		const customerId = "sub-updated-sched-addon-drop-unstamped";
+		const { autumnV1, ctx, testClockId, pro, addon, schedule } =
+			await setupAddonDropWithNewerVersion({ customerId });
+
+		await ctx.stripeCli.subscriptionSchedules.update(schedule.id, {
+			metadata: { [AUTUMN_STRIPE_METADATA_KEYS.managedAt]: "" },
 		});
 
 		await advanceToNextInvoice({
 			stripeCli: ctx.stripeCli,
 			testClockId: testClockId!,
 		});
-
-		const customer = (await expectCustomerProducts({
-			autumn: autumnV1,
+		await expectAddonDroppedProKeptAtV1({
+			autumnV1,
 			customerId,
-			settleTimeoutMs: WEBHOOK_SETTLE_TIMEOUT_MS,
-			active: [pro.id],
-			notPresent: [addon.id],
-		})) as ApiCustomerV3;
-		expect(attachedVersion({ customer, planId: pro.id })).toBe(1);
+			proId: pro.id,
+			addonId: addon.id,
+		});
 	},
 	WEBHOOK_TEST_TIMEOUT_MS,
 );

--- a/server/tests/unit/billing/execute-stripe-subscription-schedule-action.test.ts
+++ b/server/tests/unit/billing/execute-stripe-subscription-schedule-action.test.ts
@@ -101,9 +101,23 @@ describe("executeStripeSubscriptionScheduleAction", () => {
 		expect(mockState.updateCalls).toEqual([
 			{
 				scheduleId: "sched_standalone",
-				params,
+				params: {
+					...params,
+					metadata: {
+						autumn_managed_at: expect.any(String),
+					},
+				},
 			},
 		]);
+
+		const updateParams = mockState.updateCalls[0] as {
+			params: {
+				metadata: {
+					autumn_managed_at: string;
+				};
+			};
+		};
+		expect(Number(updateParams.params.metadata.autumn_managed_at)).toBeFinite();
 		expect(mockState.releaseCalls).toEqual([]);
 		expect(mockState.createCalls).toEqual([]);
 		expect(result?.id).toBe("sched_standalone");

--- a/server/tests/unit/webhooks/subscription-updated/is-autumn-scheduled-phase-change.test.ts
+++ b/server/tests/unit/webhooks/subscription-updated/is-autumn-scheduled-phase-change.test.ts
@@ -1,0 +1,70 @@
+/**
+ * sub.updated back-sync must ignore an Autumn-owned schedule advancing (Autumn's
+ * mirror already applied the phase), but still run for schedules the customer
+ * built in Stripe (e.g. license quantity changes).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type Stripe from "stripe";
+import { isAutumnScheduledPhaseChange } from "@/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/isAutumnScheduledPhaseChange";
+import type { StripeSubscriptionUpdatedContext } from "@/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/stripeSubscriptionUpdatedContext";
+import { AUTUMN_STRIPE_METADATA_KEYS } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata";
+
+const itemsChanged = {
+	items: { object: "list", data: [], has_more: false, url: "" },
+} as unknown as StripeSubscriptionUpdatedContext["previousAttributes"];
+
+const buildContext = ({
+	schedule,
+	previousAttributes = itemsChanged,
+}: {
+	schedule: Partial<Stripe.SubscriptionSchedule> | null;
+	previousAttributes?: StripeSubscriptionUpdatedContext["previousAttributes"];
+}) =>
+	({
+		stripeSubscription: { id: "sub_test", schedule },
+		previousAttributes,
+	}) as unknown as StripeSubscriptionUpdatedContext;
+
+describe("isAutumnScheduledPhaseChange", () => {
+	test("true when an Autumn-stamped schedule advances", () => {
+		const context = buildContext({
+			schedule: {
+				id: "sub_sched_autumn",
+				metadata: { [AUTUMN_STRIPE_METADATA_KEYS.managedAt]: "1" },
+			},
+		});
+		expect(
+			isAutumnScheduledPhaseChange({ subscriptionUpdatedContext: context }),
+		).toBe(true);
+	});
+
+	test("false when a customer-built Stripe schedule advances", () => {
+		const context = buildContext({
+			schedule: { id: "sub_sched_external", metadata: {} },
+		});
+		expect(
+			isAutumnScheduledPhaseChange({ subscriptionUpdatedContext: context }),
+		).toBe(false);
+	});
+
+	test("false when items change with no schedule attached", () => {
+		const context = buildContext({ schedule: null });
+		expect(
+			isAutumnScheduledPhaseChange({ subscriptionUpdatedContext: context }),
+		).toBe(false);
+	});
+
+	test("false when an Autumn schedule is attached but items did not change", () => {
+		const context = buildContext({
+			schedule: {
+				id: "sub_sched_autumn",
+				metadata: { [AUTUMN_STRIPE_METADATA_KEYS.managedAt]: "1" },
+			},
+			previousAttributes: { status: "active" },
+		});
+		expect(
+			isAutumnScheduledPhaseChange({ subscriptionUpdatedContext: context }),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug

An add-on canceled at end of cycle drops off via a Stripe schedule that Autumn built. When that phase advanced weeks later, `customer.subscription.updated` auto-sync treated the item change as an external edit, re-matched the surviving base price to the plan's *active* catalog version, and replaced the customer's pinned (custom) version. The cancel itself was fine; only the back-sync was wrong.

```
cancel add-on (EOC)            cycle turns (weeks later)
       │                              │
       ▼                              ▼
Autumn writes schedule        Stripe advances phase → sub.updated
autumn_managed_at stamped     autumn_managed_at is stale (>10 min)
on the SUBSCRIPTION           ┌──────────────────────────────────┐
                              │ handleSchedulePhaseChanges  ✔    │  expires add-on (correct)
                              │ autoSyncUpdatedSubscription ✘    │  re-matches base price → swaps version
                              └──────────────────────────────────┘
```

## Why auto-sync ran

`autoSyncUpdatedSubscription` only skips when the subscription's `autumn_managed_at` is fresh (10-minute window). A schedule phase advance looks identical to a customer editing items in Stripe. We can't blanket-skip schedule advances: some customers manage licenses via schedules they create in Stripe, and those advances *must* back-sync.

## Fix

**Who created the schedule**, stamped as schedule-level Stripe metadata at write time. For schedules created *before* this deploys (no stamp), skip back-sync when this event already applied the phase.

| schedule origin | phase advance → back-sync? |
|---|---|
| Autumn-written (`autumn_managed_at` on the schedule) | **skip** |
| Unstamped, but this event tagged `phase_changed` | **skip** (covers pre-existing schedules) |
| Customer-built in Stripe (no stamp, no phase apply) | **run** (license quantity etc.) |

Write side stamps `buildAutumnSubscriptionMetadata` on every Autumn schedule create/update (`executeStripeSubscriptionScheduleAction`, V1 `updateCurSchedule`).

Read side: `isAutumnScheduledPhaseChange` **or** `billingChangeTags.has("phase_changed")` → skip auto-sync.

Portal / `autumn_managed_source` behavior is unchanged.

## Tests

- Integration: pro v1 + add-on → publish pro v2 (same base price) → cancel add-on EOC → age the sub stamp → advance clock. Add-on gone, pro stays **v1**.
  - Stamped schedule (forward path)
  - Unstamped schedule (pre-existing path)
- Unit: Autumn schedule → skip; external schedule → don't; no schedule → don't.

Hotfix onto `main`. Same change is on #3387 targeting `dev`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3859e995-c7f2-4b78-af44-c1aa135c0fb0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3859e995-c7f2-4b78-af44-c1aa135c0fb0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `sub.updated` auto-sync from re-matching a plan's base price and swapping the customer's pinned version when an Autumn-built Stripe schedule advances at end of cycle. Autumn-owned schedule advances now skip back-sync; customer-built schedules still back-sync.

**Bug Fixes**
- Every Autumn schedule create/update now carries `autumn_managed_at` on the schedule itself.
- Auto-sync skips when an Autumn-stamped schedule advances or when `phase_changed` was already applied (covers pre-existing schedules).
- Customer-built schedules that don't meet those conditions still run back-sync.

<sup>Written for commit abaf7b0a656e83e73f4aed0644f12df35800ecf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This hotfix prevents an Autumn-managed Stripe schedule advancing to its next phase from being mistaken for an external subscription edit.

Key changes:
- **[Bug fixes]** Stamps Stripe schedules created or updated by Autumn with ownership metadata.
- **[Bug fixes]** Skips subscription back-sync when an Autumn-owned schedule appears to advance or when the phase was already handled.
- **[Improvements]** Centralizes schedule-phase detection and adds regression coverage for stamped and legacy unstamped schedules.
- **[Improvements]** Strengthens the schedule-action unit test to validate that the ownership timestamp is numeric.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because customer item edits can still be skipped whenever an Autumn-stamped schedule remains attached.

The previous blocking finding remains outstanding and was not changed since the prior review. The predicate still treats every item change with an attached Autumn-stamped schedule as a schedule advance, so a real Stripe-side quantity or item edit can bypass back-sync and leave Autumn's customer product and entitlement state stale.

**Files Needing Attention:** server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/isAutumnScheduledPhaseChange.ts, server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/isAutumnScheduledPhaseChange.ts | Detects an Autumn schedule phase change from an item change plus persistent schedule ownership metadata, which cannot distinguish an actual phase advance from a customer edit. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts | Adds early exits that protect pinned product versions during phase advancement but can also suppress valid external-edit back-sync. |
| server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionScheduleAction.ts | Adds Autumn ownership metadata to schedule creation and update operations. |
| server/src/internal/customers/attach/mergeUtils/updateCurSchedule.ts | Stamps schedules updated through the legacy attach flow. |
| server/tests/unit/billing/execute-stripe-subscription-schedule-action.test.ts | Verifies that schedule updates include a finite Autumn ownership timestamp. |
| server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-scheduled-addon-drop-keeps-version.test.ts | Covers pinned-version preservation for stamped and pre-existing unstamped schedules. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stripe subscription.updated] --> B{Price or product changed?}
    B -- No --> C[Stop]
    B -- Yes --> D{Items changed and schedule attached?}
    D -- No --> E[Run normal auto-sync checks]
    D -- Yes --> F{Schedule has Autumn ownership metadata?}
    F -- Yes --> G[Skip back-sync]
    F -- No --> H{Phase change already applied?}
    H -- Yes --> G
    H -- No --> E
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(stripe): expect autumn\_managed\_at o..."](https://github.com/useautumn/autumn/commit/abaf7b0a656e83e73f4aed0644f12df35800ecf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63232067)</sub>

<!-- /greptile_comment -->