### PR TITLE
Expose sync anchor to all users on balances card

### DIFF
--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -53,7 +53,6 @@ import {
 	handleGetSlackAdminInstall,
 	handleUpdateSlackAdminTarget,
 } from "./handleSlackAdminChat";
-import { handleSyncCustomerEntitlementAnchors } from "./handleSyncCustomerEntitlementAnchors";
 import { handleUpsertAdminAsyncBalanceUpdateConfig } from "./handleUpsertAdminAsyncBalanceUpdateConfig";
 import { handleUpsertAdminAsyncTrackConfig } from "./handleUpsertAdminAsyncTrackConfig";
 import { handleUpsertAdminBatchResetConfig } from "./handleUpsertAdminBatchResetConfig";
@@ -258,10 +257,6 @@ honoAdminRouter.patch(
 );
 honoAdminRouter.delete("/chat/slack-admin", ...handleDeleteSlackAdminInstall);
 honoAdminRouter.post("/invoice-line-items", ...handleGetInvoiceLineItems);
-honoAdminRouter.post(
-	"/customer-entitlements/sync-anchor",
-	...handleSyncCustomerEntitlementAnchors,
-);
 
 honoAdminRouter.get("/rollouts", ...handleGetRollouts);
 honoAdminRouter.put("/rollouts/:rollout_id", ...handleUpdateRollout);

--- a/server/src/internal/customers/internalCusRouter.ts
+++ b/server/src/internal/customers/internalCusRouter.ts
@@ -15,6 +15,7 @@ import { handleGetInvoiceLineItems } from "./internalHandlers/handleGetInvoiceLi
 import { handleListCustomerExports } from "./internalHandlers/handleListCustomerExports.js";
 import { handleListEntitiesInternal } from "./internalHandlers/handleListEntitiesInternal.js";
 import { handleSearchCustomers } from "./internalHandlers/handleSearchCustomers.js";
+import { handleSyncCustomerEntitlementAnchors } from "./internalHandlers/handleSyncCustomerEntitlementAnchors.js";
 
 export const internalCusRouter = new Hono<HonoEnv>();
 
@@ -22,6 +23,10 @@ internalCusRouter.post("/all/search", ...handleSearchCustomers);
 internalCusRouter.post("/all/full_customers", ...handleGetFullCustomers);
 internalCusRouter.post("/all/count", ...handleCountCustomers);
 internalCusRouter.post("/clear_cache", ...handleClearCustomerCache);
+internalCusRouter.post(
+	"/customer-entitlements/sync-anchor",
+	...handleSyncCustomerEntitlementAnchors,
+);
 // Registered before /:customer_id so "exports" is never read as a customer id.
 internalCusRouter.post("/exports", ...handleCreateCustomerExport);
 internalCusRouter.get("/exports", ...handleListCustomerExports);

--- a/server/src/internal/customers/internalHandlers/handleSyncCustomerEntitlementAnchors.ts
+++ b/server/src/internal/customers/internalHandlers/handleSyncCustomerEntitlementAnchors.ts
@@ -4,7 +4,7 @@ import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { syncCustomerEntitlementAnchors } from "@/internal/customers/cusProducts/cusEnts/actions/syncCustomerEntitlementAnchors";
 
 export const handleSyncCustomerEntitlementAnchors = createRoute({
-	scopes: [Scopes.Superuser],
+	scopes: [Scopes.Balances.Write],
 	body: z.object({
 		customer_entitlement_ids: z.array(z.string()).min(1),
 	}),

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -35,13 +35,13 @@ import { formatUnixToDateTime } from "@/utils/formatUtils/formatDateUtils";
 import { useFeatureUsageBalance } from "@/views/customers2/hooks/useFeatureUsageBalance";
 import { CustomerFeatureUsageBar } from "../customer-feature-usage/CustomerFeatureUsageBar";
 import { FeatureBalanceDisplay } from "../customer-feature-usage/FeatureBalanceDisplay";
-import { AdminSyncAnchorMenuItem } from "./AdminSyncAnchorMenuItem";
 import { CustomerBalanceFeatureCell } from "./CustomerBalanceFeatureCell";
 import type { CustomerBalanceRowData } from "./CustomerBalanceTable";
 import {
 	canDeleteCustomerBalance,
 	canRecalculateCustomerBalances,
 } from "./customerBalanceUtils";
+import { SyncAnchorMenuItem } from "./SyncAnchorMenuItem";
 
 function getActiveRowEntitlements(
 	row: Row<CustomerBalanceRowData>,
@@ -517,9 +517,7 @@ function BalanceActionsCell({
 						</DropdownMenuItem>
 					)}
 					{isParentRow && (
-						<AdminSyncAnchorMenuItem
-							customerEntitlements={customerEntitlements}
-						/>
+						<SyncAnchorMenuItem customerEntitlements={customerEntitlements} />
 					)}
 					{canDelete && onDeleteClick && (
 						<DropdownMenuItem

--- a/vite/src/views/customers2/components/table/customer-balance/SyncAnchorMenuItem.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/SyncAnchorMenuItem.tsx
@@ -6,15 +6,13 @@ import {
 } from "@autumn/shared";
 import { DropdownMenuItem } from "@autumn/ui";
 import { ArrowsClockwiseIcon } from "@phosphor-icons/react";
-import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { useSyncCustomerEntitlementAnchors } from "./useSyncCustomerEntitlementAnchors";
 
-export function AdminSyncAnchorMenuItem({
+export function SyncAnchorMenuItem({
 	customerEntitlements,
 }: {
 	customerEntitlements: FullCusEntWithFullCusProduct[];
 }) {
-	const { isAdmin } = useAdmin();
 	const { mutate, isPending } = useSyncCustomerEntitlementAnchors();
 	const canSyncAnchor = customerEntitlements.some(
 		(customerEntitlement) =>
@@ -28,7 +26,7 @@ export function AdminSyncAnchorMenuItem({
 			}),
 	);
 
-	if (!isAdmin || !canSyncAnchor) return null;
+	if (!canSyncAnchor) return null;
 
 	return (
 		<DropdownMenuItem

--- a/vite/src/views/customers2/components/table/customer-balance/useSyncCustomerEntitlementAnchors.ts
+++ b/vite/src/views/customers2/components/table/customer-balance/useSyncCustomerEntitlementAnchors.ts
@@ -24,7 +24,7 @@ export const useSyncCustomerEntitlementAnchors = () => {
 			customerEntitlementIds: string[];
 		}) => {
 			const { data } = await axiosInstance.post<SyncAnchorsResponse>(
-				"/admin/customer-entitlements/sync-anchor",
+				"/customers/customer-entitlements/sync-anchor",
 				{ customer_entitlement_ids: customerEntitlementIds },
 			);
 			return data;


### PR DESCRIPTION
## Summary

The "Sync anchor" item on the customer balances card was only shown to admins, and the endpoint behind it was admin-only server-side too. This removes both gates so any dashboard user can use it.

- **Frontend:** drop the `isAdmin` check on the menu item and rename it from `AdminSyncAnchorMenuItem` to `SyncAnchorMenuItem`. The hook now calls the new route.
- **Backend:** move the sync-anchor route from the admin router (which runs `adminAuthMiddleware`) to the internal customers router at `/customers/customer-entitlements/sync-anchor`, and change the handler scope from `Superuser` to `Balances.Write`.

The handler and the underlying `syncCustomerEntitlementAnchors` action are unchanged. The action already looks up entitlements scoped to the caller's org and env, so non-admins can only sync anchors on their own customers. The existing filter that hides the item for one-off, boolean, and lifetime entitlements is kept.

## Test plan

- [ ] `bun ts` in `server/` passes
- [ ] `tsc --noEmit` in `vite/` passes
- [ ] Biome check on touched files passes
- [ ] As a non-admin org member, open a customer, open the balances row menu, click "Sync anchor", and confirm the success toast and refreshed reset date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qoz239CrXXq7iMbExZJbt

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qoz239CrXXq7iMbExZJbt)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes the "Sync anchor" option on the balances card to all dashboard users instead of only admins.

- Removes the frontend `isAdmin` check on the menu item and the backend `Superuser` scope on the route.
- Moves the endpoint from `/admin/customer-entitlements/sync-anchor` to `/customers/customer-entitlements/sync-anchor` and scopes it to `Balances.Write`.
- Non-admins can still only sync anchors for customers in their own org and env, and the existing filter for one-off, boolean, and lifetime entitlements still applies.

<sup>Written for commit 36489916db6d016b54508b44b2313ab4d8d1ee76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves sync-anchor operations from the admin-only API to the customer API and exposes the balance-card action to non-admin dashboard users.

Key changes:
- **[API changes]** Moves the sync-anchor endpoint from `/admin/customer-entitlements/sync-anchor` to `/customers/customer-entitlements/sync-anchor`.
- **[Improvements]** Replaces the superuser requirement with the `Balances.Write` scope.
- **[Improvements]** Removes the frontend administrator check and renames the menu component.
- **[Bug fixes]** Updates the frontend hook to call the new endpoint.
- The frontend currently exposes the action to read-only users even though the endpoint rejects them.
</details>


<h3>Confidence Score: 4/5</h3>

The PR should not merge until the balance card hides the sync action from users who lack `Balances.Write`.

Read-only members can reach the balance card and are now shown the sync action, but the changed endpoint rejects their requests with 403 because it requires `Balances.Write`.

**Files Needing Attention:** vite/src/views/customers2/components/table/customer-balance/SyncAnchorMenuItem.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/admin/adminRouter.ts | Removes the old admin-only sync-anchor route. |
| server/src/internal/customers/internalCusRouter.ts | Registers the sync-anchor handler under the authenticated customer router. |
| server/src/internal/customers/internalHandlers/handleSyncCustomerEntitlementAnchors.ts | Changes authorization from superuser access to `Balances.Write`. |
| vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx | Uses the renamed sync-anchor menu component. |
| vite/src/views/customers2/components/table/customer-balance/SyncAnchorMenuItem.tsx | Removes the administrator gate but does not replace it with the endpoint's `Balances.Write` permission check. |
| vite/src/views/customers2/components/table/customer-balance/useSyncCustomerEntitlementAnchors.ts | Updates the mutation to call the new customer API route. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant UI as Balance card
    participant API as Customer sync endpoint
    User->>UI: Open balance actions
    UI->>UI: Check entitlement type only
    UI-->>User: Show "Sync anchor"
    User->>API: POST sync request
    API->>API: Require Balances.Write
    alt User has Balances.Write
        API-->>User: Anchors synchronized
    else Read-only member
        API-->>User: 403 InsufficientScopes
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/views/customers2/components/table/customer-balance/SyncAnchorMenuItem.tsx:29
**Read-Only Users See Action**

The menu now appears for any user viewing an eligible balance, but the endpoint still requires `Balances.Write`. For example, a read-only member can click “Sync anchor,” but the request returns 403 and only shows an error toast. Check `Balances.Write` before displaying the item so users only see an action they can perform.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Expose sync anchor to all users on balan..."](https://github.com/useautumn/autumn/commit/36489916db6d016b54508b44b2313ab4d8d1ee76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63272041)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->